### PR TITLE
PublicAPI: Fix spurious oblivious warning on nested enum

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -208,6 +208,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                 ApiName publicApiName = GetPublicApiName(symbol);
                 _visitedApiList.TryAdd(publicApiName.Name, default);
+                _visitedApiList.TryAdd(WithObliviousMarker(publicApiName.Name), default);
                 _visitedApiList.TryAdd(publicApiName.NameWithNullability, default);
                 _visitedApiList.TryAdd(WithObliviousMarker(publicApiName.NameWithNullability), default);
 
@@ -243,7 +244,12 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     if (!hasPublicApiEntryWithNullability && !hasPublicApiEntryWithNullabilityAndOblivious)
                     {
                         var hasPublicApiEntryWithoutNullability = _publicApiMap.TryGetValue(publicApiName.Name, out foundApiLine);
-                        if (!hasPublicApiEntryWithoutNullability)
+
+                        var hasPublicApiEntryWithoutNullabilityButOblivious =
+                            !hasPublicApiEntryWithoutNullability &&
+                            _publicApiMap.TryGetValue(WithObliviousMarker(publicApiName.Name), out foundApiLine);
+
+                        if (!hasPublicApiEntryWithoutNullability && !hasPublicApiEntryWithoutNullabilityButOblivious)
                         {
                             reportDeclareNewApi(symbol, isImplicitlyDeclaredConstructor, withObliviousIfNeeded(publicApiName.NameWithNullability));
                         }

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -548,7 +548,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             {
                 if (symbol.Kind == SymbolKind.NamedType)
                 {
-                    return ObliviousDetector.TypeDeclarationInstance.Visit(symbol);
+                    return ObliviousDetector.IgnoreTopLevelNullabilityInstance.Visit(symbol);
                 }
 
                 return ObliviousDetector.Instance.Visit(symbol);
@@ -764,14 +764,14 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             /// </summary>
             private sealed class ObliviousDetector : SymbolVisitor<bool>
             {
-                public readonly static ObliviousDetector TypeDeclarationInstance = new ObliviousDetector(forTypeDeclaration: true);
-                public readonly static ObliviousDetector Instance = new ObliviousDetector(forTypeDeclaration: false);
+                public readonly static ObliviousDetector IgnoreTopLevelNullabilityInstance = new ObliviousDetector(ignoreTopLevelNullability: true);
+                public readonly static ObliviousDetector Instance = new ObliviousDetector(ignoreTopLevelNullability: false);
 
-                private readonly bool _forTypeDeclaration;
+                private readonly bool _ignoreTopLevelNullability;
 
-                private ObliviousDetector(bool forTypeDeclaration)
+                private ObliviousDetector(bool ignoreTopLevelNullability)
                 {
-                    _forTypeDeclaration = forTypeDeclaration;
+                    _ignoreTopLevelNullability = ignoreTopLevelNullability;
                 }
 
                 public override bool VisitField(IFieldSymbol symbol)
@@ -807,34 +807,34 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                 public override bool VisitNamedType(INamedTypeSymbol symbol)
                 {
-                    if (!_forTypeDeclaration)
+                    if (!_ignoreTopLevelNullability)
                     {
-                        if (symbol.ContainingType is INamedTypeSymbol containing)
-                        {
-                            if (Visit(containing))
-                            {
-                                return true;
-                            }
-                        }
-
                         if (symbol.IsReferenceType &&
                             symbol.NullableAnnotation() == NullableAnnotation.None)
                         {
                             return true;
                         }
+                    }
 
-                        foreach (var typeArgument in symbol.TypeArguments)
+                    if (symbol.ContainingType is INamedTypeSymbol containing)
+                    {
+                        if (IgnoreTopLevelNullabilityInstance.Visit(containing))
                         {
-                            if (Visit(typeArgument))
-                            {
-                                return true;
-                            }
+                            return true;
+                        }
+                    }
+
+                    foreach (var typeArgument in symbol.TypeArguments)
+                    {
+                        if (Instance.Visit(typeArgument))
+                        {
+                            return true;
                         }
                     }
 
                     foreach (var typeParameter in symbol.TypeParameters)
                     {
-                        if (Visit(typeParameter))
+                        if (Instance.Visit(typeParameter))
                         {
                             return true;
                         }

--- a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = "AnnotatePublicApiFix"), Shared]
     public sealed class AnnotatePublicApiFix : CodeFixProvider
     {
+        private const char ObliviousMarker = '~';
+
         public sealed override ImmutableArray<string> FixableDiagnosticIds
             => ImmutableArray.Create(DiagnosticIds.AnnotatePublicApiRuleId);
 
@@ -72,7 +74,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             for (int i = 0; i < lines.Count; i++)
             {
-                if (changes.TryGetValue(lines[i], out string newLine))
+                if (changes.TryGetValue(lines[i].Trim(ObliviousMarker), out string newLine))
                 {
                     lines.Insert(i, newLine);
                     lines.RemoveAt(i + 1);

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -306,6 +306,50 @@ C.C() -> void
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedShippedText, newUnshippedApiText: unshippedText);
         }
 
+        [Fact]
+        public async Task LegacyAPIWithObliviousMarkerGetsAnnotatedAsNullable()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string? {|RS0036:Field|};
+}
+";
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C
+C.C() -> void
+~C.Field -> string";
+            var unshippedText = @"";
+            var fixedShippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C
+C.C() -> void
+C.Field -> string?";
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
+        [Fact]
+        public async Task LegacyAPIWithObliviousMarkerGetsAnnotatedAsNotNullable()
+        {
+            var source = @"
+#nullable enable
+public class C
+{
+    public string {|RS0036:Field|};
+}
+";
+            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C
+C.C() -> void
+~C.Field -> string";
+            var unshippedText = @"";
+            var fixedShippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}
+C
+C.C() -> void
+C.Field -> string!";
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedShippedText, newUnshippedApiText: unshippedText);
+        }
+
         #endregion
     }
 }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -1370,26 +1370,6 @@ C.C() -> void
         }
 
         [Fact]
-        public async Task TestAddAndRemoveMembers_CSharp_Fix_WithAddedNullability_WithOblivious()
-        {
-            var source = @"
-#nullable enable
-public class C
-{
-    public string? {|RS0016:ChangedField|};
-}
-";
-            var shippedText = $@"{DeclarePublicApiAnalyzer.NullableEnable}";
-            var unshippedText = @"C
-C.C() -> void
-{|RS0017:~C.ChangedField -> string|}";
-            var fixedUnshippedText = @"C
-C.C() -> void
-C.ChangedField -> string?";
-            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
-        }
-
-        [Fact]
         public async Task ApiFileShippedWithDuplicateNullableEnable()
         {
             var source = @"


### PR DESCRIPTION
Follows up on https://github.com/dotnet/roslyn-analyzers/pull/3386 (tracking oblivious APIs)

In trying the analyzer on roslyn, I found two bugs:
- we would produce a spurious warning on nested enums in `#nullable enable` context because of incorrect detection of oblivious types (more details below)
- in the upgrade of oblivious APIs previously marked with `~`, we would not recognize the existing API line as corresponding to a newly annotated member (the `~` needed to be trimmed)

Sorry I missed those scenarios in my previous PR :-(

Detection of oblivious types:
In `class C { enum E { None } }`, we would look at the field `C.E.None` which returns a `C.E` and see an oblivious on the containing type. That is not a place where an annotation `?` could go, therefore that is not a place where oblivious matters.

@mavasani @sharwell for review. Thanks