### PR TITLE
Add "Release tracking" analyzer to track 'analyzer releases' <-> 'shipped rules'

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -488,8 +488,8 @@
   <data name="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
     <value>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</value>
   </data>
-  <data name="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
-    <value>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</value>
+  <data name="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage" xml:space="preserve">
+    <value>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</value>
   </data>
   <data name="InvalidEntryInAnalyzerReleasesFileRuleDescription" xml:space="preserve">
     <value>Invalid entry in analyzer release file.</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -407,4 +407,91 @@
   <data name="DoNotUseCompilationGetSemanticModelTitle" xml:space="preserve">
     <value>Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer</value>
   </data>
+  <data name="DeclareDiagnosticIdInAnalyzerReleaseTitle" xml:space="preserve">
+    <value>Add analyzer diagnostic IDs to analyzer release.</value>
+  </data>
+  <data name="DeclareDiagnosticIdInAnalyzerReleaseMessage" xml:space="preserve">
+    <value>Rule '{0}' is not part of any analyzer release.</value>
+  </data>
+  <data name="DeclareDiagnosticIdInAnalyzerReleaseDescription" xml:space="preserve">
+    <value>All supported analyzer diagnostic IDs should be part of an analyzer release.</value>
+  </data>
+  <data name="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle" xml:space="preserve">
+    <value>Add rule entry to unshipped release file</value>
+  </data>
+  <data name="UpdateDiagnosticIdInAnalyzerReleaseTitle" xml:space="preserve">
+    <value>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</value>
+  </data>
+  <data name="UpdateDiagnosticIdInAnalyzerReleaseMessage" xml:space="preserve">
+    <value>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</value>
+  </data>
+  <data name="UpdateDiagnosticIdInAnalyzerReleaseDescription" xml:space="preserve">
+    <value>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</value>
+  </data>
+  <data name="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle" xml:space="preserve">
+    <value>Update rule entry in unshipped release file</value>
+  </data>
+  <data name="RemoveUnshippedDeletedDiagnosticIdTitle" xml:space="preserve">
+    <value>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</value>
+  </data>
+  <data name="RemoveUnshippedDeletedDiagnosticIdMessage" xml:space="preserve">
+    <value>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</value>
+  </data>
+  <data name="RemoveUnshippedDeletedDiagnosticIdDescription" xml:space="preserve">
+    <value>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</value>
+  </data>
+  <data name="RemoveShippedDeletedDiagnosticIdTitle" xml:space="preserve">
+    <value>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</value>
+  </data>
+  <data name="RemoveShippedDeletedDiagnosticIdMessage" xml:space="preserve">
+    <value>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</value>
+  </data>
+  <data name="RemoveShippedDeletedDiagnosticIdDescription" xml:space="preserve">
+    <value>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</value>
+  </data>
+  <data name="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle" xml:space="preserve">
+    <value>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</value>
+  </data>
+  <data name="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage" xml:space="preserve">
+    <value>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</value>
+  </data>
+  <data name="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription" xml:space="preserve">
+    <value>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle" xml:space="preserve">
+    <value>Remove duplicate entries for diagnostic ID in the same analyzer release.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage" xml:space="preserve">
+    <value>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription" xml:space="preserve">
+    <value>Remove duplicate entries for diagnostic ID in the same analyzer release.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle" xml:space="preserve">
+    <value>Remove duplicate entries for diagnostic ID between analyzer releases.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage" xml:space="preserve">
+    <value>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</value>
+  </data>
+  <data name="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription" xml:space="preserve">
+    <value>Remove duplicate entries for diagnostic ID between analyzer releases.</value>
+  </data>
+  <data name="InvalidEntryInAnalyzerReleasesFileRuleTitle" xml:space="preserve">
+    <value>Invalid entry in analyzer release file.</value>
+  </data>
+  <data name="InvalidEntryInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
+    <value>Analyzer release file '{0}' has an invalid entry '{1}'.</value>
+  </data>
+  <data name="InvalidHeaderInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
+    <value>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</value>
+  </data>
+  <data name="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
+    <value>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</value>
+  </data>
+  <data name="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage" xml:space="preserve">
+    <value>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</value>
+  </data>
+  <data name="InvalidEntryInAnalyzerReleasesFileRuleDescription" xml:space="preserve">
+    <value>Invalid entry in analyzer release file.</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -441,13 +441,13 @@
     <value>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</value>
   </data>
   <data name="RemoveShippedDeletedDiagnosticIdTitle" xml:space="preserve">
-    <value>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</value>
+    <value>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</value>
   </data>
   <data name="RemoveShippedDeletedDiagnosticIdMessage" xml:space="preserve">
-    <value>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</value>
+    <value>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</value>
   </data>
   <data name="RemoveShippedDeletedDiagnosticIdDescription" xml:space="preserve">
-    <value>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</value>
+    <value>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</value>
   </data>
   <data name="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle" xml:space="preserve">
     <value>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
@@ -34,5 +34,15 @@ namespace Microsoft.CodeAnalysis.Analyzers
         public const string ProvideCustomTagsInDescriptorRuleId = "RS1028";
         public const string DoNotUseReservedDiagnosticIdRuleId = "RS1029";
         public const string DoNotUseCompilationGetSemanticModelRuleId = "RS1030";
+
+        // Release tracking analyzer IDs
+        public const string DeclareDiagnosticIdInAnalyzerReleaseRuleId = "RS2000";
+        public const string UpdateDiagnosticIdInAnalyzerReleaseRuleId = "RS2001";
+        public const string RemoveUnshippedDeletedDiagnosticIdRuleId = "RS2002";
+        public const string RemoveShippedDeletedDiagnosticIdRuleId = "RS2003";
+        public const string UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdRuleId = "RS2004";
+        public const string RemoveDuplicateEntriesForAnalyzerReleaseRuleId = "RS2005";
+        public const string RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleId = "RS2006";
+        public const string InvalidEntryInAnalyzerReleasesFileRuleId = "RS2007";
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -4,28 +4,25 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DiagnosticDescriptorCreationAnalyzer : DiagnosticAnalyzer
+    public sealed partial class DiagnosticDescriptorCreationAnalyzer : DiagnosticAnalyzer
     {
         private const string HelpLinkUriParameterName = "helpLinkUri";
         private const string CategoryParameterName = "category";
         private const string DiagnosticIdParameterName = "id";
         private const string CustomTagsParameterName = "customTags";
-
-        private const string DiagnosticCategoryAndIdRangeFile = "DiagnosticCategoryAndIdRanges.txt";
-        private static readonly (string? prefix, int start, int end) s_defaultAllowedIdsInfo = (null, -1, -1);
+        private const string IsEnabledByDefaultParameterName = "isEnabledByDefault";
+        private const string DefaultSeverityParameterName = "defaultSeverity";
+        private const string RuleLevelParameterName = "ruleLevel";
 
         private static readonly ImmutableHashSet<string> CADiagnosticIdAllowedAssemblies = ImmutableHashSet.Create(
             StringComparer.Ordinal,
@@ -58,21 +55,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         private static readonly LocalizableString s_localizableDiagnosticIdMustBeAConstantMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeAConstantMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
         private static readonly LocalizableString s_localizableDiagnosticIdMustBeAConstantDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeAConstantDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
-        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-
         private static readonly LocalizableString s_localizableUseUniqueDiagnosticIdTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseUniqueDiagnosticIdTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
         private static readonly LocalizableString s_localizableUseUniqueDiagnosticIdMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseUniqueDiagnosticIdMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
         private static readonly LocalizableString s_localizableUseUniqueDiagnosticIdDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseUniqueDiagnosticIdDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-
-        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-
-        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
-        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
 
         private static readonly LocalizableString s_localizableProvideCustomTagsTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.ProvideCustomTagsInDescriptorTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
         private static readonly LocalizableString s_localizableProvideCustomTagsMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.ProvideCustomTagsInDescriptorMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
@@ -112,16 +97,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             description: s_localizableDiagnosticIdMustBeAConstantDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
-        public static readonly DiagnosticDescriptor DiagnosticIdMustBeInSpecifiedFormatRule = new DiagnosticDescriptor(
-            DiagnosticIds.DiagnosticIdMustBeInSpecifiedFormatRuleId,
-            s_localizableDiagnosticIdMustBeInSpecifiedFormatTitle,
-            s_localizableDiagnosticIdMustBeInSpecifiedFormatMessage,
-            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: true,
-            description: s_localizableDiagnosticIdMustBeInSpecifiedFormatDescription,
-            customTags: WellKnownDiagnosticTags.Telemetry);
-
         public static readonly DiagnosticDescriptor UseUniqueDiagnosticIdRule = new DiagnosticDescriptor(
             DiagnosticIds.UseUniqueDiagnosticIdRuleId,
             s_localizableUseUniqueDiagnosticIdTitle,
@@ -130,26 +105,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             description: s_localizableUseUniqueDiagnosticIdDescription,
-            customTags: WellKnownDiagnosticTags.Telemetry);
-
-        public static readonly DiagnosticDescriptor UseCategoriesFromSpecifiedRangeRule = new DiagnosticDescriptor(
-            DiagnosticIds.UseCategoriesFromSpecifiedRangeRuleId,
-            s_localizableUseCategoriesFromSpecifiedRangeTitle,
-            s_localizableUseCategoriesFromSpecifiedRangeMessage,
-            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: false,
-            description: s_localizableUseCategoriesFromSpecifiedRangeDescription,
-            customTags: WellKnownDiagnosticTags.Telemetry);
-
-        public static readonly DiagnosticDescriptor AnalyzerCategoryAndIdRangeFileInvalidRule = new DiagnosticDescriptor(
-            DiagnosticIds.AnalyzerCategoryAndIdRangeFileInvalidRuleId,
-            s_localizableAnalyzerCategoryAndIdRangeFileInvalidTitle,
-            s_localizableAnalyzerCategoryAndIdRangeFileInvalidMessage,
-            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
-            DiagnosticSeverity.Warning,
-            isEnabledByDefault: true,
-            description: s_localizableAnalyzerCategoryAndIdRangeFileInvalidDescription,
             customTags: WellKnownDiagnosticTags.Telemetry);
 
         public static readonly DiagnosticDescriptor ProvideCustomTagsInDescriptorRule = new DiagnosticDescriptor(
@@ -181,7 +136,18 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             UseCategoriesFromSpecifiedRangeRule,
             AnalyzerCategoryAndIdRangeFileInvalidRule,
             ProvideCustomTagsInDescriptorRule,
-            DoNotUseReservedDiagnosticIdRule);
+            DoNotUseReservedDiagnosticIdRule,
+            DeclareDiagnosticIdInAnalyzerReleaseRule,
+            UpdateDiagnosticIdInAnalyzerReleaseRule,
+            RemoveUnshippedDeletedDiagnosticIdRule,
+            RemoveShippedDeletedDiagnosticIdRule,
+            UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdRule,
+            RemoveDuplicateEntriesForAnalyzerReleaseRule,
+            RemoveDuplicateEntriesBetweenAnalyzerReleasesRule,
+            InvalidEntryInAnalyzerReleasesFileRule,
+            InvalidHeaderInAnalyzerReleasesFileRule,
+            InvalidUndetectedEntryInAnalyzerReleasesFileRule,
+            InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -200,11 +166,20 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 var checkCategoryAndAllowedIds = TryGetCategoryAndAllowedIdsMap(
                     compilationContext.Options.AdditionalFiles,
                     compilationContext.CancellationToken,
-                    out AdditionalText? additionalTextOpt,
+                    out AdditionalText? diagnosticCategoryAndIdRangeTextOpt,
                     out ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsMap,
                     out List<Diagnostic>? invalidFileDiagnostics);
 
+                // Try read the additional files containing the shipped and unshipped analyzer releases.
+                var isAnalyzerReleaseTracking = TryGetReleaseTrackingData(
+                    compilationContext.Options.AdditionalFiles,
+                    compilationContext.CancellationToken,
+                    out var shippedData,
+                    out var unshippedData,
+                    out List<Diagnostic>? invalidReleaseFileEntryDiagnostics);
+
                 var idToAnalyzerMap = new ConcurrentDictionary<string, ConcurrentDictionary<string, ConcurrentBag<Location>>>();
+                var seenRuleIds = PooledConcurrentSet<string>.GetInstance();
                 compilationContext.RegisterOperationAction(operationAnalysisContext =>
                 {
                     var fieldInitializer = (IFieldInitializerOperation)operationAnalysisContext.Operation;
@@ -214,19 +189,21 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     }
 
                     AnalyzeTitle(creationMethod, fieldInitializer, operationAnalysisContext.ReportDiagnostic);
-                    AnalyzeHelpLinkUri(operationAnalysisContext, creationArguments);
+                    AnalyzeHelpLinkUri(operationAnalysisContext, creationArguments, out var helpLink);
                     AnalyzeCustomTags(operationAnalysisContext, creationArguments);
+                    var (isEnabledByDefault, defaultSeverity) = GetDefaultSeverityAndEnabledByDefault(operationAnalysisContext.Compilation, creationArguments);
 
-                    string? categoryOpt = null;
-                    if (!checkCategoryAndAllowedIds ||
-                        !TryAnalyzeCategory(operationAnalysisContext, creationArguments,
-                            additionalTextOpt!, categoryAndAllowedIdsMap!, out categoryOpt, out var allowedIdsInfoList))
+                    string? category;
+                    if (!TryAnalyzeCategory(operationAnalysisContext, creationArguments, checkCategoryAndAllowedIds,
+                            diagnosticCategoryAndIdRangeTextOpt, categoryAndAllowedIdsMap, out category, out var allowedIdsInfoList))
                     {
                         allowedIdsInfoList = default;
+                        category = null;
                     }
 
-                    AnalyzeRuleId(operationAnalysisContext, creationArguments, additionalTextOpt,
-                        categoryOpt, allowedIdsInfoList, idToAnalyzerMap);
+                    AnalyzeRuleId(operationAnalysisContext, creationArguments,
+                        isAnalyzerReleaseTracking, shippedData, unshippedData, seenRuleIds, diagnosticCategoryAndIdRangeTextOpt,
+                        category, helpLink, isEnabledByDefault, defaultSeverity, allowedIdsInfoList, idToAnalyzerMap);
 
                 }, OperationKind.FieldInitializer);
 
@@ -265,6 +242,17 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                             }
                         }
                     }
+
+                    // Report analyzer release tracking invalid entry and compilation end diagnostics.
+                    if (isAnalyzerReleaseTracking || invalidReleaseFileEntryDiagnostics != null)
+                    {
+                        RoslynDebug.Assert(shippedData != null);
+                        RoslynDebug.Assert(unshippedData != null);
+
+                        ReportAnalyzerReleaseTrackingDiagnostics(invalidReleaseFileEntryDiagnostics, shippedData, unshippedData, seenRuleIds, compilationEndContext);
+                    }
+
+                    seenRuleIds.Free();
                 });
             });
         }
@@ -310,17 +298,23 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             }
         }
 
-        private static void AnalyzeHelpLinkUri(OperationAnalysisContext operationAnalysisContext, ImmutableArray<IArgumentOperation> creationArguments)
+        private static void AnalyzeHelpLinkUri(OperationAnalysisContext operationAnalysisContext, ImmutableArray<IArgumentOperation> creationArguments, out string? helpLink)
         {
+            helpLink = null;
+
             // Find the matching argument for helpLinkUri
             foreach (var argument in creationArguments)
             {
-                if (argument.Parameter.Name.Equals(HelpLinkUriParameterName, System.StringComparison.OrdinalIgnoreCase))
+                if (argument.Parameter.Name.Equals(HelpLinkUriParameterName, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (argument.Value.ConstantValue.HasValue && argument.Value.ConstantValue.Value == null)
+                    if (argument.Value.ConstantValue.HasValue)
                     {
-                        Diagnostic diagnostic = argument.CreateDiagnostic(ProvideHelpUriInDescriptorRule);
-                        operationAnalysisContext.ReportDiagnostic(diagnostic);
+                        helpLink = argument.Value.ConstantValue.Value as string;
+                        if (helpLink == null)
+                        {
+                            Diagnostic diagnostic = argument.CreateDiagnostic(ProvideHelpUriInDescriptorRule);
+                            operationAnalysisContext.ReportDiagnostic(diagnostic);
+                        }
                     }
 
                     return;
@@ -350,58 +344,92 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             }
         }
 
-        private static bool TryAnalyzeCategory(
-            OperationAnalysisContext operationAnalysisContext,
-            ImmutableArray<IArgumentOperation> creationArguments,
-            AdditionalText additionalText,
-            ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>> categoryAndAllowedIdsInfoMap,
-            [NotNullWhen(returnValue: true)] out string? category,
-            out ImmutableArray<(string? prefix, int start, int end)> allowedIdsInfoList)
+        private static (bool? isEnabledByDefault, DiagnosticSeverity? defaultSeverity) GetDefaultSeverityAndEnabledByDefault(Compilation compilation, ImmutableArray<IArgumentOperation> creationArguments)
         {
-            category = null;
-            allowedIdsInfoList = default;
+            var diagnosticSeverityType = compilation.GetOrCreateTypeByMetadataName(typeof(DiagnosticSeverity).FullName);
+            var ruleLevelType = compilation.GetOrCreateTypeByMetadataName(typeof(RuleLevel).FullName);
+
+            bool? isEnabledByDefault = null;
+            DiagnosticSeverity? defaultSeverity = null;
+
             foreach (var argument in creationArguments)
             {
-                if (argument.Parameter.Name.Equals(CategoryParameterName, StringComparison.Ordinal))
+                switch (argument.Parameter.Name)
                 {
-                    // Check if the category argument is a constant or refers to a string field.
-                    if (argument.Value.ConstantValue.HasValue)
-                    {
-                        if (argument.Value.Type != null &&
-                            argument.Value.Type.SpecialType == SpecialType.System_String)
+                    case IsEnabledByDefaultParameterName:
+                        if (argument.Value.ConstantValue.HasValue)
                         {
-                            category = (string)argument.Value.ConstantValue.Value;
+                            isEnabledByDefault = (bool)argument.Value.ConstantValue.Value;
                         }
-                    }
-                    else if (argument.Value is IFieldReferenceOperation fieldReference &&
-                        fieldReference.Field.Type.SpecialType == SpecialType.System_String)
-                    {
-                        category = fieldReference.ConstantValue.HasValue ? (string)fieldReference.ConstantValue.Value : fieldReference.Field.Name;
-                    }
 
-                    // Check if the category is one of the allowed values.
-                    if (category != null && categoryAndAllowedIdsInfoMap.TryGetValue(category, out allowedIdsInfoList))
-                    {
-                        return true;
-                    }
+                        break;
 
-                    // Category '{0}' is not from the allowed categories specified in the file '{1}'.
-                    string arg1 = category ?? "<unknown>";
-                    string arg2 = Path.GetFileName(additionalText.Path);
-                    var diagnostic = Diagnostic.Create(UseCategoriesFromSpecifiedRangeRule, argument.Value.Syntax.GetLocation(), arg1, arg2);
-                    operationAnalysisContext.ReportDiagnostic(diagnostic);
-                    return false;
+                    case DefaultSeverityParameterName:
+                        if (argument.Value is IFieldReferenceOperation fieldReference &&
+                            fieldReference.Field.ContainingType.Equals(diagnosticSeverityType) &&
+                            Enum.TryParse(fieldReference.Field.Name, out DiagnosticSeverity parsedSeverity))
+                        {
+                            defaultSeverity = parsedSeverity;
+                        }
+
+                        break;
+
+                    case RuleLevelParameterName:
+                        if (ruleLevelType != null &&
+                            argument.Value is IFieldReferenceOperation fieldReference2 &&
+                            fieldReference2.Field.ContainingType.Equals(ruleLevelType) &&
+                            Enum.TryParse(fieldReference2.Field.Name, out RuleLevel parsedRuleLevel))
+                        {
+                            switch (parsedRuleLevel)
+                            {
+                                case RuleLevel.BuildWarning:
+                                    defaultSeverity = DiagnosticSeverity.Warning;
+                                    isEnabledByDefault = true;
+                                    break;
+
+                                case RuleLevel.IdeSuggestion:
+                                    defaultSeverity = DiagnosticSeverity.Info;
+                                    isEnabledByDefault = true;
+                                    break;
+
+                                case RuleLevel.IdeHidden_BulkConfigurable:
+                                    defaultSeverity = DiagnosticSeverity.Hidden;
+                                    isEnabledByDefault = true;
+                                    break;
+
+                                case RuleLevel.Disabled:
+                                case RuleLevel.CandidateForRemoval:
+                                    isEnabledByDefault = false;
+                                    break;
+                            }
+
+                            return (isEnabledByDefault, defaultSeverity);
+                        }
+
+                        break;
                 }
             }
 
-            return false;
+            if (isEnabledByDefault == false)
+            {
+                defaultSeverity = null;
+            }
+
+            return (isEnabledByDefault, defaultSeverity);
         }
 
         private static void AnalyzeRuleId(
             OperationAnalysisContext operationAnalysisContext,
             ImmutableArray<IArgumentOperation> creationArguments,
-            AdditionalText? additionalTextOpt,
-            string? categoryOpt,
+            bool isAnalyzerReleaseTracking,
+            ReleaseTrackingData? shippedData,
+            ReleaseTrackingData? unshippedData,
+            PooledConcurrentSet<string> seenRuleIds,
+            AdditionalText? diagnosticCategoryAndIdRangeTextOpt,
+            string? category,
+            string? helpLink,
+            bool? isEnabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
             ImmutableArray<(string? prefix, int start, int end)> allowedIdsInfoListOpt,
             ConcurrentDictionary<string, ConcurrentDictionary<string, ConcurrentBag<Location>>> idToAnalyzerMap)
         {
@@ -417,6 +445,8 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         argument.Value.Type.SpecialType == SpecialType.System_String)
                     {
                         ruleId = (string)argument.Value.ConstantValue.Value;
+                        seenRuleIds.Add(ruleId);
+
                         var location = argument.Value.Syntax.GetLocation();
                         static string GetAnalyzerName(INamedTypeSymbol a) => a.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
@@ -462,60 +492,17 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         // If we have an additional file specifying required range and/or format for the ID, validate the ID.
                         if (!allowedIdsInfoListOpt.IsDefault)
                         {
-                            RoslynDebug.Assert(!allowedIdsInfoListOpt.IsEmpty);
-                            RoslynDebug.Assert(categoryOpt != null);
-                            RoslynDebug.Assert(additionalTextOpt != null);
+                            AnalyzeAllowedIdsInfoList(ruleId, argument, diagnosticCategoryAndIdRangeTextOpt, category, allowedIdsInfoListOpt, operationAnalysisContext.ReportDiagnostic);
+                        }
 
-                            var foundMatch = false;
-                            static bool ShouldValidateRange((string? prefix, int start, int end) range)
-                                => range.start >= 0 && range.end >= 0;
+                        // If we have an additional file specifying required range and/or format for the ID, validate the ID.
+                        if (isAnalyzerReleaseTracking)
+                        {
+                            RoslynDebug.Assert(shippedData != null);
+                            RoslynDebug.Assert(unshippedData != null);
 
-                            // Check if ID matches any one of the required ranges.
-                            foreach (var allowedIds in allowedIdsInfoListOpt)
-                            {
-                                RoslynDebug.Assert(allowedIds.prefix != null);
-
-                                if (ruleId.StartsWith(allowedIds.prefix, StringComparison.Ordinal))
-                                {
-                                    if (ShouldValidateRange(allowedIds))
-                                    {
-                                        var suffix = ruleId.Substring(allowedIds.prefix.Length);
-                                        if (int.TryParse(suffix, out int ruleIdInt) &&
-                                            ruleIdInt >= allowedIds.start &&
-                                            ruleIdInt <= allowedIds.end)
-                                        {
-                                            foundMatch = true;
-                                            break;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        foundMatch = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (!foundMatch)
-                            {
-                                // Diagnostic Id '{0}' belonging to category '{1}' is not in the required range and/or format '{2}' specified in the file '{3}'.
-                                string arg1 = ruleId;
-                                string arg2 = categoryOpt;
-                                string arg3 = string.Empty;
-                                foreach (var range in allowedIdsInfoListOpt)
-                                {
-                                    if (arg3.Length != 0)
-                                    {
-                                        arg3 += ", ";
-                                    }
-
-                                    arg3 += !ShouldValidateRange(range) ? range.prefix + "XXXX" : $"{range.prefix}{range.start}-{range.prefix}{range.end}";
-                                }
-
-                                string arg4 = Path.GetFileName(additionalTextOpt.Path);
-                                var diagnostic = Diagnostic.Create(DiagnosticIdMustBeInSpecifiedFormatRule, argument.Value.Syntax.GetLocation(), arg1, arg2, arg3, arg4);
-                                operationAnalysisContext.ReportDiagnostic(diagnostic);
-                            }
+                            AnalyzeAnalyzerReleases(ruleId, argument, category, helpLink, isEnabledByDefault,
+                                defaultSeverity, shippedData, unshippedData, operationAnalysisContext.ReportDiagnostic);
                         }
                     }
                     else
@@ -529,195 +516,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     return;
                 }
             }
-        }
-
-        private static bool TryGetCategoryAndAllowedIdsMap(
-            ImmutableArray<AdditionalText> additionalFiles,
-            CancellationToken cancellationToken,
-            [NotNullWhen(returnValue: true)] out AdditionalText? additionalText,
-            [NotNullWhen(returnValue: true)] out ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsMap,
-            out List<Diagnostic>? invalidFileDiagnostics)
-        {
-            invalidFileDiagnostics = null;
-            categoryAndAllowedIdsMap = null;
-
-            // Parse the additional file with allowed diagnostic categories and corresponding ID range.
-            // Bail out if there is no such additional file or it contains at least one invalid entry.
-            additionalText = TryGetCategoryAndAllowedIdsInfoFile(additionalFiles, cancellationToken);
-            return additionalText != null &&
-                TryParseCategoryAndAllowedIdsInfoFile(additionalText, cancellationToken, out categoryAndAllowedIdsMap, out invalidFileDiagnostics);
-        }
-
-        private static AdditionalText? TryGetCategoryAndAllowedIdsInfoFile(ImmutableArray<AdditionalText> additionalFiles, CancellationToken cancellationToken)
-        {
-            StringComparer comparer = StringComparer.Ordinal;
-            foreach (AdditionalText textFile in additionalFiles)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                string fileName = Path.GetFileName(textFile.Path);
-                if (comparer.Equals(fileName, DiagnosticCategoryAndIdRangeFile))
-                {
-                    return textFile;
-                }
-            }
-
-            return null;
-        }
-
-        private static bool TryParseCategoryAndAllowedIdsInfoFile(
-            AdditionalText additionalText,
-            CancellationToken cancellationToken,
-            [NotNullWhen(returnValue: true)] out ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsInfoMap,
-            out List<Diagnostic>? invalidFileDiagnostics)
-        {
-            // Parse the additional file with allowed diagnostic categories and corresponding ID range.
-            // FORMAT:
-            // 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
-
-            categoryAndAllowedIdsInfoMap = null;
-            invalidFileDiagnostics = null;
-
-            var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<(string? prefix, int start, int end)>>();
-            var lines = additionalText.GetText(cancellationToken).Lines;
-            foreach (var line in lines)
-            {
-                var contents = line.ToString();
-                if (contents.Length == 0 || contents.StartsWith("#", StringComparison.Ordinal))
-                {
-                    // Ignore empty lines and comments.
-                    continue;
-                }
-
-                var parts = contents.Split(':');
-                for (int i = 0; i < parts.Length; i++)
-                {
-                    parts[i] = parts[i].Trim();
-                }
-
-                var isInvalidLine = false;
-                string category = parts[0];
-                if (parts.Length > 2 ||                 // We allow only 0 or 1 ':' separator in the line.
-                    category.Any(char.IsWhiteSpace) ||  // We do not allow white spaces in category name.
-                    builder.ContainsKey(category))      // We do not allow multiple lines with same category.
-                {
-                    isInvalidLine = true;
-                }
-                else
-                {
-                    if (parts.Length == 1)
-                    {
-                        // No ':' symbol, so the entry just specifies the category.
-                        builder.Add(category, default);
-                        continue;
-                    }
-
-                    // Entry with the following possible formats:
-                    // 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
-                    var ranges = parts[1].Split(',');
-
-                    var infoList = ImmutableArray.CreateBuilder<(string? prefix, int start, int end)>(ranges.Length);
-                    for (int i = 0; i < ranges.Length; i++)
-                    {
-                        (string? prefix, int start, int end) allowedIdsInfo = s_defaultAllowedIdsInfo;
-                        string range = ranges[i].Trim();
-                        if (!range.Contains('-'))
-                        {
-                            if (TryParseIdRangeEntry(range, out string prefix, out int start))
-                            {
-                                // Specific Id validation.
-                                allowedIdsInfo.prefix = prefix;
-                                allowedIdsInfo.start = start;
-                                allowedIdsInfo.end = start;
-                            }
-                            else if (range.All(ch => char.IsLetter(ch)))
-                            {
-                                // Only prefix validation.
-                                allowedIdsInfo.prefix = range;
-                            }
-                            else
-                            {
-                                isInvalidLine = true;
-                                break;
-                            }
-                        }
-                        else
-                        {
-                            // Prefix and start-end range validation.
-                            var rangeParts = range.Split('-');
-                            if (TryParseIdRangeEntry(rangeParts[0], out string prefix1, out int start) &&
-                                TryParseIdRangeEntry(rangeParts[1], out string prefix2, out int end) &&
-                                prefix1.Equals(prefix2, StringComparison.Ordinal))
-                            {
-                                allowedIdsInfo.prefix = prefix1;
-                                allowedIdsInfo.start = start;
-                                allowedIdsInfo.end = end;
-                            }
-                            else
-                            {
-                                isInvalidLine = true;
-                                break;
-                            }
-                        }
-
-                        infoList.Add(allowedIdsInfo);
-                    }
-
-                    if (!isInvalidLine)
-                    {
-                        builder.Add(category, infoList.ToImmutable());
-                    }
-                }
-
-                if (isInvalidLine)
-                {
-                    // Invalid entry '{0}' in analyzer category and diagnostic ID range specification file '{1}'.
-                    string arg1 = contents;
-                    string arg2 = Path.GetFileName(additionalText.Path);
-                    LinePositionSpan linePositionSpan = lines.GetLinePositionSpan(line.Span);
-                    Location location = Location.Create(additionalText.Path, line.Span, linePositionSpan);
-                    invalidFileDiagnostics ??= new List<Diagnostic>();
-                    var diagnostic = Diagnostic.Create(AnalyzerCategoryAndIdRangeFileInvalidRule, location, arg1, arg2);
-                    invalidFileDiagnostics.Add(diagnostic);
-                }
-            }
-
-            categoryAndAllowedIdsInfoMap = builder.ToImmutable();
-            return invalidFileDiagnostics == null;
-        }
-
-        private static bool TryParseIdRangeEntry(string entry, out string prefix, out int suffix)
-        {
-            // Parse an entry for diagnostic ID.
-            // We require diagnostic ID to have an alphabetical prefix followed by a numerical suffix.
-            prefix = string.Empty;
-            suffix = -1;
-            string suffixStr = string.Empty;
-            bool seenDigit = false;
-            foreach (char ch in entry)
-            {
-                bool isDigit = char.IsDigit(ch);
-                if (seenDigit && !isDigit)
-                {
-                    return false;
-                }
-
-                if (isDigit)
-                {
-                    suffixStr += ch;
-                    seenDigit = true;
-                }
-                else if (!char.IsLetter(ch))
-                {
-                    return false;
-                }
-                else
-                {
-                    prefix += ch;
-                }
-            }
-
-            return prefix.Length > 0 && suffixStr.Length > 0 && int.TryParse(suffixStr, out suffix);
         }
 
         private static bool IsReservedDiagnosticId(string ruleId, string assemblyName)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             InvalidEntryInAnalyzerReleasesFileRule,
             InvalidHeaderInAnalyzerReleasesFileRule,
             InvalidUndetectedEntryInAnalyzerReleasesFileRule,
-            InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule);
+            InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_IdRangeAndCategoryValidation.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_IdRangeAndCategoryValidation.cs
@@ -1,0 +1,374 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
+{
+    public sealed partial class DiagnosticDescriptorCreationAnalyzer
+    {
+        private const string DiagnosticCategoryAndIdRangeFile = "DiagnosticCategoryAndIdRanges.txt";
+        private static readonly (string? prefix, int start, int end) s_defaultAllowedIdsInfo = (null, -1, -1);
+
+        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableDiagnosticIdMustBeInSpecifiedFormatDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.DiagnosticIdMustBeInSpecifiedFormatDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+
+        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableUseCategoriesFromSpecifiedRangeDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.UseCategoriesFromSpecifiedRangeDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+
+        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidTitle = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidTitle), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidMessage = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidMessage), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+        private static readonly LocalizableString s_localizableAnalyzerCategoryAndIdRangeFileInvalidDescription = new LocalizableResourceString(nameof(CodeAnalysisDiagnosticsResources.AnalyzerCategoryAndIdRangeFileInvalidDescription), CodeAnalysisDiagnosticsResources.ResourceManager, typeof(CodeAnalysisDiagnosticsResources));
+
+        public static readonly DiagnosticDescriptor DiagnosticIdMustBeInSpecifiedFormatRule = new DiagnosticDescriptor(
+            DiagnosticIds.DiagnosticIdMustBeInSpecifiedFormatRuleId,
+            s_localizableDiagnosticIdMustBeInSpecifiedFormatTitle,
+            s_localizableDiagnosticIdMustBeInSpecifiedFormatMessage,
+            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: s_localizableDiagnosticIdMustBeInSpecifiedFormatDescription,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public static readonly DiagnosticDescriptor UseCategoriesFromSpecifiedRangeRule = new DiagnosticDescriptor(
+            DiagnosticIds.UseCategoriesFromSpecifiedRangeRuleId,
+            s_localizableUseCategoriesFromSpecifiedRangeTitle,
+            s_localizableUseCategoriesFromSpecifiedRangeMessage,
+            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: false,
+            description: s_localizableUseCategoriesFromSpecifiedRangeDescription,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        public static readonly DiagnosticDescriptor AnalyzerCategoryAndIdRangeFileInvalidRule = new DiagnosticDescriptor(
+            DiagnosticIds.AnalyzerCategoryAndIdRangeFileInvalidRuleId,
+            s_localizableAnalyzerCategoryAndIdRangeFileInvalidTitle,
+            s_localizableAnalyzerCategoryAndIdRangeFileInvalidMessage,
+            DiagnosticCategory.MicrosoftCodeAnalysisDesign,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: s_localizableAnalyzerCategoryAndIdRangeFileInvalidDescription,
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        private static void AnalyzeAllowedIdsInfoList(
+            string ruleId,
+            IArgumentOperation argument,
+            AdditionalText? additionalTextOpt,
+            string? category,
+            ImmutableArray<(string? prefix, int start, int end)> allowedIdsInfoList,
+            Action<Diagnostic> addDiagnostic)
+        {
+            RoslynDebug.Assert(!allowedIdsInfoList.IsDefaultOrEmpty);
+            RoslynDebug.Assert(category != null);
+            RoslynDebug.Assert(additionalTextOpt != null);
+
+            var foundMatch = false;
+            static bool ShouldValidateRange((string? prefix, int start, int end) range)
+                => range.start >= 0 && range.end >= 0;
+
+            // Check if ID matches any one of the required ranges.
+            foreach (var allowedIds in allowedIdsInfoList)
+            {
+                RoslynDebug.Assert(allowedIds.prefix != null);
+
+                if (ruleId.StartsWith(allowedIds.prefix, StringComparison.Ordinal))
+                {
+                    if (ShouldValidateRange(allowedIds))
+                    {
+                        var suffix = ruleId.Substring(allowedIds.prefix.Length);
+                        if (int.TryParse(suffix, out int ruleIdInt) &&
+                            ruleIdInt >= allowedIds.start &&
+                            ruleIdInt <= allowedIds.end)
+                        {
+                            foundMatch = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        foundMatch = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!foundMatch)
+            {
+                // Diagnostic Id '{0}' belonging to category '{1}' is not in the required range and/or format '{2}' specified in the file '{3}'.
+                string arg1 = ruleId;
+                string arg2 = category;
+                string arg3 = string.Empty;
+                foreach (var range in allowedIdsInfoList)
+                {
+                    if (arg3.Length != 0)
+                    {
+                        arg3 += ", ";
+                    }
+
+                    arg3 += !ShouldValidateRange(range) ? range.prefix + "XXXX" : $"{range.prefix}{range.start}-{range.prefix}{range.end}";
+                }
+
+                string arg4 = Path.GetFileName(additionalTextOpt.Path);
+                var diagnostic = Diagnostic.Create(DiagnosticIdMustBeInSpecifiedFormatRule, argument.Value.Syntax.GetLocation(), arg1, arg2, arg3, arg4);
+                addDiagnostic(diagnostic);
+            }
+        }
+
+        private static bool TryAnalyzeCategory(
+            OperationAnalysisContext operationAnalysisContext,
+            ImmutableArray<IArgumentOperation> creationArguments,
+            bool checkCategoryAndAllowedIds,
+            AdditionalText? additionalText,
+            ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsInfoMap,
+            [NotNullWhen(returnValue: true)] out string? category,
+            out ImmutableArray<(string? prefix, int start, int end)> allowedIdsInfoList)
+        {
+            category = null;
+            allowedIdsInfoList = default;
+            foreach (var argument in creationArguments)
+            {
+                if (argument.Parameter.Name.Equals(CategoryParameterName, StringComparison.Ordinal))
+                {
+                    // Check if the category argument is a constant or refers to a string field.
+                    if (argument.Value.ConstantValue.HasValue)
+                    {
+                        if (argument.Value.Type != null &&
+                            argument.Value.Type.SpecialType == SpecialType.System_String)
+                        {
+                            category = (string)argument.Value.ConstantValue.Value;
+                        }
+                    }
+                    else if (argument.Value is IFieldReferenceOperation fieldReference &&
+                        fieldReference.Field.Type.SpecialType == SpecialType.System_String)
+                    {
+                        category = fieldReference.ConstantValue.HasValue ? (string)fieldReference.ConstantValue.Value : fieldReference.Field.Name;
+                    }
+
+                    if (!checkCategoryAndAllowedIds)
+                    {
+                        return category != null;
+                    }
+
+                    // Check if the category is one of the allowed values.
+                    RoslynDebug.Assert(categoryAndAllowedIdsInfoMap != null);
+                    RoslynDebug.Assert(additionalText != null);
+
+                    if (category != null &&
+                        categoryAndAllowedIdsInfoMap.TryGetValue(category, out allowedIdsInfoList))
+                    {
+                        return true;
+                    }
+
+                    // Category '{0}' is not from the allowed categories specified in the file '{1}'.
+                    string arg1 = category ?? "<unknown>";
+                    string arg2 = Path.GetFileName(additionalText.Path);
+                    var diagnostic = Diagnostic.Create(UseCategoriesFromSpecifiedRangeRule, argument.Value.Syntax.GetLocation(), arg1, arg2);
+                    operationAnalysisContext.ReportDiagnostic(diagnostic);
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetCategoryAndAllowedIdsMap(
+            ImmutableArray<AdditionalText> additionalFiles,
+            CancellationToken cancellationToken,
+            [NotNullWhen(returnValue: true)] out AdditionalText? additionalText,
+            [NotNullWhen(returnValue: true)] out ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsMap,
+            out List<Diagnostic>? invalidFileDiagnostics)
+        {
+            invalidFileDiagnostics = null;
+            categoryAndAllowedIdsMap = null;
+
+            // Parse the additional file with allowed diagnostic categories and corresponding ID range.
+            // Bail out if there is no such additional file or it contains at least one invalid entry.
+            additionalText = TryGetCategoryAndAllowedIdsInfoFile(additionalFiles, cancellationToken);
+            return additionalText != null &&
+                TryParseCategoryAndAllowedIdsInfoFile(additionalText, cancellationToken, out categoryAndAllowedIdsMap, out invalidFileDiagnostics);
+        }
+
+        private static AdditionalText? TryGetCategoryAndAllowedIdsInfoFile(ImmutableArray<AdditionalText> additionalFiles, CancellationToken cancellationToken)
+        {
+            StringComparer comparer = StringComparer.Ordinal;
+            foreach (AdditionalText textFile in additionalFiles)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                string fileName = Path.GetFileName(textFile.Path);
+                if (comparer.Equals(fileName, DiagnosticCategoryAndIdRangeFile))
+                {
+                    return textFile;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryParseCategoryAndAllowedIdsInfoFile(
+            AdditionalText additionalText,
+            CancellationToken cancellationToken,
+            [NotNullWhen(returnValue: true)] out ImmutableDictionary<string, ImmutableArray<(string? prefix, int start, int end)>>? categoryAndAllowedIdsInfoMap,
+            out List<Diagnostic>? invalidFileDiagnostics)
+        {
+            // Parse the additional file with allowed diagnostic categories and corresponding ID range.
+            // FORMAT:
+            // 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+
+            categoryAndAllowedIdsInfoMap = null;
+            invalidFileDiagnostics = null;
+
+            var builder = ImmutableDictionary.CreateBuilder<string, ImmutableArray<(string? prefix, int start, int end)>>();
+            var lines = additionalText.GetText(cancellationToken).Lines;
+            foreach (var line in lines)
+            {
+                var contents = line.ToString();
+                if (contents.Length == 0 || contents.StartsWith("#", StringComparison.Ordinal))
+                {
+                    // Ignore empty lines and comments.
+                    continue;
+                }
+
+                var parts = contents.Split(':');
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    parts[i] = parts[i].Trim();
+                }
+
+                var isInvalidLine = false;
+                string category = parts[0];
+                if (parts.Length > 2 ||                 // We allow only 0 or 1 ':' separator in the line.
+                    category.Any(char.IsWhiteSpace) ||  // We do not allow white spaces in category name.
+                    builder.ContainsKey(category))      // We do not allow multiple lines with same category.
+                {
+                    isInvalidLine = true;
+                }
+                else
+                {
+                    if (parts.Length == 1)
+                    {
+                        // No ':' symbol, so the entry just specifies the category.
+                        builder.Add(category, default);
+                        continue;
+                    }
+
+                    // Entry with the following possible formats:
+                    // 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
+                    var ranges = parts[1].Split(',');
+
+                    var infoList = ImmutableArray.CreateBuilder<(string? prefix, int start, int end)>(ranges.Length);
+                    for (int i = 0; i < ranges.Length; i++)
+                    {
+                        (string? prefix, int start, int end) allowedIdsInfo = s_defaultAllowedIdsInfo;
+                        string range = ranges[i].Trim();
+                        if (!range.Contains('-'))
+                        {
+                            if (TryParseIdRangeEntry(range, out string prefix, out int start))
+                            {
+                                // Specific Id validation.
+                                allowedIdsInfo.prefix = prefix;
+                                allowedIdsInfo.start = start;
+                                allowedIdsInfo.end = start;
+                            }
+                            else if (range.All(ch => char.IsLetter(ch)))
+                            {
+                                // Only prefix validation.
+                                allowedIdsInfo.prefix = range;
+                            }
+                            else
+                            {
+                                isInvalidLine = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // Prefix and start-end range validation.
+                            var rangeParts = range.Split('-');
+                            if (TryParseIdRangeEntry(rangeParts[0], out string prefix1, out int start) &&
+                                TryParseIdRangeEntry(rangeParts[1], out string prefix2, out int end) &&
+                                prefix1.Equals(prefix2, StringComparison.Ordinal))
+                            {
+                                allowedIdsInfo.prefix = prefix1;
+                                allowedIdsInfo.start = start;
+                                allowedIdsInfo.end = end;
+                            }
+                            else
+                            {
+                                isInvalidLine = true;
+                                break;
+                            }
+                        }
+
+                        infoList.Add(allowedIdsInfo);
+                    }
+
+                    if (!isInvalidLine)
+                    {
+                        builder.Add(category, infoList.ToImmutable());
+                    }
+                }
+
+                if (isInvalidLine)
+                {
+                    // Invalid entry '{0}' in analyzer category and diagnostic ID range specification file '{1}'.
+                    string arg1 = contents;
+                    string arg2 = Path.GetFileName(additionalText.Path);
+                    LinePositionSpan linePositionSpan = lines.GetLinePositionSpan(line.Span);
+                    Location location = Location.Create(additionalText.Path, line.Span, linePositionSpan);
+                    invalidFileDiagnostics ??= new List<Diagnostic>();
+                    var diagnostic = Diagnostic.Create(AnalyzerCategoryAndIdRangeFileInvalidRule, location, arg1, arg2);
+                    invalidFileDiagnostics.Add(diagnostic);
+                }
+            }
+
+            categoryAndAllowedIdsInfoMap = builder.ToImmutable();
+            return invalidFileDiagnostics == null;
+        }
+
+        private static bool TryParseIdRangeEntry(string entry, out string prefix, out int suffix)
+        {
+            // Parse an entry for diagnostic ID.
+            // We require diagnostic ID to have an alphabetical prefix followed by a numerical suffix.
+            prefix = string.Empty;
+            suffix = -1;
+            string suffixStr = string.Empty;
+            bool seenDigit = false;
+            foreach (char ch in entry)
+            {
+                bool isDigit = char.IsDigit(ch);
+                if (seenDigit && !isDigit)
+                {
+                    return false;
+                }
+
+                if (isDigit)
+                {
+                    suffixStr += ch;
+                    seenDigit = true;
+                }
+                else if (!char.IsLetter(ch))
+                {
+                    return false;
+                }
+                else
+                {
+                    prefix += ch;
+                }
+            }
+
+            return prefix.Length > 0 && suffixStr.Length > 0 && int.TryParse(suffixStr, out suffix);
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
@@ -192,7 +192,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             shippedText = null;
             unshippedText = null;
 
-            StringComparer comparer = StringComparer.Ordinal;
+            StringComparer comparer = StringComparer.OrdinalIgnoreCase;
             foreach (AdditionalText text in additionalTexts)
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
@@ -1,0 +1,699 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
+{
+    public sealed partial class DiagnosticDescriptorCreationAnalyzer
+    {
+        internal const string ShippedFileName = "AnalyzerReleases.Shipped.md";
+        internal const string UnshippedFileName = "AnalyzerReleases.Unshipped.md";
+        internal const string RemovedPrefix = "*REMOVED*";
+        internal const string ReleasePrefix = "## Release";
+        internal const string ReleaseHeaderLine1 = @"Rule ID | Category | Severity | HelpLink (optional)";
+        internal const string ReleaseHeaderLine2 = @"--------|----------|----------|--------------------";
+        private const string DisabledText = "Disabled";
+        internal const string UndetectedText = @"<Undetected>";
+
+        // Property names which are keys for diagnostic property bag passed to the code fixer.
+        internal const string EntryToAddPropertyName = nameof(EntryToAddPropertyName);
+        internal const string EntryToUpdatePropertyName = nameof(EntryToUpdatePropertyName);
+
+        private static readonly Version s_unshippedVersion = new Version(int.MaxValue, int.MaxValue);
+
+        internal static readonly DiagnosticDescriptor DeclareDiagnosticIdInAnalyzerReleaseRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.DeclareDiagnosticIdInAnalyzerReleaseRuleId,
+            title: CodeAnalysisDiagnosticsResources.DeclareDiagnosticIdInAnalyzerReleaseTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.DeclareDiagnosticIdInAnalyzerReleaseMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.DeclareDiagnosticIdInAnalyzerReleaseDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor UpdateDiagnosticIdInAnalyzerReleaseRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.UpdateDiagnosticIdInAnalyzerReleaseRuleId,
+            title: CodeAnalysisDiagnosticsResources.UpdateDiagnosticIdInAnalyzerReleaseTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.UpdateDiagnosticIdInAnalyzerReleaseMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.UpdateDiagnosticIdInAnalyzerReleaseDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor RemoveUnshippedDeletedDiagnosticIdRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.RemoveUnshippedDeletedDiagnosticIdRuleId,
+            title: CodeAnalysisDiagnosticsResources.RemoveUnshippedDeletedDiagnosticIdTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.RemoveUnshippedDeletedDiagnosticIdMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.RemoveUnshippedDeletedDiagnosticIdDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor RemoveShippedDeletedDiagnosticIdRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.RemoveShippedDeletedDiagnosticIdRuleId,
+            title: CodeAnalysisDiagnosticsResources.RemoveShippedDeletedDiagnosticIdTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.RemoveShippedDeletedDiagnosticIdMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.RemoveShippedDeletedDiagnosticIdDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdRuleId,
+            title: CodeAnalysisDiagnosticsResources.UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor RemoveDuplicateEntriesForAnalyzerReleaseRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.RemoveDuplicateEntriesForAnalyzerReleaseRuleId,
+            title: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor RemoveDuplicateEntriesBetweenAnalyzerReleasesRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleId,
+            title: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor InvalidEntryInAnalyzerReleasesFileRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.InvalidEntryInAnalyzerReleasesFileRuleId,
+            title: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor InvalidHeaderInAnalyzerReleasesFileRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.InvalidEntryInAnalyzerReleasesFileRuleId,
+            title: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.InvalidHeaderInAnalyzerReleasesFileRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor InvalidUndetectedEntryInAnalyzerReleasesFileRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.InvalidEntryInAnalyzerReleasesFileRuleId,
+            title: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        internal static readonly DiagnosticDescriptor InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule = new DiagnosticDescriptor(
+            id: DiagnosticIds.InvalidEntryInAnalyzerReleasesFileRuleId,
+            title: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleTitle,
+            messageFormat: CodeAnalysisDiagnosticsResources.InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage,
+            category: DiagnosticCategory.MicrosoftCodeAnalysisReleaseTracking,
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: CodeAnalysisDiagnosticsResources.InvalidEntryInAnalyzerReleasesFileRuleDescription,
+            helpLinkUri: "https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md",
+            customTags: WellKnownDiagnosticTags.Telemetry);
+
+        private static bool TryGetReleaseTrackingData(
+            ImmutableArray<AdditionalText> additionalTexts,
+            CancellationToken cancellationToken,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingData? shippedData,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingData? unshippedData,
+            out List<Diagnostic>? invalidFileDiagnostics)
+        {
+            if (!TryGetReleaseTrackingFiles(additionalTexts, cancellationToken, out var shippedText, out var unshippedText))
+            {
+                // TODO: Report a diagnostic that both must be specified if either shippedText or unshippedText is non-null.
+                shippedData = default;
+                unshippedData = default;
+                invalidFileDiagnostics = null;
+                return false;
+            }
+
+            invalidFileDiagnostics = new List<Diagnostic>();
+            shippedData = ReadReleaseTrackingData(shippedText.Path, shippedText.GetText(cancellationToken), invalidFileDiagnostics.Add, isShippedFile: true);
+            unshippedData = ReadReleaseTrackingData(unshippedText.Path, unshippedText.GetText(cancellationToken), invalidFileDiagnostics.Add, isShippedFile: false);
+
+            return invalidFileDiagnostics.Count == 0;
+        }
+
+        private static bool TryGetReleaseTrackingFiles(
+            ImmutableArray<AdditionalText> additionalTexts,
+            CancellationToken cancellationToken,
+            [NotNullWhen(returnValue: true)] out AdditionalText? shippedText,
+            [NotNullWhen(returnValue: true)] out AdditionalText? unshippedText)
+        {
+            shippedText = null;
+            unshippedText = null;
+
+            StringComparer comparer = StringComparer.Ordinal;
+            foreach (AdditionalText text in additionalTexts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                string fileName = Path.GetFileName(text.Path);
+                if (comparer.Equals(fileName, ShippedFileName))
+                {
+                    shippedText = text;
+                    continue;
+                }
+
+                if (comparer.Equals(fileName, UnshippedFileName))
+                {
+                    unshippedText = text;
+                    continue;
+                }
+            }
+
+            return shippedText != null && unshippedText != null;
+        }
+
+        private static ReleaseTrackingData ReadReleaseTrackingData(
+            string path,
+            SourceText sourceText,
+            Action<Diagnostic> addInvalidFileDiagnostic,
+            bool isShippedFile)
+        {
+            var releaseTrackingDataByRulesBuilder = new Dictionary<string, ReleaseTrackingDataForRuleBuilder>();
+            var currentVersion = s_unshippedVersion;
+            int? expectedReleaseHeaderLine = isShippedFile ? 0 : 1;
+            using var reportedInvalidLines = PooledHashSet<TextLine>.GetInstance();
+
+            foreach (TextLine line in sourceText.Lines)
+            {
+                string lineText = line.ToString().Trim();
+                if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith(";", StringComparison.Ordinal))
+                {
+                    // Skip blank and comment lines.
+                    continue;
+                }
+
+                // Parse release header if applicable.
+                switch (expectedReleaseHeaderLine)
+                {
+                    case 0:
+                    default:
+                        // Parse new release, if any.
+                        if (lineText.StartsWith(ReleasePrefix, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!isShippedFile)
+                            {
+                                ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
+                                return ReleaseTrackingData.Default;
+                            }
+
+                            // Expect release header line 1 after this line.
+                            expectedReleaseHeaderLine = 1;
+
+                            // Parse the release version.
+                            string versionString = lineText.Substring(ReleasePrefix.Length).Trim();
+                            if (!Version.TryParse(versionString, out var version))
+                            {
+                                ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
+                                return ReleaseTrackingData.Default;
+                            }
+                            else
+                            {
+                                currentVersion = version;
+                            }
+
+                            continue;
+                        }
+                        else if (expectedReleaseHeaderLine == 0)
+                        {
+                            ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
+                            return ReleaseTrackingData.Default;
+                        }
+                        else
+                        {
+                            break;
+                        }
+
+                    case 1:
+                        if (lineText.StartsWith(ReleaseHeaderLine1, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedReleaseHeaderLine = 2;
+                            continue;
+                        }
+
+                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    case 2:
+                        expectedReleaseHeaderLine = null;
+                        if (lineText.StartsWith(ReleaseHeaderLine2, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+                }
+
+                bool hasRemovedPrefix;
+                if (lineText.StartsWith(RemovedPrefix, StringComparison.Ordinal))
+                {
+                    hasRemovedPrefix = true;
+                    lineText = lineText.Substring(RemovedPrefix.Length);
+                }
+                else
+                {
+                    hasRemovedPrefix = false;
+                }
+
+                var parts = lineText.Split('|').Select(s => s.Trim()).ToArray();
+                switch (parts.Length)
+                {
+                    // Last field 'Helplink' is optional
+                    case 3:
+                    case 4:
+                        string ruleId = parts[0];
+
+                        string category = parts[1];
+                        if (category.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
+                        {
+                            ReportInvalidEntryDiagnostic(line, InvalidEntryKind.UndetectedField);
+                        }
+
+                        DiagnosticSeverity? defaultSeverity;
+                        bool? enabledByDefault;
+                        var severityPart = parts[2];
+                        if (Enum.TryParse(severityPart, ignoreCase: true, out DiagnosticSeverity parsedSeverity))
+                        {
+                            defaultSeverity = parsedSeverity;
+                            enabledByDefault = true;
+                        }
+                        else
+                        {
+                            defaultSeverity = null;
+                            if (string.Equals(severityPart, DisabledText, StringComparison.OrdinalIgnoreCase))
+                            {
+                                enabledByDefault = false;
+                            }
+                            else if (severityPart.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
+                            {
+                                enabledByDefault = null;
+                                ReportInvalidEntryDiagnostic(line, InvalidEntryKind.UndetectedField);
+                            }
+                            else
+                            {
+                                enabledByDefault = null;
+                                ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Other);
+                            }
+                        }
+
+                        var releaseTrackingLine = new ReleaseTrackingLine(ruleId, category, enabledByDefault,
+                            defaultSeverity, line.Span, sourceText, path, isShippedFile, hasRemovedPrefix);
+
+                        if (!releaseTrackingDataByRulesBuilder.TryGetValue(ruleId, out var releaseTrackingDataForRuleBuilder))
+                        {
+                            releaseTrackingDataForRuleBuilder = new ReleaseTrackingDataForRuleBuilder();
+                            releaseTrackingDataByRulesBuilder.Add(ruleId, releaseTrackingDataForRuleBuilder);
+                        }
+
+                        releaseTrackingDataForRuleBuilder.AddEntry(currentVersion, releaseTrackingLine, out var hasExistingEntry);
+                        if (hasExistingEntry && reportedInvalidLines.Add(line))
+                        {
+                            // Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.
+                            string arg1 = ruleId;
+                            string arg2 = currentVersion == s_unshippedVersion ? "unshipped" : currentVersion.ToString();
+                            string arg3 = Path.GetFileName(path);
+                            LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
+                            Location location = Location.Create(path, line.Span, linePositionSpan);
+                            var diagnostic = Diagnostic.Create(RemoveDuplicateEntriesForAnalyzerReleaseRule, location, arg1, arg2, arg3);
+                            addInvalidFileDiagnostic(diagnostic);
+                        }
+
+                        break;
+
+                    default:
+                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Other);
+                        break;
+                }
+            }
+
+            var builder = ImmutableSortedDictionary.CreateBuilder<string, ReleaseTrackingDataForRule>();
+            foreach (var (ruleId, value) in releaseTrackingDataByRulesBuilder)
+            {
+                var releaseTrackingDataForRule = new ReleaseTrackingDataForRule(ruleId, value);
+                builder.Add(ruleId, releaseTrackingDataForRule);
+            }
+
+            return new ReleaseTrackingData(builder.ToImmutable());
+
+            // Local functions
+            void ReportInvalidEntryDiagnostic(TextLine line, InvalidEntryKind invalidEntryKind)
+            {
+                if (!reportedInvalidLines.Add(line))
+                {
+                    // Already reported.
+                    return;
+                }
+
+                var rule = invalidEntryKind switch
+                {
+                    // Analyzer release file '{0}' has a missing or invalid release header '{1}'.
+                    InvalidEntryKind.Header => InvalidHeaderInAnalyzerReleasesFileRule,
+
+                    // Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.
+                    InvalidEntryKind.UndetectedField => InvalidUndetectedEntryInAnalyzerReleasesFileRule,
+
+                    // Analyzer release file '{0}' has an invalid entry '{1}'.
+                    InvalidEntryKind.Other => InvalidEntryInAnalyzerReleasesFileRule,
+                    _ => throw new NotImplementedException(),
+                };
+
+                string arg1 = Path.GetFileName(path);
+                string arg2 = line.ToString();
+                LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
+                Location location = Location.Create(path, line.Span, linePositionSpan);
+                var diagnostic = Diagnostic.Create(rule, location, arg1, arg2);
+                addInvalidFileDiagnostic(diagnostic);
+            }
+        }
+
+        private enum InvalidEntryKind
+        {
+            Header,
+            UndetectedField,
+            Other
+        }
+
+        private static void AnalyzeAnalyzerReleases(
+            string ruleId,
+            IArgumentOperation ruleIdArgument,
+            string? category,
+            string? helpLink,
+            bool? isEnabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
+            ReleaseTrackingData shippedData,
+            ReleaseTrackingData unshippedData,
+            Action<Diagnostic> addDiagnostic)
+        {
+            if (!TryGetLatestReleaseTrackingLine(ruleId, shippedData, unshippedData, out var version, out var releaseTrackingLine) ||
+                releaseTrackingLine.IsShipped && releaseTrackingLine.HasRemovedPrefix)
+            {
+                var properties = ImmutableDictionary<string, string?>.Empty.Add(
+                    EntryToAddPropertyName, GetEntry(ruleId, category, helpLink, isEnabledByDefault, defaultSeverity));
+                var diagnostic = ruleIdArgument.CreateDiagnostic(DeclareDiagnosticIdInAnalyzerReleaseRule, properties, ruleId);
+                addDiagnostic(diagnostic);
+                return;
+            }
+
+            if (releaseTrackingLine.HasRemovedPrefix)
+            {
+                var diagnostic = ruleIdArgument.CreateDiagnostic(UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdRule, ruleId);
+                addDiagnostic(diagnostic);
+                return;
+            }
+
+            if (category != null && !string.Equals(category, releaseTrackingLine.Category, StringComparison.OrdinalIgnoreCase) ||
+                isEnabledByDefault != null && isEnabledByDefault != releaseTrackingLine.EnabledByDefault ||
+                defaultSeverity != null && defaultSeverity != releaseTrackingLine.DefaultSeverity)
+            {
+                var propertyName = version == s_unshippedVersion ?
+                    EntryToUpdatePropertyName :
+                    EntryToAddPropertyName;
+                var newEntry = GetEntry(ruleId, category, helpLink, isEnabledByDefault, defaultSeverity);
+                var properties = ImmutableDictionary<string, string?>.Empty.Add(propertyName, newEntry);
+                var diagnostic = ruleIdArgument.CreateDiagnostic(UpdateDiagnosticIdInAnalyzerReleaseRule, properties, ruleId);
+                addDiagnostic(diagnostic);
+                return;
+            }
+        }
+
+        private static string GetEntry(
+            string ruleId,
+            string? category,
+            string? helpLink,
+            bool? isEnabledByDefault,
+            DiagnosticSeverity? defaultSeverity)
+        {
+            var categoryText = category ?? UndetectedText;
+            var defaultSeverityText = isEnabledByDefault == false ? DisabledText : (defaultSeverity?.ToString() ?? UndetectedText);
+
+            // Rule ID | Category | Severity | HelpLink (optional)
+            var entry = $"{ruleId} | {categoryText} | {defaultSeverityText} |";
+
+            helpLink ??= TryGetHelpLinkForCARule(ruleId);
+            if (!string.IsNullOrEmpty(helpLink))
+            {
+                entry += $" [Documentation]({helpLink})";
+            }
+
+            return entry;
+
+            static string? TryGetHelpLinkForCARule(string ruleId)
+            {
+                if (ruleId.StartsWith("CA", StringComparison.OrdinalIgnoreCase) &&
+                    ruleId.Length > 2 &&
+                    long.TryParse(ruleId.Substring(2), out _))
+                {
+#pragma warning disable CA1308 // Normalize strings to uppercase - use lower case ID in help link
+                    return $"https://docs.microsoft.com/visualstudio/code-quality/{ruleId.ToLowerInvariant()}";
+#pragma warning restore CA1308 // Normalize strings to uppercase
+                }
+
+                return null;
+            }
+        }
+
+        private static bool TryGetLatestReleaseTrackingLine(
+            string ruleId,
+            ReleaseTrackingData shippedData,
+            ReleaseTrackingData unshippedData,
+            [NotNullWhen(returnValue: true)] out Version? version,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
+        {
+            // Unshipped data is considered to always have a higher version then shipped data.
+            return unshippedData.TryGetLatestReleaseTrackingLine(ruleId, out version, out releaseTrackingLine) ||
+                shippedData.TryGetLatestReleaseTrackingLine(ruleId, out version, out releaseTrackingLine);
+        }
+
+        private static void ReportAnalyzerReleaseTrackingDiagnostics(
+            List<Diagnostic>? invalidReleaseTrackingDiagnostics,
+            ReleaseTrackingData shippedData,
+            ReleaseTrackingData unshippedData,
+            PooledConcurrentSet<string> seenRuleIds,
+            CompilationAnalysisContext compilationEndContext)
+        {
+            // Report any invalid release tracking file diagnostics.
+            if (invalidReleaseTrackingDiagnostics?.Count > 0)
+            {
+                foreach (var diagnostic in invalidReleaseTrackingDiagnostics)
+                {
+                    compilationEndContext.ReportDiagnostic(diagnostic);
+                }
+
+                // Do not report additional cascaded diagnostics.
+                return;
+            }
+
+            // Map to track and report duplicate entries for same rule ID.
+            using var lastEntriesByRuleMap = PooledDictionary<string, (Version version, ReleaseTrackingLine releaseTrackingLine)>.GetInstance();
+
+            // Process each entry in unshipped file to flag rules which are not seen.
+            foreach (var (ruleId, releaseTrackingDataForRule) in unshippedData.ReleaseTrackingDataByRuleIdMap)
+            {
+                var releaseTrackingLine = releaseTrackingDataForRule.ReleasesByVersionMap[s_unshippedVersion];
+                lastEntriesByRuleMap[ruleId] = (s_unshippedVersion, releaseTrackingLine);
+                if (seenRuleIds.Add(ruleId) && !releaseTrackingLine.HasRemovedPrefix)
+                {
+                    compilationEndContext.ReportNoLocationDiagnostic(RemoveUnshippedDeletedDiagnosticIdRule, ruleId);
+                }
+            }
+
+            // Process each entry in shipped file to flag rules which are not seen.
+            foreach (var (ruleId, releaseTrackingDataForRule) in shippedData.ReleaseTrackingDataByRuleIdMap)
+            {
+                foreach (var (version, releaseTrackingLine) in releaseTrackingDataForRule.ReleasesByVersionMap)
+                {
+                    if (seenRuleIds.Add(ruleId) && !releaseTrackingLine.HasRemovedPrefix)
+                    {
+                        compilationEndContext.ReportNoLocationDiagnostic(RemoveShippedDeletedDiagnosticIdRule, ruleId, version);
+                    }
+
+                    if (lastEntriesByRuleMap.TryGetValue(ruleId, out var lastEntry) &&
+                        lastEntry.version != version &&
+                        lastEntry.releaseTrackingLine.Category.Equals(releaseTrackingLine.Category, StringComparison.OrdinalIgnoreCase) &&
+                        lastEntry.releaseTrackingLine.EnabledByDefault == releaseTrackingLine.EnabledByDefault &&
+                        lastEntry.releaseTrackingLine.DefaultSeverity == releaseTrackingLine.DefaultSeverity &&
+                        lastEntry.releaseTrackingLine.HasRemovedPrefix == releaseTrackingLine.HasRemovedPrefix)
+                    {
+                        // Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.
+                        string arg1 = ruleId;
+                        string arg2 = lastEntry.version == s_unshippedVersion ? "unshipped" : lastEntry.version.ToString();
+                        string arg3 = version.ToString();
+                        LinePositionSpan linePositionSpan = lastEntry.releaseTrackingLine.SourceText.Lines.GetLinePositionSpan(lastEntry.releaseTrackingLine.Span);
+                        Location location = Location.Create(lastEntry.releaseTrackingLine.Path, lastEntry.releaseTrackingLine.Span, linePositionSpan);
+                        var diagnostic = Diagnostic.Create(RemoveDuplicateEntriesBetweenAnalyzerReleasesRule, location, arg1, arg2, arg3);
+                        compilationEndContext.ReportDiagnostic(diagnostic);
+                    }
+
+                    lastEntriesByRuleMap[ruleId] = (version, releaseTrackingLine);
+                }
+            }
+
+            // 'lastEntriesByRuleMap' should now have the first entry for each rule.
+            // Flag each such first entry that is marked as removed - a removed entry without a prior shipped entry is invalid.
+            foreach (var (_, releaseTrackingLine) in lastEntriesByRuleMap.Values)
+            {
+                if (releaseTrackingLine.HasRemovedPrefix)
+                {
+                    // Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.
+                    string arg1 = Path.GetFileName(releaseTrackingLine.Path);
+                    string arg2 = releaseTrackingLine.RuleId;
+                    LinePositionSpan linePositionSpan = releaseTrackingLine.SourceText.Lines.GetLinePositionSpan(releaseTrackingLine.Span);
+                    Location location = Location.Create(releaseTrackingLine.Path, releaseTrackingLine.Span, linePositionSpan);
+                    var diagnostic = Diagnostic.Create(InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule, location, arg1, arg2);
+                    compilationEndContext.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+        private sealed class ReleaseTrackingData
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+        {
+            public static readonly ReleaseTrackingData Default = new ReleaseTrackingData();
+            public ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> ReleaseTrackingDataByRuleIdMap { get; }
+
+            private ReleaseTrackingData()
+                : this(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule>.Empty)
+            {
+            }
+
+            internal ReleaseTrackingData(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> releaseTrackingDataByRuleIdMap)
+            {
+                ReleaseTrackingDataByRuleIdMap = releaseTrackingDataByRuleIdMap;
+            }
+
+            public bool TryGetLatestReleaseTrackingLine(
+                string ruleId,
+                [NotNullWhen(returnValue: true)] out Version? version,
+                [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
+            {
+                version = null;
+                releaseTrackingLine = null;
+                if (!ReleaseTrackingDataByRuleIdMap.TryGetValue(ruleId, out var releaseTrackingDataForRule) ||
+                    releaseTrackingDataForRule.ReleasesByVersionMap.IsEmpty)
+                {
+                    return false;
+                }
+
+                (version, releaseTrackingLine) = releaseTrackingDataForRule.ReleasesByVersionMap.First();
+                return true;
+            }
+        }
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+        private readonly struct ReleaseTrackingDataForRule
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+        {
+            public string RuleId { get; }
+            public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ReleasesByVersionMap { get; }
+
+            internal ReleaseTrackingDataForRule(string ruleId, ReleaseTrackingDataForRuleBuilder builder)
+            {
+                RuleId = ruleId;
+                ReleasesByVersionMap = builder.ToImmutable();
+            }
+        }
+
+        private sealed class ReleaseTrackingDataForRuleBuilder
+        {
+            private readonly ImmutableSortedDictionary<Version, ReleaseTrackingLine>.Builder _builder
+                = ImmutableSortedDictionary.CreateBuilder<Version, ReleaseTrackingLine>(ReverseComparer.Instance);
+
+            public void AddEntry(Version version, ReleaseTrackingLine releaseTrackingLine, out bool hasExistingEntry)
+            {
+                hasExistingEntry = _builder.ContainsKey(version);
+                _builder[version] = releaseTrackingLine;
+            }
+
+            public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ToImmutable()
+                => _builder.ToImmutable();
+
+            private sealed class ReverseComparer : IComparer<Version>
+            {
+                public static readonly IComparer<Version> Instance = new ReverseComparer();
+                private ReverseComparer() { }
+
+                public int Compare(Version x, Version y)
+                {
+                    return x.CompareTo(y) * -1;
+                }
+            }
+        }
+
+        private sealed class ReleaseTrackingLine
+        {
+            public string RuleId { get; }
+            public string Category { get; }
+            public bool? EnabledByDefault { get; }
+            public DiagnosticSeverity? DefaultSeverity { get; }
+
+            public TextSpan Span { get; }
+            public SourceText SourceText { get; }
+            public string Path { get; }
+            public bool IsShipped { get; }
+            public bool HasRemovedPrefix { get; }
+
+            internal ReleaseTrackingLine(
+                string ruleId, string category, bool? enabledByDefault,
+                DiagnosticSeverity? defaultSeverity, TextSpan span, SourceText sourceText,
+                string path, bool isShipped, bool hasRemovedPrefix)
+            {
+                RuleId = ruleId;
+                Category = category;
+                EnabledByDefault = enabledByDefault;
+                DefaultSeverity = defaultSeverity;
+                Span = span;
+                SourceText = sourceText;
+                Path = path;
+                IsShipped = isShipped;
+                HasRemovedPrefix = hasRemovedPrefix;
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
     {
         internal const string ShippedFileName = "AnalyzerReleases.Shipped.md";
         internal const string UnshippedFileName = "AnalyzerReleases.Unshipped.md";
-        internal const string RemovedPrefix = "*REMOVED*";
         internal const string ReleasePrefix = "## Release";
         internal const string TableTitleNewRules = "### New Rules";
         internal const string TableTitleRemovedRules = "### Removed Rules";

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
+{
+    public sealed partial class AnalyzerReleaseTrackingFix
+    {
+        private sealed class ReleaseTrackingFixAllProvider : FixAllProvider
+        {
+            public static readonly FixAllProvider Instance = new ReleaseTrackingFixAllProvider();
+            public ReleaseTrackingFixAllProvider() { }
+            public override async Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+            {
+                var diagnosticsToFix = new List<KeyValuePair<Project, ImmutableArray<Diagnostic>>>();
+                switch (fixAllContext.Scope)
+                {
+                    case FixAllScope.Document:
+                        {
+                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document).ConfigureAwait(false);
+                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            break;
+                        }
+
+                    case FixAllScope.Project:
+                        {
+                            Project project = fixAllContext.Project;
+                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            break;
+                        }
+
+                    case FixAllScope.Solution:
+                        {
+                            foreach (Project project in fixAllContext.Solution.Projects)
+                            {
+                                ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                                diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(project, diagnostics));
+                            }
+
+                            break;
+                        }
+
+                    case FixAllScope.Custom:
+                        return null;
+
+                    default:
+                        Debug.Fail($"Unknown FixAllScope '{fixAllContext.Scope}'");
+                        return null;
+                }
+
+                return new FixAllAdditionalDocumentChangeAction(fixAllContext.Scope, fixAllContext.Solution, diagnosticsToFix, fixAllContext.CodeActionEquivalenceKey);
+            }
+
+            private sealed class FixAllAdditionalDocumentChangeAction : CodeAction
+            {
+                private readonly List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> _diagnosticsToFix;
+                private readonly Solution _solution;
+
+                public FixAllAdditionalDocumentChangeAction(FixAllScope fixAllScope, Solution solution, List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> diagnosticsToFix, string equivalenceKey)
+                {
+                    this.Title = fixAllScope.ToString();
+                    _solution = solution;
+                    _diagnosticsToFix = diagnosticsToFix;
+                    this.EquivalenceKey = equivalenceKey;
+                }
+
+                public override string Title { get; }
+                public override string EquivalenceKey { get; }
+
+                protected override async Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
+                {
+                    var updatedUnshippedText = new List<(DocumentId, SourceText)>();
+
+                    foreach (KeyValuePair<Project, ImmutableArray<Diagnostic>> pair in _diagnosticsToFix)
+                    {
+                        Project project = pair.Key;
+                        ImmutableArray<Diagnostic> diagnostics = pair.Value;
+
+                        TextDocument? unshippedDocument = project.AdditionalDocuments.FirstOrDefault(a => a.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+                        if (unshippedDocument == null || diagnostics.IsEmpty)
+                        {
+                            continue;
+                        }
+
+                        if (EquivalenceKey == CodeAnalysisDiagnosticsResources.AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle)
+                        {
+                            var newText = await AddEntriesToUnshippedFileForDiagnosticsAsync(unshippedDocument, diagnostics, cancellationToken).ConfigureAwait(false);
+                            updatedUnshippedText.Add((unshippedDocument.Id, newText));
+                        }
+                        else if (EquivalenceKey == CodeAnalysisDiagnosticsResources.UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle)
+                        {
+                            var newText = await UpdateEntriesInUnshippedFileForDiagnosticsAsync(unshippedDocument, diagnostics, cancellationToken).ConfigureAwait(false);
+                            updatedUnshippedText.Add((unshippedDocument.Id, newText));
+                        }
+                    }
+
+                    Solution newSolution = _solution;
+                    foreach (var (unshippedDocumentId, newText) in updatedUnshippedText)
+                    {
+                        newSolution = newSolution.WithAdditionalDocumentText(unshippedDocumentId, newText);
+                    }
+
+                    return newSolution;
+                }
+
+                private static async Task<SourceText> AddEntriesToUnshippedFileForDiagnosticsAsync(TextDocument unshippedDataDocument, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
+                {
+                    var entriesToAdd = new SortedSet<string>();
+                    foreach (var diagnostic in diagnostics)
+                    {
+                        if (IsAddEntryToUnshippedFileDiagnostic(diagnostic, out var entryToAdd))
+                        {
+                            entriesToAdd.Add(entryToAdd);
+                        }
+                    }
+
+                    return await AddEntriesToUnshippedFileAsync(unshippedDataDocument, entriesToAdd, cancellationToken).ConfigureAwait(false);
+                }
+
+                private static async Task<SourceText> UpdateEntriesInUnshippedFileForDiagnosticsAsync(TextDocument unshippedDataDocument, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
+                {
+                    var entriesToUpdate = new Dictionary<string, string>();
+                    foreach (var diagnostic in diagnostics)
+                    {
+                        if (IsUpdateEntryToUnshippedFileDiagnostic(diagnostic, out var ruleId, out var entryToUpdate))
+                        {
+                            entriesToUpdate.Add(ruleId, entryToUpdate);
+                        }
+                    }
+
+                    return await UpdateEntriesInUnshippedFileAsync(unshippedDataDocument, entriesToUpdate, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
@@ -131,7 +131,8 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                     var entriesToUpdate = new Dictionary<string, string>();
                     foreach (var diagnostic in diagnostics)
                     {
-                        if (IsUpdateEntryToUnshippedFileDiagnostic(diagnostic, out var ruleId, out var entryToUpdate))
+                        if (IsUpdateEntryToUnshippedFileDiagnostic(diagnostic, out var ruleId, out var entryToUpdate) &&
+                            !entriesToUpdate.ContainsKey(ruleId))
                         {
                             entriesToUpdate.Add(ruleId, entryToUpdate);
                         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
@@ -1,0 +1,261 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = nameof(AnalyzerReleaseTrackingFix))]
+    [Shared]
+    public sealed partial class AnalyzerReleaseTrackingFix : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticIds.DeclareDiagnosticIdInAnalyzerReleaseRuleId, DiagnosticIds.UpdateDiagnosticIdInAnalyzerReleaseRuleId);
+
+        public override FixAllProvider GetFixAllProvider()
+            => new ReleaseTrackingFixAllProvider();
+
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                CodeAction? codeAction = null;
+                switch (diagnostic.Id)
+                {
+                    case DiagnosticIds.DeclareDiagnosticIdInAnalyzerReleaseRuleId:
+                        if (IsAddEntryToUnshippedFileDiagnostic(diagnostic, out var entryToAdd))
+                        {
+                            codeAction = CodeAction.Create(
+                                CodeAnalysisDiagnosticsResources.AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle,
+                                cancellationToken => AddEntryToUnshippedFileAsync(context.Document.Project, entryToAdd, cancellationToken),
+                                equivalenceKey: CodeAnalysisDiagnosticsResources.AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle);
+                        }
+
+                        break;
+
+                    case DiagnosticIds.UpdateDiagnosticIdInAnalyzerReleaseRuleId:
+                        if (IsAddEntryToUnshippedFileDiagnostic(diagnostic, out entryToAdd))
+                        {
+                            codeAction = CodeAction.Create(
+                                CodeAnalysisDiagnosticsResources.AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle,
+                                cancellationToken => AddEntryToUnshippedFileAsync(context.Document.Project, entryToAdd, cancellationToken),
+                                equivalenceKey: CodeAnalysisDiagnosticsResources.AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle);
+                        }
+                        else if (IsUpdateEntryToUnshippedFileDiagnostic(diagnostic, out var ruleId, out var entryToUpdate))
+                        {
+                            codeAction = CodeAction.Create(
+                                CodeAnalysisDiagnosticsResources.UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle,
+                                cancellationToken => UpdateEntryInUnshippedFileAsync(context.Document.Project, ruleId, entryToUpdate, cancellationToken),
+                                equivalenceKey: CodeAnalysisDiagnosticsResources.UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle);
+                        }
+                        break;
+
+                    default:
+                        Debug.Fail($"Unsupported diagnostic ID {diagnostic.Id}");
+                        continue;
+                }
+
+                if (codeAction != null)
+                {
+                    context.RegisterCodeFix(codeAction, diagnostic);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static bool IsAddEntryToUnshippedFileDiagnostic(Diagnostic diagnostic, [NotNullWhen(returnValue: true)] out string? entryToAdd)
+        {
+            if (diagnostic.Properties != null &&
+                diagnostic.Properties.TryGetValue(DiagnosticDescriptorCreationAnalyzer.EntryToAddPropertyName, out entryToAdd) &&
+                !string.IsNullOrEmpty(entryToAdd))
+            {
+                return true;
+            }
+
+            entryToAdd = null;
+            return false;
+        }
+
+        private static bool IsUpdateEntryToUnshippedFileDiagnostic(
+            Diagnostic diagnostic,
+            [NotNullWhen(returnValue: true)] out string? ruleId,
+            [NotNullWhen(returnValue: true)] out string? entryToUpdate)
+        {
+            if (diagnostic.Properties != null &&
+                diagnostic.Properties.TryGetValue(DiagnosticDescriptorCreationAnalyzer.EntryToUpdatePropertyName, out entryToUpdate) &&
+                !string.IsNullOrEmpty(entryToUpdate) &&
+                TryGetRuleIdForEntry(entryToUpdate, out ruleId))
+            {
+                return true;
+            }
+
+            ruleId = null;
+            entryToUpdate = null;
+            return false;
+        }
+
+        private static bool TryGetRuleIdForEntry(string entry, [NotNullWhen(returnValue: true)] out string? ruleId)
+        {
+            var index = entry.IndexOf("|", StringComparison.Ordinal);
+            if (index > 0)
+            {
+                ruleId = entry.Substring(0, index).Trim();
+                if (ruleId.StartsWith(DiagnosticDescriptorCreationAnalyzer.RemovedPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    ruleId = ruleId.Substring(DiagnosticDescriptorCreationAnalyzer.RemovedPrefix.Length);
+                }
+
+                return true;
+            }
+
+            ruleId = null;
+            return false;
+        }
+
+        private static async Task<Solution> AddEntryToUnshippedFileAsync(Project project, string entryToAdd, CancellationToken cancellationToken)
+        {
+            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+            if (unshippedDataDocument == null)
+            {
+                return project.Solution;
+            }
+
+            var newText = await AddEntriesToUnshippedFileAsync(unshippedDataDocument, new SortedSet<string>() { entryToAdd }, cancellationToken).ConfigureAwait(false);
+            return project.Solution.WithAdditionalDocumentText(unshippedDataDocument.Id, newText);
+        }
+
+        private static Task<SourceText> AddEntriesToUnshippedFileAsync(
+            TextDocument unshippedDataDocument,
+            SortedSet<string> entriesToAdd,
+            CancellationToken cancellationToken)
+            => AddOrUpdateEntriesToUnshippedFileAsync(unshippedDataDocument, entriesToAdd, entriesToUpdate: null, cancellationToken);
+
+        private static async Task<Solution> UpdateEntryInUnshippedFileAsync(Project project, string ruleId, string entryToUpdate, CancellationToken cancellationToken)
+        {
+            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+            if (unshippedDataDocument == null)
+            {
+                return project.Solution;
+            }
+
+            var newText = await UpdateEntriesInUnshippedFileAsync(unshippedDataDocument, new Dictionary<string, string>() { { ruleId, entryToUpdate } }, cancellationToken).ConfigureAwait(false);
+            return project.Solution.WithAdditionalDocumentText(unshippedDataDocument.Id, newText);
+        }
+
+        private static Task<SourceText> UpdateEntriesInUnshippedFileAsync(
+            TextDocument unshippedDataDocument,
+            Dictionary<string, string> entriesToUpdate,
+            CancellationToken cancellationToken)
+            => AddOrUpdateEntriesToUnshippedFileAsync(unshippedDataDocument, entriesToAdd: null, entriesToUpdate, cancellationToken);
+
+        private static async Task<SourceText> AddOrUpdateEntriesToUnshippedFileAsync(
+            TextDocument unshippedDataDocument,
+            SortedSet<string>? entriesToAdd,
+            Dictionary<string, string>? entriesToUpdate,
+            CancellationToken cancellationToken)
+        {
+            var unshippedText = await unshippedDataDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            var builder = new StringBuilder();
+            var needsHeader = true;
+            var first = true;
+
+            foreach (TextLine line in unshippedText.Lines)
+            {
+                if (!first)
+                {
+                    builder.AppendLine();
+                }
+                else
+                {
+                    first = false;
+                }
+
+                string originalLineText = line.ToString();
+                var lineText = originalLineText.Trim();
+                if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith(";", StringComparison.Ordinal))
+                {
+                    // Skip blank and comment lines.
+                    builder.Append(originalLineText);
+                    continue;
+                }
+
+                if (needsHeader)
+                {
+                    // Add the the header, if not present
+                    if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1, StringComparison.OrdinalIgnoreCase))
+                    {
+                        builder.Append(originalLineText);
+                        continue;
+                    }
+                    else if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2, StringComparison.OrdinalIgnoreCase))
+                    {
+                        builder.Append(originalLineText);
+                        needsHeader = false;
+                    }
+                    else
+                    {
+                        builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1);
+                        builder.Append(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2);
+                        needsHeader = false;
+                    }
+
+                    continue;
+                }
+                else if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1, StringComparison.OrdinalIgnoreCase) ||
+                    lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Skip misplaced header lines
+                    continue;
+                }
+
+                while (entriesToAdd?.Count > 0 &&
+                    string.Compare(entriesToAdd.First(), lineText, StringComparison.OrdinalIgnoreCase) <= 0)
+                {
+                    builder.AppendLine(entriesToAdd.First());
+                    entriesToAdd.Remove(entriesToAdd.First());
+                }
+
+                if (entriesToUpdate?.Count > 0 &&
+                    TryGetRuleIdForEntry(lineText, out var ruleIdForLine) &&
+                    entriesToUpdate.TryGetValue(ruleIdForLine, out var entryToUpdate))
+                {
+                    builder.Append(entryToUpdate);
+                    entriesToUpdate.Remove(ruleIdForLine);
+                    continue;
+                }
+
+                builder.Append(originalLineText);
+            }
+
+            if (needsHeader)
+            {
+                builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1);
+                builder.Append(DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2);
+            }
+
+            if (entriesToAdd != null)
+            {
+                foreach (var entryToAdd in entriesToAdd)
+                {
+                    builder.AppendLine();
+                    builder.Append(entryToAdd);
+                }
+            }
+
+            return unshippedText.Replace(new TextSpan(0, unshippedText.Length), builder.ToString());
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
@@ -116,11 +116,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             if (index > 0)
             {
                 ruleId = entry.Substring(0, index).Trim();
-                if (ruleId.StartsWith(DiagnosticDescriptorCreationAnalyzer.RemovedPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    ruleId = ruleId.Substring(DiagnosticDescriptorCreationAnalyzer.RemovedPrefix.Length);
-                }
-
                 return true;
             }
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Zděďte typ {0} z DiagnosticAnalyzer, nebo odeberte atributy DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Nakonfigurovat analýzu vygenerovaného kódu</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">GetSemanticModel je náročná metoda na to, aby se volala v diagnostickém analyzátoru, protože vytváří zcela nový sémantický model, který nesdílí data kompilace s kompilátorem nebo jinými analyzátory. To dále snižuje výkon během analýzy sémantiky. Zvažte místo toho možnost zaregistrovat jinou akci analyzátoru, která umožňuje používat sdílený SemanticModel, třeba RegisterOperationAction, RegisterSyntaxNodeAction nebo RegisterSemanticModelAction.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Povolit souběžné provádění</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Poskytněte konstruktoru diagnostických popisovačů nenulovou hodnotu customTags</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">U akcí analyzátoru symbolů se SymbolKind {0} nepodporuje.</target>
@@ -255,6 +380,26 @@
 3. Zaregistrujte alespoň jednu neukončovací akci, která odkazuje na tento stav ve spouštěcí akci. Pokud žádnou takovou akci nepotřebujete, zvažte nahrazení spouštěcí akce neukončovací akcí. Například akci CodeBlockStartAction bez registrovaných akcí nebo s pouze zaregistrovanou akcí CodeBlockEndAction byste měli nahradit akcí CodeBlockAction.
 4. Pokud je to potřeba, zaregistrujte ukončovací akci, která bude reportovat diagnostiku na základě koncového stavu.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Übernehmen Sie den Typ "{0}" von DiagnosticAnalyzer, oder entfernen Sie DiagnosticAnalyzerAttribute(s).</target>
@@ -52,6 +57,21 @@
         <target state="translated">Konfigurieren der Analyse von generiertem Code</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">"GetSemanticModel" ist eine kostspielige Methode zum Aufruf in einem Diagnoseanalysetool, weil damit ein vollständig neues Semantikmodell erstellt wird, das keine Kompilierungsdaten mit dem Compiler oder anderen Analysetools teilt. Dies führt zu zusätzlichen Leistungseinbußen bei der Semantikanalyse. Erwägen Sie stattdessen die Registrierung einer anderen Analysetoolaktion, die die Verwendung eines freigegebenen "SemanticModel" wie z. B. "RegisterOperationAction", "RegisterSyntaxNodeAction" oder "RegisterSemanticModelAction" ermöglicht.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Gleichzeitige Ausführung aktivieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Geben Sie einen customTags-Wert ungleich NULL für den Konstruktor des Diagnosedeskriptors an.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">Der SymbolKind-Wert "{0}" wird für Symbolanalyseaktionen nicht unterstützt.</target>
@@ -255,6 +380,26 @@
 3. Registrieren Sie mindestens eine Nicht-Endaktion, die auf diesen Zustand in der Startaktion verweist. Falls keine solche Aktion erforderlich ist, ziehen Sie in Betracht, die Startaktion durch eine Nicht-Startaktion zu ersetzen. Beispielsweise sollte eine CodeBlockStartAction ohne registrierte Aktionen oder mit nur einer registrierten CodeBlockEndAction durch eine CodeBlockAction ersetzt werden.
 4. Registrieren Sie bei Bedarf eine Endaktion, um die Diagnose basierend auf dem Endzustand zu melden.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Herede el tipo "{0}" de DiagnosticAnalyzer o quite los elementos DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Configurar análisis de código generado</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">"GetSemanticModel" es un método caro para invocar dentro de un analizador de diagnóstico porque crea un modelo semántico completamente nuevo que no comparte datos de compilación con el compilador u otros analizadores. Como consecuencia, se generan costos de rendimiento adicionales durante el análisis semántico. En su lugar, podría registrar una acción del analizador diferente que permita usar un elemento "SemanticModel" compartido, como "RegisterOperationAction", "RegisterSyntaxNodeAction" o "RegisterSemanticModelAction".</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Habilitar la ejecución simultánea</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Proporcione un valor "customTags" que no sea NULL para el constructor del descriptor de diagnóstico.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">El argumento SymbolKind “{0}” no se admite para las acciones del analizador de símbolos.</target>
@@ -255,6 +380,26 @@
 3. Registre al menos una acción no final que haga referencia a este estado en la acción de inicio. Si no es necesaria una acción de este tipo, considere reemplazar la acción de inicio por otra que no lo sea. Por ejemplo, una acción CodeBlockStartAction sin acciones registradas o solo una acción CodeBlockEndAction registrada deberían reemplazarse por una acción CodeBlockAction.
 4. Si se requiere, registre una acción de final para notificar los diagnósticos en función del estado final.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Effectuez un héritage de type '{0}' à partir de DiagnosticAnalyzer, ou supprimez les instances de DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Configurer l'analyse du code générée</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel' est une méthode coûteuse à appeler dans un analyseur de diagnostic, car elle crée un modèle sémantique complètement nouveau, qui ne partage pas les données de compilation avec le compilateur ou d'autres analyseurs. Cela entraîne un coût supplémentaire au niveau des performances au moment de l'analyse sémantique. À la place, inscrivez une autre action d'analyseur qui permet d'utiliser un 'SemanticModel' partagé, par exemple 'RegisterOperationAction', 'RegisterSyntaxNodeAction' ou 'RegisterSemanticModelAction'.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Activer l'exécution simultanée</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Fournissez une valeur 'customTags' non null au constructeur de descripteur de diagnostic.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">Le SymbolKind '{0}' n'est pas pris en charge pour les actions d'analyseur de symbole.</target>
@@ -255,6 +380,26 @@
 3. Inscrivez au moins une action qui n'est pas une action de fin et qui fait référence à cet état dans l'action de démarrage. Si aucune action de ce type n'est nécessaire, remplacez l'action de démarrage par une action qui n'est pas une action de fin. Par exemple, un CodeBlockStartAction sans action inscrite ou uniquement un CodeBlockEndAction inscrit doit être remplacé par CodeBlockAction.
 4. Si nécessaire, inscrivez une action de fin de pour créer un rapport de diagnostics en fonction de l'état final.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Ereditare il tipo '{0}' da DiagnosticAnalyzer o rimuovere gli attributi DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Configura l'analisi del codice generato</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel' è un metodo dispendioso da richiamare in un analizzatore diagnostico perché crea un modello semantico completamente nuovo, che non condivide i dati di compilazione con il compilatore o con altri analizzatori, comportando un ulteriore costo in termini di prestazioni durante l'analisi semantica. Provare invece a registrare un'azione diversa dell'analizzatore che consenta l'uso di un elemento 'SemanticModel' condiviso, come 'RegisterOperationAction', 'RegisterSyntaxNodeAction' o 'RegisterSemanticModelAction'.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Abilita l'esecuzione simultanea</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Fornire un valore 'customTags' non Null al costruttore del descrittore di diagnostica.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">L'elemento SymbolKind '{0}' non è supportato per le azioni dell'analizzatore di simboli.</target>
@@ -255,6 +380,26 @@
 3. Registrare almeno un'azione non di fine che fa riferimento a questo stato nell'azione di avvio. Se una tale azione non è necessaria, provare a sostituire l'azione di avvio con un'azione non di avvio. Ad esempio un elemento CodeBlockStartAction senza azioni registrate o un solo elemento CodeBlockEndAction registrato deve essere sostituito da un elemento CodeBlockAction.
 4. Se necessario, registrare un'azione di fine per restituire i dati di diagnostica in base allo stato finale.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">DiagnosticAnalyzer から型 '{0}' を継承するか、DiagnosticAnalyzerAttribute を削除してください。</target>
@@ -52,6 +57,21 @@
         <target state="translated">生成されたコード分析を構成します</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel' は、コンパイラやその他のアナライザーとコンパイル データを共有しないまったく新しいセマンティック モデルを作成するため、診断アナライザー内で呼び出すのにコストの高い方法です。セマンティック分析中に追加のパフォーマンス コストが発生します。代わりに、'RegisterOperationAction'、'RegisterSyntaxNodeAction'、'RegisterSemanticModelAction' など、共有されている 'SemanticModel' を使用できる別のアナライザー操作を登録することをご検討ください。</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">同時実行を有効にします</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">null 以外の 'customTags' 値を診断記述子コンストラクターに提供してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">SymbolKind '{0}' は、シンボル アナライザー アクションではサポートされていません。</target>
@@ -255,6 +380,26 @@
 3.開始アクションのこの状態を参照する終了以外のアクションを 1 つ以上登録します。このようなアクションが不要な場合は、開始アクションを開始以外のアクションに置き換えることを検討します。たとえば、アクションが登録されていない CodeBlockStartAction や登録された単独の CodeBlockEndAction は、CodeBlockAction に置き換える必要があります。
 4.必要に応じて、最終状態に基づく診断を報告するために、終了アクションを登録します。
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">DiagnosticAnalyzer에서 '{0}' 형식을 상속하거나 DiagnosticAnalyzerAttribute를 제거하세요.</target>
@@ -52,6 +57,21 @@
         <target state="translated">생성된 코드 분석 구성</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel'은 컴파일러나 다른 분석기와 컴파일 데이터를 공유하지 않는 완전히 새로운 의미 체계 모델을 만들므로 진단 분석기 내에서 호출하는 데 부담이 큰 메서드입니다. 이 메서드를 사용하면 의미 체계 분석 중 추가 성능 비용이 발생합니다. 대신 공유 'SemanticModel'을 사용할 수 있는 'RegisterOperationAction', 'RegisterSyntaxNodeAction', 'RegisterSemanticModelAction' 등과 같은 다른 분석기 작업을 등록하세요.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">동시 실행 사용</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">null이 아닌 'customTags' 값을 진단 설명자 생성자에 제공하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">SymbolKind '{0}'이(가) 기호 분석기 작업에 대해 지원되지 않습니다.</target>
@@ -255,6 +380,26 @@
 3. 시작 작업에서 이 상태를 참조하는 비종료 작업을 하나 이상 등록합니다. 이러한 작업이 필요하지 않은 경우 시작 작업을 비종료 작업으로 바꾸세요. 예를 들어 등록된 작업이 없는 CodeBlockStartAction 또는 등록된 CodeBlockEndAction만 CodeBlockAction으로 바꿀 수 있습니다.
 4. 필요한 경우 종료 작업을 등록하여 최종 상태를 기준으로 진단을 보고합니다.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Dziedzicz typ „{0}” z elementu DiagnosticAnalyzer lub usuń elementy DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Konfigurowanie analizy wygenerowanego kodu</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">Wywołanie metody „GetSemanticModel” w analizatorze diagnostycznym jest kosztowne, ponieważ powoduje utworzenie całkowicie nowego modelu semantycznego, który nie współdzieli danych kompilacji z kompilatorem ani innymi analizatorami. Wiąże się to z dodatkowym kosztem wydajności podczas analizy semantycznej. Zamiast tego rozważ zarejestrowanie innej akcji analizatora, która umożliwia użycie współdzielonego modelu „SemanticModel”, takiego jak „RegisterOperationAction”, „RegisterSyntaxNodeAction” lub „RegisterSemanticModelAction”.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Włącz wykonywanie współbieżne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Podaj inną niż null wartość „customTags” w konstruktorze deskryptorów diagnostycznych.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">Rodzaj SymbolKind „{0}” nie jest obsługiwany dla akcji analizatora symboli.</target>
@@ -255,6 +380,26 @@
 3. Zarejestruj co najmniej jedną akcję niekończącą, która odnosi się do tego stanu w akcji uruchamiania. Jeśli żadna taka akcja nie jest niezbędna, rozważ zastąpienie akcji uruchamiania przez akcję inną niż uruchamianie. Na przykład akcja CodeBlockStartAction bez zarejestrowanych akcji lub tylko zarejestrowana akcja CodeBlockEndAction powinny być zastąpione przez akcję CodeBlockAction.
 4. W razie potrzeby zarejestruj akcję kończącą, aby zgłaszać diagnostykę na podstawie stanu końcowego.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Herdar o tipo '{0}' de DiagnosticAnalyzer ou remover os DiagnosticAnalyzerAttributes.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Configurar análise de código gerado</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel' é um método caro para ser invocado em um analisador de diagnóstico porque ele cria um modelo semântico completamente novo, que não compartilha dados de compilação com o compilador ou com outros analisadores. Isso gera um custo de desempenho adicional durante a análise semântica. Nesse caso, considere o registro de uma ação do analisador diferente que permita o uso de um 'SemanticModel' compartilhado, como 'RegisterOperationAction', 'RegisterSyntaxNodeAction' ou 'RegisterSemanticModelAction'.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Habilitar execução simultânea</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Forneça um valor de 'customTags' não nulo para o construtor de descritor de diagnóstico.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">Não há suporte para SymbolKind '{0}' para ações de analisador de símbolo.</target>
@@ -255,6 +380,26 @@
 3. Registre pelo menos uma ação não final que referencia esse estado na ação inicial. Se nenhuma ação assim for necessária, considere substituir a ação inicial por uma ação não inicial. Por exemplo, um CodeBlockStartAction com ações não registradas ou apenas um CodeBlockEndAction registrado deve ser substituído por um CodeBlockAction.
 4. Se necessário, registre uma ação final para relatar o diagnóstico com base no estado final.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">Наследовать тип "{0}" от DiagnosticAnalyzer или удалить DiagnosticAnalyzerAttribute.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Настройка анализа созданного кода</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">"GetSemanticModel" является затратным методом для вызова в диагностическом анализаторе, так как при этом создается совершенно новая семантическая модель, которая не использует данные компиляции совместно с компилятором или другими анализаторами. Это приводит к снижению производительности во время семантического анализа. Вместо этого попробуйте зарегистрировать другое действие анализатора, которое позволит использовать общую модель "SemanticModel", например "RegisterOperationAction", "RegisterSyntaxNodeAction" или "RegisterSemanticModelAction".</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Включение параллельного выполнения</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Передайте значение параметра "customTags", отличное от NULL, в конструктор дескриптора диагностики.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">SymbolKind "{0}" не поддерживается для действий анализатора для символов.</target>
@@ -255,6 +380,26 @@
 3. Зарегистрируйте по меньшей мере одно неконечное действие, ссылающееся на это состояние в начальном действии. Если подобное действие не требуется, рекомендуется заменить начальное действие неначальным. Например, CodeBlockStartAction без зарегистрированных действий или с единственным зарегистрированным действием CodeBlockEndAction следует заменить на CodeBlockAction.
 4. При необходимости зарегистрируйте конечное действие, чтобы предоставлять диагностические сведения на основе конечного состояния.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">DiagnosticAnalyzer'dan '{0}' türünü devralın veya DiagnosticAnalyzerAttribute'ları kaldırın.</target>
@@ -52,6 +57,21 @@
         <target state="translated">Oluşturulan kod analizini yapılandır</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">'GetSemanticModel', derleme verilerini derleyici veya diğer çözümleyiciler ile paylaşmayan tamamen yeni bir anlam modeli oluşturduğundan bir tanılama çözümleyicisi içinde çağırmak için pahalı bir yöntemdir. Bu işlem, anlamsal analiz sırasında ek bir performans maliyetine neden olur. Bunun yerine, 'RegisterOperationAction', 'RegisterSyntaxNodeAction' veya 'RegisterSemanticModelAction' gibi paylaşılan bir 'SemanticModel' kullanılmasına izin veren farklı bir çözümleyici eylemini kaydetmeyi deneyin.</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">Eşzamanlı yürütmeyi etkinleştir</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">Tanılama tanımlayıcı oluşturucusuna null olmayan 'customTags' değeri sağlayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">SymbolKind '{0}' sembol çözümleyici eylemleri için desteklenmiyor.</target>
@@ -255,6 +380,26 @@
 3. Başlangıç eyleminde bu duruma başvuran en az bir bitiş eylemi olmayan eylem kaydedin. Böyle bir eyleme gerek yoksa, başlangıç eylemini başlangıç eylemi olmayan bir eylemle değiştirmeyi düşünün. Örneğin, kayıtlı eylemi olmayan veya yalnızca kayıtlı bir CodeBlockEndAction’ı olan bir CodeBlockStartAction, bir CodeBlockAction ile değiştirilmelidir.
 4. Gerekirse, son durumu temel alan tanılamaları raporlamak için bir bitiş eylemi kaydedin.
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANS" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">从 DiagnosticAnalyzer 继承类型“{0}”，或者删除 DiagnosticAnalyzerAttribute。</target>
@@ -52,6 +57,21 @@
         <target state="translated">配置生成的代码分析</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">"GetSemanticModel" 是在诊断分析器中调用的昂贵方法，因为它创建了一个全新的语义模型，该语义模型不与编译器或其他分析器共享编译数据。这会在语义分析期间产生额外的性能开销。请考虑改为注册允许使用共享 "SemanticModel" (如 "RegisterOperationAction"、"RegisterSyntaxNodeAction" 或 "RegisterSemanticModelAction")的其他分析器操作。</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">启用并发执行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">向诊断描述符构造函数提供非 null "customTags" 值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">符号分析器操作不支持 SymbolKind“{0}”。</target>
@@ -255,6 +380,26 @@
 3.至少在启动操作中注册一个引用此状态的非结束操作。如果不需要此类操作，请考虑将启动操作替换为非启动操作。例如，未注册有操作或仅注册了一个 CodeBlockEndAction 的 CodeBlockStartAction 应替换为 CodeBlockAction。
 4.必要时，请注册一个结束操作，根据最终状态对诊断进行报告。
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -263,18 +263,18 @@
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
-        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
-        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule in a 'Removed Rules' table to unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
-        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
-        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -142,9 +142,9 @@
         <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
-        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
-        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+      <trans-unit id="InvalidRemovedOrChangedWithoutPriorNewEntryInAnalyzerReleasesFileRuleMessageMessage">
+        <source>Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid '{1}' entry without a prior shipped release for the rule '{2}'. Instead, add a separate '{1}' entry for the rule in unshipped release file.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-HANT" original="../CodeAnalysisDiagnosticsResources.resx">
     <body>
+      <trans-unit id="AddEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Add rule entry to unshipped release file</source>
+        <target state="new">Add rule entry to unshipped release file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClassIsNotDiagnosticAnalyzerMessage">
         <source>Inherit type '{0}' from DiagnosticAnalyzer or remove the DiagnosticAnalyzerAttribute(s).</source>
         <target state="translated">從 DiagnosticAnalyzer 繼承類型 '{0}' 或移除 DiagnosticAnalyzerAttribute。</target>
@@ -52,6 +57,21 @@
         <target state="translated">設定產生的程式碼分析</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseDescription">
+        <source>All supported analyzer diagnostic IDs should be part of an analyzer release.</source>
+        <target state="new">All supported analyzer diagnostic IDs should be part of an analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' is not part of any analyzer release.</source>
+        <target state="new">Rule '{0}' is not part of any analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DeclareDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Add analyzer diagnostic IDs to analyzer release.</source>
+        <target state="new">Add analyzer diagnostic IDs to analyzer release.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseCompilationGetSemanticModelDescription">
         <source>'GetSemanticModel' is an expensive method to invoke within a diagnostic analyzer because it creates a completely new semantic model, which does not share compilation data with the compiler or other analyzers. This incurs an additional performance cost during semantic analysis. Instead, consider registering a different analyzer action which allows used of a shared 'SemanticModel', such as 'RegisterOperationAction', 'RegisterSyntaxNodeAction', or 'RegisterSemanticModelAction'.</source>
         <target state="translated">在診斷分析器內叫用方法時，'GetSemanticModel' 是成本較高的方法，原因是其會建立全新的語意模型，而不會與編譯器或其他分析器共用編譯資料，此舉會在分析語意期間產生額外的效能成本。請改為考慮註冊不同的分析器動作，以允許使用共用的 'SemanticModel'，例如 'RegisterOperationAction'、'RegisterSyntaxNodeAction' 或 'RegisterSemanticModelAction'。</target>
@@ -100,6 +120,36 @@
       <trans-unit id="EnableConcurrentExecutionTitle">
         <source>Enable concurrent execution</source>
         <target state="translated">啟用同時執行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid entry '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid entry '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleTitle">
+        <source>Invalid entry in analyzer release file.</source>
+        <target state="new">Invalid entry in analyzer release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidHeaderInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has a missing or invalid release header '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has a missing or invalid release header '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</source>
+        <target state="new">Analyzer release file '{0}' has an invalid removed entry without a prior shipped release for the rule '{1}'. Instead, add a separate removed entry for the rule in unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidUndetectedEntryInAnalyzerReleasesFileRuleMessage">
+        <source>Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</source>
+        <target state="new">Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingAttributeMessage">
@@ -182,6 +232,81 @@
         <target state="translated">請提供非 null 的 'customTags' 值給診斷描述項建構函式。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleMessage">
+        <source>Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</source>
+        <target state="new">Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesBetweenAnalyzerReleasesRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID between analyzer releases.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID between analyzer releases.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleDescription">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleMessage">
+        <source>Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</source>
+        <target state="new">Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveDuplicateEntriesForAnalyzerReleaseRuleTitle">
+        <source>Remove duplicate entries for diagnostic ID in the same analyzer release.</source>
+        <target state="new">Remove duplicate entries for diagnostic ID in the same analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdDescription">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</source>
+        <target state="new">Rule '{0}' was shipped in analyzer release '{1}', but is no longer a supported diagnostic for any analyzer. Add an entry for this rule with '*REMOVED*' prefix to unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveShippedDeletedDiagnosticIdTitle">
+        <source>Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</source>
+        <target state="new">Shipped diagnostic IDs that are no longer reported should have an entry with '*REMOVED*' prefix in unshipped file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdDescription">
+        <source>Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</source>
+        <target state="new">Entries for analyzer diagnostic IDs that are no longer reported and never shipped can be removed from unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdMessage">
+        <source>Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</source>
+        <target state="new">Rule '{0}' is part of the next unshipped analyzer release, but is not a supported diagnostic for any analyzer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveUnshippedDeletedDiagnosticIdTitle">
+        <source>Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</source>
+        <target state="new">Do not add removed analyzer diagnostic IDs to unshipped analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdDescription">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdMessage">
+        <source>Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</source>
+        <target state="new">Rule '{0}' is marked as removed in the latest analyzer release, but is still being reported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnexpectedAnalyzerDiagnosticForRemovedDiagnosticIdTitle">
+        <source>Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</source>
+        <target state="new">Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnsupportedSymbolKindArgumentToRegisterActionMessage">
         <source>SymbolKind '{0}' is not supported for symbol analyzer actions.</source>
         <target state="translated">對符號分析器動作不支援 SymbolKind '{0}'。</target>
@@ -255,6 +380,26 @@
 3.至少註冊一個非結束動作，其參考起始動作中的這個狀態。如果不需要這類動作，請考慮以非起始動作取代起始動作。例如，CodeBlockStartAction 沒有任何註冊動作或只有一個註冊的 CodeBlockEndAction 時，應以 CodeBlockAction 取代。
 4.如有必要，請註冊結束動作，以根據最終狀態回報診斷。
 </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseDescription">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseMessage">
+        <source>Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</source>
+        <target state="new">Rule '{0}' has a changed 'Category' or 'Severity' from the last release. Either revert the update(s) in source or add a new up-to-date entry to unshipped release file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateDiagnosticIdInAnalyzerReleaseTitle">
+        <source>Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</source>
+        <target state="new">Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpdateEntryForDiagnosticIdInAnalyzerReleaseCodeFixTitle">
+        <source>Update rule entry in unshipped release file</source>
+        <target state="new">Update rule entry in unshipped release file</target>
         <note />
       </trans-unit>
       <trans-unit id="UseLocalizableStringsInDescriptorMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Directory.Build.props
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Directory.Build.props
@@ -1,0 +1,8 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Import Project="..\Directory.Build.props"/>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants),MICROSOFT_CODEANALYSIS_ANALYZERS</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
@@ -1,0 +1,100 @@
+# Release tracking analyzer
+
+Release tracking analyzer enables third party analyzer packages to define analyzer releases with associated versions. Each release can track the following changes:
+1. Additions: Set of new analyzer rules that shipped for the first time in this release.
+2. Removals: Set of old analyzer rules that shipped in an earlier release, but are removed starting this release.
+3. Changes: Set of existing analyzer rules that shipped in an earlier release, but one of the following attributes of the diagnostic changed in this release:
+   1. Category of the diagnostic.
+   2. Default severity of the diagnostic
+   3. Enabled by default status.
+
+This analyzer expects that the thirdparty analyzer project has two additional files, namely `AnalyzerReleases.Unshipped.md` and `AnalyzerReleases.Shipped.md`, to track this release specific metadata.
+1. `AnalyzerReleases.Unshipped.md`: Additional file for the upcoming or unshipped analyzer release. This file will start empty at the beginning of each release. While working on the upcoming release, it will track additions/removals/changes to analyzer rules in the repo.
+1. `AnalyzerReleases.Shipped.md`: Additional file for shipped analyzer releases. This file only tracks analyzer rules for shipped releases. It cannot be changed while work is in progress for upcoming release. When a new analyzer package is released, a new release with shipped package version should be created in the shipped file, and all the entries from the unshipped file should be mvoed under the new shipped release.
+
+Release tracking analyzer provides the diagnostics and code fixes to enable analyzer authors to maintain the shipped and unshipped files. Analyzer author only requires to perform the following two manual tasks:
+1. Create these two files and pass mark them as additional files for their analyzer project (steps explained in next section), and
+2. Move all the entries from unshipped file to the shipped file after each release.
+
+Consider the following example:
+
+1. `AnalyzerReleases.Shipped.md`:
+
+```
+## Release 1.0
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA1000  |  Design  |  Warning | CA1000_Documentation_Link
+CA2000  | Security |  Info    | CA2000_Documentation_Link
+CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
+
+## Release 2.0
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA2000  | Security | Disabled | CA2000_Documentation_Link
+*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+```
+
+2. `AnalyzerReleases.Unshipped.md`:
+```
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA5000  | Security |  Warning |
+CA6000  |  Design  |  Warning |
+```
+
+Analyzer author has shipped 2 analyzer releases:
+1. Version 1.0 shipped three rules: CA1000, CA2000 and CA3000.
+2. Version 2.0 changed the default severity of a shipped rule CA2000 from 'Warning' to 'Disabled'. It removed a shipped rule CA3000 and added a new rule CA4000.
+3. Upcoming release will add 2 new rules CA5000 and CA6000.
+ 
+When the next release is shipped, say version '3.0', a new release section for 3.0 should be created at the end of the shipped file and the entries from unshipped file should be moved under it. The files will change as below:
+
+1. `AnalyzerReleases.Shipped.md`:
+
+```
+## Release 1.0
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA1000  |  Design  |  Warning | CA1000_Documentation_Link
+CA2000  | Security |  Info    | CA2000_Documentation_Link
+CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
+
+## Release 2.0
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA2000  | Security | Disabled | CA2000_Documentation_Link
+*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+
+## Release 3.0
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA5000  | Security |  Warning |
+CA6000  |  Design  |  Warning |
+```
+
+2. `AnalyzerReleases.Unshipped.md` (empty):
+```
+```
+
+
+# How to enable Release Tracking analyzer
+
+The following files have to be added to any project referencing this package to enable analysis:
+
+- `AnalyzerReleases.Shipped.md`
+- `AnalyzerReleases.Unshipped.md`
+
+This can be done by:
+
+- In Visual Studio, right click project in Solution Explorer, and choose "Add -> New Items", then select "Text File" in "Add new item" dialog.
+- Or, create these two files at the location you desire, then add the following text to your project/target file (replace file path with its actual location):
+
+```xml
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+```

--- a/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
@@ -8,9 +8,11 @@ Release tracking analyzer enables third party analyzer packages to define analyz
    2. Default severity of the diagnostic
    3. Enabled by default status.
 
-This analyzer expects that the thirdparty analyzer project has two additional files, namely `AnalyzerReleases.Unshipped.md` and `AnalyzerReleases.Shipped.md`, to track this release specific metadata.
+This analyzer expects that the third party analyzer project has two additional files, namely `AnalyzerReleases.Unshipped.md` and `AnalyzerReleases.Shipped.md`, to track this release specific metadata.
 1. `AnalyzerReleases.Unshipped.md`: Additional file for the upcoming or unshipped analyzer release. This file will start empty at the beginning of each release. While working on the upcoming release, it will track additions/removals/changes to analyzer rules in the repo.
-1. `AnalyzerReleases.Shipped.md`: Additional file for shipped analyzer releases. This file only tracks analyzer rules for shipped releases. It cannot be changed while work is in progress for upcoming release. When a new analyzer package is released, a new release with shipped package version should be created in the shipped file, and all the entries from the unshipped file should be mvoed under the new shipped release.
+2. `AnalyzerReleases.Shipped.md`: Additional file for shipped analyzer releases. This file only tracks analyzer rules for shipped releases. It cannot be changed while work is in progress for upcoming release. When a new analyzer package is released, a new release with shipped package version should be created in the shipped file, and all the entries from the unshipped file should be mvoed under the new shipped release.
+
+Note that each analyzer project that contributes an assembly to the analyzer NuGet package would require these additional files.
 
 Release tracking analyzer provides the diagnostics and code fixes to enable analyzer authors to maintain the shipped and unshipped files. Analyzer author only requires to perform the following two manual tasks:
 1. Create these two files and pass mark them as additional files for their analyzer project (steps explained in next section), and

--- a/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
@@ -22,22 +22,36 @@ Consider the following example:
 
 ```
 ## Release 1.0
+
+### New Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA1000  |  Design  |  Warning | CA1000_Documentation_Link
 CA2000  | Security |  Info    | CA2000_Documentation_Link
 CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
 
+
 ## Release 2.0
+
+### New Rules
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+
+### Removed Rules
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+
+### Changed Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA2000  | Security | Disabled | CA2000_Documentation_Link
-*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
-CA4000  |  Design  |  Warning | CA4000_Documentation_Link
 ```
 
 2. `AnalyzerReleases.Unshipped.md`:
 ```
+### New Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA5000  | Security |  Warning |
@@ -55,20 +69,36 @@ When the next release is shipped, say version '3.0', a new release section for 3
 
 ```
 ## Release 1.0
+
+### New Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA1000  |  Design  |  Warning | CA1000_Documentation_Link
 CA2000  | Security |  Info    | CA2000_Documentation_Link
 CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
 
+
 ## Release 2.0
+
+### New Rules
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+
+### Removed Rules
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+
+### Changed Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA2000  | Security | Disabled | CA2000_Documentation_Link
-*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
-CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+
 
 ## Release 3.0
+
+### New Rules
 Rule ID | Category | Severity | HelpLink (optional)
 --------|----------|----------|--------------------
 CA5000  | Security |  Warning |

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -1,0 +1,854 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
+using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
+using Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Analyzers.UnitTests.MetaAnalyzers
+{
+    public class ReleaseTrackingAnalyzerTests
+    {
+        [Fact]
+        public async Task TestNoDeclaredAnalyzers()
+        {
+            var source = @"";
+
+            var shippedText = @"";
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [InlineData(@"""Id1""", null, null)]
+        [InlineData(@"""Id1""", "", null)]
+        [InlineData(@"""Id1""", null, "")]
+        [InlineData(@"{|RS2000:""Id1""|}", "", "")]
+        [Theory]
+        public async Task TestMissingReleasesFiles(string id, string shippedText, string unshippedText)
+        {
+            var source = $@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({id}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) {{ }} 
+}}";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [InlineData("", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |", "")]
+        [Theory]
+        public async Task TestReleasesFileAlreadyHasEntry(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) {{ }} 
+}";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [Fact]
+        public async Task TestRemoveUnshippedDeletedDiagnosticIdRule()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+    public override void Initialize(AnalysisContext context) {{ }} 
+}";
+            var shippedText = @"";
+            var unshippedText = DefaultUnshippedHeader + "Id1 | Category1 | Warning |";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                new DiagnosticResult(DiagnosticDescriptorCreationAnalyzer.RemoveUnshippedDeletedDiagnosticIdRule).WithArguments("Id1"));
+        }
+
+        [Fact]
+        public async Task TestRemoveShippedDeletedDiagnosticIdRule()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+    public override void Initialize(AnalysisContext context) {{ }} 
+}";
+            var shippedText = DefaultShippedHeader + "Id1 | Category1 | Warning |";
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                new DiagnosticResult(DiagnosticDescriptorCreationAnalyzer.RemoveShippedDeletedDiagnosticIdRule).WithArguments("Id1", "1.0"));
+        }
+
+        [Fact]
+        public async Task TestCodeFixToAddUnshippedEntries()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({|RS2000:""Id1""|}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    // Duplicate descriptor with different message.
+    private static readonly DiagnosticDescriptor descriptor1_dupe =
+        new DiagnosticDescriptor({|RS2000:""Id1""|}, ""Title1"", ""DifferentMessage"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    // Disabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor2 =
+        new DiagnosticDescriptor({|RS2000:""Id2""|}, ""Title2"", ""Message2"", ""Category2"", DiagnosticSeverity.Warning, isEnabledByDefault: false);
+
+    // Descriptor with help link.
+    private static readonly DiagnosticDescriptor descriptor3 =
+        new DiagnosticDescriptor({|RS2000:""Id3""|}, ""Title3"", ""Message3"", ""Category3"", DiagnosticSeverity.Warning, isEnabledByDefault: true, helpLinkUri: ""Dummy"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1, descriptor1_dupe, descriptor2, descriptor3);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var shippedText = @"";
+            var unshippedText = @"";
+            var fixedUnshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | Category1 | Warning |
+Id2 | Category2 | Disabled |
+Id3 | Category3 | Warning | [Documentation](Dummy)";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestCodeFixToAddUnshippedEntries_DiagnosticDescriptorHelper()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        DiagnosticDescriptorHelper.Create({|RS2000:""Id1""|}, ""Title1"", ""Message1"", ""Category1"", RuleLevel.BuildWarning);
+
+    // Duplicate descriptor with different message.
+    private static readonly DiagnosticDescriptor descriptor1_dupe =
+        DiagnosticDescriptorHelper.Create({|RS2000:""Id1""|}, ""Title1"", ""DifferentMessage"", ""Category1"", RuleLevel.BuildWarning);
+
+    // Disabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor2 =
+        DiagnosticDescriptorHelper.Create({|RS2000:""Id2""|}, ""Title2"", ""Message2"", ""Category2"", RuleLevel.Disabled);
+
+    // Descriptor with help link.
+    private static readonly DiagnosticDescriptor descriptor3 =
+        DiagnosticDescriptorHelper.Create({|RS2000:""Id3""|}, ""Title3"", ""Message3"", ""Category3"", RuleLevel.BuildWarning, helpLinkUri: ""Dummy"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1, descriptor1_dupe, descriptor2, descriptor3);
+    public override void Initialize(AnalysisContext context) { }
+}" + CSharpDiagnosticDescriptorCreationHelper;
+
+            var shippedText = @"";
+            var unshippedText = @"";
+            var fixedUnshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | Category1 | Warning |
+Id2 | Category2 | Disabled |
+Id3 | Category3 | Warning | [Documentation](Dummy)";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        private const string BlankLine = @"
+";
+
+        [InlineData(DefaultUnshippedHeader + @"; Comments are preserved")]
+        [InlineData(DefaultUnshippedHeader + BlankLine)] // Blank lines are preserved
+        [InlineData(DefaultUnshippedHeader + BlankLine + @"; Comments are preserved" + BlankLine)] // Mixed
+        [Theory]
+        public async Task TestCodeFixToAddUnshippedEntries_TriviaIsPreserved(string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({|RS2000:""Id1""|}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var shippedText = @"";
+            var fixedUnshippedText = unshippedText + @"
+Id1 | Category1 | Warning |";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        // Added after current entry.
+        [InlineData("Id0", DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning |",
+                           DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning |" + BlankLine + @"Id1 | Category1 | Warning |")]
+        // Added before current entry.
+        [InlineData("Id2", DefaultUnshippedHeader + @"Id2 | DifferentCategory | Warning |",
+                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + @"Id2 | DifferentCategory | Warning |")]
+        [Theory]
+        public async Task TestCodeFixToAddUnshippedEntries_AlreadyHasDifferentUnshippedEntries(string differentRuleId, string unshippedText, string fixedUnshippedText)
+        {
+            var source = $@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({{|RS2000:""Id1""|}}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor descriptor2 =
+        new DiagnosticDescriptor(""{differentRuleId}"", ""DifferentTitle"", ""DifferentMessage"", ""DifferentCategory"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1, descriptor2);
+    public override void Initialize(AnalysisContext context) {{ }}
+}}";
+
+            var shippedText = @"";
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [InlineData("", "RS2000")]
+        [InlineData(DefaultShippedHeader + "Id1 | DifferentCategory | Warning |", "RS2001")]
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Disabled |", "RS2001")]
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Info |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Info |", "RS2000")]
+        [Theory]
+        public async Task TestCodeFixToAddUnshippedEntries_AlreadyHasDifferentShippedEntry(string shippedText, string expectedDiagnosticId)
+        {
+            var source = $@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({{|{expectedDiagnosticId}:""Id1""|}}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) {{ }}
+}}";
+
+            var unshippedText = @"";
+            var fixedUnshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | Category1 | Warning |";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestCodeFixToUpdateMultipleUnshippedEntries()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    // Enabled by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({|RS2001:""Id1""|}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    // Disable by default descriptor.
+    private static readonly DiagnosticDescriptor descriptor2 =
+        new DiagnosticDescriptor({|RS2001:""Id2""|}, ""Title2"", ""Message2"", ""Category2"", DiagnosticSeverity.Warning, isEnabledByDefault: false);
+
+    // Descriptor with help - ensure that just adding a help link does not require a new analyzer release entry.
+    private static readonly DiagnosticDescriptor descriptor3 =
+        new DiagnosticDescriptor(""Id3"", ""Title3"", ""Message3"", ""Category3"", DiagnosticSeverity.Warning, isEnabledByDefault: true, helpLinkUri: ""Dummy"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1, descriptor2, descriptor3);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var shippedText = @"";
+
+            var unshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | DifferentCategory | Warning |
+Id2 | Category2 | Warning |
+Id3 | Category3 | Warning |";
+
+            var fixedUnshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | Category1 | Warning |
+Id2 | Category2 | Disabled |
+Id3 | Category3 | Warning |";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
+        }
+
+        [Fact]
+        public async Task TestCodeFixToAddUnshippedEntries_UndetectedFields()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+public static class DiagnosticDescriptorHelper
+{
+    public static DiagnosticDescriptor Create(
+        string id,
+        LocalizableString title,
+        LocalizableString messageFormat)
+    => null;
+}
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        DiagnosticDescriptorHelper.Create({|RS2000:""Id1""|}, ""Title1"", ""Message1"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var shippedText = @"";
+            var unshippedText = @"";
+            var fixedUnshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | <Undetected> | <Undetected> |";
+
+            await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText, additionalExpectedDiagnosticsInInput: ImmutableArray<DiagnosticResult>.Empty,
+                additionalExpectedDiagnosticsInResult: ImmutableArray.Create(
+                    GetAdditionalFileResultAt(3, 1,
+                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        DiagnosticDescriptorCreationAnalyzer.InvalidUndetectedEntryInAnalyzerReleasesFileRule,
+                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        "Id1 | <Undetected> | <Undetected> |")));
+        }
+
+        [Fact]
+        public async Task TestNoCodeFixToAddUnshippedEntries_UndetectedFields()
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+public static class DiagnosticDescriptorHelper
+{
+    public static DiagnosticDescriptor Create(
+        string id,
+        LocalizableString title,
+        LocalizableString messageFormat)
+    => null;
+}
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        DiagnosticDescriptorHelper.Create(""Id1"", ""Title1"", ""Message1"");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var shippedText = @"";
+            var unshippedText =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+Id1 | CustomCategory | Warning |";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        // No header in unshipped
+        [InlineData("", "Id1 | Category1 | Warning |")]
+        // No header in shipped
+        [InlineData("Id1 | Category1 | Warning |", "")]
+        // Missing ReleaseHeaderLine1 in unshipped
+        [InlineData("", DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2 + BlankLine + "Id1 | Category1 | Warning |")]
+        // Missing ReleaseHeaderLine2 in unshipped
+        [InlineData("", DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1 + BlankLine + "Id1 | Category1 | Warning |", 2)]
+        // Missing Release Version line in shipped
+        [InlineData(DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
+        // Missing Release Version in shipped
+        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
+        // Invalid Release Version in shipped
+        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " InvalidVersion" + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
+        // Missing ReleaseHeaderLine1 in shipped
+        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + "1.0" + BlankLine + DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine2 + BlankLine + "Id1 | Category1 | Warning |", "", 2)]
+        // Missing ReleaseHeaderLine2 in shipped
+        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 1.0" + BlankLine + DiagnosticDescriptorCreationAnalyzer.ReleaseHeaderLine1 + BlankLine + "Id1 | Category1 | Warning |", "", 3)]
+        // Invalid Release Version line in unshipped
+        [InlineData("", DefaultShippedHeader + "Id1 | Category1 | Warning |")]
+        [Theory]
+        public async Task TestInvalidHeaderDiagnostic(string shippedText, string unshippedText, int line = 1)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+
+            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var diagnosticText = (shippedText.Length > 0 ? shippedText : unshippedText).Split(new[] { Environment.NewLine }, StringSplitOptions.None).ElementAt(line - 1);
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                    GetAdditionalFileResultAt(line, 1,
+                        fileWithDiagnostics,
+                        DiagnosticDescriptorCreationAnalyzer.InvalidHeaderInAnalyzerReleasesFileRule,
+                        fileWithDiagnostics,
+                        diagnosticText));
+        }
+
+        // Undetected category
+        [InlineData("Id1 | <Undetected> | Warning |", true)]
+        // Undetected severity
+        [InlineData("Id1 | Category1 | <Undetected> |", true)]
+        // Undetected category and severity
+        [InlineData("Id1 | <Undetected> | <Undetected> |", true)]
+        // Invalid severity
+        [InlineData("Id1 | Category1 | Invalid |", false)]
+        // Missing required fields - category + severity
+        [InlineData("Id1", false)]
+        // Missing required field - category
+        [InlineData("Id1 | Warning ", false)]
+        // Missing required field - severity
+        [InlineData("Id1 | Category1 |", false)]
+        // Extra fields
+        [InlineData("Id1 | Category1 | Warning | HelpLink | InvalidField", false)]
+        [Theory]
+        public async Task TestInvalidEntryDiagnostic(string entry, bool hasUndetectedField)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+            var rule = hasUndetectedField ?
+                DiagnosticDescriptorCreationAnalyzer.InvalidUndetectedEntryInAnalyzerReleasesFileRule :
+                DiagnosticDescriptorCreationAnalyzer.InvalidEntryInAnalyzerReleasesFileRule;
+
+            var shippedText = @"";
+            var unshippedText = DefaultUnshippedHeader + entry;
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                    GetAdditionalFileResultAt(3, 1,
+                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        rule,
+                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        entry));
+        }
+
+        // Duplicate entries in shipped.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:Id1 | Category1 | Warning ||}", "")]
+        // Duplicate entries in unshipped.
+        [InlineData("", DefaultUnshippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:Id1 | Category1 | Warning ||}")]
+        // Duplicate entries with changed field in shipped.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:Id1 | Category2 | Warning ||}", "")]
+        // Duplicate entries with changed field in unshipped.
+        [InlineData("", DefaultUnshippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:Id1 | Category1 | Info ||}")]
+        // Duplicate entries with in shipped with first removed entry.
+        [InlineData(DefaultShippedHeader + "*REMOVED*Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:Id1 | Category2 | Warning ||}", "")]
+        // Duplicate entries with in shipped with second removed entry.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "{|RS2005:*REMOVED*Id1 | Category2 | Warning ||}", "")]
+        [Theory]
+        public async Task TestDuplicateEntryInReleaseDiagnostic(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        // Duplicate entries across shipped and unshipped.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |", DefaultUnshippedHeader + "{|RS2006:Id1 | Category1 | Warning ||}")]
+        // Duplicate entries across consecutive shipped releases.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "{|RS2006:Id1 | Category1 | Warning ||}", "")]
+        // Duplicate entries across non-consecutive shipped releases.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + BlankLine + DefaultShippedHeader3 + "{|RS2006:Id1 | Category1 | Warning ||}", "")]
+        // Duplicate entries across shipped and unshipped, but with an intermediate entry with changed category - no diagnostic expected.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "Id1 | Category2 | Warning |", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        // Duplicate entries across shipped and unshipped, but with an intermediate entry with changed severity - no diagnostic expected.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "Id1 | Category1 | Info |", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        // Duplicate entries across shipped and unshipped, but with an intermediate entry with removed prefix - no diagnostic expected.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Warning |", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        [Theory]
+        public async Task TestDuplicateEntryBetweenReleasesDiagnostic(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        // Remove entry in unshipped for already shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |", DefaultUnshippedHeader + "*REMOVED*Id1 | Category1 | Warning |", "RS2004")]
+        // Remove entry in shipped for a prior shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Warning |", "", "RS2000")]
+        // Remove entry with changed severity in shipped for a prior shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Info |", "", "RS2000")]
+        [Theory]
+        public async Task TestRemoveEntryInReleaseFile_DiagnosticCases(string shippedText, string unshippedText, string expectedDiagnosticId)
+        {
+            var source = $@"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor({{|{expectedDiagnosticId}:""Id1""|}}, ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) {{ }}
+}}";
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        // Invalid remove entry without prior shipped entry in shipped.
+        [InlineData(DefaultShippedHeader + "*REMOVED*Id1 | Category1 | Warning |", "")]
+        // Invalid remove entry without prior shipped entry in unshipped.
+        [InlineData("", DefaultUnshippedHeader + "*REMOVED*Id1 | Category1 | Warning |")]
+        [Theory]
+        public async Task TestInvalidRemoveWithoutShippedEntryInReleaseFile(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+    public override void Initialize(AnalysisContext context) { }
+}";
+            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var lineCount = (shippedText.Length > 0 ? shippedText : unshippedText).Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                    GetAdditionalFileResultAt(lineCount, 1,
+                        fileWithDiagnostics,
+                        DiagnosticDescriptorCreationAnalyzer.InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule,
+                        fileWithDiagnostics,
+                        "Id1"));
+        }
+
+        // Invalid remove entry without prior shipped entry in shipped, followed by a shipped entry.
+        [InlineData(DefaultShippedHeader + "*REMOVED*Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "Id1 | Category1 | Warning |", "")]
+        // Invalid remove entry without prior shipped entry in shipped, followed by an unshipped entry.
+        [InlineData(DefaultShippedHeader + "*REMOVED*Id1 | Category1 | Warning |", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        [Theory]
+        public async Task TestInvalidRemoveWithoutShippedEntryInReleaseFile_02(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor descriptor1 =
+        new DiagnosticDescriptor(""Id1"", ""Title1"", ""Message1"", ""Category1"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
+    public override void Initialize(AnalysisContext context) { }
+}";
+            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            await VerifyCSharpAsync(source, shippedText, unshippedText,
+                    GetAdditionalFileResultAt(5, 1,
+                        fileWithDiagnostics,
+                        DiagnosticDescriptorCreationAnalyzer.InvalidRemovedWithoutShippedEntryInAnalyzerReleasesFileRule,
+                        fileWithDiagnostics,
+                        "Id1"));
+        }
+
+        // Remove entry in unshipped for already shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |", DefaultUnshippedHeader + "*REMOVED*Id1 | Category1 | Warning |")]
+        // Remove entry in shipped for a prior shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Warning |", "")]
+        // Remove entry with changed severity in shipped for a prior shipped release.
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + DefaultShippedHeader2 + "*REMOVED*Id1 | Category1 | Info |", "")]
+        [Theory]
+        public async Task TestRemoveEntryInReleaseFile_NoDiagnosticCases(string shippedText, string unshippedText)
+        {
+            var source = @"
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+class MyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+    public override void Initialize(AnalysisContext context) { }
+}";
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+        #region Helpers
+
+        private const string DefaultUnshippedHeader =
+@"Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+";
+
+        private const string DefaultShippedHeader =
+@"## Release 1.0
+
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+";
+
+        private const string DefaultShippedHeader2 =
+@"## Release 2.0
+
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+";
+
+        private const string DefaultShippedHeader3 =
+@"## Release 3.0
+
+Rule ID | Category | Severity | HelpLink (optional)
+--------|----------|----------|--------------------
+";
+
+        private static DiagnosticResult GetAdditionalFileResultAt(int line, int column, string path, DiagnosticDescriptor descriptor, params object[] arguments)
+        {
+            return new DiagnosticResult(descriptor)
+                .WithLocation(path, line, column)
+                .WithArguments(arguments);
+        }
+
+        private static readonly ImmutableDictionary<string, ReportDiagnostic> s_nonReleaseTrackingWarningsDisabled = ImmutableDictionary<string, ReportDiagnostic>.Empty
+            .Add(DiagnosticDescriptorCreationAnalyzer.DiagnosticIdMustBeInSpecifiedFormatRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.DoNotUseReservedDiagnosticIdRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.ProvideCustomTagsInDescriptorRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.ProvideHelpUriInDescriptorRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.UseCategoriesFromSpecifiedRangeRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.UseLocalizableStringsInDescriptorRule.Id, ReportDiagnostic.Suppress)
+            .Add(DiagnosticDescriptorCreationAnalyzer.UseUniqueDiagnosticIdRule.Id, ReportDiagnostic.Suppress);
+
+        private static Solution DisableNonReleaseTrackingWarnings(Solution solution, ProjectId projectId)
+        {
+            var compilationOptions = solution.GetProject(projectId)!.CompilationOptions!;
+            compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(s_nonReleaseTrackingWarningsDisabled));
+            return solution.WithProjectCompilationOptions(projectId, compilationOptions);
+        }
+
+        private async Task VerifyCSharpAsync(string source, string shippedText, string unshippedText, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpCodeFixTest<DiagnosticDescriptorCreationAnalyzer, AnalyzerReleaseTrackingFix, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { },
+                },
+                ReferenceAssemblies = AdditionalMetadataReferences.Default,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
+            };
+
+            if (shippedText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
+            }
+
+            if (unshippedText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, unshippedText));
+            }
+
+            test.SolutionTransforms.Add(DisableNonReleaseTrackingWarnings);
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
+
+        private async Task VerifyCSharpAdditionalFileFixAsync(string source, string shippedText, string oldUnshippedText, string newUnshippedText)
+        {
+            await VerifyAdditionalFileFixAsync(LanguageNames.CSharp, source, shippedText, oldUnshippedText, newUnshippedText, ImmutableArray<DiagnosticResult>.Empty, ImmutableArray<DiagnosticResult>.Empty);
+        }
+
+        private async Task VerifyCSharpAdditionalFileFixAsync(string source, string shippedText, string oldUnshippedText, string newUnshippedText,
+            ImmutableArray<DiagnosticResult> additionalExpectedDiagnosticsInInput, ImmutableArray<DiagnosticResult> additionalExpectedDiagnosticsInResult)
+        {
+            await VerifyAdditionalFileFixAsync(LanguageNames.CSharp, source, shippedText, oldUnshippedText, newUnshippedText, additionalExpectedDiagnosticsInInput, additionalExpectedDiagnosticsInResult);
+        }
+
+        private async Task VerifyAdditionalFileFixAsync(string language, string source, string shippedText, string oldUnshippedText, string newUnshippedText,
+            ImmutableArray<DiagnosticResult> additionalExpectedDiagnosticsInInput, ImmutableArray<DiagnosticResult> additionalExpectedDiagnosticsInResult)
+        {
+            var test = language == LanguageNames.CSharp
+                ? new CSharpCodeFixTest<DiagnosticDescriptorCreationAnalyzer, AnalyzerReleaseTrackingFix, XUnitVerifier>()
+                : (CodeFixTest<XUnitVerifier>)new VisualBasicCodeFixTest<DiagnosticDescriptorCreationAnalyzer, AnalyzerReleaseTrackingFix, XUnitVerifier>();
+
+            test.ReferenceAssemblies = AdditionalMetadataReferences.Default;
+            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
+            test.SolutionTransforms.Add(DisableNonReleaseTrackingWarnings);
+
+            test.TestState.Sources.Add(source);
+            test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
+            test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, oldUnshippedText));
+            test.TestState.ExpectedDiagnostics.AddRange(additionalExpectedDiagnosticsInInput);
+
+            test.FixedState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
+            test.FixedState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, newUnshippedText));
+            test.FixedState.ExpectedDiagnostics.AddRange(additionalExpectedDiagnosticsInResult);
+
+            await test.RunAsync();
+        }
+
+        private const string CSharpDiagnosticDescriptorCreationHelper = @"
+internal static class DiagnosticDescriptorHelper
+{
+    // Dummy DiagnosticDescriptor creation helper.
+    public static DiagnosticDescriptor Create(
+        string id,
+        LocalizableString title,
+        LocalizableString messageFormat,
+        string category,
+        RuleLevel ruleLevel,
+        string helpLinkUri = null)
+    => null;
+}
+
+namespace Microsoft.CodeAnalysis
+{
+    internal enum RuleLevel
+    {
+        BuildWarning = 1,
+        IdeSuggestion = 2,
+        IdeHidden_BulkConfigurable = 3,
+        Disabled = 4,
+        CandidateForRemoval = 5,
+    }
+}";
+        #endregion
+    }
+}

--- a/src/Utilities/Compiler/DiagnosticCategory.cs
+++ b/src/Utilities/Compiler/DiagnosticCategory.cs
@@ -29,5 +29,6 @@ namespace Analyzer.Utilities
         public const string MicrosoftCodeAnalysisLocalization = nameof(MicrosoftCodeAnalysisLocalization);
         public const string MicrosoftCodeAnalysisPerformance = nameof(MicrosoftCodeAnalysisPerformance);
         public const string MicrosoftCodeAnalysisCompatibility = nameof(MicrosoftCodeAnalysisCompatibility);
+        public const string MicrosoftCodeAnalysisReleaseTracking = nameof(MicrosoftCodeAnalysisReleaseTracking);
     }
 }

--- a/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
+++ b/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
@@ -21,6 +21,7 @@ MicrosoftCodeAnalysisDocumentation: RS1000-RS1999
 MicrosoftCodeAnalysisLocalization: RS1000-RS1999
 MicrosoftCodeAnalysisPerformance: RS1000-RS1999
 MicrosoftCodeAnalysisCompatibility: RS1000-RS1999
+MicrosoftCodeAnalysisReleaseTracking: RS2000-RS2100
 
 # Roslyn specific rules
 RoslynDiagnosticsDesign: RS0000-RS0999

--- a/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
@@ -16,14 +16,12 @@ namespace Analyzer.Utilities.Extensions
             this SyntaxNode node,
             DiagnosticDescriptor rule,
             params object[] args)
-        {
-            return node.GetLocation().CreateDiagnostic(rule, args);
-        }
+            => node.CreateDiagnostic(rule, properties: null, args);
 
         public static Diagnostic CreateDiagnostic(
             this SyntaxNode node,
             DiagnosticDescriptor rule,
-            ImmutableDictionary<string, string?> properties,
+            ImmutableDictionary<string, string?>? properties,
             params object[] args)
             => node
                 .GetLocation()
@@ -36,8 +34,15 @@ namespace Analyzer.Utilities.Extensions
             this IOperation operation,
             DiagnosticDescriptor rule,
             params object[] args)
+            => operation.CreateDiagnostic(rule, properties: null, args);
+
+        public static Diagnostic CreateDiagnostic(
+            this IOperation operation,
+            DiagnosticDescriptor rule,
+            ImmutableDictionary<string, string?>? properties,
+            params object[] args)
         {
-            return operation.Syntax.CreateDiagnostic(rule, args);
+            return operation.Syntax.CreateDiagnostic(rule, properties, args);
         }
 
         public static Diagnostic CreateDiagnostic(
@@ -69,7 +74,7 @@ namespace Analyzer.Utilities.Extensions
         public static Diagnostic CreateDiagnostic(
             this Location location,
             DiagnosticDescriptor rule,
-            ImmutableDictionary<string, string?> properties,
+            ImmutableDictionary<string, string?>? properties,
             params object[] args)
         {
             if (!location.IsInSource)

--- a/src/Utilities/Compiler/RuleLevel.cs
+++ b/src/Utilities/Compiler/RuleLevel.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#if NET_ANALYZERS || FXCOP_ANALYZERS
+#if NET_ANALYZERS || FXCOP_ANALYZERS || MICROSOFT_CODEANALYSIS_ANALYZERS
 
 namespace Microsoft.CodeAnalysis
 {


### PR DESCRIPTION
Release tracking analyzer enables third party analyzer packages to define analyzer releases with associated versions. Each release can track the following changes:
1. Additions: Set of new analyzer rules that shipped for the first time in this release.
2. Removals: Set of old analyzer rules that shipped in an earlier release, but are removed starting this release.
3. Changes: Set of existing analyzer rules that shipped in an earlier release, but one of the following attributes of the diagnostic changed in this release:
   1. Category of the diagnostic.
   2. Default severity of the diagnostic
   3. Enabled by default status.

This analyzer expects that the third party analyzer project has two additional files, namely `AnalyzerReleases.Unshipped.md` and `AnalyzerReleases.Shipped.md`, to track this release specific metadata.
1. `AnalyzerReleases.Unshipped.md`: Additional file for the upcoming or unshipped analyzer release. This file will start empty at the beginning of each release. While working on the upcoming release, it will track additions/removals/changes to analyzer rules in the repo.
1. `AnalyzerReleases.Shipped.md`: Additional file for shipped analyzer releases. This file only tracks analyzer rules for shipped releases. It cannot be changed while work is in progress for upcoming release. When a new analyzer package is released, a new release with shipped package version should be created in the shipped file, and all the entries from the unshipped file should be mvoed under the new shipped release.

Release tracking analyzer provides the diagnostics and code fixes to enable analyzer authors to maintain the shipped and unshipped files. Analyzer author only requires to perform the following two manual tasks:
1. Create these two files and pass mark them as additional files for their analyzer project (steps explained in next section), and
2. Move all the entries from unshipped file to the shipped file after each release.

Consider the following example:

1. `AnalyzerReleases.Shipped.md`:

```
## Release 1.0
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA1000  |  Design  |  Warning | CA1000_Documentation_Link
CA2000  | Security |  Info    | CA2000_Documentation_Link
CA3000  |  Usage   | Disabled | CA3000_Documentation_Link

## Release 2.0
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA2000  | Security | Disabled | CA2000_Documentation_Link
*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
CA4000  |  Design  |  Warning | CA4000_Documentation_Link
```

2. `AnalyzerReleases.Unshipped.md`:
```
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA5000  | Security |  Warning |
CA6000  |  Design  |  Warning |
```

Analyzer author has shipped 2 analyzer releases:
1. Version 1.0 shipped three rules: CA1000, CA2000 and CA3000.
2. Version 2.0 changed the default severity of a shipped rule CA2000 from 'Warning' to 'Disabled'. It removed a shipped rule CA3000 and added a new rule CA4000.
3. Upcoming release will add 2 new rules CA5000 and CA6000.

When the next release is shipped, say version '3.0', a new release section for 3.0 should be created at the end of the shipped file and the entries from unshipped file should be moved under it. The files will change as below:

1. `AnalyzerReleases.Shipped.md`:

```
## Release 1.0
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA1000  |  Design  |  Warning | CA1000_Documentation_Link
CA2000  | Security |  Info    | CA2000_Documentation_Link
CA3000  |  Usage   | Disabled | CA3000_Documentation_Link

## Release 2.0
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA2000  | Security | Disabled | CA2000_Documentation_Link
*REMOVED*CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
CA4000  |  Design  |  Warning | CA4000_Documentation_Link

## Release 3.0
Rule ID | Category | Severity | HelpLink (optional)
--------|----------|----------|--------------------
CA5000  | Security |  Warning |
CA6000  |  Design  |  Warning |
```

2. `AnalyzerReleases.Unshipped.md` (empty):
```
```