### PR TITLE
Fix null ref in UseValueTasksCorrectly for parentless operation

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -357,10 +357,10 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             public bool ThisConsumption { get; set; }
         }
 
-        private static bool TryGetLocalSymbolAssigned(IOperation operation, [NotNullWhen(true)] out ISymbol? symbol, [NotNullWhen(true)] out BasicBlock? startingBlock)
+        private static bool TryGetLocalSymbolAssigned(IOperation? operation, [NotNullWhen(true)] out ISymbol? symbol, [NotNullWhen(true)] out BasicBlock? startingBlock)
         {
             ControlFlowGraph? cfg;
-            switch (operation.Kind)
+            switch (operation?.Kind)
             {
                 case OperationKind.VariableInitializer when operation.Parent is IVariableDeclaratorOperation decl:
                     if (decl.TryGetEnclosingControlFlowGraph(out cfg))
@@ -409,7 +409,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             foreach (var op in block.DescendantOperations())
             {
                 if (IsLocalOrParameterSymbolReference(op, valueTaskSymbol) &&
-                    op.Parent.Kind switch
+                    op.Parent?.Kind switch
                     {
                         OperationKind.Await => true,
                         OperationKind.Return => true,
@@ -493,7 +493,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             // Determines if the operation itself is a direct access to the ValueTask's Result or GetAwaiter().GetResult().
             bool HasDirectResultAccess(IOperation op) =>
                 IsLocalOrParameterSymbolReference(op, valueTaskSymbol) &&
-                op.Parent.Kind switch
+                op.Parent?.Kind switch
                 {
                     OperationKind.PropertyReference when op.Parent is IPropertyReferenceOperation { Property: { Name: nameof(ValueTask<int>.Result) } } => true,
                     OperationKind.Invocation when op.Parent is IInvocationOperation { TargetMethod: { Name: nameof(ValueTask.GetAwaiter) } } => true,
@@ -535,7 +535,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
         }
 
         private static bool IsLocalOrParameterSymbolReference(IOperation op, ISymbol valueTaskSymbol) =>
-            op.Kind switch
+            op?.Kind switch
             {
                 OperationKind.LocalReference => ((ILocalReferenceOperation)op).Local.Equals(valueTaskSymbol),
                 OperationKind.ParameterReference => ((IParameterReferenceOperation)op).Parameter.Equals(valueTaskSymbol),

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
@@ -361,6 +361,44 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
         }
 
         [Fact]
+        public async Task NoDiagnostics_AssignVariableThenReturnValueTask()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public ValueTask ReturnValueTaskExpression() => Helpers.ReturnsValueTask();
+
+                    public ValueTask<T> ReturnValueTaskOfTExpression<T>() => Helpers.ReturnsValueTaskOfT<T>();
+
+                    public ValueTask<int> ReturnValueTaskOfIntExpression() => Helpers.ReturnsValueTaskOfInt();
+
+                    public ValueTask ReturnValueTask()
+                    {
+                        var inst = this;
+                        var vt = inst.ReturnValueTaskExpression();
+                        return vt;
+                    }
+
+                    public ValueTask<T> ReturnValueTaskOfT<T>()
+                    {
+                        var inst = this;
+                        var vt = inst.ReturnValueTaskOfTExpression<T>();
+                        return vt;
+                    }
+
+                    public ValueTask<int> ReturnValueTaskOfInt()
+                    {
+                        var inst = this;
+                        var vt = inst.ReturnValueTaskOfIntExpression();
+                        return vt;
+                    }
+                }"));
+        }
+
+        [Fact]
         public async Task NoDiagnostics_OutValueTask()
         {
             await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
@@ -697,6 +735,61 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
                         catch
                         {
                             await t;
+                        }
+                    }
+                }"));
+        }
+
+        [Fact]
+        public async Task NoDiagnostics_ReturnOutOfPropertyExpressionBodied()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public ValueTask Prop => Helpers.ReturnsValueTask();
+                    public ValueTask<string> PropString => Helpers.ReturnsValueTaskOfT<string>();
+                    public ValueTask<int> PropInt => Helpers.ReturnsValueTaskOfInt();
+                }"));
+        }
+
+        [Fact]
+        public async Task NoDiagnostics_ReturnOutOfPropertyStatements()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public ValueTask Prop
+                    {
+                        get
+                        {
+                            var vt = Helpers.ReturnsValueTask();
+                            return vt;
+                        }
+                    }
+
+                    public ValueTask<string> PropString
+                    {
+                        get
+                        {
+                            var vt = Helpers.ReturnsValueTaskOfT<string>();
+                            return vt;
+                        }
+                    }
+
+                    public ValueTask<int> PropInt
+                    {
+                        get
+                        {
+                            var vt = Helpers.ReturnsValueTaskOfInt();
+                            return vt;
                         }
                     }
                 }"));


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/3433
cc: @mavasani, @Tan90909090 