### PR TITLE
Couple of bug fixes to ReleaseTrackingAnalyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -198,12 +198,12 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                             diagnosticCategoryAndIdRangeTextOpt, categoryAndAllowedIdsMap, out category, out var allowedIdsInfoList))
                     {
                         allowedIdsInfoList = default;
-                        category = null;
                     }
 
+                    var analyzerName = fieldInitializer.InitializedFields.First().ContainingType.Name;
                     AnalyzeRuleId(operationAnalysisContext, creationArguments,
                         isAnalyzerReleaseTracking, shippedData, unshippedData, seenRuleIds, diagnosticCategoryAndIdRangeTextOpt,
-                        category, helpLink, isEnabledByDefault, defaultSeverity, allowedIdsInfoList, idToAnalyzerMap);
+                        category, analyzerName, helpLink, isEnabledByDefault, defaultSeverity, allowedIdsInfoList, idToAnalyzerMap);
 
                 }, OperationKind.FieldInitializer);
 
@@ -427,6 +427,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             PooledConcurrentSet<string> seenRuleIds,
             AdditionalText? diagnosticCategoryAndIdRangeTextOpt,
             string? category,
+            string analyzerName,
             string? helpLink,
             bool? isEnabledByDefault,
             DiagnosticSeverity? defaultSeverity,
@@ -501,7 +502,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                             RoslynDebug.Assert(shippedData != null);
                             RoslynDebug.Assert(unshippedData != null);
 
-                            AnalyzeAnalyzerReleases(ruleId, argument, category, helpLink, isEnabledByDefault,
+                            AnalyzeAnalyzerReleases(ruleId, argument, category, analyzerName, helpLink, isEnabledByDefault,
                                 defaultSeverity, shippedData, unshippedData, operationAnalysisContext.ReportDiagnostic);
                         }
                     }

--- a/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
@@ -26,38 +26,38 @@ Consider the following example:
 ## Release 1.0
 
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA1000  |  Design  |  Warning | CA1000_Documentation_Link
-CA2000  | Security |  Info    | CA2000_Documentation_Link
-CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
+CA1000  |  Design  |  Warning | CA1000_AnalyzerName, [Documentation](CA1000_Documentation_Link)
+CA2000  | Security |  Info    | CA2000_AnalyzerName, [Documentation](CA2000_Documentation_Link)
+CA3000  |  Usage   | Disabled | CA3000_AnalyzerName, [Documentation](CA3000_Documentation_Link)
 
 
 ## Release 2.0
 
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+CA4000  |  Design  |  Warning | CA4000_AnalyzerName, [Documentation](CA4000_Documentation_Link)
 
 ### Removed Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+CA3000  |  Usage   |  Disable | CA3000_AnalyzerName, [Documentation](CA3000_Documentation_Link)
 
 ### Changed Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA2000  | Security | Disabled | CA2000_Documentation_Link
+CA2000  | Security | Disabled | CA2000_AnalyzerName, [Documentation](CA2000_Documentation_Link)
 ```
 
 2. `AnalyzerReleases.Unshipped.md`:
 ```
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA5000  | Security |  Warning |
-CA6000  |  Design  |  Warning |
+CA5000  | Security |  Warning | CA5000_AnalyzerName
+CA6000  |  Design  |  Warning | CA6000_AnalyzerName
 ```
 
 Analyzer author has shipped 2 analyzer releases:
@@ -73,38 +73,38 @@ When the next release is shipped, say version '3.0', a new release section for 3
 ## Release 1.0
 
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA1000  |  Design  |  Warning | CA1000_Documentation_Link
-CA2000  | Security |  Info    | CA2000_Documentation_Link
-CA3000  |  Usage   | Disabled | CA3000_Documentation_Link
+CA1000  |  Design  |  Warning | CA1000_AnalyzerName, [Documentation](CA1000_Documentation_Link)
+CA2000  | Security |  Info    | CA2000_AnalyzerName, [Documentation](CA2000_Documentation_Link)
+CA3000  |  Usage   | Disabled | CA3000_AnalyzerName, [Documentation](CA3000_Documentation_Link)
 
 
 ## Release 2.0
 
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA4000  |  Design  |  Warning | CA4000_Documentation_Link
+CA4000  |  Design  |  Warning | CA4000_AnalyzerName, [Documentation](CA4000_Documentation_Link)
 
 ### Removed Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA3000  |  Usage   |  Disable | CA3000_Documentation_Link
+CA3000  |  Usage   |  Disable | CA3000_AnalyzerName, [Documentation](CA3000_Documentation_Link)
 
 ### Changed Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA2000  | Security | Disabled | CA2000_Documentation_Link
+CA2000  | Security | Disabled | CA2000_AnalyzerName, [Documentation](CA2000_Documentation_Link)
 
 
 ## Release 3.0
 
 ### New Rules
-Rule ID | Category | Severity | HelpLink (optional)
+Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-CA5000  | Security |  Warning |
-CA6000  |  Design  |  Warning |
+CA5000  | Security |  Warning | CA5000_AnalyzerName
+CA6000  |  Design  |  Warning | CA6000_AnalyzerName
 ```
 
 2. `AnalyzerReleases.Unshipped.md` (empty):

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -178,9 +178,9 @@ class MyAnalyzer : DiagnosticAnalyzer
             var shippedText = @"";
             var unshippedText = @"";
             var fixedUnshippedText =
-$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning |
-Id2 | Category2 | Disabled |
-Id3 | Category3 | Warning | [Documentation](Dummy)";
+$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning | MyAnalyzer
+Id2 | Category2 | Disabled | MyAnalyzer
+Id3 | Category3 | Warning | MyAnalyzer, [Documentation](Dummy)";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
         }
@@ -220,9 +220,9 @@ class MyAnalyzer : DiagnosticAnalyzer
             var shippedText = @"";
             var unshippedText = @"";
             var fixedUnshippedText =
-$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning |
-Id2 | Category2 | Disabled |
-Id3 | Category3 | Warning | [Documentation](Dummy)";
+$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning | MyAnalyzer
+Id2 | Category2 | Disabled | MyAnalyzer
+Id3 | Category3 | Warning | MyAnalyzer, [Documentation](Dummy)";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
         }
@@ -232,13 +232,13 @@ Id3 | Category3 | Warning | [Documentation](Dummy)";
 
         // Comments
         [InlineData(DefaultUnshippedHeader + @"; Comments are preserved" + BlankLine,
-                    DefaultUnshippedHeader + @"; Comments are preserved" + BlankLine + @"Id1 | Category1 | Warning |" + BlankLine)]
+                    DefaultUnshippedHeader + @"; Comments are preserved" + BlankLine + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine)]
         // Blank lines are preserved
         [InlineData(DefaultUnshippedHeader + BlankLine,
-                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine)]
+                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine)]
         // Mixed
         [InlineData(DefaultUnshippedHeader + BlankLine + @"; Comments are preserved" + BlankLine,
-                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine + @"; Comments are preserved" + BlankLine)]
+                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine + @"; Comments are preserved" + BlankLine)]
         [Theory]
         public async Task TestCodeFixToAddUnshippedEntries_TriviaIsPreserved(string unshippedText, string fixedUnshippedText)
         {
@@ -263,19 +263,19 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         // Added after current entry.
-        [InlineData("Id0", DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning |",
-                           DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning |" + BlankLine + @"Id1 | Category1 | Warning |")]
+        [InlineData("Id0", DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning | MyAnalyzer",
+                           DefaultUnshippedHeader + @"Id0 | DifferentCategory | Warning | MyAnalyzer" + BlankLine + @"Id1 | Category1 | Warning | MyAnalyzer")]
         // Added before current entry.
-        [InlineData("Id2", DefaultUnshippedHeader + @"Id2 | DifferentCategory | Warning |",
-                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + @"Id2 | DifferentCategory | Warning |")]
+        [InlineData("Id2", DefaultUnshippedHeader + @"Id2 | DifferentCategory | Warning | MyAnalyzer",
+                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + @"Id2 | DifferentCategory | Warning | MyAnalyzer")]
         // Has existing changed rules table.
-        [InlineData("Id2", DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning |",
-                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning |",
-                           DefaultShippedHeader + @"Id2 | Category | Warning |")]
+        [InlineData("Id2", DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning | MyAnalyzer",
+                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning | MyAnalyzer",
+                           DefaultShippedHeader + @"Id2 | Category | Warning | MyAnalyzer")]
         // Has existing removed rules table.
-        [InlineData("Id2", DefaultRemovedUnshippedHeader + @"Id3 | Category | Warning |",
-                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader + @"Id3 | Category | Warning |",
-                           DefaultShippedHeader + @"Id2 | DifferentCategory | Warning |" + BlankLine + @"Id3 | Category | Warning |")]
+        [InlineData("Id2", DefaultRemovedUnshippedHeader + @"Id3 | Category | Warning | MyAnalyzer",
+                           DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader + @"Id3 | Category | Warning | MyAnalyzer",
+                           DefaultShippedHeader + @"Id2 | DifferentCategory | Warning | MyAnalyzer" + BlankLine + @"Id3 | Category | Warning | MyAnalyzer")]
         [Theory]
         public async Task TestCodeFixToAddUnshippedEntries_AlreadyHasDifferentUnshippedEntries(string differentRuleId, string unshippedText, string fixedUnshippedText, string shippedText = "")
         {
@@ -302,13 +302,13 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         // Adds to existing new rules table and creates a new changed rules table.
-        [InlineData(DefaultUnshippedHeader + @"Id0 | Category0 | Warning |",
-                    DefaultUnshippedHeader + @"Id0 | Category0 | Warning |" + BlankLine + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning |",
-                    DefaultShippedHeader + @"Id2 | Category | Warning |")]
+        [InlineData(DefaultUnshippedHeader + @"Id0 | Category0 | Warning | MyAnalyzer",
+                    DefaultUnshippedHeader + @"Id0 | Category0 | Warning | MyAnalyzer" + BlankLine + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id2 | DifferentCategory | Warning | Category | Warning | MyAnalyzer",
+                    DefaultShippedHeader + @"Id2 | Category | Warning | MyAnalyzer")]
         // Adds to existing new rules table and changed rules table.
-        [InlineData(DefaultChangedUnshippedHeader + @"Id0 | Category0 | Warning | Category | Warning |",
-                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning |" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id0 | Category0 | Warning | Category | Warning |" + BlankLine + @"Id2 | DifferentCategory | Warning | Category | Warning |",
-                    DefaultShippedHeader + @"Id0 | Category | Warning |" + BlankLine + @"Id2 | Category | Warning |")]
+        [InlineData(DefaultChangedUnshippedHeader + @"Id0 | Category0 | Warning | Category | Warning | MyAnalyzer",
+                    DefaultUnshippedHeader + @"Id1 | Category1 | Warning | MyAnalyzer" + BlankLine + BlankLine + DefaultChangedUnshippedHeader + @"Id0 | Category0 | Warning | Category | Warning | MyAnalyzer" + BlankLine + @"Id2 | DifferentCategory | Warning | Category | Warning | MyAnalyzer",
+                    DefaultShippedHeader + @"Id0 | Category | Warning | MyAnalyzer" + BlankLine + @"Id2 | Category | Warning | MyAnalyzer")]
         [Theory]
         public async Task TestCodeFixToAddUnshippedEntriesToMultipleTables(string unshippedText, string fixedUnshippedText, string shippedText = "")
         {
@@ -338,16 +338,16 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         [InlineData("",
-                    DefaultUnshippedHeader + "Id1 | Category1 | Warning |",
+                    DefaultUnshippedHeader + "Id1 | Category1 | Warning | MyAnalyzer",
                     "RS2000")]
-        [InlineData(DefaultShippedHeader + "Id1 | DifferentCategory | Warning |",
-                    DefaultChangedUnshippedHeader + "Id1 | Category1 | Warning | DifferentCategory | Warning |",
+        [InlineData(DefaultShippedHeader + "Id1 | DifferentCategory | Warning | MyAnalyzer",
+                    DefaultChangedUnshippedHeader + "Id1 | Category1 | Warning | DifferentCategory | Warning | MyAnalyzer",
                     "RS2001")]
-        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Disabled |",
-                    DefaultChangedUnshippedHeader + "Id1 | Category1 | Warning | Category1 | Disabled |",
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Disabled | MyAnalyzer",
+                    DefaultChangedUnshippedHeader + "Id1 | Category1 | Warning | Category1 | Disabled | MyAnalyzer",
                     "RS2001")]
-        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Info |" + BlankLine + DefaultRemovedShippedHeader2 + "Id1 | Category1 | Info |",
-                    DefaultUnshippedHeader + "Id1 | Category1 | Warning |",
+        [InlineData(DefaultShippedHeader + "Id1 | Category1 | Info |" + BlankLine + DefaultRemovedShippedHeader2 + "Id1 | Category1 | Info | MyAnalyzer",
+                    DefaultUnshippedHeader + "Id1 | Category1 | Warning | MyAnalyzer",
                     "RS2000")]
         [Theory]
         public async Task TestCodeFixToAddUnshippedEntries_AlreadyHasDifferentShippedEntry(string shippedText, string fixedUnshippedText, string expectedDiagnosticId)
@@ -404,14 +404,14 @@ class MyAnalyzer : DiagnosticAnalyzer
             var shippedText = @"";
 
             var unshippedText =
-$@"{DefaultUnshippedHeader}Id1 | DifferentCategory | Warning |
-Id2 | Category2 | Warning |
-Id3 | Category3 | Warning |";
+$@"{DefaultUnshippedHeader}Id1 | DifferentCategory | Warning | MyAnalyzer
+Id2 | Category2 | Warning | MyAnalyzer
+Id3 | Category3 | Warning | MyAnalyzer";
 
             var fixedUnshippedText =
-$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning |
-Id2 | Category2 | Disabled |
-Id3 | Category3 | Warning |";
+$@"{DefaultUnshippedHeader}Id1 | Category1 | Warning | MyAnalyzer
+Id2 | Category2 | Disabled | MyAnalyzer
+Id3 | Category3 | Warning | MyAnalyzer";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText);
         }
@@ -446,7 +446,8 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             var shippedText = @"";
             var unshippedText = @"";
-            var fixedUnshippedText = $@"{DefaultUnshippedHeader}Id1 | <Undetected> | <Undetected> |";
+            var entry = $@"Id1 | {DiagnosticDescriptorCreationAnalyzer.UndetectedText} | {DiagnosticDescriptorCreationAnalyzer.UndetectedText} | MyAnalyzer";
+            var fixedUnshippedText = $@"{DefaultUnshippedHeader}{entry}";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText, additionalExpectedDiagnosticsInInput: ImmutableArray<DiagnosticResult>.Empty,
                 additionalExpectedDiagnosticsInResult: ImmutableArray.Create(
@@ -454,7 +455,7 @@ class MyAnalyzer : DiagnosticAnalyzer
                         DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
                         DiagnosticDescriptorCreationAnalyzer.InvalidUndetectedEntryInAnalyzerReleasesFileRule,
                         DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
-                        "Id1 | <Undetected> | <Undetected> |")));
+                        entry)));
         }
 
         [Fact]
@@ -549,11 +550,11 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         // Undetected category
-        [InlineData("Id1 | <Undetected> | Warning |", true)]
+        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning |", true)]
         // Undetected severity
-        [InlineData("Id1 | Category1 | <Undetected> |", true)]
+        [InlineData("Id1 | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
         // Undetected category and severity
-        [InlineData("Id1 | <Undetected> | <Undetected> |", true)]
+        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
         // Invalid severity
         [InlineData("Id1 | Category1 | Invalid |", false)]
         // Missing required fields - category + severity
@@ -563,7 +564,7 @@ class MyAnalyzer : DiagnosticAnalyzer
         // Missing required field - severity
         [InlineData("Id1 | Category1 |", false)]
         // Extra fields
-        [InlineData("Id1 | Category1 | Warning | HelpLink | InvalidField", false)]
+        [InlineData("Id1 | Category1 | Warning | Notes | InvalidField", false)]
         [Theory]
         public async Task TestInvalidEntryDiagnostic(string entry, bool hasUndetectedField)
         {
@@ -598,15 +599,15 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         // Undetected category
-        [InlineData("Id1 | <Undetected> | Warning | Category1 | Warning |", true)]
+        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning | Category1 | Warning |", true)]
         // Undetected old category
-        [InlineData("Id1 | Category1 | Warning | <Undetected> | Warning |", true)]
+        [InlineData("Id1 | Category1 | Warning | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning |", true)]
         // Undetected severity
-        [InlineData("Id1 | Category1 | <Undetected> | Category1 | Warning |", true)]
+        [InlineData("Id1 | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Category1 | Warning |", true)]
         // Undetected old severity
-        [InlineData("Id1 | Category1 | Warning | Category1 | <Undetected> |", true)]
+        [InlineData("Id1 | Category1 | Warning | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
         // Undetected category and severity
-        [InlineData("Id1 | <Undetected> | <Undetected> | Category1 | Warning |", true)]
+        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Category1 | Warning |", true)]
         // Invalid severity
         [InlineData("Id1 | Category1 | Invalid | Category1 | Warning |", false)]
         // Invalid old severity
@@ -624,7 +625,7 @@ class MyAnalyzer : DiagnosticAnalyzer
         // Missing required field - severity
         [InlineData("Id1 | Category1 |", false)]
         // Extra fields
-        [InlineData("Id1 | Category1 | Warning | Category2 | Warning | HelpLink | InvalidField", false)]
+        [InlineData("Id1 | Category1 | Warning | Category2 | Warning | Notes | InvalidField", false)]
         [Theory]
         public async Task TestInvalidEntryDiagnostic_ChangedRules(string entry, bool hasUndetectedField)
         {


### PR DESCRIPTION
1. Use quoted `<Undetected>` instead of unquoted <Undetected> for undetected fields in AnalyzerReleases file - this renders properly in md file viewers.
2. Rename the optional "HelpLink" column to "Notes" column in AnalyzerReleases file and also include the analyzer name in the Notes generated by the code fix.