### PR TITLE
Add infrastructure support to generate global analyzer config files f…

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,6 +18,10 @@
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletVersion)" PrivateAssets="all" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(NonShipping)' == 'true' or '$(IsVsixProject)' == 'true' or '$(FxCopAnalyzersProject)' == 'true'">
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Coverage)' == 'true'">
     <!-- https://github.com/tonerdo/coverlet/issues/363 -->
     <DeterministicSourcePaths>false</DeterministicSourcePaths>

--- a/RoslynAnalyzers.sln
+++ b/RoslynAnalyzers.sln
@@ -162,6 +162,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Anal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.Package", "nuget\Microsoft.CodeAnalysis.RulesetToEditorconfigConverter\Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.Package.csproj", "{64D70469-18B0-446C-80E9-A7C45A747B3E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenerateGlobalAnalyzerConfigs", "GenerateGlobalAnalyzerConfigs", "{0194F644-14D0-4AF4-8FA1-5CEA07DC7F5F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateGlobalAnalyzerConfigs", "src\Tools\GenerateGlobalAnalyzerConfigs\GenerateGlobalAnalyzerConfigs.csproj", "{3DD9D249-13D4-4DD2-B043-1F025F550013}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{0a0621f2-d1dc-47ff-b643-c6646557505e}*SharedItemsImports = 5
@@ -174,6 +178,7 @@ Global
 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{2a4af3a4-307b-4252-888e-e6546244585a}*SharedItemsImports = 5
 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{2a520f3e-8c5d-43fe-aa03-fe5e3c5f23d1}*SharedItemsImports = 5
 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{3727e79d-8250-492e-8082-9a5d0c0ad0d9}*SharedItemsImports = 5
+		src\Utilities\Compiler\Analyzer.Utilities.projitems*{3dd9d249-13d4-4dd2-b043-1f025f550013}*SharedItemsImports = 5
 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{730c2d1c-0276-4132-85ea-675ce60068bb}*SharedItemsImports = 5
 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{730c2d1c-0276-4132-85ea-675ce60068bb}*SharedItemsImports = 5
 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{99f594b1-3916-471d-a761-a6731fc50e9a}*SharedItemsImports = 13
@@ -424,6 +429,10 @@ Global
 		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DD9D249-13D4-4DD2-B043-1F025F550013}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DD9D249-13D4-4DD2-B043-1F025F550013}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DD9D249-13D4-4DD2-B043-1F025F550013}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DD9D249-13D4-4DD2-B043-1F025F550013}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -493,6 +502,8 @@ Global
 		{B969F316-815C-47B9-82B3-67FDD9ED694F} = {1A3624C9-EB8A-4F27-98F8-9FAEAB30604E}
 		{3F998217-4174-4AD0-A015-A9BFFADB075F} = {1A3624C9-EB8A-4F27-98F8-9FAEAB30604E}
 		{64D70469-18B0-446C-80E9-A7C45A747B3E} = {02F88961-A08F-451A-93AB-328792A32EBC}
+		{0194F644-14D0-4AF4-8FA1-5CEA07DC7F5F} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+		{3DD9D249-13D4-4DD2-B043-1F025F550013} = {0194F644-14D0-4AF4-8FA1-5CEA07DC7F5F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FC44ACA9-AEA3-4EE6-881C-2E08ED281B5F}

--- a/eng/GenerateAnalyzerNuspec.csx
+++ b/eng/GenerateAnalyzerNuspec.csx
@@ -21,6 +21,7 @@ var analyzerSarifFileDir = Args[17];
 var analyzerSarifFileName = Args[18];
 var analyzerConfigurationFileDir = Args[19];
 var analyzerConfigurationFileName = Args[20];
+var globalAnalyzerConfigsDir = Args[21];
 
 var result = new StringBuilder();
 
@@ -215,6 +216,17 @@ if (editorconfigsDir.Length > 0 && Directory.Exists(editorconfigsDir))
         foreach (string editorconfig in Directory.EnumerateFiles(directory))
         {
             result.AppendLine(FileElement(Path.Combine(directory, editorconfig), $"editorconfig\\{directoryName}"));
+        }
+    }
+}
+
+if (globalAnalyzerConfigsDir.Length > 0 && Directory.Exists(globalAnalyzerConfigsDir))
+{
+    foreach (string editorconfig in Directory.EnumerateFiles(globalAnalyzerConfigsDir))
+    {
+        if (Path.GetExtension(editorconfig) == ".editorconfig")
+        {
+            result.AppendLine(FileElement(Path.Combine(globalAnalyzerConfigsDir, editorconfig), "build\\config\\"));
         }
     }
 }

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -50,9 +50,6 @@
       <PackageTargetsFileDir>$(IntermediateOutputPath)Build</PackageTargetsFileDir>
       <PackageTargetsFileName>$(NuspecPackageId).targets</PackageTargetsFileName>
     </PropertyGroup>
-    <ItemGroup>
-      <AnalyzerNupkgFile Include="$(PackageTargetsFileDir)\$(PackageTargetsFileName)"/>
-    </ItemGroup>
 
     <PropertyGroup Condition="'$(GenerateAnalyzerMdFile)' == 'true'">
       <AnalyzerDocumentationFileDir Condition="'$(AnalyzerDocumentationFileDir)' == ''">$(RepoRoot)src\$(NuspecPackageId)</AnalyzerDocumentationFileDir>
@@ -84,6 +81,10 @@
     </MSBuild>
 
     <Exec Command='"$(DotNetRoot)dotnet.exe" "$(_GenerateGlobalAnalyzerConfigsPath)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(NuspecPackageId)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "@(AnalyzerRulesetAssembly)" "$(ArtifactsBinDir)\" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "$(ReleaseTrackingOptOut)"' />
+
+    <ItemGroup Condition="Exists('$(PackageTargetsFileDir)\$(PackageTargetsFileName)')">
+      <AnalyzerNupkgFile Include="$(PackageTargetsFileDir)\$(PackageTargetsFileName)"/>
+    </ItemGroup>
   </Target>
   
   <Target Name="GenerateAnalyzerNuspecFile"

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -22,13 +22,14 @@
     <PackageLicenseExpression Condition="'$(PackageLicenseExpression)' == ''">Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
-  <Target Name="GenerateAnalyzerRulesets"
+  <Target Name="GenerateAnalyzerConfigAndDocumentationFiles"
           DependsOnTargets="InitializeSourceControlInformation" 
           Condition="'@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerRulesetAssembly)' != ''">
 
     <PropertyGroup>
       <_GeneratedRulesetsDir>$(IntermediateOutputPath)Rulesets</_GeneratedRulesetsDir>
       <_GeneratedEditorconfigsDir>$(IntermediateOutputPath)Editorconfig</_GeneratedEditorconfigsDir>
+      <_GeneratedGlobalAnalyzerConfigsDir>$(IntermediateOutputPath)GlobalAnalyzerConfigs</_GeneratedGlobalAnalyzerConfigsDir>
       <ContainsPortedFxCopRules Condition="'$(ContainsPortedFxCopRules)' == ''">false</ContainsPortedFxCopRules>
       <GeneratePackagePropsFile Condition="'$(GeneratePackagePropsFile)' == ''">true</GeneratePackagePropsFile>
       <DevelopmentDependency Condition="'@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerNupkgDependency)' != ''">true</DevelopmentDependency>
@@ -43,6 +44,14 @@
     </PropertyGroup>
     <ItemGroup Condition="'$(GeneratePackagePropsFile)' == 'true'" >
       <AnalyzerNupkgFile Include="$(PackagePropsFileDir)\$(PackagePropsFileName)"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <PackageTargetsFileDir>$(IntermediateOutputPath)Build</PackageTargetsFileDir>
+      <PackageTargetsFileName>$(NuspecPackageId).targets</PackageTargetsFileName>
+    </PropertyGroup>
+    <ItemGroup>
+      <AnalyzerNupkgFile Include="$(PackageTargetsFileDir)\$(PackageTargetsFileName)"/>
     </ItemGroup>
 
     <PropertyGroup Condition="'$(GenerateAnalyzerMdFile)' == 'true'">
@@ -69,11 +78,17 @@
       <AnalyzerRulesetAssembly Update="@(AnalyzerRulesetAssembly)" Condition="'%(AnalyzerRulesetAssembly.TargetFramework)' == ''" TargetFramework="$(TargetFramework)" />
     </ItemGroup>
     <Exec Command='"$(DotNetRoot)dotnet.exe" "$(_GenerateAnalyzerRulesetsPath)" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "$(ArtifactsBinDir)\" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "@(AnalyzerRulesetAssembly)" "$(PackagePropsFileDir)" "$(PackagePropsFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(VersionPrefix)" $(NuspecPackageId) $(ContainsPortedFxCopRules)' />
+
+    <MSBuild Projects="$(RepoRoot)src\Tools\GenerateGlobalAnalyzerConfigs\GenerateGlobalAnalyzerConfigs.csproj" Targets="Build">
+      <Output TaskParameter="TargetOutputs" PropertyName="_GenerateGlobalAnalyzerConfigsPath"/>
+    </MSBuild>
+
+    <Exec Command='"$(DotNetRoot)dotnet.exe" "$(_GenerateGlobalAnalyzerConfigsPath)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(NuspecPackageId)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "@(AnalyzerRulesetAssembly)" "$(ArtifactsBinDir)\" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "$(ReleaseTrackingOptOut)"' />
   </Target>
   
   <Target Name="GenerateAnalyzerNuspecFile"
           BeforeTargets="GenerateNuspec"
-          DependsOnTargets="InitializeSourceControlInformation;GenerateAnalyzerRulesets" 
+          DependsOnTargets="InitializeSourceControlInformation;GenerateAnalyzerConfigAndDocumentationFiles" 
           Condition="'@(AnalyzerNupkgFile)' != '' or '@(AnalyzerNupkgFolder)' != '' or '@(AnalyzerNupkgAssembly)' != '' or '@(AnalyzerNupkgDependency)' != '' or '@(AnalyzerNupkgLibrary)' != ''">
     <ItemGroup>
       <_NuspecMetadata Include="version=$(PackageVersion)" />
@@ -102,6 +117,6 @@
       <_CscToolPath Condition="!HasTrailingSlash('$(_CscToolPath)')">$(_CscToolPath)\</_CscToolPath>
     </PropertyGroup>
 
-    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFrameworksForPackage)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgFolder)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "@(AnalyzerNupkgLibrary)" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "@(AnalyzerLegacyRuleset)" "$(ArtifactsBinDir)\" "$(AnalyzerDocumentationFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(AnalyzerConfigurationFileDir)" "$(AnalyzerConfigurationFileName)"' />
+    <Exec Command='"$(_CscToolPath)csi.exe" "$(RepoRoot)eng\GenerateAnalyzerNuspec.csx" "$(NuspecFile)" "$(AssetsDir)\" "$(MSBuildProjectDirectory)" "$(Configuration)" "$(TargetFrameworksForPackage)" "@(_NuspecMetadata)" "@(AnalyzerNupkgFile)" "@(AnalyzerNupkgFolder)" "@(AnalyzerNupkgAssembly)" "@(AnalyzerNupkgDependency)" "@(AnalyzerNupkgLibrary)" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "@(AnalyzerLegacyRuleset)" "$(ArtifactsBinDir)\" "$(AnalyzerDocumentationFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(AnalyzerConfigurationFileDir)" "$(AnalyzerConfigurationFileName)" "$(_GeneratedGlobalAnalyzerConfigsDir)"' />
   </Target>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,6 +21,7 @@
 
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.0.0</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.3.1</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
     <MicrosoftCodeAnalysisForShippedApisVersion>3.5.0-beta2-20056-01</MicrosoftCodeAnalysisForShippedApisVersion>
     <MicrosoftNetCompilersVersion>3.6.0-1.final</MicrosoftNetCompilersVersion>
     <DogfoodAnalyzersVersion>3.0.0-beta4.20177.1</DogfoodAnalyzersVersion>

--- a/nuget/MetaCompilation.Analyzers/MetaCompilation.Analyzers.Package.csproj
+++ b/nuget/MetaCompilation.Analyzers/MetaCompilation.Analyzers.Package.csproj
@@ -10,6 +10,7 @@
     <Summary>MetaCompilation Analyzers</Summary>
     <ReleaseNotes>MetaCompilation Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>
+    <NonShipping>true</NonShipping>
   </PropertyGroup>
   
   <ItemGroup>

--- a/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.Package.csproj
@@ -21,7 +21,6 @@
     <AnalyzerNupkgAssembly Include="Microsoft.CodeAnalysis.Analyzers.dll" />
     <AnalyzerNupkgAssembly Include="Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <AnalyzerNupkgAssembly Include="Microsoft.CodeAnalysis.VisualBasic.Analyzers.dll" />
-    <AnalyzerNupkgFile Include="Microsoft.CodeAnalysis.Analyzers.targets" />
   </ItemGroup>
 
   <ItemGroup>

--- a/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.targets
+++ b/nuget/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.targets
@@ -1,9 +1,0 @@
-<Project>
-  <!-- Workaround for https://github.com/dotnet/roslyn/issues/4655 -->
-  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md')" >
-	  <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
-  </ItemGroup>
-  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md')" >
-	  <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
-  </ItemGroup>
-</Project>

--- a/nuget/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.Package.csproj
@@ -10,6 +10,7 @@
     <Summary>Microsoft FxCop Analyzers</Summary>
     <ReleaseNotes>Microsoft FxCop rules implemented as analyzers using the .NET Compiler Platform ("Roslyn").</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
   </PropertyGroup>
   
   <ItemGroup>

--- a/nuget/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.Package.csproj
@@ -10,6 +10,7 @@
     <Summary>Microsoft.CodeAnalysis Version Check Analyzer</Summary>
     <ReleaseNotes>Version Check Analyzer</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics VersionCheckAnalyzer</PackageTags>
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.Package.csproj
+++ b/nuget/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.Package.csproj
@@ -11,6 +11,7 @@
     <ReleaseNotes>Diagnostic analyzers for the Microsoft .NET Compiler Platform (Roslyn)</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>
     <ContainsPortedFxCopRules>true</ContainsPortedFxCopRules>
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
   </PropertyGroup>
   
   <ItemGroup>

--- a/nuget/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.Package.csproj
+++ b/nuget/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.Package.csproj
@@ -11,6 +11,7 @@
     <ReleaseNotes>Microsoft .NetCore API Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>
     <ContainsPortedFxCopRules>true</ContainsPortedFxCopRules>
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.Package.csproj
+++ b/nuget/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.Package.csproj
@@ -11,6 +11,7 @@
     <ReleaseNotes>Microsoft.NetFramework.Analyzers</ReleaseNotes>
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Diagnostic Analyzers Syntax Semantics</PackageTags>
     <ContainsPortedFxCopRules>true</ContainsPortedFxCopRules>
+    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -20,15 +20,25 @@
     <UpToDateCheckInput Include="$(MSBuildThisFileDirectory)..\eng\Analyzers_ShippingRules.ruleset" Condition="'$(CodeAnalysisRuleSet)' == '$(MSBuildThisFileDirectory)..\build\Analyzers_NonShippingRules.ruleset'" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(NonShipping)' == 'true' or '$(IsVsixProject)' == 'true' or '$(FxCopAnalyzersProject)' == 'true'">
-    <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
-  </PropertyGroup>
+  <!-- Add analyzer release tracking additional files -->
+  <!-- Unshipped release -->
+  <ItemGroup Condition="'$(ReleaseTrackingOptOut)' != 'true' AND Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md')">
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+  <!-- Shipped releases -->
+  <ItemGroup  Condition="'$(ReleaseTrackingOptOut)' != 'true' AND Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md')">
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md" />
+    <!-- Copy the shipped releases file to output directory so it can be used in 'GenerateGlobalAnalyzerConfigs' post-build target -->
+    <!-- Include shipped file also as 'None' - Workaround for 'CopyToOutputDirectory' not being respected for additional files -->
+    <None Include="$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>$(OutputDirectory)\AnalyzerReleases\$(AssemblyName)\AnalyzerReleases.Shipped.md</Link>
+    </None>
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(MicrosoftCodeAnalysisBannedApiAnalyzersVersion)" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(BannedSymbolsOptOut)' != 'true'" />
-	  <AdditionalFiles Include="$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md" Condition="'$(ReleaseTrackingOptOut)' != 'true' AND Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md')" />
-    <AdditionalFiles Include="$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md" Condition="'$(ReleaseTrackingOptOut)' != 'true' AND Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md')" />
   </ItemGroup>
 
   <Target Name="BeforeBuild" Condition="'$(ReleaseTrackingOptOut)' != 'true'" >

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -10,6 +10,7 @@ using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.ReleaseTracking;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -13,30 +12,17 @@ using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.ReleaseTracking;
 using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.ReleaseTracking.ReleaseTrackingHelper;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 {
     public sealed partial class DiagnosticDescriptorCreationAnalyzer
     {
-        internal const string ShippedFileName = "AnalyzerReleases.Shipped.md";
-        internal const string UnshippedFileName = "AnalyzerReleases.Unshipped.md";
-        internal const string ReleasePrefix = "## Release";
-        internal const string TableTitleNewRules = "### New Rules";
-        internal const string TableTitleRemovedRules = "### Removed Rules";
-        internal const string TableTitleChangedRules = "### Changed Rules";
-        internal const string TableHeaderNewOrRemovedRulesLine1 = @"Rule ID | Category | Severity | Notes";
-        internal const string TableHeaderNewOrRemovedRulesLine2 = @"--------|----------|----------|-------";
-        internal const string TableHeaderChangedRulesLine1 = @"Rule ID | New Category | New Severity | Old Category | Old Severity | Notes";
-        internal const string TableHeaderChangedRulesLine2 = @"--------|--------------|--------------|--------------|--------------|-------";
-        private const string DisabledText = "Disabled";
-        internal const string UndetectedText = @"`<Undetected>`";
-
         // Property names which are keys for diagnostic property bag passed to the code fixer.
         internal const string EntryToAddPropertyName = nameof(EntryToAddPropertyName);
         internal const string EntryToUpdatePropertyName = nameof(EntryToUpdatePropertyName);
-
-        private static readonly Version s_unshippedVersion = new Version(int.MaxValue, int.MaxValue);
 
         internal static readonly DiagnosticDescriptor DeclareDiagnosticIdInAnalyzerReleaseRule = new DiagnosticDescriptor(
             id: DiagnosticIds.DeclareDiagnosticIdInAnalyzerReleaseRuleId,
@@ -186,11 +172,66 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 return false;
             }
 
-            invalidFileDiagnostics = new List<Diagnostic>();
-            shippedData = ReadReleaseTrackingData(shippedText.Path, shippedText.GetText(cancellationToken), invalidFileDiagnostics.Add, isShippedFile: true);
-            unshippedData = ReadReleaseTrackingData(unshippedText.Path, unshippedText.GetText(cancellationToken), invalidFileDiagnostics.Add, isShippedFile: false);
+            var diagnostics = new List<Diagnostic>();
+            using var reportedInvalidLines = PooledHashSet<TextLine>.GetInstance();
+            shippedData = ReadReleaseTrackingData(shippedText.Path, shippedText.GetText(cancellationToken), OnDuplicateEntryInRelease, OnInvalidEntry, isShippedFile: true);
+            unshippedData = ReadReleaseTrackingData(unshippedText.Path, unshippedText.GetText(cancellationToken), OnDuplicateEntryInRelease, OnInvalidEntry, isShippedFile: false);
 
+            invalidFileDiagnostics = diagnostics;
             return invalidFileDiagnostics.Count == 0;
+
+            // Local functions.
+            void OnDuplicateEntryInRelease(string ruleId, Version currentVersion, string path, SourceText sourceText, TextLine line)
+            {
+                if (!reportedInvalidLines.Add(line))
+                {
+                    // Already reported.
+                    return;
+                }
+
+                RoslynDebug.Assert(diagnostics != null);
+
+                // Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.
+                string arg1 = ruleId;
+                string arg2 = currentVersion == UnshippedVersion ? "unshipped" : currentVersion.ToString();
+                string arg3 = Path.GetFileName(path);
+                LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
+                Location location = Location.Create(path, line.Span, linePositionSpan);
+                var diagnostic = Diagnostic.Create(RemoveDuplicateEntriesForAnalyzerReleaseRule, location, arg1, arg2, arg3);
+                diagnostics.Add(diagnostic);
+            }
+
+            void OnInvalidEntry(TextLine line, InvalidEntryKind invalidEntryKind, string path, SourceText sourceText)
+            {
+                RoslynDebug.Assert(diagnostics != null);
+                RoslynDebug.Assert(reportedInvalidLines != null);
+
+                if (!reportedInvalidLines.Add(line))
+                {
+                    // Already reported.
+                    return;
+                }
+
+                var rule = invalidEntryKind switch
+                {
+                    // Analyzer release file '{0}' has a missing or invalid release header '{1}'.
+                    InvalidEntryKind.Header => InvalidHeaderInAnalyzerReleasesFileRule,
+
+                    // Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.
+                    InvalidEntryKind.UndetectedField => InvalidUndetectedEntryInAnalyzerReleasesFileRule,
+
+                    // Analyzer release file '{0}' has an invalid entry '{1}'.
+                    InvalidEntryKind.Other => InvalidEntryInAnalyzerReleasesFileRule,
+                    _ => throw new NotImplementedException(),
+                };
+
+                string arg1 = Path.GetFileName(path);
+                string arg2 = line.ToString();
+                LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
+                Location location = Location.Create(path, line.Span, linePositionSpan);
+                var diagnostic = Diagnostic.Create(rule, location, arg1, arg2);
+                diagnostics.Add(diagnostic);
+            }
         }
 
         private static bool TryGetReleaseTrackingFiles(
@@ -222,324 +263,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             }
 
             return shippedText != null && unshippedText != null;
-        }
-
-        private static ReleaseTrackingData ReadReleaseTrackingData(
-            string path,
-            SourceText sourceText,
-            Action<Diagnostic> addInvalidFileDiagnostic,
-            bool isShippedFile)
-        {
-            var releaseTrackingDataByRulesBuilder = new Dictionary<string, ReleaseTrackingDataForRuleBuilder>();
-            var currentVersion = s_unshippedVersion;
-            using var reportedInvalidLines = PooledHashSet<TextLine>.GetInstance();
-            ReleaseTrackingHeaderKind? expectedHeaderKind = isShippedFile ? ReleaseTrackingHeaderKind.ReleaseHeader : ReleaseTrackingHeaderKind.TableHeaderTitle;
-            ReleaseTrackingRuleEntryKind? currentRuleEntryKind = null;
-
-            foreach (TextLine line in sourceText.Lines)
-            {
-                string lineText = line.ToString().Trim();
-                if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith(";", StringComparison.Ordinal))
-                {
-                    // Skip blank and comment lines.
-                    continue;
-                }
-
-                // Parse release header if applicable.
-                switch (expectedHeaderKind)
-                {
-                    case ReleaseTrackingHeaderKind.ReleaseHeader:
-                        // Parse new release, if any.
-                        if (lineText.StartsWith(ReleasePrefix, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // Expect new table after this line.
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderTitle;
-
-                            // Parse the release version.
-                            string versionString = lineText.Substring(ReleasePrefix.Length).Trim();
-                            if (!Version.TryParse(versionString, out var version))
-                            {
-                                ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                                return ReleaseTrackingData.Default;
-                            }
-                            else
-                            {
-                                currentVersion = version;
-                            }
-
-                            continue;
-                        }
-
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                        return ReleaseTrackingData.Default;
-
-                    case ReleaseTrackingHeaderKind.TableHeaderTitle:
-                        if (lineText.StartsWith(TableTitleNewRules, StringComparison.OrdinalIgnoreCase))
-                        {
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1;
-                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.New;
-                        }
-                        else if (lineText.StartsWith(TableTitleRemovedRules, StringComparison.OrdinalIgnoreCase))
-                        {
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1;
-                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.Removed;
-                        }
-                        else if (lineText.StartsWith(TableTitleChangedRules, StringComparison.OrdinalIgnoreCase))
-                        {
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine1;
-                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.Changed;
-                        }
-                        else
-                        {
-                            ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                            return ReleaseTrackingData.Default;
-                        }
-
-                        continue;
-
-                    case ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1:
-                        if (lineText.StartsWith(TableHeaderNewOrRemovedRulesLine1, StringComparison.OrdinalIgnoreCase))
-                        {
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine2;
-                            continue;
-                        }
-
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                        return ReleaseTrackingData.Default;
-
-                    case ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine2:
-                        expectedHeaderKind = null;
-                        if (lineText.StartsWith(TableHeaderNewOrRemovedRulesLine2, StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                        return ReleaseTrackingData.Default;
-
-                    case ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine1:
-                        if (lineText.StartsWith(TableHeaderChangedRulesLine1, StringComparison.OrdinalIgnoreCase))
-                        {
-                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine2;
-                            continue;
-                        }
-
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                        return ReleaseTrackingData.Default;
-
-                    case ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine2:
-                        expectedHeaderKind = null;
-                        if (lineText.StartsWith(TableHeaderChangedRulesLine2, StringComparison.OrdinalIgnoreCase))
-                        {
-                            continue;
-                        }
-
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Header);
-                        return ReleaseTrackingData.Default;
-
-                    default:
-                        // We might be starting a new release or table.
-                        if (lineText.StartsWith("## ", StringComparison.OrdinalIgnoreCase))
-                        {
-                            goto case ReleaseTrackingHeaderKind.ReleaseHeader;
-                        }
-                        else if (lineText.StartsWith("### ", StringComparison.OrdinalIgnoreCase))
-                        {
-                            goto case ReleaseTrackingHeaderKind.TableHeaderTitle;
-                        }
-
-                        break;
-                }
-
-                RoslynDebug.Assert(currentRuleEntryKind != null);
-
-                var parts = lineText.Split('|').Select(s => s.Trim()).ToArray();
-                if (IsInvalidEntry(parts, currentRuleEntryKind.Value))
-                {
-                    // Report invalid entry, but continue parsing remaining entries.
-                    ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Other);
-                    continue;
-                }
-
-                //  New or Removed rule entry: 
-                //      "Rule ID | Category | Severity | Notes"
-                //      "   0    |     1    |    2     |        3           "
-                //
-                //  Changed rule entry:
-                //      "Rule ID | New Category | New Severity | Old Category | Old Severity | Notes"
-                //      "   0    |     1        |     2        |     3        |     4        |        5           "
-
-                string ruleId = parts[0];
-
-                InvalidEntryKind? invalidEntryKind = TryParseFields(parts, categoryIndex: 1, severityIndex: 2,
-                    out var category, out var defaultSeverity, out var enabledByDefault);
-                if (invalidEntryKind.HasValue)
-                {
-                    ReportInvalidEntryDiagnostic(line, invalidEntryKind.Value);
-                }
-
-                ReleaseTrackingLine releaseTrackingLine;
-                if (currentRuleEntryKind.Value == ReleaseTrackingRuleEntryKind.Changed)
-                {
-                    invalidEntryKind = TryParseFields(parts, categoryIndex: 3, severityIndex: 4,
-                        out var oldCategory, out var oldDefaultSeverity, out var oldEnabledByDefault);
-                    if (invalidEntryKind.HasValue)
-                    {
-                        ReportInvalidEntryDiagnostic(line, invalidEntryKind.Value);
-                    }
-
-                    // Verify at least one field is changed for the entry:
-                    if (string.Equals(category, oldCategory, StringComparison.OrdinalIgnoreCase) &&
-                        defaultSeverity == oldDefaultSeverity &&
-                        enabledByDefault == oldEnabledByDefault)
-                    {
-                        ReportInvalidEntryDiagnostic(line, InvalidEntryKind.Other);
-                        return ReleaseTrackingData.Default;
-                    }
-
-                    releaseTrackingLine = new ChangedRuleReleaseTrackingLine(ruleId,
-                        category, enabledByDefault, defaultSeverity,
-                        oldCategory, oldEnabledByDefault, oldDefaultSeverity,
-                        line.Span, sourceText, path, isShippedFile);
-                }
-                else
-                {
-                    releaseTrackingLine = new NewOrRemovedRuleReleaseTrackingLine(ruleId,
-                        category, enabledByDefault, defaultSeverity, line.Span, sourceText,
-                        path, isShippedFile, currentRuleEntryKind.Value);
-                }
-
-                if (!releaseTrackingDataByRulesBuilder.TryGetValue(ruleId, out var releaseTrackingDataForRuleBuilder))
-                {
-                    releaseTrackingDataForRuleBuilder = new ReleaseTrackingDataForRuleBuilder();
-                    releaseTrackingDataByRulesBuilder.Add(ruleId, releaseTrackingDataForRuleBuilder);
-                }
-
-                releaseTrackingDataForRuleBuilder.AddEntry(currentVersion, releaseTrackingLine, out var hasExistingEntry);
-                if (hasExistingEntry && reportedInvalidLines.Add(line))
-                {
-                    // Rule '{0}' has more then one entry for release '{1}' in analyzer release file '{2}'.
-                    string arg1 = ruleId;
-                    string arg2 = currentVersion == s_unshippedVersion ? "unshipped" : currentVersion.ToString();
-                    string arg3 = Path.GetFileName(path);
-                    LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
-                    Location location = Location.Create(path, line.Span, linePositionSpan);
-                    var diagnostic = Diagnostic.Create(RemoveDuplicateEntriesForAnalyzerReleaseRule, location, arg1, arg2, arg3);
-                    addInvalidFileDiagnostic(diagnostic);
-                }
-            }
-
-            var builder = ImmutableSortedDictionary.CreateBuilder<string, ReleaseTrackingDataForRule>();
-            foreach (var (ruleId, value) in releaseTrackingDataByRulesBuilder)
-            {
-                var releaseTrackingDataForRule = new ReleaseTrackingDataForRule(ruleId, value);
-                builder.Add(ruleId, releaseTrackingDataForRule);
-            }
-
-            return new ReleaseTrackingData(builder.ToImmutable());
-
-            // Local functions
-            void ReportInvalidEntryDiagnostic(TextLine line, InvalidEntryKind invalidEntryKind)
-            {
-                if (!reportedInvalidLines.Add(line))
-                {
-                    // Already reported.
-                    return;
-                }
-
-                var rule = invalidEntryKind switch
-                {
-                    // Analyzer release file '{0}' has a missing or invalid release header '{1}'.
-                    InvalidEntryKind.Header => InvalidHeaderInAnalyzerReleasesFileRule,
-
-                    // Analyzer release file '{0}' has an entry with one or more 'Undetected' fields that need to be manually filled in '{1}'.
-                    InvalidEntryKind.UndetectedField => InvalidUndetectedEntryInAnalyzerReleasesFileRule,
-
-                    // Analyzer release file '{0}' has an invalid entry '{1}'.
-                    InvalidEntryKind.Other => InvalidEntryInAnalyzerReleasesFileRule,
-                    _ => throw new NotImplementedException(),
-                };
-
-                string arg1 = Path.GetFileName(path);
-                string arg2 = line.ToString();
-                LinePositionSpan linePositionSpan = sourceText.Lines.GetLinePositionSpan(line.Span);
-                Location location = Location.Create(path, line.Span, linePositionSpan);
-                var diagnostic = Diagnostic.Create(rule, location, arg1, arg2);
-                addInvalidFileDiagnostic(diagnostic);
-            }
-
-            static bool IsInvalidEntry(string[] parts, ReleaseTrackingRuleEntryKind currentRuleEntryKind)
-            {
-                // Expected entry for New or Removed rules has 3 or 4 parts:
-                //      "Rule ID | Category | Severity | Notes"
-                //
-                // Expected entry for Changed rules has 5 or 6 parts:
-                //      "Rule ID | New Category | New Severity | Old Category | Old Severity | Notes"
-                //
-                // NOTE: Last field 'Helplink' is optional for both cases.
-
-                if (parts.Length < 3 || parts.Length > 6)
-                {
-                    return true;
-                }
-
-                return currentRuleEntryKind switch
-                {
-                    ReleaseTrackingRuleEntryKind.New => parts.Length > 4,
-                    ReleaseTrackingRuleEntryKind.Removed => parts.Length > 4,
-                    ReleaseTrackingRuleEntryKind.Changed => parts.Length <= 4,
-                    _ => throw new NotImplementedException()
-                };
-            }
-
-            static InvalidEntryKind? TryParseFields(
-                string[] parts, int categoryIndex, int severityIndex,
-                out string category,
-                out DiagnosticSeverity? defaultSeverity,
-                out bool? enabledByDefault)
-            {
-                InvalidEntryKind? invalidEntryKind = null;
-
-                category = parts[categoryIndex];
-                if (category.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
-                {
-                    invalidEntryKind = InvalidEntryKind.UndetectedField;
-                }
-
-                var severityPart = parts[severityIndex];
-                if (Enum.TryParse(severityPart, ignoreCase: true, out DiagnosticSeverity parsedSeverity))
-                {
-                    defaultSeverity = parsedSeverity;
-                    enabledByDefault = true;
-                }
-                else
-                {
-                    defaultSeverity = null;
-                    if (string.Equals(severityPart, DisabledText, StringComparison.OrdinalIgnoreCase))
-                    {
-                        enabledByDefault = false;
-                    }
-                    else if (severityPart.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
-                    {
-                        enabledByDefault = null;
-                        invalidEntryKind = InvalidEntryKind.UndetectedField;
-                    }
-                    else
-                    {
-                        enabledByDefault = null;
-                        invalidEntryKind = InvalidEntryKind.Other;
-                    }
-                }
-
-                return invalidEntryKind;
-            }
-        }
-
-        private enum InvalidEntryKind
-        {
-            Header,
-            UndetectedField,
-            Other
         }
 
         private static void AnalyzeAnalyzerReleases(
@@ -715,7 +438,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     {
                         // Rule '{0}' has duplicate entry between release '{1}' and release '{2}'.
                         string arg1 = ruleId;
-                        string arg2 = lastEntry.version == s_unshippedVersion ? "unshipped" : lastEntry.version.ToString();
+                        string arg2 = lastEntry.version == UnshippedVersion ? "unshipped" : lastEntry.version.ToString();
                         string arg3 = version.ToString();
                         LinePositionSpan linePositionSpan = lastEntry.releaseTrackingLine.SourceText.Lines.GetLinePositionSpan(lastEntry.releaseTrackingLine.Span);
                         Location location = Location.Create(lastEntry.releaseTrackingLine.Path, lastEntry.releaseTrackingLine.Span, linePositionSpan);
@@ -743,173 +466,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     compilationEndContext.ReportDiagnostic(diagnostic);
                 }
             }
-        }
-
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-        private sealed class ReleaseTrackingData
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public static readonly ReleaseTrackingData Default = new ReleaseTrackingData();
-            public ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> ReleaseTrackingDataByRuleIdMap { get; }
-
-            private ReleaseTrackingData()
-                : this(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule>.Empty)
-            {
-            }
-
-            internal ReleaseTrackingData(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> releaseTrackingDataByRuleIdMap)
-            {
-                ReleaseTrackingDataByRuleIdMap = releaseTrackingDataByRuleIdMap;
-            }
-
-            public bool TryGetLatestReleaseTrackingLine(
-                string ruleId,
-                [NotNullWhen(returnValue: true)] out Version? version,
-                [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
-            {
-                version = null;
-                releaseTrackingLine = null;
-                if (!ReleaseTrackingDataByRuleIdMap.TryGetValue(ruleId, out var releaseTrackingDataForRule) ||
-                    releaseTrackingDataForRule.ReleasesByVersionMap.IsEmpty)
-                {
-                    return false;
-                }
-
-                (version, releaseTrackingLine) = releaseTrackingDataForRule.ReleasesByVersionMap.First();
-                return true;
-            }
-        }
-
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-        private readonly struct ReleaseTrackingDataForRule
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public string RuleId { get; }
-            public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ReleasesByVersionMap { get; }
-
-            internal ReleaseTrackingDataForRule(string ruleId, ReleaseTrackingDataForRuleBuilder builder)
-            {
-                RuleId = ruleId;
-                ReleasesByVersionMap = builder.ToImmutable();
-            }
-        }
-
-        private sealed class ReleaseTrackingDataForRuleBuilder
-        {
-            private readonly ImmutableSortedDictionary<Version, ReleaseTrackingLine>.Builder _builder
-                = ImmutableSortedDictionary.CreateBuilder<Version, ReleaseTrackingLine>(ReverseComparer.Instance);
-
-            public void AddEntry(Version version, ReleaseTrackingLine releaseTrackingLine, out bool hasExistingEntry)
-            {
-                hasExistingEntry = _builder.ContainsKey(version);
-                _builder[version] = releaseTrackingLine;
-            }
-
-            public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ToImmutable()
-                => _builder.ToImmutable();
-
-            private sealed class ReverseComparer : IComparer<Version>
-            {
-                public static readonly IComparer<Version> Instance = new ReverseComparer();
-                private ReverseComparer() { }
-
-                public int Compare(Version x, Version y)
-                {
-                    return x.CompareTo(y) * -1;
-                }
-            }
-        }
-
-        private abstract class ReleaseTrackingLine
-        {
-            public string RuleId { get; }
-            public string Category { get; }
-            public bool? EnabledByDefault { get; }
-            public DiagnosticSeverity? DefaultSeverity { get; }
-
-            public TextSpan Span { get; }
-            public SourceText SourceText { get; }
-            public string Path { get; }
-            public bool IsShipped { get; }
-            public bool IsRemovedRule => Kind == ReleaseTrackingRuleEntryKind.Removed;
-            public ReleaseTrackingRuleEntryKind Kind { get; }
-
-            internal static ReleaseTrackingLine Create(
-                string ruleId, string category, bool? enabledByDefault,
-                DiagnosticSeverity? defaultSeverity,
-                TextSpan span, SourceText sourceText,
-                string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
-            {
-                return new NewOrRemovedRuleReleaseTrackingLine(ruleId, category,
-                    enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, kind);
-            }
-
-            protected ReleaseTrackingLine(string ruleId, string category, bool? enabledByDefault,
-                DiagnosticSeverity? defaultSeverity,
-                TextSpan span, SourceText sourceText,
-                string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
-            {
-                RuleId = ruleId;
-                Category = category;
-                EnabledByDefault = enabledByDefault;
-                DefaultSeverity = defaultSeverity;
-                Span = span;
-                SourceText = sourceText;
-                Path = path;
-                IsShipped = isShipped;
-                Kind = kind;
-            }
-        }
-
-        private sealed class NewOrRemovedRuleReleaseTrackingLine : ReleaseTrackingLine
-        {
-            internal NewOrRemovedRuleReleaseTrackingLine(
-                string ruleId, string category, bool? enabledByDefault,
-                DiagnosticSeverity? defaultSeverity,
-                TextSpan span, SourceText sourceText,
-                string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
-                : base(ruleId, category, enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, kind)
-            {
-                Debug.Assert(kind == ReleaseTrackingRuleEntryKind.New || kind == ReleaseTrackingRuleEntryKind.Removed);
-            }
-        }
-
-        private sealed class ChangedRuleReleaseTrackingLine : ReleaseTrackingLine
-        {
-            public string OldCategory { get; }
-            public bool? OldEnabledByDefault { get; }
-            public DiagnosticSeverity? OldDefaultSeverity { get; }
-
-            internal ChangedRuleReleaseTrackingLine(
-                string ruleId, string category, bool? enabledByDefault,
-                DiagnosticSeverity? defaultSeverity,
-                string oldCategory, bool? oldEnabledByDefault,
-                DiagnosticSeverity? oldDefaultSeverity,
-                TextSpan span, SourceText sourceText,
-                string path, bool isShipped)
-                : base(ruleId, category, enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, ReleaseTrackingRuleEntryKind.Changed)
-            {
-                OldCategory = oldCategory;
-                OldEnabledByDefault = oldEnabledByDefault;
-                OldDefaultSeverity = oldDefaultSeverity;
-            }
-        }
-
-        private enum ReleaseTrackingHeaderKind
-        {
-            ReleaseHeader,
-            TableHeaderTitle,
-            TableHeaderNewOrRemovedRulesLine1,
-            TableHeaderNewOrRemovedRulesLine2,
-            TableHeaderChangedRulesLine1,
-            TableHeaderChangedRulesLine2,
-        }
-
-        private enum ReleaseTrackingRuleEntryKind
-        {
-            New,
-            Removed,
-            Changed,
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.FixAllProvider.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.ReleaseTracking;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
@@ -92,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                         Project project = pair.Key;
                         ImmutableArray<Diagnostic> diagnostics = pair.Value;
 
-                        TextDocument? unshippedDocument = project.AdditionalDocuments.FirstOrDefault(a => a.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+                        TextDocument? unshippedDocument = project.AdditionalDocuments.FirstOrDefault(a => a.Name == ReleaseTrackingHelper.UnshippedFileName);
                         if (unshippedDocument == null || diagnostics.IsEmpty)
                         {
                             continue;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/AnalyzerReleaseTrackingFix.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.ReleaseTracking;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
@@ -96,8 +97,8 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
 
         private static Task<Solution> AddAnalyzerReleaseTrackingFilesAsync(Project project)
         {
-            project = AddAdditionalDocument(project, DiagnosticDescriptorCreationAnalyzer.ShippedFileName, ShippedAnalyzerReleaseTrackingFileDefaultContent);
-            project = AddAdditionalDocument(project, DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, UnshippedAnalyzerReleaseTrackingFileDefaultContent);
+            project = AddAdditionalDocument(project, ReleaseTrackingHelper.ShippedFileName, ShippedAnalyzerReleaseTrackingFileDefaultContent);
+            project = AddAdditionalDocument(project, ReleaseTrackingHelper.UnshippedFileName, UnshippedAnalyzerReleaseTrackingFileDefaultContent);
             return Task.FromResult(project.Solution);
 
             // Local functions.
@@ -159,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
 
         private static async Task<Solution> AddEntryToUnshippedFileAsync(Project project, string entryToAdd, CancellationToken cancellationToken)
         {
-            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == ReleaseTrackingHelper.UnshippedFileName);
             if (unshippedDataDocument == null)
             {
                 return project.Solution;
@@ -177,7 +178,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
 
         private static async Task<Solution> UpdateEntryInUnshippedFileAsync(Project project, string ruleId, string entryToUpdate, CancellationToken cancellationToken)
         {
-            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == DiagnosticDescriptorCreationAnalyzer.UnshippedFileName);
+            var unshippedDataDocument = project.AdditionalDocuments.FirstOrDefault(d => d.Name == ReleaseTrackingHelper.UnshippedFileName);
             if (unshippedDataDocument == null)
             {
                 return project.Solution;
@@ -302,7 +303,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
 
                 if (lineText.StartsWith("###", StringComparison.Ordinal))
                 {
-                    if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules, StringComparison.OrdinalIgnoreCase))
+                    if (lineText.StartsWith(ReleaseTrackingHelper.TableTitleNewRules, StringComparison.OrdinalIgnoreCase))
                     {
                         currentTableKind = RuleEntryTableKind.New;
                     }
@@ -317,11 +318,11 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                             builder.AppendLine();
                         }
 
-                        if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableTitleRemovedRules, StringComparison.OrdinalIgnoreCase))
+                        if (lineText.StartsWith(ReleaseTrackingHelper.TableTitleRemovedRules, StringComparison.OrdinalIgnoreCase))
                         {
                             currentTableKind = RuleEntryTableKind.Removed;
                         }
-                        else if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules, StringComparison.OrdinalIgnoreCase))
+                        else if (lineText.StartsWith(ReleaseTrackingHelper.TableTitleChangedRules, StringComparison.OrdinalIgnoreCase))
                         {
                             currentTableKind = RuleEntryTableKind.Changed;
                         }
@@ -341,13 +342,13 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                 {
                     builder.Append(originalLineText);
 
-                    if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1, StringComparison.OrdinalIgnoreCase) ||
-                        lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1, StringComparison.OrdinalIgnoreCase))
+                    if (lineText.StartsWith(ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1, StringComparison.OrdinalIgnoreCase) ||
+                        lineText.StartsWith(ReleaseTrackingHelper.TableHeaderChangedRulesLine1, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
                     }
-                    else if (lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2, StringComparison.OrdinalIgnoreCase) ||
-                        lineText.StartsWith(DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine2, StringComparison.OrdinalIgnoreCase))
+                    else if (lineText.StartsWith(ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2, StringComparison.OrdinalIgnoreCase) ||
+                        lineText.StartsWith(ReleaseTrackingHelper.TableHeaderChangedRulesLine2, StringComparison.OrdinalIgnoreCase))
                     {
                         parsingHeaderLines = false;
                     }
@@ -434,9 +435,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                     builder.AppendLine();
                 }
 
-                builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules);
-                builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1);
-                builder.Append(DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2);
+                builder.AppendLine(ReleaseTrackingHelper.TableTitleNewRules);
+                builder.AppendLine(ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1);
+                builder.Append(ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2);
             }
 
             static void AddChangedRulesTableHeader(StringBuilder builder, bool prependNewLine)
@@ -447,9 +448,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                     builder.AppendLine();
                 }
 
-                builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules);
-                builder.AppendLine(DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1);
-                builder.Append(DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine2);
+                builder.AppendLine(ReleaseTrackingHelper.TableTitleChangedRules);
+                builder.AppendLine(ReleaseTrackingHelper.TableHeaderChangedRulesLine1);
+                builder.Append(ReleaseTrackingHelper.TableHeaderChangedRulesLine2);
             }
 
             static bool AddAllEntries(SortedSet<string>? entriesToAdd, StringBuilder builder, bool prependNewLine)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReleaseTrackingHelper.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReleaseTrackingHelper.cs
@@ -1,0 +1,516 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+#if MICROSOFT_CODEANALYSIS_ANALYZERS
+using Analyzer.Utilities.Extensions;
+#endif
+
+namespace Microsoft.CodeAnalysis.ReleaseTracking
+{
+    internal static class ReleaseTrackingHelper
+    {
+        internal const string ShippedFileName = "AnalyzerReleases.Shipped.md";
+        internal const string UnshippedFileName = "AnalyzerReleases.Unshipped.md";
+        internal const string DisabledText = "Disabled";
+        internal const string UndetectedText = @"`<Undetected>`";
+        internal const string ReleasePrefix = "## Release";
+        internal const string TableTitleNewRules = "### New Rules";
+        internal const string TableTitleRemovedRules = "### Removed Rules";
+        internal const string TableTitleChangedRules = "### Changed Rules";
+        internal const string TableHeaderNewOrRemovedRulesLine1 = @"Rule ID | Category | Severity | Notes";
+        internal const string TableHeaderNewOrRemovedRulesLine2 = @"--------|----------|----------|-------";
+        internal const string TableHeaderChangedRulesLine1 = @"Rule ID | New Category | New Severity | Old Category | Old Severity | Notes";
+        internal const string TableHeaderChangedRulesLine2 = @"--------|--------------|--------------|--------------|--------------|-------";
+
+        internal static Version UnshippedVersion { get; } = new Version(int.MaxValue, int.MaxValue);
+
+        internal static ReleaseTrackingData ReadReleaseTrackingData(
+            string path,
+            SourceText sourceText,
+            Action<string, Version, string, SourceText, TextLine> onDuplicateEntryInRelease,
+            Action<TextLine, InvalidEntryKind, string, SourceText> onInvalidEntry,
+            bool isShippedFile)
+        {
+            var releaseTrackingDataByRulesBuilder = new Dictionary<string, ReleaseTrackingDataForRuleBuilder>();
+            var currentVersion = UnshippedVersion;
+            ReleaseTrackingHeaderKind? expectedHeaderKind = isShippedFile ? ReleaseTrackingHeaderKind.ReleaseHeader : ReleaseTrackingHeaderKind.TableHeaderTitle;
+            ReleaseTrackingRuleEntryKind? currentRuleEntryKind = null;
+            using var versionsBuilder = PooledHashSet<Version>.GetInstance();
+
+            foreach (TextLine line in sourceText.Lines)
+            {
+                string lineText = line.ToString().Trim();
+                if (string.IsNullOrWhiteSpace(lineText) || lineText.StartsWith(";", StringComparison.Ordinal))
+                {
+                    // Skip blank and comment lines.
+                    continue;
+                }
+
+                // Parse release header if applicable.
+                switch (expectedHeaderKind)
+                {
+                    case ReleaseTrackingHeaderKind.ReleaseHeader:
+                        // Parse new release, if any.
+                        if (lineText.StartsWith(ReleasePrefix, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Expect new table after this line.
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderTitle;
+
+                            // Parse the release version.
+                            string versionString = lineText.Substring(ReleasePrefix.Length).Trim();
+                            if (!Version.TryParse(versionString, out var version))
+                            {
+                                OnInvalidEntry(line, InvalidEntryKind.Header);
+                                return ReleaseTrackingData.Default;
+                            }
+                            else
+                            {
+                                currentVersion = version;
+                                versionsBuilder.Add(version);
+                            }
+
+                            continue;
+                        }
+
+                        OnInvalidEntry(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    case ReleaseTrackingHeaderKind.TableHeaderTitle:
+                        if (lineText.StartsWith(TableTitleNewRules, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1;
+                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.New;
+                        }
+                        else if (lineText.StartsWith(TableTitleRemovedRules, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1;
+                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.Removed;
+                        }
+                        else if (lineText.StartsWith(TableTitleChangedRules, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine1;
+                            currentRuleEntryKind = ReleaseTrackingRuleEntryKind.Changed;
+                        }
+                        else
+                        {
+                            OnInvalidEntry(line, InvalidEntryKind.Header);
+                            return ReleaseTrackingData.Default;
+                        }
+
+                        continue;
+
+                    case ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine1:
+                        if (lineText.StartsWith(TableHeaderNewOrRemovedRulesLine1, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine2;
+                            continue;
+                        }
+
+                        OnInvalidEntry(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    case ReleaseTrackingHeaderKind.TableHeaderNewOrRemovedRulesLine2:
+                        expectedHeaderKind = null;
+                        if (lineText.StartsWith(TableHeaderNewOrRemovedRulesLine2, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        OnInvalidEntry(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    case ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine1:
+                        if (lineText.StartsWith(TableHeaderChangedRulesLine1, StringComparison.OrdinalIgnoreCase))
+                        {
+                            expectedHeaderKind = ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine2;
+                            continue;
+                        }
+
+                        OnInvalidEntry(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    case ReleaseTrackingHeaderKind.TableHeaderChangedRulesLine2:
+                        expectedHeaderKind = null;
+                        if (lineText.StartsWith(TableHeaderChangedRulesLine2, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        OnInvalidEntry(line, InvalidEntryKind.Header);
+                        return ReleaseTrackingData.Default;
+
+                    default:
+                        // We might be starting a new release or table.
+                        if (lineText.StartsWith("## ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            goto case ReleaseTrackingHeaderKind.ReleaseHeader;
+                        }
+                        else if (lineText.StartsWith("### ", StringComparison.OrdinalIgnoreCase))
+                        {
+                            goto case ReleaseTrackingHeaderKind.TableHeaderTitle;
+                        }
+
+                        break;
+                }
+
+                RoslynDebug.Assert(currentRuleEntryKind != null);
+
+                var parts = lineText.Split('|').Select(s => s.Trim()).ToArray();
+                if (IsInvalidEntry(parts, currentRuleEntryKind.Value))
+                {
+                    // Report invalid entry, but continue parsing remaining entries.
+                    OnInvalidEntry(line, InvalidEntryKind.Other);
+                    continue;
+                }
+
+                //  New or Removed rule entry: 
+                //      "Rule ID | Category | Severity | Notes"
+                //      "   0    |     1    |    2     |        3           "
+                //
+                //  Changed rule entry:
+                //      "Rule ID | New Category | New Severity | Old Category | Old Severity | Notes"
+                //      "   0    |     1        |     2        |     3        |     4        |        5           "
+
+                string ruleId = parts[0];
+
+                InvalidEntryKind? invalidEntryKind = TryParseFields(parts, categoryIndex: 1, severityIndex: 2,
+                    out var category, out var defaultSeverity, out var enabledByDefault);
+                if (invalidEntryKind.HasValue)
+                {
+                    OnInvalidEntry(line, invalidEntryKind.Value);
+                }
+
+                ReleaseTrackingLine releaseTrackingLine;
+                if (currentRuleEntryKind.Value == ReleaseTrackingRuleEntryKind.Changed)
+                {
+                    invalidEntryKind = TryParseFields(parts, categoryIndex: 3, severityIndex: 4,
+                        out var oldCategory, out var oldDefaultSeverity, out var oldEnabledByDefault);
+                    if (invalidEntryKind.HasValue)
+                    {
+                        OnInvalidEntry(line, invalidEntryKind.Value);
+                    }
+
+                    // Verify at least one field is changed for the entry:
+                    if (string.Equals(category, oldCategory, StringComparison.OrdinalIgnoreCase) &&
+                        defaultSeverity == oldDefaultSeverity &&
+                        enabledByDefault == oldEnabledByDefault)
+                    {
+                        OnInvalidEntry(line, InvalidEntryKind.Other);
+                        return ReleaseTrackingData.Default;
+                    }
+
+                    releaseTrackingLine = new ChangedRuleReleaseTrackingLine(ruleId,
+                        category, enabledByDefault, defaultSeverity,
+                        oldCategory, oldEnabledByDefault, oldDefaultSeverity,
+                        line.Span, sourceText, path, isShippedFile);
+                }
+                else
+                {
+                    releaseTrackingLine = new NewOrRemovedRuleReleaseTrackingLine(ruleId,
+                        category, enabledByDefault, defaultSeverity, line.Span, sourceText,
+                        path, isShippedFile, currentRuleEntryKind.Value);
+                }
+
+                if (!releaseTrackingDataByRulesBuilder.TryGetValue(ruleId, out var releaseTrackingDataForRuleBuilder))
+                {
+                    releaseTrackingDataForRuleBuilder = new ReleaseTrackingDataForRuleBuilder();
+                    releaseTrackingDataByRulesBuilder.Add(ruleId, releaseTrackingDataForRuleBuilder);
+                }
+
+                releaseTrackingDataForRuleBuilder.AddEntry(currentVersion, releaseTrackingLine, out var hasExistingEntry);
+                if (hasExistingEntry)
+                {
+                    onDuplicateEntryInRelease(ruleId, currentVersion, path, sourceText, line);
+                }
+            }
+
+            var builder = ImmutableSortedDictionary.CreateBuilder<string, ReleaseTrackingDataForRule>();
+            foreach (var (ruleId, value) in releaseTrackingDataByRulesBuilder)
+            {
+                var releaseTrackingDataForRule = new ReleaseTrackingDataForRule(ruleId, value);
+                builder.Add(ruleId, releaseTrackingDataForRule);
+            }
+
+            return new ReleaseTrackingData(builder.ToImmutable(), versionsBuilder.ToImmutable());
+
+            // Local functions
+            void OnInvalidEntry(TextLine line, InvalidEntryKind invalidEntryKind)
+                => onInvalidEntry(line, invalidEntryKind, path, sourceText);
+
+            static bool IsInvalidEntry(string[] parts, ReleaseTrackingRuleEntryKind currentRuleEntryKind)
+            {
+                // Expected entry for New or Removed rules has 3 or 4 parts:
+                //      "Rule ID | Category | Severity | Notes"
+                //
+                // Expected entry for Changed rules has 5 or 6 parts:
+                //      "Rule ID | New Category | New Severity | Old Category | Old Severity | Notes"
+                //
+                // NOTE: Last field 'Helplink' is optional for both cases.
+
+                if (parts.Length < 3 || parts.Length > 6)
+                {
+                    return true;
+                }
+
+                return currentRuleEntryKind switch
+                {
+                    ReleaseTrackingRuleEntryKind.New => parts.Length > 4,
+                    ReleaseTrackingRuleEntryKind.Removed => parts.Length > 4,
+                    ReleaseTrackingRuleEntryKind.Changed => parts.Length <= 4,
+                    _ => throw new NotImplementedException()
+                };
+            }
+
+            static InvalidEntryKind? TryParseFields(
+                string[] parts, int categoryIndex, int severityIndex,
+                out string category,
+                out DiagnosticSeverity? defaultSeverity,
+                out bool? enabledByDefault)
+            {
+                InvalidEntryKind? invalidEntryKind = null;
+
+                category = parts[categoryIndex];
+                if (category.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
+                {
+                    invalidEntryKind = InvalidEntryKind.UndetectedField;
+                }
+
+                var severityPart = parts[severityIndex];
+                if (Enum.TryParse(severityPart, ignoreCase: true, out DiagnosticSeverity parsedSeverity))
+                {
+                    defaultSeverity = parsedSeverity;
+                    enabledByDefault = true;
+                }
+                else
+                {
+                    defaultSeverity = null;
+                    if (string.Equals(severityPart, DisabledText, StringComparison.OrdinalIgnoreCase))
+                    {
+                        enabledByDefault = false;
+                    }
+                    else if (severityPart.Equals(UndetectedText, StringComparison.OrdinalIgnoreCase))
+                    {
+                        enabledByDefault = null;
+                        invalidEntryKind = InvalidEntryKind.UndetectedField;
+                    }
+                    else
+                    {
+                        enabledByDefault = null;
+                        invalidEntryKind = InvalidEntryKind.Other;
+                    }
+                }
+
+                return invalidEntryKind;
+            }
+        }
+    }
+
+    internal enum InvalidEntryKind
+    {
+        Header,
+        UndetectedField,
+        Other
+    }
+
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+    internal sealed class ReleaseTrackingData
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+    {
+        public static readonly ReleaseTrackingData Default = new ReleaseTrackingData();
+        public ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> ReleaseTrackingDataByRuleIdMap { get; }
+        public ImmutableHashSet<Version> Versions { get; }
+
+        private ReleaseTrackingData()
+            : this(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule>.Empty, ImmutableHashSet<Version>.Empty)
+        {
+        }
+
+        internal ReleaseTrackingData(ImmutableSortedDictionary<string, ReleaseTrackingDataForRule> releaseTrackingDataByRuleIdMap, ImmutableHashSet<Version> versions)
+        {
+            ReleaseTrackingDataByRuleIdMap = releaseTrackingDataByRuleIdMap;
+            Versions = versions;
+        }
+
+        public bool TryGetLatestReleaseTrackingLine(
+            string ruleId,
+            [NotNullWhen(returnValue: true)] out Version? version,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
+        => TryGetLatestReleaseTrackingLineCore(ruleId, maxVersion: null, out version, out releaseTrackingLine);
+
+        public bool TryGetLatestReleaseTrackingLine(
+            string ruleId,
+            Version maxVersion,
+            [NotNullWhen(returnValue: true)] out Version? version,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
+        => TryGetLatestReleaseTrackingLineCore(ruleId, maxVersion, out version, out releaseTrackingLine);
+
+        private bool TryGetLatestReleaseTrackingLineCore(
+            string ruleId,
+            Version? maxVersion,
+            [NotNullWhen(returnValue: true)] out Version? version,
+            [NotNullWhen(returnValue: true)] out ReleaseTrackingLine? releaseTrackingLine)
+        {
+            version = null;
+            releaseTrackingLine = null;
+            if (!ReleaseTrackingDataByRuleIdMap.TryGetValue(ruleId, out var releaseTrackingDataForRule) ||
+                releaseTrackingDataForRule.ReleasesByVersionMap.IsEmpty)
+            {
+                return false;
+            }
+
+            foreach (var (releaseVersion, releaseLine) in releaseTrackingDataForRule.ReleasesByVersionMap)
+            {
+                if (maxVersion == null || releaseVersion <= maxVersion)
+                {
+                    version = releaseVersion;
+                    releaseTrackingLine = releaseLine;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+#pragma warning disable CA1815 // Override equals and operator equals on value types
+    internal readonly struct ReleaseTrackingDataForRule
+#pragma warning restore CA1815 // Override equals and operator equals on value types
+    {
+        public string RuleId { get; }
+        public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ReleasesByVersionMap { get; }
+
+        internal ReleaseTrackingDataForRule(string ruleId, ReleaseTrackingDataForRuleBuilder builder)
+        {
+            RuleId = ruleId;
+            ReleasesByVersionMap = builder.ToImmutable();
+        }
+    }
+
+    internal sealed class ReleaseTrackingDataForRuleBuilder
+    {
+        private readonly ImmutableSortedDictionary<Version, ReleaseTrackingLine>.Builder _builder
+            = ImmutableSortedDictionary.CreateBuilder<Version, ReleaseTrackingLine>(ReverseComparer.Instance);
+
+        public void AddEntry(Version version, ReleaseTrackingLine releaseTrackingLine, out bool hasExistingEntry)
+        {
+            hasExistingEntry = _builder.ContainsKey(version);
+            _builder[version] = releaseTrackingLine;
+        }
+
+        public ImmutableSortedDictionary<Version, ReleaseTrackingLine> ToImmutable()
+            => _builder.ToImmutable();
+
+        private sealed class ReverseComparer : IComparer<Version>
+        {
+            public static readonly IComparer<Version> Instance = new ReverseComparer();
+            private ReverseComparer() { }
+
+            public int Compare(Version x, Version y)
+            {
+                return x.CompareTo(y) * -1;
+            }
+        }
+    }
+
+    internal abstract class ReleaseTrackingLine
+    {
+        public string RuleId { get; }
+        public string Category { get; }
+        public bool? EnabledByDefault { get; }
+        public DiagnosticSeverity? DefaultSeverity { get; }
+
+        public TextSpan Span { get; }
+        public SourceText SourceText { get; }
+        public string Path { get; }
+        public bool IsShipped { get; }
+        public bool IsRemovedRule => Kind == ReleaseTrackingRuleEntryKind.Removed;
+        public ReleaseTrackingRuleEntryKind Kind { get; }
+
+        internal static ReleaseTrackingLine Create(
+            string ruleId, string category, bool? enabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
+            TextSpan span, SourceText sourceText,
+            string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
+        {
+            return new NewOrRemovedRuleReleaseTrackingLine(ruleId, category,
+                enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, kind);
+        }
+
+        protected ReleaseTrackingLine(string ruleId, string category, bool? enabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
+            TextSpan span, SourceText sourceText,
+            string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
+        {
+            RuleId = ruleId;
+            Category = category;
+            EnabledByDefault = enabledByDefault;
+            DefaultSeverity = defaultSeverity;
+            Span = span;
+            SourceText = sourceText;
+            Path = path;
+            IsShipped = isShipped;
+            Kind = kind;
+        }
+    }
+
+    internal sealed class NewOrRemovedRuleReleaseTrackingLine : ReleaseTrackingLine
+    {
+        internal NewOrRemovedRuleReleaseTrackingLine(
+            string ruleId, string category, bool? enabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
+            TextSpan span, SourceText sourceText,
+            string path, bool isShipped, ReleaseTrackingRuleEntryKind kind)
+            : base(ruleId, category, enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, kind)
+        {
+            Debug.Assert(kind == ReleaseTrackingRuleEntryKind.New || kind == ReleaseTrackingRuleEntryKind.Removed);
+        }
+    }
+
+    internal sealed class ChangedRuleReleaseTrackingLine : ReleaseTrackingLine
+    {
+        public string OldCategory { get; }
+        public bool? OldEnabledByDefault { get; }
+        public DiagnosticSeverity? OldDefaultSeverity { get; }
+
+        internal ChangedRuleReleaseTrackingLine(
+            string ruleId, string category, bool? enabledByDefault,
+            DiagnosticSeverity? defaultSeverity,
+            string oldCategory, bool? oldEnabledByDefault,
+            DiagnosticSeverity? oldDefaultSeverity,
+            TextSpan span, SourceText sourceText,
+            string path, bool isShipped)
+            : base(ruleId, category, enabledByDefault, defaultSeverity, span, sourceText, path, isShipped, ReleaseTrackingRuleEntryKind.Changed)
+        {
+            OldCategory = oldCategory;
+            OldEnabledByDefault = oldEnabledByDefault;
+            OldDefaultSeverity = oldDefaultSeverity;
+        }
+    }
+
+    internal enum ReleaseTrackingHeaderKind
+    {
+        ReleaseHeader,
+        TableHeaderTitle,
+        TableHeaderNewOrRemovedRulesLine1,
+        TableHeaderNewOrRemovedRulesLine2,
+        TableHeaderChangedRulesLine1,
+        TableHeaderChangedRulesLine2,
+    }
+
+    internal enum ReleaseTrackingRuleEntryKind
+    {
+        New,
+        Removed,
+        Changed,
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers;
 using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.ReleaseTracking;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
@@ -87,9 +88,9 @@ class MyAnalyzer : DiagnosticAnalyzer
                 {
                     Sources = { source },
                     AdditionalFiles = {
-                        (DiagnosticDescriptorCreationAnalyzer.ShippedFileName,
+                        (ReleaseTrackingHelper.ShippedFileName,
                             AnalyzerReleaseTrackingFix.ShippedAnalyzerReleaseTrackingFileDefaultContent),
-                        (DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        (ReleaseTrackingHelper.UnshippedFileName,
                             AnalyzerReleaseTrackingFix.UnshippedAnalyzerReleaseTrackingFileDefaultContent + DefaultUnshippedHeader + "Id1 | Category1 | Warning | MyAnalyzer")
                     }
                 },
@@ -490,15 +491,15 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             var shippedText = @"";
             var unshippedText = @"";
-            var entry = $@"Id1 | {DiagnosticDescriptorCreationAnalyzer.UndetectedText} | {DiagnosticDescriptorCreationAnalyzer.UndetectedText} | MyAnalyzer";
+            var entry = $@"Id1 | {ReleaseTrackingHelper.UndetectedText} | {ReleaseTrackingHelper.UndetectedText} | MyAnalyzer";
             var fixedUnshippedText = $@"{DefaultUnshippedHeader}{entry}";
 
             await VerifyCSharpAdditionalFileFixAsync(source, shippedText, unshippedText, fixedUnshippedText, additionalExpectedDiagnosticsInInput: ImmutableArray<DiagnosticResult>.Empty,
                 additionalExpectedDiagnosticsInResult: ImmutableArray.Create(
                     GetAdditionalFileResultAt(4, 1,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         DiagnosticDescriptorCreationAnalyzer.InvalidUndetectedEntryInAnalyzerReleasesFileRule,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         entry)));
         }
 
@@ -541,29 +542,29 @@ class MyAnalyzer : DiagnosticAnalyzer
         // No header in shipped
         [InlineData("Id1 | Category1 | Warning |", "")]
         // Missing TableTitle in unshipped
-        [InlineData("", DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |")]
+        [InlineData("", ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |")]
         // Missing TableHeaderLine1 in unshipped
-        [InlineData("", DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 2)]
+        [InlineData("", ReleaseTrackingHelper.TableTitleNewRules + BlankLine + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 2)]
         // Missing TableHeaderLine2 in unshipped
-        [InlineData("", DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", 3)]
+        [InlineData("", ReleaseTrackingHelper.TableTitleNewRules + BlankLine + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", 3)]
         // Missing Release Version line in shipped
         [InlineData(DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
         // Missing Release Version in shipped
-        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
+        [InlineData(ReleaseTrackingHelper.ReleasePrefix + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
         // Invalid Release Version in shipped
-        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " InvalidVersion" + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
+        [InlineData(ReleaseTrackingHelper.ReleasePrefix + " InvalidVersion" + BlankLine + DefaultUnshippedHeader + "Id1 | Category1 | Warning |", "")]
         // Missing TableTitle in shipped
-        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + "1.0" + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", "", 2)]
+        [InlineData(ReleaseTrackingHelper.ReleasePrefix + "1.0" + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", "", 2)]
         // Missing TableHeaderLine1 in shipped
-        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + "1.0" + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", "", 3)]
+        [InlineData(ReleaseTrackingHelper.ReleasePrefix + "1.0" + BlankLine + ReleaseTrackingHelper.TableTitleChangedRules + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", "", 3)]
         // Missing TableHeaderLine2 in shipped
-        [InlineData(DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 1.0" + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", "", 4)]
+        [InlineData(ReleaseTrackingHelper.ReleasePrefix + " 1.0" + BlankLine + ReleaseTrackingHelper.TableTitleChangedRules + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + BlankLine + "Id1 | Category1 | Warning |", "", 4)]
         // Invalid Release Version line in unshipped
         [InlineData("", DefaultShippedHeader + "Id1 | Category1 | Warning |")]
         // Mismatch Table title and TableHeaderLine1 in unshipped
-        [InlineData("", DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1 + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 2)]
+        [InlineData("", ReleaseTrackingHelper.TableTitleNewRules + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 2)]
         // Mismatch Table title and TableHeaderLine2 in unshipped
-        [InlineData("", DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1 + BlankLine + DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 3)]
+        [InlineData("", ReleaseTrackingHelper.TableTitleChangedRules + BlankLine + ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + BlankLine + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + BlankLine + "Id1 | Category1 | Warning |", 3)]
         [Theory]
         public async Task TestInvalidHeaderDiagnostic(string shippedText, string unshippedText, int line = 1)
         {
@@ -583,7 +584,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     public override void Initialize(AnalysisContext context) { }
 }";
 
-            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var fileWithDiagnostics = shippedText.Length > 0 ? ReleaseTrackingHelper.ShippedFileName : ReleaseTrackingHelper.UnshippedFileName;
             var diagnosticText = (shippedText.Length > 0 ? shippedText : unshippedText).Split(new[] { Environment.NewLine }, StringSplitOptions.None).ElementAt(line - 1);
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(line, 1,
@@ -594,11 +595,11 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
 
         // Undetected category
-        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning |", true)]
+        [InlineData("Id1 | " + ReleaseTrackingHelper.UndetectedText + " | Warning |", true)]
         // Undetected severity
-        [InlineData("Id1 | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
+        [InlineData("Id1 | Category1 | " + ReleaseTrackingHelper.UndetectedText + " |", true)]
         // Undetected category and severity
-        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
+        [InlineData("Id1 | " + ReleaseTrackingHelper.UndetectedText + " | " + ReleaseTrackingHelper.UndetectedText + " |", true)]
         // Invalid severity
         [InlineData("Id1 | Category1 | Invalid |", false)]
         // Missing required fields - category + severity
@@ -636,22 +637,22 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(4, 1,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         rule,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         entry));
         }
 
         // Undetected category
-        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning | Category1 | Warning |", true)]
+        [InlineData("Id1 | " + ReleaseTrackingHelper.UndetectedText + " | Warning | Category1 | Warning |", true)]
         // Undetected old category
-        [InlineData("Id1 | Category1 | Warning | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Warning |", true)]
+        [InlineData("Id1 | Category1 | Warning | " + ReleaseTrackingHelper.UndetectedText + " | Warning |", true)]
         // Undetected severity
-        [InlineData("Id1 | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Category1 | Warning |", true)]
+        [InlineData("Id1 | Category1 | " + ReleaseTrackingHelper.UndetectedText + " | Category1 | Warning |", true)]
         // Undetected old severity
-        [InlineData("Id1 | Category1 | Warning | Category1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " |", true)]
+        [InlineData("Id1 | Category1 | Warning | Category1 | " + ReleaseTrackingHelper.UndetectedText + " |", true)]
         // Undetected category and severity
-        [InlineData("Id1 | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | " + DiagnosticDescriptorCreationAnalyzer.UndetectedText + " | Category1 | Warning |", true)]
+        [InlineData("Id1 | " + ReleaseTrackingHelper.UndetectedText + " | " + ReleaseTrackingHelper.UndetectedText + " | Category1 | Warning |", true)]
         // Invalid severity
         [InlineData("Id1 | Category1 | Invalid | Category1 | Warning |", false)]
         // Invalid old severity
@@ -697,9 +698,9 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(4, 1,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         rule,
-                        DiagnosticDescriptorCreationAnalyzer.UnshippedFileName,
+                        ReleaseTrackingHelper.UnshippedFileName,
                         entry));
         }
 
@@ -819,7 +820,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
     public override void Initialize(AnalysisContext context) { }
 }";
-            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var fileWithDiagnostics = shippedText.Length > 0 ? ReleaseTrackingHelper.ShippedFileName : ReleaseTrackingHelper.UnshippedFileName;
             var lineCount = (shippedText.Length > 0 ? shippedText : unshippedText).Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(lineCount, 1,
@@ -852,7 +853,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
     public override void Initialize(AnalysisContext context) { }
 }";
-            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var fileWithDiagnostics = shippedText.Length > 0 ? ReleaseTrackingHelper.ShippedFileName : ReleaseTrackingHelper.UnshippedFileName;
             var lineCount = (shippedText.Length > 0 ? shippedText : unshippedText).Split(new[] { Environment.NewLine }, StringSplitOptions.None).Length;
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(lineCount, 1,
@@ -885,7 +886,7 @@ class MyAnalyzer : DiagnosticAnalyzer
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor1);
     public override void Initialize(AnalysisContext context) { }
 }";
-            var fileWithDiagnostics = shippedText.Length > 0 ? DiagnosticDescriptorCreationAnalyzer.ShippedFileName : DiagnosticDescriptorCreationAnalyzer.UnshippedFileName;
+            var fileWithDiagnostics = shippedText.Length > 0 ? ReleaseTrackingHelper.ShippedFileName : ReleaseTrackingHelper.UnshippedFileName;
             await VerifyCSharpAsync(source, shippedText, unshippedText,
                     GetAdditionalFileResultAt(6, 1,
                         fileWithDiagnostics,
@@ -920,28 +921,28 @@ class MyAnalyzer : DiagnosticAnalyzer
         }
         #region Helpers
 
-        private const string DefaultUnshippedHeader = DiagnosticDescriptorCreationAnalyzer.TableTitleNewRules + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1 + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2 + BlankLine;
+        private const string DefaultUnshippedHeader = ReleaseTrackingHelper.TableTitleNewRules + BlankLine +
+            ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + BlankLine +
+            ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + BlankLine;
 
-        private const string DefaultRemovedUnshippedHeader = DiagnosticDescriptorCreationAnalyzer.TableTitleRemovedRules + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine1 + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderNewOrRemovedRulesLine2 + BlankLine;
+        private const string DefaultRemovedUnshippedHeader = ReleaseTrackingHelper.TableTitleRemovedRules + BlankLine +
+            ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + BlankLine +
+            ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + BlankLine;
 
-        private const string DefaultChangedUnshippedHeader = DiagnosticDescriptorCreationAnalyzer.TableTitleChangedRules + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine1 + BlankLine +
-            DiagnosticDescriptorCreationAnalyzer.TableHeaderChangedRulesLine2 + BlankLine;
+        private const string DefaultChangedUnshippedHeader = ReleaseTrackingHelper.TableTitleChangedRules + BlankLine +
+            ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + BlankLine +
+            ReleaseTrackingHelper.TableHeaderChangedRulesLine2 + BlankLine;
 
-        private const string DefaultShippedHeader = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
-        private const string DefaultRemovedShippedHeader = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader;
-        private const string DefaultChangedShippedHeader = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
+        private const string DefaultShippedHeader = ReleaseTrackingHelper.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
+        private const string DefaultRemovedShippedHeader = ReleaseTrackingHelper.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader;
+        private const string DefaultChangedShippedHeader = ReleaseTrackingHelper.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
 
-        private const string DefaultShippedHeader2 = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
-        private const string DefaultRemovedShippedHeader2 = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader;
-        private const string DefaultChangedShippedHeader2 = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
+        private const string DefaultShippedHeader2 = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
+        private const string DefaultRemovedShippedHeader2 = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultRemovedUnshippedHeader;
+        private const string DefaultChangedShippedHeader2 = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
 
-        private const string DefaultShippedHeader3 = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
-        private const string DefaultChangedShippedHeader3 = DiagnosticDescriptorCreationAnalyzer.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
+        private const string DefaultShippedHeader3 = ReleaseTrackingHelper.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
+        private const string DefaultChangedShippedHeader3 = ReleaseTrackingHelper.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
 
         private static DiagnosticResult GetAdditionalFileResultAt(int line, int column, string path, DiagnosticDescriptor descriptor, params object[] arguments)
         {
@@ -981,12 +982,12 @@ class MyAnalyzer : DiagnosticAnalyzer
 
             if (shippedText != null)
             {
-                test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
+                test.TestState.AdditionalFiles.Add((ReleaseTrackingHelper.ShippedFileName, shippedText));
             }
 
             if (unshippedText != null)
             {
-                test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, unshippedText));
+                test.TestState.AdditionalFiles.Add((ReleaseTrackingHelper.UnshippedFileName, unshippedText));
             }
 
             test.SolutionTransforms.Add(DisableNonReleaseTrackingWarnings);
@@ -1017,12 +1018,12 @@ class MyAnalyzer : DiagnosticAnalyzer
             test.SolutionTransforms.Add(DisableNonReleaseTrackingWarnings);
 
             test.TestState.Sources.Add(source);
-            test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
-            test.TestState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, oldUnshippedText));
+            test.TestState.AdditionalFiles.Add((ReleaseTrackingHelper.ShippedFileName, shippedText));
+            test.TestState.AdditionalFiles.Add((ReleaseTrackingHelper.UnshippedFileName, oldUnshippedText));
             test.TestState.ExpectedDiagnostics.AddRange(additionalExpectedDiagnosticsInInput);
 
-            test.FixedState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.ShippedFileName, shippedText));
-            test.FixedState.AdditionalFiles.Add((DiagnosticDescriptorCreationAnalyzer.UnshippedFileName, newUnshippedText));
+            test.FixedState.AdditionalFiles.Add((ReleaseTrackingHelper.ShippedFileName, shippedText));
+            test.FixedState.AdditionalFiles.Add((ReleaseTrackingHelper.UnshippedFileName, newUnshippedText));
             test.FixedState.ExpectedDiagnostics.AddRange(additionalExpectedDiagnosticsInResult);
 
             await test.RunAsync();

--- a/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/Roslyn.Diagnostics.Analyzers.csproj
@@ -7,7 +7,7 @@
       Restore would conclude that there is a cyclic dependency between us and the Roslyn.Diagnostics.Analyzers package.
     -->
     <PackageId>*$(MSBuildProjectFullPath)*</PackageId>
-    <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
+    <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Roslyn.Diagnostics.CSharp.Analyzers" />

--- a/src/Tools/GenerateAnalyzerRulesets/GenerateAnalyzerRulesets.csproj
+++ b/src/Tools/GenerateAnalyzerRulesets/GenerateAnalyzerRulesets.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <NonShipping>true</NonShipping>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />

--- a/src/Tools/GenerateAnalyzerRulesets/Program.cs
+++ b/src/Tools/GenerateAnalyzerRulesets/Program.cs
@@ -61,6 +61,7 @@ namespace GenerateAnalyzerRulesets
                 }
 
                 var analyzerFileReference = new AnalyzerFileReference(path, AnalyzerAssemblyLoader.Instance);
+                analyzerFileReference.AnalyzerLoadFailed += AnalyzerFileReference_AnalyzerLoadFailed;
                 var analyzers = analyzerFileReference.GetAnalyzersForAllLanguages();
 
                 var assemblyRulesMetadata = (path, rules: new SortedList<string, (DiagnosticDescriptor rule, string typeName, string[]? languages)>());
@@ -151,6 +152,9 @@ namespace GenerateAnalyzerRulesets
             return 0;
 
             // Local functions.
+            static void AnalyzerFileReference_AnalyzerLoadFailed(object sender, AnalyzerLoadFailureEventArgs e)
+                => throw e.Exception;
+
             void createRulesetAndEditorconfig(
                 string fileName,
                 string title,

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">  
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <NonShipping>true</NonShipping>
+  </PropertyGroup>  
+  <ItemGroup>
+    <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
+  </ItemGroup>
+  <Import Project="..\..\Utilities\Compiler\Analyzer.Utilities.projitems" Label="Shared" />
+</Project>

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <NonShipping>true</NonShipping>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>  
   <ItemGroup>
     <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -195,13 +195,6 @@ namespace GenerateGlobalAnalyzerConfigs
                 EditorConfigKind editorConfigKind,
                 (ImmutableArray<ReleaseTrackingData> shippedFiles, Version version)? shippedReleaseData = null)
             {
-                // Only generate live analysis specific global analyzer config if we have at least one info or hidden diagnostic
-                // that needs to be skipped during command line build.
-                if (!hasInfoOrHiddenDiagnostic && editorConfigKind == EditorConfigKind.LiveAnalysis)
-                {
-                    return;
-                }
-
                 CreateEditorconfig(outputDir, fileName, title, description, editorConfigKind, allRulesById, shippedReleaseData);
             }
         }

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -223,7 +223,7 @@ namespace GenerateGlobalAnalyzerConfigs
                 shippedReleaseData);
 
             var directory = Directory.CreateDirectory(folder);
-            var editorconfigFilePath = Path.Combine(directory.FullName, $"{ fileName}.editorconfig");
+            var editorconfigFilePath = Path.Combine(directory.FullName, $"{fileName}.editorconfig");
             File.WriteAllText(editorconfigFilePath, text);
             return;
 

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -25,7 +25,7 @@ namespace GenerateGlobalAnalyzerConfigs
 
             if (args.Length != expectedArguments)
             {
-                Console.Error.WriteLine($"Excepted {expectedArguments} arguments, found {args.Length}: {string.Join(';', args)}");
+                Console.Error.WriteLine($"Expected {expectedArguments} arguments, found {args.Length}: {string.Join(';', args)}");
                 return 1;
             }
 

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -1,0 +1,408 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Analyzer.Utilities.PooledObjects;
+using Analyzer.Utilities.PooledObjects.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.ReleaseTracking;
+using Microsoft.CodeAnalysis.Text;
+
+namespace GenerateGlobalAnalyzerConfigs
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            const int expectedArguments = 9;
+
+            if (args.Length != expectedArguments)
+            {
+                Console.Error.WriteLine($"Excepted {expectedArguments} arguments, found {args.Length}: {string.Join(';', args)}");
+                return 1;
+            }
+
+            var outputDir = args[0];
+            var packageName = args[1];
+            string targetsFileDir = args[2];
+            string targetsFileName = args[3];
+            var assemblyList = args[4].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var binDirectory = args[5];
+            var configuration = args[6];
+            var tfm = args[7];
+            var releaseTrackingOptOutString = args[8];
+
+            if (!bool.TryParse(releaseTrackingOptOutString, out bool releaseTrackingOptOut))
+            {
+                releaseTrackingOptOut = false;
+            }
+
+            using var shippedFilesDataBuilder = ArrayBuilder<ReleaseTrackingData>.GetInstance();
+            using var versionsBuilder = PooledHashSet<Version>.GetInstance();
+
+            // Validate all assemblies exist on disk and can be loaded.
+            foreach (string assembly in assemblyList)
+            {
+                var assemblyPath = GetAssemblyPath(assembly);
+                if (!File.Exists(assemblyPath))
+                {
+                    Console.Error.WriteLine($"'{assemblyPath}' does not exist");
+                    return 2;
+                }
+
+                try
+                {
+                    _ = Assembly.LoadFrom(assemblyPath);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                    Console.Error.WriteLine(ex.Message);
+                    return 3;
+                }
+            }
+
+            // Compute descriptors by rule ID and shipped analyzer release versions and shipped data.
+            var allRulesById = new SortedList<string, DiagnosticDescriptor>();
+            var hasInfoOrHiddenDiagnostic = false;
+            foreach (string assembly in assemblyList)
+            {
+                var assemblyPath = GetAssemblyPath(assembly);
+                var analyzerFileReference = new AnalyzerFileReference(assemblyPath, AnalyzerAssemblyLoader.Instance);
+                var analyzers = analyzerFileReference.GetAnalyzersForAllLanguages();
+
+                foreach (var analyzer in analyzers)
+                {
+                    foreach (var rule in analyzer.SupportedDiagnostics)
+                    {
+                        allRulesById[rule.Id] = rule;
+                        hasInfoOrHiddenDiagnostic = hasInfoOrHiddenDiagnostic ||
+                            rule.IsEnabledByDefault && (rule.DefaultSeverity == DiagnosticSeverity.Info || rule.DefaultSeverity == DiagnosticSeverity.Hidden);
+                    }
+                }
+
+                var assemblyDir = Path.GetDirectoryName(assemblyPath);
+                var assemblyName = Path.GetFileNameWithoutExtension(assembly);
+                var shippedFile = Path.Combine(assemblyDir, "AnalyzerReleases", assemblyName, ReleaseTrackingHelper.ShippedFileName);
+                if (!File.Exists(shippedFile) && !releaseTrackingOptOut)
+                {
+                    Console.Error.WriteLine($"'{shippedFile}' does not exist");
+                    return 4;
+                }
+                else
+                {
+                    try
+                    {
+                        using var fileStream = File.OpenRead(shippedFile);
+                        var sourceText = SourceText.From(fileStream);
+                        var releaseTrackingData = ReleaseTrackingHelper.ReadReleaseTrackingData(shippedFile, sourceText,
+                            onDuplicateEntryInRelease: (_1, _2, _3, _4, line) => throw new Exception($"Duplicate entry in {shippedFile} at {line.LineNumber}: '{line}'"),
+                            onInvalidEntry: (line, _2, _3, _4) => throw new Exception($"Invalid entry in {shippedFile} at {line.LineNumber}: '{line}'"),
+                            isShippedFile: true);
+                        shippedFilesDataBuilder.Add(releaseTrackingData);
+                        versionsBuilder.AddRange(releaseTrackingData.Versions);
+                    }
+#pragma warning disable CA1031 // Do not catch general exception types
+                    catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                    {
+                        Console.Error.WriteLine(ex.Message);
+                        return 5;
+                    }
+                }
+            }
+
+            // Bail out if following conditions hold for the analyzer package:
+            //  1. No Info/Hidden diagnostic in the package: No need for have different global analyzer config for build and live analysis.
+            //  2. No shipped releases: User cannot choose a version specific global analyzer config.
+            if (!hasInfoOrHiddenDiagnostic && versionsBuilder.Count == 0)
+            {
+                return 0;
+            }
+
+            var shippedFilesData = shippedFilesDataBuilder.ToImmutable();
+
+            // Generate build and live analysis global analyzer config files for latest/unshipped version.
+            CreateGlobalAnalyzerConfig(
+                "BuildRules",
+                "All build rules with default severity",
+                "All build rules (warnings/errors) with default severity. Rules with IsEnabledByDefault = false or default severity Suggestion/Hidden are disabled.",
+                EditorConfigKind.CommandLine);
+
+            CreateGlobalAnalyzerConfig(
+                "LiveAnalysisRules",
+                "All rules with default severity",
+                "All rules are enabled with default severity. Rules with IsEnabledByDefault = false are disabled.",
+                EditorConfigKind.LiveAnalysis);
+
+            // Generate build and live analysis global analyzer config files for each shipped version.
+            foreach (var version in versionsBuilder)
+            {
+                var versionString = version.ToString().Replace(".", "_", StringComparison.Ordinal);
+                CreateGlobalAnalyzerConfig(
+                $"BuildRulesVersion{versionString}",
+                $"All '{version}' build rules with default severity in",
+                $"All '{version}' build rules (warnings/errors) with default severity. Rules with IsEnabledByDefault = false or first released in a version later then {version} or default severity Suggestion/Hidden are disabled.",
+                EditorConfigKind.CommandLine,
+                (shippedFilesData, version));
+
+                CreateGlobalAnalyzerConfig(
+                    $"LiveAnalysisRules{versionString}",
+                    $"All '{version}' rules with default severity",
+                    $"All '{version}' rules are enabled with default severity. Rules with IsEnabledByDefault = false or first released in a version later then {version} are disabled.",
+                    EditorConfigKind.LiveAnalysis,
+                    (shippedFilesData, version));
+            }
+
+            CreateTargetsFile(targetsFileDir, targetsFileName, packageName);
+
+            return 0;
+
+            // Local functions.
+            string GetAssemblyPath(string assembly)
+            {
+                var assemblyName = Path.GetFileNameWithoutExtension(assembly);
+                var assemblyDir = Path.Combine(binDirectory, assemblyName, configuration, tfm);
+                return Path.Combine(assemblyDir, assembly);
+            }
+
+            void CreateGlobalAnalyzerConfig(
+                string fileName,
+                string title,
+                string description,
+                EditorConfigKind editorConfigKind,
+                (ImmutableArray<ReleaseTrackingData> shippedFiles, Version version)? shippedReleaseData = null)
+            {
+                // Only generate live analysis specific global analyzer config if we have at least one info or hidden diagnostic
+                // that needs to be skipped during command line build.
+                if (!hasInfoOrHiddenDiagnostic && editorConfigKind == EditorConfigKind.LiveAnalysis)
+                {
+                    return;
+                }
+
+                CreateEditorconfig(outputDir, fileName, title, description, editorConfigKind, allRulesById, shippedReleaseData);
+            }
+        }
+
+        private static void CreateEditorconfig(
+            string folder,
+            string fileName,
+            string editorconfigTitle,
+            string editorconfigDescription,
+            EditorConfigKind editorConfigKind,
+            SortedList<string, DiagnosticDescriptor> sortedRulesById,
+            (ImmutableArray<ReleaseTrackingData> shippedFiles, Version version)? shippedReleaseData)
+        {
+            var text = GetEditorconfigText(
+                editorconfigTitle,
+                editorconfigDescription,
+                editorConfigKind,
+                sortedRulesById,
+                shippedReleaseData);
+
+            var directory = Directory.CreateDirectory(folder);
+            var editorconfigFilePath = Path.Combine(directory.FullName, $"{ fileName}.editorconfig");
+            File.WriteAllText(editorconfigFilePath, text);
+            return;
+
+            // Local functions
+            static string GetEditorconfigText(
+                string editorconfigTitle,
+                string editorconfigDescription,
+                EditorConfigKind editorConfigKind,
+                SortedList<string, DiagnosticDescriptor> sortedRulesById,
+                (ImmutableArray<ReleaseTrackingData> shippedFiles, Version version)? shippedReleaseData)
+            {
+                var result = new StringBuilder();
+                StartEditorconfig();
+                AddRules();
+                return result.ToString();
+
+                void StartEditorconfig()
+                {
+                    result.AppendLine(@"# NOTE: Requires **VS2019 16.3** or later");
+                    result.AppendLine();
+                    result.AppendLine($@"# {editorconfigTitle}");
+                    result.AppendLine($@"# Description: {editorconfigDescription}");
+                    result.AppendLine();
+                }
+
+                void AddRules()
+                {
+                    Debug.Assert(sortedRulesById.Count > 0);
+
+                    foreach (var rule in sortedRulesById)
+                    {
+                        AddRule(rule.Value);
+                    }
+
+                    return;
+
+                    void AddRule(DiagnosticDescriptor rule)
+                    {
+                        var (isEnabledByDefault, severity) = GetEnabledByDefaultAndSeverity(rule);
+                        string severityString = GetRuleSeverity(isEnabledByDefault, severity);
+
+                        result.AppendLine();
+                        result.AppendLine($"# {rule.Id}: {rule.Title}");
+                        result.AppendLine($@"dotnet_diagnostic.{rule.Id}.severity = {severityString}");
+                    }
+
+                    (bool isEnabledByDefault, DiagnosticSeverity effectiveSeverity) GetEnabledByDefaultAndSeverity(DiagnosticDescriptor rule)
+                    {
+                        var isEnabledByDefault = rule.IsEnabledByDefault;
+                        var effectiveSeverity = rule.DefaultSeverity;
+
+                        if (shippedReleaseData != null)
+                        {
+                            isEnabledByDefault = false;
+                            var maxVersion = shippedReleaseData.Value.version;
+                            foreach (var shippedFile in shippedReleaseData.Value.shippedFiles)
+                            {
+                                if (shippedFile.TryGetLatestReleaseTrackingLine(rule.Id, maxVersion, out _, out var releaseTrackingLine) &&
+                                    releaseTrackingLine.EnabledByDefault.HasValue &&
+                                    releaseTrackingLine.DefaultSeverity.HasValue)
+                                {
+                                    isEnabledByDefault = releaseTrackingLine.EnabledByDefault.Value && !releaseTrackingLine.IsRemovedRule;
+                                    effectiveSeverity = releaseTrackingLine.DefaultSeverity.Value;
+                                    break;
+                                }
+                            }
+                        }
+
+                        return (isEnabledByDefault, effectiveSeverity);
+                    }
+
+                    string GetRuleSeverity(bool isEnabledByDefault, DiagnosticSeverity defaultSeverity)
+                    {
+                        return editorConfigKind switch
+                        {
+                            EditorConfigKind.CommandLine => GetRuleSeverityCore(enable: isEnabledByDefault &&
+                                (defaultSeverity == DiagnosticSeverity.Warning || defaultSeverity == DiagnosticSeverity.Error)),
+
+                            EditorConfigKind.LiveAnalysis => GetRuleSeverityCore(enable: isEnabledByDefault),
+
+                            _ => throw new InvalidProgramException(),
+                        };
+
+                        string GetRuleSeverityCore(bool enable)
+                        {
+                            if (enable)
+                            {
+                                return GetSeverityString(defaultSeverity);
+                            }
+                            else
+                            {
+                                return GetSeverityString(null);
+                            }
+                        }
+
+                        static string GetSeverityString(DiagnosticSeverity? severityOpt)
+                        {
+                            if (!severityOpt.HasValue)
+                            {
+                                return "none";
+                            }
+
+                            return severityOpt.Value switch
+                            {
+                                DiagnosticSeverity.Error => "error",
+                                DiagnosticSeverity.Warning => "warning",
+                                DiagnosticSeverity.Info => "suggestion",
+                                DiagnosticSeverity.Hidden => "silent",
+                                _ => throw new NotImplementedException(severityOpt.Value.ToString()),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        private enum EditorConfigKind
+        {
+            CommandLine,
+            LiveAnalysis
+        }
+
+        private static void CreateTargetsFile(string targetsFileDir, string targetsFileName, string packageName)
+        {
+            if (string.IsNullOrEmpty(targetsFileDir) || string.IsNullOrEmpty(targetsFileName))
+            {
+                return;
+            }
+
+            var fileContents =
+$@"<Project>{GetCommonContents(packageName)}{GetPackageSpecificContents(packageName)}
+</Project>";
+            var directory = Directory.CreateDirectory(targetsFileDir);
+            var fileWithPath = Path.Combine(directory.FullName, targetsFileName);
+            File.WriteAllText(fileWithPath, fileContents);
+
+            static string GetCommonContents(string packageName)
+            {
+                string packageVersionPropName = packageName.Replace(".", string.Empty, StringComparison.Ordinal) + "Version";
+                return $@"
+  <Target Name=""AddGlobalAnalyzerConfigForPackage"" BeforeTargets=""Build""  Condition=""'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'"">
+    <!-- PropertyGroup to compute global analyzer config file to be used -->
+    <PropertyGroup>
+      <!-- Use 'BuildRules' for command line build and 'LiveAnalysisRules' for live analysis -->
+      <_GlobalAnalyzerConfigFileNamePrefix Condition=""'$(DesignTimeBuild)' == 'true' or '$(BuildingProject)' != 'true'"">LiveAnalysisRules</_GlobalAnalyzerConfigFileNamePrefix>
+      <_GlobalAnalyzerConfigFileNamePrefix Condition=""'$(_GlobalAnalyzerConfigFileNamePrefix)' == ''"">BuildRules</_GlobalAnalyzerConfigFileNamePrefix>
+  
+      <!-- Optional suffix based on user specified version '{packageVersionPropName}', if any. We replace '.' with '_' to map the version string to file name suffix. -->
+      <_GlobalAnalyzerConfigFileNameSuffix Condition=""'$({packageVersionPropName})' != ''"">Version$({packageVersionPropName}.Replace(""."",""_""))</_GlobalAnalyzerConfigFileNameSuffix>
+
+      <_GlobalAnalyzerConfigFileName Condition=""'$(_GlobalAnalyzerConfigFileName)' == ''"">$(_GlobalAnalyzerConfigFileNamePrefix)$(_GlobalAnalyzerConfigFileNameSuffix).editorconfig</_GlobalAnalyzerConfigFileName>
+      <_GlobalAnalyzerConfigDir Condition=""'$(_GlobalAnalyzerConfigDir)' == ''"">$(MSBuildThisFileDirectory)config</_GlobalAnalyzerConfigDir>
+      <_GlobalAnalyzerConfigFile Condition=""'$(_GlobalAnalyzerConfigFile)' == ''"">$(_GlobalAnalyzerConfigDir)\$(_GlobalAnalyzerConfigFileName)</_GlobalAnalyzerConfigFile>
+    </PropertyGroup>
+
+    <ItemGroup Condition=""Exists('$(_GlobalAnalyzerConfigFile)')"">
+      <GlobalAnalyzerConfigFiles Include=""$(_GlobalAnalyzerConfigFile)"" />
+    </ItemGroup>
+  </Target>";
+            }
+
+            static string GetPackageSpecificContents(string packageName)
+            {
+                if (packageName == "Microsoft.CodeAnalysis.Analyzers")
+                {
+                    return @"
+
+  <!-- Workaround for https://github.com/dotnet/roslyn/issues/4655 -->
+  <ItemGroup Condition=""Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Shipped.md')"" >
+	<AdditionalFiles Include=""AnalyzerReleases.Shipped.md"" />
+  </ItemGroup>
+  <ItemGroup Condition=""Exists('$(MSBuildProjectDirectory)\AnalyzerReleases.Unshipped.md')"" >
+	<AdditionalFiles Include=""AnalyzerReleases.Unshipped.md"" />
+  </ItemGroup>";
+                }
+
+                return string.Empty;
+            }
+        }
+
+        private sealed class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+        {
+            public static IAnalyzerAssemblyLoader Instance = new AnalyzerAssemblyLoader();
+
+            private AnalyzerAssemblyLoader() { }
+            public void AddDependencyLocation(string fullPath)
+            {
+            }
+
+            public Assembly LoadFromPath(string fullPath)
+            {
+                return Assembly.LoadFrom(fullPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…or analyzer packages

_Recommended to review commit by commit_

This change adds the core repo infrastructure for _Analyzer warning waves_ feature, building on top of dotnet/roslyn#42219 that will enable passing in one or more global analyzer config files to the compiler. Given that the design of compiler feature has not yet been finalized, it is likely that there will be future tweaks in the functionality added here. However, the core assumption should be valid regardless of the final design: A new MSBuild item group, similar to `AdditionFiles`, will be supported for denoting global analyzer config files that should be passed to the compiler. This PR uses the name `GlobalAnalyzerConfigFiles`, which can be modified later.

This change adds the following functionality:
1. Changes to enable copying the AnalyzerReleases.Shipped.md to project output directory
2. New post-build utility project `GenerateGlobalAnalyzerConfigs` to generate set of analyzer config files for all analyzer packages in the repo based on the shipped analyzer releases files + diagnostic analyzers implemented in package.
3. This utility runs as a post build step for each Package.csproj and generates the following files, which are added to the `build` folder of the generated analyzer NuGet package:
   1. Global analyzer config files for build and live analysis for _latest/unshipped version_. Build one disables all IDE suggestions/hidden by setting their editorconfig severity to `none`.
   2. Global analyzer config files for build and live analysis for _each shipped version_ identified from AnalyzerReleases.Shipped.md. All rules added after the version are disabled by default by setting their editorconfig severity to `none`.
   3. _Targets file_ while selects and includes the appropriate global analyzer config based on whether we are executing a design time build or command line build + specified analyzer package version.
4. SDK repo should embed these analyzer config files + targets file along with the .NET analyzers assemblies into the SDK. Additionally, it should add a props file that maps the user facing .NET analyzers analysis level MSBuild property to the analyzer package version understood by the above targets file to ensure correct global analyzer config is passed to the compiler. Tag @jmarolf @mikadumont as FYI 

I have attached the locally built analyzer NuGet package for `Microsoft.CodeAnalysis.NetAnalyzers`. You can view the contents of the "build" folder in the package, which contains the new config files and targets file: [Microsoft.CodeAnalysis.NetAnalyzers.3.0.0-dev.zip](https://github.com/dotnet/roslyn-analyzers/files/4416104/Microsoft.CodeAnalysis.NetAnalyzers.3.0.0-dev.zip)