### PR TITLE
Enabled coverage with deterministic build

### DIFF
--- a/DeterministicBuild.targets
+++ b/DeterministicBuild.targets
@@ -12,7 +12,7 @@ https://github.com/dotnet/sourcelink/issues/572 -->
     <SourceRoot Include="$(NuGetPackageRoot)" />
   </ItemGroup>
 
-  <Target Name="GetPathMap"
+  <Target Name="CoverletGetPathMap"
           DependsOnTargets="InitializeSourceRootMappedPaths"
           Returns="@(_LocalTopLevelSourceRoot)"
           Condition="'$(DeterministicSourcePaths)' == 'true'"

--- a/DeterministicBuild.targets
+++ b/DeterministicBuild.targets
@@ -1,0 +1,24 @@
+<!-- This target must be imported into Directory.Build.targets -->
+<!-- Workaround. Remove once we're on 3.1.300+
+https://github.com/dotnet/sourcelink/issues/572 -->
+<Project>
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <SourceRoot Include="$(NuGetPackageRoot)" />
+  </ItemGroup>
+
+  <Target Name="GetPathMap"
+          DependsOnTargets="InitializeSourceRootMappedPaths"
+          Returns="@(_LocalTopLevelSourceRoot)"
+          Condition="'$(DeterministicSourcePaths)' == 'true'"
+          >
+    <ItemGroup>
+      <_LocalTopLevelSourceRoot Include="@(SourceRoot)" Condition="'%(SourceRoot.NestedRoot)' == ''"/>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,6 +23,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Coverage)' == 'true'">
+    <!-- https://github.com/tonerdo/coverlet/issues/363 -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
+
     <!-- https://github.com/tonerdo/coverlet/issues/618 -->
     <IncludeTestAssembly>true</IncludeTestAssembly>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,9 +23,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Coverage)' == 'true'">
-    <!-- https://github.com/tonerdo/coverlet/issues/363 -->
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-
     <!-- https://github.com/tonerdo/coverlet/issues/618 -->
     <IncludeTestAssembly>true</IncludeTestAssembly>
 
@@ -67,4 +64,7 @@
       ThresholdStat="$(ThresholdStat)"
       InstrumenterState="$(InstrumenterState)"/>
   </Target>
+
+  <!-- Deterministic build workaround -->
+  <Import Project="$(MSBuildThisFileDirectory)DeterministicBuild.targets" />
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <CodecovVersion>1.9.0</CodecovVersion>
-    <CoverletVersion>2.8.1-g15593cedd0</CoverletVersion>
+    <CoverletVersion>2.8.1-g61c134dec1</CoverletVersion>
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <CodecovVersion>1.9.0</CodecovVersion>
-    <CoverletVersion>2.8.1-g61c134dec1</CoverletVersion>
+    <CoverletVersion>2.8.1-ge100499287</CoverletVersion>
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
     <MicrosoftVSSDKVersion>15.0.26201-alpha</MicrosoftVSSDKVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <CodecovVersion>1.9.0</CodecovVersion>
-    <CoverletVersion>2.7.0</CoverletVersion>
+    <CoverletVersion>2.8.1-g15593cedd0</CoverletVersion>
     <ReportGeneratorVersion>4.3.6</ReportGeneratorVersion>
 
     <!-- Roslyn -->
@@ -49,7 +49,8 @@
       $(RestoreSources);
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json
+      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json;
+      https://f.feedz.io/marcorossignoli/coverletunofficial/nuget/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Test coverage with deterministic build.

@sharwell let me know if update are enough to enable deterministic build or feel free to PR on my branch.
Also I'd like to know if coverage looks correct from your perspective.

On my local it seems to work

<img width="688" alt="coverageFolder" src="https://user-images.githubusercontent.com/7894084/78505707-93a27d00-7775-11ea-8d17-f43e3e8de431.PNG">

<img width="716" alt="ILSpySample" src="https://user-images.githubusercontent.com/7894084/78505719-a2892f80-7775-11ea-824c-43cc1bf1a803.PNG">


Repro commands https://github.com/tonerdo/coverlet/issues/363#issuecomment-554003958

cc: @clairernovotny @tmat @tonerdo 