### PR TITLE
Disable analyzer by default in fxcop

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/AvoidExcessiveParametersOnGenericTypes.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/AvoidExcessiveParametersOnGenericTypes.cs
@@ -26,7 +26,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             RuleLevel.Disabled,
             s_localizableDescription,
             isPortedFxCopRule: true,
-            isDataflowRule: false);
+            isDataflowRule: false,
+            isEnabledByDefaultInFxCopAnalyzers: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotNameEnumValuesReserved.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotNameEnumValuesReserved.cs
@@ -27,7 +27,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             RuleLevel.Disabled,
             description: s_localizableDescription,
             isPortedFxCopRule: true,
-            isDataflowRule: false);
+            isDataflowRule: false,
+            isEnabledByDefaultInFxCopAnalyzers: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotPassTypesByReference.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotPassTypesByReference.cs
@@ -25,7 +25,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             RuleLevel.Disabled,
             description: s_localizableDescription,
             isPortedFxCopRule: true,
-            isDataflowRule: false);
+            isDataflowRule: false,
+            isEnabledByDefaultInFxCopAnalyzers: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
I have disabled in fxcop all newly added fxcop analyzers (in the unshipped file) for which the state is disabled.

Tagging @mavasani 