### PR TITLE
Update global analyzer config generation in the repo

### DIFF
--- a/eng/GenerateAnalyzerNuspec.csx
+++ b/eng/GenerateAnalyzerNuspec.csx
@@ -222,11 +222,12 @@ if (editorconfigsDir.Length > 0 && Directory.Exists(editorconfigsDir))
 
 if (globalAnalyzerConfigsDir.Length > 0 && Directory.Exists(globalAnalyzerConfigsDir))
 {
-    foreach (string editorconfig in Directory.EnumerateFiles(globalAnalyzerConfigsDir))
+    foreach (string directory in Directory.EnumerateDirectories(globalAnalyzerConfigsDir))
     {
-        if (Path.GetExtension(editorconfig) == ".editorconfig")
+        var directoryName = new DirectoryInfo(directory).Name;
+        foreach (string editorconfig in Directory.EnumerateFiles(directory))
         {
-            result.AppendLine(FileElement(Path.Combine(globalAnalyzerConfigsDir, editorconfig), "build\\config\\"));
+            result.AppendLine(FileElement(Path.Combine(directory, editorconfig), $"build\\config\\{directoryName}"));
         }
     }
 }


### PR DESCRIPTION
1. Do not generate different global analyzer config files for build and live analysis. https://github.com/dotnet/roslyn/pull/43546 will ensure that we do not need special logic in each analyzer package to disable hidden/suggestion analyzers in build - this will be baked into the compiler.
2. Update the contents of generated targets and editorconfig file as per the new design for global analyzer config: Everything for global analyzer config files will match regular analyzer config files (file name should be .editorconfig, existing MSBuild property "EditorConfigFiles" will be used, etc.), except for a special entry "is_global = true" to indicate global analyzer config.

I verified that a locally built analyzer NuGet package has the desired global editor config and it also gets passed to the referencing project's csc command line.