### PR TITLE
Fixer: Prefer Memory overloads for Stream async Read/Write methods

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -34,10 +34,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 return args.FirstOrDefault(argOperation =>
                 {
                     return argOperation.Syntax is ArgumentSyntax argNode &&
-                           argNode.NameColon != null &&
-                           argNode.NameColon.Name != null &&
-                           argNode.NameColon.Name.Identifier != null &&
-                           argNode.NameColon.Name.Identifier.ValueText == name;
+                           argNode.NameColon?.Name?.Identifier.ValueText == name;
                 });
             }
         }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.NetCore.Analyzers.Runtime;
+
+namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public sealed class PreferStreamAsyncMemoryOverloadsCSharpFixer : PreferStreamAsyncMemoryOverloadsFixer
+    {
+        protected override IArgumentOperation? GetArgumentByPositionOrName(ImmutableArray<IArgumentOperation> args, int index, string name, out bool isNamed)
+        {
+            isNamed = false;
+
+            // The expected position is beyond the total arguments, so we don't expect to find the argument in the array
+            if (index >= args.Length)
+            {
+                return null;
+            }
+            // If the argument in the specified index does not have a name, then it is in its expected position
+            else if (args[index].Syntax is ArgumentSyntax argNode && argNode.NameColon == null)
+            {
+                return args[index];
+            }
+            // Otherwise, find it by name
+            else
+            {
+                isNamed = true;
+                return args.FirstOrDefault(argOperation =>
+                {
+                    return argOperation.Syntax is ArgumentSyntax argNode &&
+                           argNode.NameColon != null &&
+                           argNode.NameColon.Name != null &&
+                           argNode.NameColon.Name.Identifier != null &&
+                           argNode.NameColon.Name.Identifier.ValueText == name;
+                });
+            }
+        }
+    }
+}

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1278,23 +1278,14 @@
   <data name="DoNotUseStackallocInLoopsMessage" xml:space="preserve">
     <value>Potential stack overflow. Move the stackalloc out of the loop.</value>
   </data>
-  <data name="PreferStreamReadAsyncMemoryOverloadsTitle" xml:space="preserve">
-    <value>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</value>
+  <data name="PreferStreamAsyncMemoryOverloadsTitle" xml:space="preserve">
+    <value>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</value>
   </data>
-  <data name="PreferStreamReadAsyncMemoryOverloadsDescription" xml:space="preserve">
-    <value>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</value>
+  <data name="PreferStreamAsyncMemoryOverloadsDescription" xml:space="preserve">
+    <value>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</value>
   </data>
   <data name="PreferStreamAsyncMemoryOverloadsMessage" xml:space="preserve">
     <value>Change the '{0}' method call to the overload that receives a '{1}'.</value>
-  </data>
-  <data name="PreferStreamWriteAsyncMemoryOverloadsTitle" xml:space="preserve">
-    <value>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</value>
-  </data>
-  <data name="PreferStreamWriteAsyncMemoryOverloadsDescription" xml:space="preserve">
-    <value>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</value>
-  </data>
-  <data name="PreferStreamWriteAsyncMemoryOverloadsMessage" xml:space="preserve">
-    <value>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</value>
   </data>
   <data name="InstantiateArgumentExceptionsCorrectlyChangeToTwoArgumentCodeFixTitle" xml:space="preserve">
     <value>Change to call the two argument constructor, pass null for the message.</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -61,6 +62,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
+            IArgumentOperation bufferArgumentOperation = invocation.Arguments.FirstOrDefault(a => a.Value.Type.Equals(SpecialType.System_Byte));
+            if (bufferArgumentOperation == null)
+            {
+                return;
+            }
+            IArgumentOperation offsetArgumentOperation = invocation.Arguments.FirstOrDefault(a => a.Value.Type.Equals(SpecialType.System_Int32));
+
             string title = MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsTitle;
 
             context.RegisterCodeFix(
@@ -79,9 +87,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             SyntaxNode instanceNode = invocation.Instance.Syntax;
 
             // Need the byte array object so we can invoke its AsMemory() method
+            
             SyntaxNode bufferInstanceNode = invocation.Arguments[0].Value.Syntax; // byte[] buffer
 
-            // These arguments are not modified, just moved inside AsMemory
             SyntaxNode offsetNode = invocation.Arguments[1].Syntax; // int offset
             SyntaxNode countNode = invocation.Arguments[2].Syntax;  // int count
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -84,7 +84,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // No nullcheck for this, because there is an overload that may not contain it
             IArgumentOperation? cancellationTokenOperation = GetArgumentByPositionOrName(invocation.Arguments, 3, "cancellationToken", out bool isCancellationTokenNamed);
 
-            string titleAndMethodName = MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsTitle + invocation.TargetMethod.Name;
+            string title = MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsTitle;
 
             Func<CancellationToken, Task<Document>> createChangedDocument = _ => FixInvocation(doc, root, invocation, invocation.TargetMethod.Name,
                                                          bufferOperation.Value.Syntax, isBufferNamed,
@@ -92,12 +92,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                          countOperation.Value.Syntax, isCountNamed,
                                                          cancellationTokenOperation?.Value.Syntax, isCancellationTokenNamed);
 
-            context.RegisterCodeFix(
-                MyCodeAction.Create(
-                    title: titleAndMethodName,
+            var action = new MyCodeAction(
+                    title: title,
                     createChangedDocument,
-                    equivalenceKey: titleAndMethodName),
-                context.Diagnostics);
+                    equivalenceKey: title + invocation.TargetMethod.Name);
+
+            context.RegisterCodeFix(action, context.Diagnostics);
         }
 
         private static Task<Document> FixInvocation(Document doc, SyntaxNode root, IInvocationOperation invocation, string methodName,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -86,18 +86,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             string title = MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsTitle;
 
-            Func<CancellationToken, Task<Document>> createChangedDocument = _ => FixInvocation(doc, root, invocation, invocation.TargetMethod.Name,
+            Task<Document> createChangedDocument(CancellationToken _) => FixInvocation(doc, root, invocation, invocation.TargetMethod.Name,
                                                          bufferOperation.Value.Syntax, isBufferNamed,
                                                          offsetOperation.Value.Syntax, isOffsetNamed,
                                                          countOperation.Value.Syntax, isCountNamed,
                                                          cancellationTokenOperation?.Value.Syntax, isCancellationTokenNamed);
 
-            var action = new MyCodeAction(
+            context.RegisterCodeFix(
+                new MyCodeAction(
                     title: title,
                     createChangedDocument,
-                    equivalenceKey: title + invocation.TargetMethod.Name);
-
-            context.RegisterCodeFix(action, context.Diagnostics);
+                    equivalenceKey: title + invocation.TargetMethod.Name),
+                context.Diagnostics);
         }
 
         private static Task<Document> FixInvocation(Document doc, SyntaxNode root, IInvocationOperation invocation, string methodName,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Runtime
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic), Shared]
+    public class PreferStreamAsyncMemoryOverloadsFixer : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(PreferStreamAsyncMemoryOverloads.RuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Document doc = context.Document;
+            CancellationToken ct = context.CancellationToken;
+            SyntaxNode root = await doc.GetSyntaxRootAsync(ct).ConfigureAwait(false);
+            if (root.FindNode(context.Span) is SyntaxNode node)
+            {
+                SemanticModel model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+                if (model.GetOperation(node, ct) is IInvocationOperation invocation)
+                {
+                    string methodName = invocation.TargetMethod.Name;
+
+                    string title;
+                    if (methodName == "ReadAsync")
+                    {
+                        title = MicrosoftNetCoreAnalyzersResources.PreferStreamReadAsyncMemoryOverloadsTitle;
+                    }
+                    else if (methodName == "WriteAsync")
+                    {
+                        title = MicrosoftNetCoreAnalyzersResources.PreferStreamWriteAsyncMemoryOverloadsTitle;
+                    }
+                    else
+                    {
+                        return;
+                    }
+
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            title: title,
+                            createChangedDocument: c => FixInvocation(doc, root, invocation, methodName),
+                            equivalenceKey: MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsMessage),
+                        context.Diagnostics);
+                }
+            }
+        }
+
+        private static Task<Document> FixInvocation(Document doc, SyntaxNode root, IInvocationOperation invocation, string methodName)
+        {
+            SyntaxGenerator generator = SyntaxGenerator.GetGenerator(doc);
+
+            // The stream object
+            SyntaxNode instanceNode = invocation.Instance.Syntax;
+
+            // Need the byte array object so we can invoke its AsMemory() method
+            SyntaxNode bufferInstanceNode = invocation.Arguments[0].Value.Syntax; // byte[] buffer
+
+            // These arguments are not modified, just moved inside AsMemory
+            SyntaxNode offsetNode = invocation.Arguments[1].Syntax; // int offset
+            SyntaxNode countNode = invocation.Arguments[2].Syntax;  // int count
+
+            // Generate an invocation of the AsMemory() methdo from the byte array object
+            SyntaxNode asMemoryExtensionMethodNode = generator.IdentifierName("AsMemory");
+            SyntaxNode asMemoryExpressionNode = generator.MemberAccessExpression(bufferInstanceNode, asMemoryExtensionMethodNode);
+            SyntaxNode asMemoryInvocationNode = generator.InvocationExpression(asMemoryExpressionNode, offsetNode, countNode);
+
+            // Create a new async method call for the stream object, no arguments yet
+            SyntaxNode asyncMethodIdentifierNode = generator.IdentifierName(methodName);
+            SyntaxNode asyncMethodNode = generator.MemberAccessExpression(instanceNode, asyncMethodIdentifierNode);
+
+            // Add the arguments to the async method call, with or without CancellationToken
+            SyntaxNode newInvocationExpression;
+            if (invocation.Arguments.Length > 3)
+            {
+                newInvocationExpression = generator.InvocationExpression(
+                    asyncMethodNode, asMemoryInvocationNode,
+                    invocation.Arguments[3].Syntax /* CancellationToken */);
+            }
+            else
+            {
+                newInvocationExpression = generator.InvocationExpression(asyncMethodNode, asMemoryInvocationNode);
+            }
+
+            SyntaxNode newInvocation = generator.ReplaceNode(root, invocation.Syntax, newInvocationExpression);
+            return Task.FromResult(doc.WithSyntaxRoot(newInvocation));
+        }
+    }
+}

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
@@ -37,43 +37,33 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             MicrosoftNetCoreAnalyzersResources.ResourceManager,
             typeof(MicrosoftNetCoreAnalyzersResources));
 
-        private static readonly LocalizableString s_localizableTitleRead = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamReadAsyncMemoryOverloadsTitle),
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(
+            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsTitle),
             MicrosoftNetCoreAnalyzersResources.ResourceManager,
             typeof(MicrosoftNetCoreAnalyzersResources));
 
-        private static readonly LocalizableString s_localizableDescriptionRead = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamReadAsyncMemoryOverloadsDescription),
-            MicrosoftNetCoreAnalyzersResources.ResourceManager,
-            typeof(MicrosoftNetCoreAnalyzersResources));
-
-        private static readonly LocalizableString s_localizableTitleWrite = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamWriteAsyncMemoryOverloadsTitle),
-            MicrosoftNetCoreAnalyzersResources.ResourceManager,
-            typeof(MicrosoftNetCoreAnalyzersResources));
-
-        private static readonly LocalizableString s_localizableDescriptionWrite = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamWriteAsyncMemoryOverloadsDescription),
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(
+            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsDescription),
             MicrosoftNetCoreAnalyzersResources.ResourceManager,
             typeof(MicrosoftNetCoreAnalyzersResources));
 
         internal static DiagnosticDescriptor PreferStreamReadAsyncMemoryOverloadsRule = DiagnosticDescriptorHelper.Create(
                                                                                         RuleId,
-                                                                                        s_localizableTitleRead,
+                                                                                        s_localizableTitle,
                                                                                         s_localizableMessage,
                                                                                         DiagnosticCategory.Performance,
                                                                                         RuleLevel.IdeSuggestion,
-                                                                                        s_localizableDescriptionRead,
+                                                                                        s_localizableDescription,
                                                                                         isPortedFxCopRule: false,
                                                                                         isDataflowRule: false);
 
         internal static DiagnosticDescriptor PreferStreamWriteAsyncMemoryOverloadsRule = DiagnosticDescriptorHelper.Create(
                                                                                         RuleId,
-                                                                                        s_localizableTitleWrite,
+                                                                                        s_localizableTitle,
                                                                                         s_localizableMessage,
                                                                                         DiagnosticCategory.Performance,
                                                                                         RuleLevel.IdeSuggestion,
-                                                                                        s_localizableDescriptionWrite,
+                                                                                        s_localizableDescription,
                                                                                         isPortedFxCopRule: false,
                                                                                         isDataflowRule: false);
 
@@ -272,20 +262,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             actualMethod = null;
 
             // The await should have a known operation child, check its kind
-            if (!(awaitOperation.Operation is IInvocationOperation childOperation))
+            if (!(awaitOperation.Operation is IInvocationOperation awaitedInvocation))
             {
                 return false;
             }
 
-            actualInvocation = childOperation;
-            IMethodSymbol method = childOperation.TargetMethod;
+            actualInvocation = awaitedInvocation;
+            IMethodSymbol method = awaitedInvocation.TargetMethod;
 
             // Check if the child operation of the await is ConfigureAwait
             // in which case we should analyze the grandchild operation
             if (method.OriginalDefinition.Equals(configureAwaitMethod) ||
                 method.OriginalDefinition.Equals(genericConfigureAwaitMethod))
             {
-                if (childOperation.Instance is IInvocationOperation instanceOperation)
+                if (awaitedInvocation.Instance is IInvocationOperation instanceOperation)
                 {
                     actualInvocation = instanceOperation;
                     method = instanceOperation.TargetMethod;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
@@ -32,13 +32,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     {
         internal const string RuleId = "CA1835";
 
-        private static readonly LocalizableString s_localizableTitleRead = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamReadAsyncMemoryOverloadsTitle),
+        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(
+            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsMessage),
             MicrosoftNetCoreAnalyzersResources.ResourceManager,
             typeof(MicrosoftNetCoreAnalyzersResources));
 
-        private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(
-            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamAsyncMemoryOverloadsMessage),
+        private static readonly LocalizableString s_localizableTitleRead = new LocalizableResourceString(
+            nameof(MicrosoftNetCoreAnalyzersResources.PreferStreamReadAsyncMemoryOverloadsTitle),
             MicrosoftNetCoreAnalyzersResources.ResourceManager,
             typeof(MicrosoftNetCoreAnalyzersResources));
 
@@ -100,6 +100,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 return;
             }
+
             if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemMemory1, out INamedTypeSymbol? memoryType))
             {
                 return;
@@ -139,21 +140,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 ParameterInfo.GetParameterInfo(cancellationTokenType)
             };
 
-            // Create the arrays with the exact parameter order of the desired methods
-            var preferredReadAsyncParameters = new[]
-            {
-                ParameterInfo.GetParameterInfo(readOnlyMemoryType),  // ReadOnlyMemory<byte> buffer
-                ParameterInfo.GetParameterInfo(cancellationTokenType), // CancellationToken
-            };
-
-            var preferredWriteAsyncParameters = new[]
-            {
-                ParameterInfo.GetParameterInfo(memoryType),  // ReadOnlyMemory<byte> buffer
-                ParameterInfo.GetParameterInfo(cancellationTokenType), // CancellationToken
-            };
-
             // Retrieve the ReadAsync/WriteSync methods available in Stream
-            // If we don't find them all, the Memory based overloads are not supported in this .NET version
             IEnumerable<IMethodSymbol> readAsyncMethodGroup = streamType.GetMembers("ReadAsync").OfType<IMethodSymbol>();
             IEnumerable<IMethodSymbol> writeAsyncMethodGroup = streamType.GetMembers("WriteAsync").OfType<IMethodSymbol>();
 
@@ -184,14 +171,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             // Retrieve the preferred methods, which are used for constructing the rule message
             IMethodSymbol? preferredReadAsyncMethod = readAsyncMethodGroup.FirstOrDefault(x =>
-                x.Parameters.Count() == 2 && x.Parameters[0].Type is INamedTypeSymbol type && type.ConstructedFrom.Equals(memoryType));
+                x.Parameters.Count() == 2 &&
+                x.Parameters[0].Type is INamedTypeSymbol type &&
+                type.ConstructedFrom.Equals(memoryType));
             if (preferredReadAsyncMethod == null)
             {
                 return;
             }
 
             IMethodSymbol? preferredWriteAsyncMethod = writeAsyncMethodGroup.FirstOrDefault(x =>
-                x.Parameters.Count() == 2 && x.Parameters[0].Type is INamedTypeSymbol type && type.ConstructedFrom.Equals(readOnlyMemoryType));
+                x.Parameters.Count() == 2 &&
+                x.Parameters[0].Type is INamedTypeSymbol type &&
+                type.ConstructedFrom.Equals(readOnlyMemoryType));
             if (preferredWriteAsyncMethod == null)
             {
                 return;
@@ -227,20 +218,31 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             context.RegisterOperationAction(context =>
             {
                 IAwaitOperation awaitOperation = (IAwaitOperation)context.Operation;
-                if (ShouldAnalyze(awaitOperation, configureAwaitMethod, genericConfigureAwaitMethod, streamType, out IMethodSymbol? method) && method != null)
+
+                if (ShouldAnalyze(
+                        awaitOperation,
+                        configureAwaitMethod,
+                        genericConfigureAwaitMethod,
+                        streamType,
+                        out IInvocationOperation? invocation,
+                        out IMethodSymbol? method) &&
+                    invocation != null &&
+                    method != null)
                 {
                     DiagnosticDescriptor rule;
                     string ruleMessageMethod;
                     string ruleMessagePreferredMethod;
 
                     // Verify if the method is an undesired Async overload
-                    if (method.Equals(undesiredReadAsyncMethod) || method.Equals(undesiredReadAsyncMethodWithCancellationToken))
+                    if (method.Equals(undesiredReadAsyncMethod) ||
+                        method.Equals(undesiredReadAsyncMethodWithCancellationToken))
                     {
                         rule = PreferStreamReadAsyncMemoryOverloadsRule;
                         ruleMessageMethod = undesiredReadAsyncMethod.Name;
                         ruleMessagePreferredMethod = preferredReadAsyncMethod.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
                     }
-                    else if (method.Equals(undesiredWriteAsyncMethod) || method.Equals(undesiredWriteAsyncMethodWithCancellationToken))
+                    else if (method.Equals(undesiredWriteAsyncMethod) ||
+                             method.Equals(undesiredWriteAsyncMethodWithCancellationToken))
                     {
                         rule = PreferStreamWriteAsyncMemoryOverloadsRule;
                         ruleMessageMethod = undesiredWriteAsyncMethod.Name;
@@ -252,7 +254,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return;
                     }
 
-                    context.ReportDiagnostic(awaitOperation.Operation.CreateDiagnostic(rule, ruleMessageMethod, ruleMessagePreferredMethod));
+                    context.ReportDiagnostic(invocation.CreateDiagnostic(rule, ruleMessageMethod, ruleMessagePreferredMethod));
                 }
             },
             OperationKind.Await);
@@ -263,26 +265,30 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             IMethodSymbol configureAwaitMethod,
             IMethodSymbol genericConfigureAwaitMethod,
             INamedTypeSymbol streamType,
+            out IInvocationOperation? actualInvocation,
             out IMethodSymbol? actualMethod)
         {
+            actualInvocation = null;
             actualMethod = null;
 
             // The await should have a known operation child, check its kind
-            if (!(awaitOperation.Operation is IInvocationOperation invocation))
+            if (!(awaitOperation.Operation is IInvocationOperation childOperation))
             {
                 return false;
             }
 
-            IMethodSymbol method = invocation.TargetMethod;
+            actualInvocation = childOperation;
+            IMethodSymbol method = childOperation.TargetMethod;
 
             // Check if the child operation of the await is ConfigureAwait
             // in which case we should analyze the grandchild operation
             if (method.OriginalDefinition.Equals(configureAwaitMethod) ||
                 method.OriginalDefinition.Equals(genericConfigureAwaitMethod))
             {
-                if (invocation.Instance is IInvocationOperation instanceInvocation)
+                if (childOperation.Instance is IInvocationOperation instanceOperation)
                 {
-                    method = instanceInvocation.TargetMethod;
+                    actualInvocation = instanceOperation;
+                    method = instanceOperation.TargetMethod;
                 }
                 else
                 {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
@@ -222,6 +222,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     DiagnosticDescriptor rule;
                     string ruleMessageMethod;
                     string ruleMessagePreferredMethod;
+                    string ruleMessageMemoryType;
 
                     // Verify if the method is an undesired Async overload
                     if (method.Equals(undesiredReadAsyncMethod) ||
@@ -230,6 +231,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         rule = PreferStreamReadAsyncMemoryOverloadsRule;
                         ruleMessageMethod = undesiredReadAsyncMethod.Name;
                         ruleMessagePreferredMethod = preferredReadAsyncMethod.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+                        ruleMessageMemoryType = memoryType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
                     }
                     else if (method.Equals(undesiredWriteAsyncMethod) ||
                              method.Equals(undesiredWriteAsyncMethodWithCancellationToken))
@@ -237,6 +239,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         rule = PreferStreamWriteAsyncMemoryOverloadsRule;
                         ruleMessageMethod = undesiredWriteAsyncMethod.Name;
                         ruleMessagePreferredMethod = preferredWriteAsyncMethod.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+                        ruleMessageMemoryType = readOnlyMemoryType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
                     }
                     else
                     {
@@ -244,7 +247,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return;
                     }
 
-                    context.ReportDiagnostic(invocation.CreateDiagnostic(rule, ruleMessageMethod, ruleMessagePreferredMethod));
+                    context.ReportDiagnostic(invocation.CreateDiagnostic(rule, ruleMessageMethod, ruleMessagePreferredMethod, ruleMessageMemoryType));
                 }
             },
             OperationKind.Await);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">Metody P/Invoke nemají být viditelné</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes dürfen nicht sichtbar sein</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">Los elementos P/Invoke no deben estar visibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">Les P/Invoke ne doivent pas être visibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">I metodi P/Invoke non devono essere visibili</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes は参照可能にすることはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes를 표시하지 않아야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1379,8 +1379,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1389,8 +1389,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1378,34 +1378,19 @@
         <target state="translated">Elementy P/Invoke nie powinny być widoczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes não deve ser visível</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">Методы P/Invoke не должны быть видимыми</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes görünür olmamalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">P/Invokes 应该是不可见的</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1378,8 +1378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <source>'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</source>
+        <target state="new">'Stream' has a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Prefer calling the memory based overloads, which are more efficient.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
@@ -1388,8 +1388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
-        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
-        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
+        <source>Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1377,34 +1377,19 @@
         <target state="translated">不應看得見 P/Invoke</target>
         <note />
       </trans-unit>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsDescription">
+        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</source>
+        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as the first argument, and a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as the first argument. Whenever possible, prefer the memory based overloads, which are more efficient.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PreferStreamAsyncMemoryOverloadsMessage">
         <source>Change the '{0}' method call to the overload that receives a '{1}'.</source>
         <target state="new">Change the '{0}' method call to the overload that receives a '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'ReadAsync' overload that takes a 'Memory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'Memory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamReadAsyncMemoryOverloadsTitle">
-        <source>Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</source>
-        <target state="new">Prefer 'Memory&lt;Byte&gt;' overload for 'ReadAsync'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsDescription">
-        <source>All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</source>
-        <target state="new">All 'Stream' based classes provide a 'WriteAsync' overload that takes a 'ReadOnlyMemory&lt;Byte&gt;' as first argument. When possible, prefer the overload that takes a 'ReadOnlyMemory&lt;Byte&gt;', which is more efficient.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsMessage">
-        <source>Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</source>
-        <target state="new">Change the 'WriteAsync' method call to the overload that receives a 'ReadOnlyMemory&lt;Byte&gt;'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PreferStreamWriteAsyncMemoryOverloadsTitle">
-        <source>Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</source>
-        <target state="new">Prefer 'ReadOnlyMemory&lt;Byte&gt;' overload for 'WriteAsync'.</target>
+      <trans-unit id="PreferStreamAsyncMemoryOverloadsTitle">
+        <source>Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</source>
+        <target state="new">Prefer the memory based overloads for 'ReadAsync' and 'WriteAsync'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -133,9 +133,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                                         "buffer: buffer.AsMemory(0, buffer.Length)" };
             yield return new object[] { "buffer, offset: 0, buffer.Length",
                                         "buffer.AsMemory(start: 0, buffer.Length)" };
-            yield return new object[] { "buffer, 0, length: buffer.Length",
+            yield return new object[] { "buffer, 0, count: buffer.Length",
                                         "buffer.AsMemory(0, length: buffer.Length)" };
-            yield return new object[] { "buffer: buffer, 0, length: buffer.Length",
+            yield return new object[] { "buffer: buffer, 0, count: buffer.Length",
                                         "buffer: buffer.AsMemory(0, length: buffer.Length)" };
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -5,26 +5,34 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsFixer>;
+
+#pragma warning disable CA1305 // Specify IFormatProvider in string.Format
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class PreferStreamAsyncMemoryOverloadsTestBase
     {
         protected static Task AnalyzeCSAsync(string source, params DiagnosticResult[] expected) =>
-            AnalyzeCSForVersionAsync(source, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            VerifyCSForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+
+        protected static Task FixCSAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
+            VerifyCSForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
         protected static Task AnalyzeCSUnsupportedAsync(string source, params DiagnosticResult[] expected) =>
-            AnalyzeCSForVersionAsync(source, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
+            VerifyCSForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
 
         protected static Task AnalyzeVBAsync(string source, params DiagnosticResult[] expected) =>
-            AnalyzeVBForVersionAsync(source, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            VerifyVBForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+
+        protected static Task FixVBAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
+            VerifyVBForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
         protected static Task AnalyzeVBUnsupportedAsync(string source, params DiagnosticResult[] expected) =>
-            AnalyzeVBForVersionAsync(source, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
+            VerifyVBForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
 
         protected static DiagnosticResult GetCSResultForRule(int startLine, int startColumn, int endLine, int endColumn, DiagnosticDescriptor rule, string methodName, string methodPreferredName)
             => VerifyCS.Diagnostic(rule)
@@ -36,27 +44,58 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                 .WithSpan(startLine, startColumn, endLine, endColumn)
                 .WithArguments(methodName, methodPreferredName);
 
-        private static Task AnalyzeCSForVersionAsync(string source, ReferenceAssemblies version, params DiagnosticResult[] expected)
+        protected static string GetFormattedSourceCode(string source, string asyncMethodPrefix, string args, bool withConfigureAwait, string language)
+        {
+            string configureAwait = string.Empty;
+
+            if (withConfigureAwait)
+            {
+                char booleanArgumentInitial = 'f';
+                if (language == LanguageNames.VisualBasic)
+                {
+                    booleanArgumentInitial = 'F';
+                }
+                configureAwait = $".ConfigureAwait({booleanArgumentInitial}alse)";
+            }
+
+            asyncMethodPrefix = string.Format("s.{0}Async({1}){2}", asyncMethodPrefix, args, configureAwait);
+
+            return string.Format(source, asyncMethodPrefix);
+        }
+
+        private static Task VerifyCSForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
         {
             var test = new VerifyCS.Test
             {
-                TestCode = source,
+                TestCode = originalSource,
                 ReferenceAssemblies = version,
             };
 
+            if (!string.IsNullOrEmpty(fixedSource))
+            {
+                test.FixedCode = fixedSource;
+            }
+
             test.ExpectedDiagnostics.AddRange(expected);
+
             return test.RunAsync();
         }
 
-        private static Task AnalyzeVBForVersionAsync(string source, ReferenceAssemblies version, params DiagnosticResult[] expected)
+        private static Task VerifyVBForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
         {
             var test = new VerifyVB.Test
             {
-                TestCode = source,
+                TestCode = originalSource,
                 ReferenceAssemblies = version,
             };
 
+            if (!string.IsNullOrEmpty(fixedSource))
+            {
+                test.FixedCode = fixedSource;
+            }
+
             test.ExpectedDiagnostics.AddRange(expected);
+
             return test.RunAsync();
         }
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -133,10 +133,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                                         "buffer: buffer.AsMemory(0, buffer.Length)" };
             yield return new object[] { "buffer, offset: 0, buffer.Length",
                                         "buffer.AsMemory(start: 0, buffer.Length)" };
-            yield return new object[] { "buffer, 0, count: buffer.Length",
-                                        "buffer.AsMemory(0, count: buffer.Length)" };
-            yield return new object[] { "buffer: buffer, 0, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(0, count: buffer.Length)" };
+            yield return new object[] { "buffer, 0, length: buffer.Length",
+                                        "buffer.AsMemory(0, length: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, 0, length: buffer.Length",
+                                        "buffer: buffer.AsMemory(0, length: buffer.Length)" };
         }
 
         public static IEnumerable<object[]> CSharpNamedArgumentsWithCancellationTokenTestData()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -6,10 +6,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsCSharpFixer>;
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsCSharpFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsVisualBasicFixer>;
+    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsVisualBasicFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -16,54 +16,33 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class PreferStreamAsyncMemoryOverloadsTestBase
     {
-        protected static Task AnalyzeCSAsync(string source, params DiagnosticResult[] expected) =>
-            VerifyCSForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+        // Verifies that the analyzer generates the specified C# diagnostic results, if any.
+        protected static Task CSharpVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
+            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
-        protected static Task FixCSAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
-            VerifyCSForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+        // Verifies that the analyzer generates the specified VB diagnostic results, if any.
+        protected static Task VisualBasicVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
+            VisualBasicVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
-        protected static Task AnalyzeCSUnsupportedAsync(string source, params DiagnosticResult[] expected) =>
-            VerifyCSForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
+        // Verifies that the analyzer generates the specified C# diagnostic results, if any, in an unsupported .NET version.
+        protected static Task CSharpVerifyAnalyzerForUnsupportedVersionAsync(string source, params DiagnosticResult[] expected) =>
+            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
 
-        protected static Task AnalyzeVBAsync(string source, params DiagnosticResult[] expected) =>
-            VerifyVBForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+        // Verifies that the analyzer generates the specified VB diagnostic results, if any, in an unsupported .NET version.
+        protected static Task VisualBasicVerifyAnalyzerForUnsupportedVersionAsync(string source, params DiagnosticResult[] expected) =>
+            VisualBasicVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
 
-        protected static Task FixVBAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
-            VerifyVBForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+        // Verifies that the fixer generates the fixes for the specified C# diagnostic results, if any.
+        protected static Task CSharpVerifyCodeFixAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
+            CSharpVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
-        protected static Task AnalyzeVBUnsupportedAsync(string source, params DiagnosticResult[] expected) =>
-            VerifyVBForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
+        // Verifies that the fixer generates the fixes for the specified VB diagnostic results, if any.
+        protected static Task VisualBasicVerifyCodeFixAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
+            VisualBasicVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
 
-        protected static DiagnosticResult GetCSResultForRule(int startLine, int startColumn, int endLine, int endColumn, DiagnosticDescriptor rule, string methodName, string methodPreferredName)
-            => VerifyCS.Diagnostic(rule)
-                .WithSpan(startLine, startColumn, endLine, endColumn)
-                .WithArguments(methodName, methodPreferredName);
-
-        protected static DiagnosticResult GetVBResultForRule(int startLine, int startColumn, int endLine, int endColumn, DiagnosticDescriptor rule, string methodName, string methodPreferredName)
-            => VerifyVB.Diagnostic(rule)
-                .WithSpan(startLine, startColumn, endLine, endColumn)
-                .WithArguments(methodName, methodPreferredName);
-
-        protected static string GetFormattedSourceCode(string source, string asyncMethodPrefix, string args, bool withConfigureAwait, string language)
-        {
-            string configureAwait = string.Empty;
-
-            if (withConfigureAwait)
-            {
-                char booleanArgumentInitial = 'f';
-                if (language == LanguageNames.VisualBasic)
-                {
-                    booleanArgumentInitial = 'F';
-                }
-                configureAwait = $".ConfigureAwait({booleanArgumentInitial}alse)";
-            }
-
-            asyncMethodPrefix = string.Format("s.{0}Async({1}){2}", asyncMethodPrefix, args, configureAwait);
-
-            return string.Format(source, asyncMethodPrefix);
-        }
-
-        private static Task VerifyCSForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
+        // Verifies that the analyzer generates the specified C# diagnostic results, if any, for the specified originalSource.
+        // If fixedSource is provided, also verifies that the fixer generates the fixes for the verified diagnostic results, if any.
+        private static Task CSharpVerifyForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
         {
             var test = new VerifyCS.Test
             {
@@ -81,7 +60,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             return test.RunAsync();
         }
 
-        private static Task VerifyVBForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
+        // Verifies that the analyzer generates the specified VB diagnostic results, if any, for the specified originalSource.
+        // If fixedSource is provided, also verifies that the fixer generates the fixes for the verified diagnostic results, if any.
+        private static Task VisualBasicVerifyForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
         {
             var test = new VerifyVB.Test
             {
@@ -98,5 +79,34 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             return test.RunAsync();
         }
+
+        // Embeds the specified invocation strings into the provided source code and returns it.
+        protected static string GetSourceCodeForInvocation(string source, string asyncMethodPrefix, string args, bool withConfigureAwait, string language)
+        {
+            string configureAwait = string.Empty;
+
+            if (withConfigureAwait)
+            {
+                string booleanArg = (language == LanguageNames.VisualBasic) ? "False" : "false";
+                configureAwait = $".ConfigureAwait({booleanArg})";
+            }
+
+            asyncMethodPrefix = string.Format("s.{0}Async({1}){2}", asyncMethodPrefix, args, configureAwait);
+
+            return string.Format(source, asyncMethodPrefix);
+        }
+
+        // Retrieves the C# diagnostic for the specified rule, lines, columns, method and preferred method.
+        protected static DiagnosticResult GetCSResultForRule(int startLine, int startColumn, int endLine, int endColumn, DiagnosticDescriptor rule, string methodName, string methodPreferredName)
+            => VerifyCS.Diagnostic(rule)
+                .WithSpan(startLine, startColumn, endLine, endColumn)
+                .WithArguments(methodName, methodPreferredName);
+
+        // Retrieves the VB diagnostic for the specified rule, lines, columns, method and preferred method.
+        protected static DiagnosticResult GetVBResultForRule(int startLine, int startColumn, int endLine, int endColumn, DiagnosticDescriptor rule, string methodName, string methodPreferredName)
+            => VerifyVB.Diagnostic(rule)
+                .WithSpan(startLine, startColumn, endLine, endColumn)
+                .WithArguments(methodName, methodPreferredName);
+
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -128,6 +128,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                                         "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
             yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer",
                                         "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+            // Skipping naming
+            yield return new object[] { "buffer: buffer, 0, buffer.Length",
+                                        "buffer: buffer.AsMemory(0, buffer.Length)" };
+            yield return new object[] { "buffer, offset: 0, buffer.Length",
+                                        "buffer.AsMemory(start: 0, buffer.Length)" };
+            yield return new object[] { "buffer, 0, count: buffer.Length",
+                                        "buffer.AsMemory(0, count: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, 0, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(0, count: buffer.Length)" };
         }
 
         public static IEnumerable<object[]> CSharpNamedArgumentsWithCancellationTokenTestData()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Read()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System.IO;
 class C
 {
@@ -33,7 +33,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ReadAsync_ByteMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -55,7 +55,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ReadAsync_AsMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -76,7 +76,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_NoAwait_SaveAsTask()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -98,7 +98,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_FileStream_NoAwait_ReturnMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -116,7 +116,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -134,7 +134,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod_InvokeGetBufferMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -156,7 +156,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_NoAwait_ExpressionBodyMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -171,7 +171,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -192,7 +192,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ContinueWith_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -213,7 +213,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_AutoCastedToMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -234,7 +234,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_AutoCastedToMemory_CancellationToken()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -255,7 +255,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_UnsupportedVersion()
         {
-            return AnalyzeCSUnsupportedAsync(@"
+            return CSharpVerifyAnalyzerForUnsupportedVersionAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -280,7 +280,7 @@ class C
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Read()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System.IO
 Class C
     Public Sub M()
@@ -296,7 +296,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ReadAsync_ByteMemory()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -315,7 +315,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ReadAsync_AsMemory()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -333,7 +333,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_NoAwait_SaveAsTask()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -352,7 +352,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_FileStream_NoAwait_ReturnMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -368,7 +368,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -384,7 +384,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod_InvokeGetBufferMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -406,7 +406,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -425,7 +425,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ContinueWith_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -445,7 +445,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_AutoCastedToMemory()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -463,7 +463,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_AutoCastedToMemory_CancellationToken()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -481,7 +481,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_UnsupportedVersion()
         {
-            return AnalyzeVBUnsupportedAsync(@"
+            return VisualBasicVerifyAnalyzerForUnsupportedVersionAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -531,7 +531,7 @@ class C
     }}
 }}
             ";
-            return GetCSReadAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
+            return CSharpVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
         }
 
         [Theory]
@@ -564,7 +564,7 @@ class C
     }}
 }}
             ";
-            return GetCSReadAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 11, 19, 11, endColumn);
+            return CSharpVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 11, 19, 11, endColumn);
         }
 
         #endregion
@@ -599,7 +599,7 @@ Public Module C
     End Sub
 End Module
             ";
-            return GetVBReadAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
+            return VisualBasicVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
         }
 
         [Theory]
@@ -629,7 +629,7 @@ Public Module C
     End Sub
 End Module
             ";
-            return GetVBReadAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 8, 19, 8, endColumn);
+            return VisualBasicVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 8, 19, 8, endColumn);
         }
 
         #endregion
@@ -638,27 +638,31 @@ End Module
 
         private const string AsyncMethodName = "Read";
 
-        private Task GetCSReadAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        // Verifies that the fixer generates the fixes for the specified C# diagnostic result configuration for the ReadAsync method.
+        private Task CSharpVerifyCodeFixAsync(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
         {
-            return FixCSAsync(
-                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.CSharp),
-                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.CSharp),
+            return CSharpVerifyCodeFixAsync(
+                GetSourceCodeForInvocation(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.CSharp),
+                GetSourceCodeForInvocation(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.CSharp),
                 GetCSResult(startLine, startColumn, endLine, endColumn));
         }
 
-        private Task GetVBReadAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        // Verifies that the fixer generates the fixes for the specified VB diagnostic result configuration for the ReadAsync method.
+        private Task VisualBasicVerifyCodeFixAsync(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
         {
-            return FixVBAsync(
-                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.VisualBasic),
-                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.VisualBasic),
+            return VisualBasicVerifyCodeFixAsync(
+                GetSourceCodeForInvocation(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.VisualBasic),
+                GetSourceCodeForInvocation(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.VisualBasic),
                 GetVBResult(startLine, startColumn, endLine, endColumn));
         }
 
+        // Returns a C# diagnostic result using the specified rule, lines, columns and preferred method signature for the ReadAsync method.
         private static DiagnosticResult GetCSResult(int startLine, int startColumn, int endLine, int endColumn)
             => GetCSResultForRule(startLine, startColumn, endLine, endColumn,
                 PreferStreamAsyncMemoryOverloads.PreferStreamReadAsyncMemoryOverloadsRule,
                 "ReadAsync", "System.IO.Stream.ReadAsync(System.Memory<byte>, System.Threading.CancellationToken)");
 
+        // Returns a VB diagnostic result using the specified rule, lines, columns and preferred method signature for the ReadAsync method.
         private static DiagnosticResult GetVBResult(int startLine, int startColumn, int endLine, int endColumn)
             => GetVBResultForRule(startLine, startColumn, endLine, endColumn,
                 PreferStreamAsyncMemoryOverloads.PreferStreamReadAsyncMemoryOverloadsRule,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
@@ -22,9 +23,9 @@ class C
     void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            fs.Write(buffer, 0, buffer.Length);
+            s.Write(buffer, 0, buffer.Length);
         }
     }
 }
@@ -42,11 +43,11 @@ class C
 {
     public async void M()
     {
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
             Memory<byte> memory = new Memory<byte>(buffer);
-            await fs.WriteAsync(memory, new CancellationToken()).ConfigureAwait(false);
+            await s.WriteAsync(memory, new CancellationToken()).ConfigureAwait(false);
        }
     }
 }
@@ -65,9 +66,9 @@ class C
     public async void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            await fs.WriteAsync(buffer.AsMemory(), new CancellationToken()).ConfigureAwait(false);
+            await s.WriteAsync(buffer.AsMemory(), new CancellationToken()).ConfigureAwait(false);
         }
     }
 }
@@ -87,9 +88,9 @@ class C
     public void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            Task t = fs.WriteAsync(buffer, 0, buffer.Length);
+            Task t = s.WriteAsync(buffer, 0, buffer.Length);
         }
     }
 }
@@ -106,9 +107,9 @@ using System.Threading;
 using System.Threading.Tasks;
 class C
 {
-    public Task M(FileStream fs, byte[] buffer)
+    public Task M(FileStream s, byte[] buffer)
     {
-        return fs.WriteAsync(buffer, 0, buffer.Length);
+        return s.WriteAsync(buffer, 0, buffer.Length);
     }
 }
             ");
@@ -164,7 +165,7 @@ using System.Threading;
 using System.Threading.Tasks;
 class C
 {
-    public Task M(FileStream fs, byte[] buffer) => fs.WriteAsync(buffer, 0, buffer.Length);
+    public Task M(FileStream s, byte[] buffer) => s.WriteAsync(buffer, 0, buffer.Length);
 }
             ");
         }
@@ -181,9 +182,9 @@ class C
     public async void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            await fs.WriteAsync(buffer, 0, buffer.Length).ContinueWith(c => {}).ConfigureAwait(false);
+            await s.WriteAsync(buffer, 0, buffer.Length).ContinueWith(c => {}).ConfigureAwait(false);
         }
     }
 }
@@ -202,9 +203,51 @@ class C
     public async void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            await fs.WriteAsync(buffer, 0, buffer.Length).ContinueWith(c => {}).ContinueWith(c => {}).ConfigureAwait(false);
+            await s.WriteAsync(buffer, 0, buffer.Length).ContinueWith(c => {}).ContinueWith(c => {}).ConfigureAwait(false);
+        }
+    }
+}
+            ");
+        }
+
+        [Fact]
+        public Task CS_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory()
+        {
+            return AnalyzeCSAsync(@"
+using System;
+using System.IO;
+using System.Threading;
+class C
+{
+    public async void M()
+    {
+        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {
+            await s.WriteAsync(buffer);
+        }
+    }
+}
+            ");
+        }
+
+        [Fact]
+        public Task CS_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory_CancellationToken()
+        {
+            return AnalyzeCSAsync(@"
+using System;
+using System.IO;
+using System.Threading;
+class C
+{
+    public async void M()
+    {
+        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {
+            await s.WriteAsync(buffer, new CancellationToken());
         }
     }
 }
@@ -223,9 +266,9 @@ class C
     public async void M()
     {
         byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
-            await fs.WriteAsync(buffer, 0, buffer.Length);
+            await s.WriteAsync(buffer, 0, buffer.Length);
         }
     }
 }
@@ -246,8 +289,8 @@ Imports System.Threading
 Class C
     Private Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""path.txt"", FileMode.Create)
-            fs.Write(buffer, 0, buffer.Length)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            s.Write(buffer, 0, buffer.Length)
         End Using
     End Sub
 End Class
@@ -264,8 +307,8 @@ Imports System.Threading
 Class C
     Public Async Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""path.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer.AsMemory(), New CancellationToken()).ConfigureAwait(False)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer.AsMemory(), New CancellationToken()).ConfigureAwait(False)
         End Using
     End Sub
 End Class
@@ -283,8 +326,8 @@ Imports System.Threading.Tasks
 Class C
     Public Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""path.txt"", FileMode.Create)
-            Dim t As Task = fs.WriteAsync(buffer, 0, buffer.Length)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Dim t As Task = s.WriteAsync(buffer, 0, buffer.Length)
         End Using
     End Sub
 End Class
@@ -300,8 +343,8 @@ Imports System.IO
 Imports System.Threading
 Imports System.Threading.Tasks
 Class C
-    Public Function M(ByVal fs As FileStream, ByVal buffer As Byte()) As Task
-        Return fs.WriteAsync(buffer, 0, buffer.Length)
+    Public Function M(ByVal s As FileStream, ByVal buffer As Byte()) As Task
+        Return s.WriteAsync(buffer, 0, buffer.Length)
     End Function
 End Class
             ");
@@ -355,8 +398,8 @@ Imports System.Threading
 Class C
     Public Async Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length).ContinueWith(Sub(c)
+        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer, 0, buffer.Length).ContinueWith(Sub(c)
                                                                        End Sub).ConfigureAwait(False)
         End Using
     End Sub
@@ -374,10 +417,48 @@ Imports System.Threading
 Class C
     Public Async Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length).ContinueWith(Sub(c)
+        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer, 0, buffer.Length).ContinueWith(Sub(c)
                                                                        End Sub).ContinueWith(Sub(c)
                                                                                              End Sub).ConfigureAwait(False)
+        End Using
+    End Sub
+End Class
+            ");
+        }
+
+        [Fact]
+        public Task VB_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory()
+        {
+            return AnalyzeVBAsync(@"
+Imports System
+Imports System.IO
+Imports System.Threading
+
+Class C
+    Public Async Sub M()
+        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer)
+        End Using
+    End Sub
+End Class
+            ");
+        }
+
+        [Fact]
+        public Task VB_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory_CancellationToken()
+        {
+            return AnalyzeVBAsync(@"
+Imports System
+Imports System.IO
+Imports System.Threading
+
+Class C
+    Public Async Sub M()
+        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer, New CancellationToken())
         End Using
     End Sub
 End Class
@@ -394,8 +475,8 @@ Imports System.Threading
 Class C
     Public Async Sub M()
         Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""path.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Await s.WriteAsync(buffer, 0, buffer.Length)
         End Using
     End Sub
 End Class
@@ -406,356 +487,224 @@ End Class
 
         #region C# - Diagnostic - Analyzer
 
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_ByteArray()
+        [Theory]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    false, 57)]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    true, 57)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    false, 82)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    true, 82)]
+        public Task CS_Analyzer_Diagnostic_VarByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            return AnalyzeCSAsync(@"
+            string source = @"
 using System;
 using System.IO;
 using System.Threading;
 class C
-{
+{{
     public async void M()
-    {
-        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(buffer, 0, buffer.Length);
-        }
-    }
-}
-            ", GetCSResult(12, 19, 12, 58));
+    {{
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {{
+            byte[] buffer = {{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }};
+            await {0};
+        }}
+    }}
+}}
+            ";
+            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
         }
 
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_AsStream()
+        [Theory]
+        [InlineData("new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8",
+                    "(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }).AsMemory(0, 8)",
+                    false, 99)]
+        [InlineData("new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8",
+                    "(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }).AsMemory(0, 8)",
+                    true, 99)]
+        [InlineData("new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8, new CancellationToken()",
+                    "(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }).AsMemory(0, 8), new CancellationToken()",
+                    false, 124)]
+        [InlineData("new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8, new CancellationToken()",
+                    "(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }).AsMemory(0, 8), new CancellationToken()",
+                    true, 124)]
+        public Task CS_Analyzer_Diagnostic_InlineByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            return AnalyzeCSAsync(@"
+            string source = @"
 using System;
 using System.IO;
 using System.Threading;
 class C
-{
+{{
     public async void M()
-    {
-        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
+    {{
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {{
+            await {0};
+        }}
+    }}
+}}
+            ";
+            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 11, 19, 11, endColumn);
+        }
+
+        [Theory]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    false, 57)]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    true, 57)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    false, 82)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    true, 82)]
+        public Task CS_Analyzer_Diagnostic_AsStream(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
+        {
+            string source = @"
+using System;
+using System.IO;
+using System.Threading;
+class C
+{{
+    public async void M()
+    {{
         using (Stream s = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await s.WriteAsync(buffer, 0, buffer.Length);
-        }
-    }
-}
-            ", GetCSResult(12, 19, 12, 57));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_CancellationToken()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(buffer, 0, buffer.Length, new CancellationToken());
-        }
-    }
-}
-            ", GetCSResult(12, 19, 12, 83));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_InlineBuffer()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8);
-        }
-    }
-}
-            ", GetCSResult(11, 19, 11, 100));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_InlineBuffer_CancellationToken()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8, new CancellationToken());
-        }
-    }
-}
-            ", GetCSResult(11, 19, 11, 125));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_ConfigureAwait()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
-        }
-    }
-}
-            ", GetCSResult(12, 19, 12, 80));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_CancellationToken_ConfigureAwait()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(buffer, 0, buffer.Length, new CancellationToken()).ConfigureAwait(false);
-        }
-    }
-}
-            ", GetCSResult(12, 19, 12, 105));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_InlineBuffer_ConfigureAwait()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8).ConfigureAwait(false);
-        }
-    }
-}
-            ", GetCSResult(11, 19, 11, 122));
-        }
-
-        [Fact]
-        public Task CS_Analyzer_Diagnostic_InlineBuffer_CancellationToken_ConfigureAwait()
-        {
-            return AnalyzeCSAsync(@"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{
-    public async void M()
-    {
-        using (FileStream fs = new FileStream(""path.txt"", FileMode.Create))
-        {
-            await fs.WriteAsync(new byte[]{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }, 0, 8, new CancellationToken()).ConfigureAwait(false);
-        }
-    }
-}
-            ", GetCSResult(11, 19, 11, 147));
+        {{
+            byte[] buffer = {{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }};
+            await {0};
+        }}
+    }}
+}}
+            ";
+            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
         }
 
         #endregion
 
         #region VB - Diagnostic - Analyzer
 
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_Basic()
+        [Theory]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    false, 57)]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    true, 57)]
+        [InlineData("buffer, 0, buffer.Length, New CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), New CancellationToken()",
+                    false, 82)]
+        [InlineData("buffer, 0, buffer.Length, New CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), New CancellationToken()",
+                    true, 82)]
+        public Task VB_Analyzer_Diagnostic_VarByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            return AnalyzeVBAsync(@"
+            string source = @"
 Imports System
 Imports System.IO
 Imports System.Threading
-Class C
+Public Module C
     Public Async Sub M()
-        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length)
+        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
+            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
+            Await {0}
         End Using
     End Sub
-End Class
-            ", GetVBResult(9, 19, 9, 58));
+End Module
+            ";
+            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
         }
 
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_AsStream()
+        [Theory]
+        [InlineData("New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8",
+                    "(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}).AsMemory(0, 8)",
+                    false, 98)]
+        [InlineData("New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8",
+                    "(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}).AsMemory(0, 8)",
+                    true, 98)]
+        [InlineData("New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8, New CancellationToken()",
+                    "(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}).AsMemory(0, 8), New CancellationToken()",
+                    false, 123)]
+        [InlineData("New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8, New CancellationToken()",
+                    "(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}).AsMemory(0, 8), New CancellationToken()",
+                    true, 123)]
+        public Task VB_Analyzer_Diagnostic_InlineByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            return AnalyzeVBAsync(@"
+            string source = @"
 Imports System
 Imports System.IO
 Imports System.Threading
-Class C
+Public Module C
     Public Async Sub M()
-        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
+        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
+            Await {0}
+        End Using
+    End Sub
+End Module
+            ";
+            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 8, 19, 8, endColumn);
+        }
+
+        [Theory]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    false, 57)]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    true, 57)]
+        [InlineData("buffer, 0, buffer.Length, New CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), New CancellationToken()",
+                    false, 82)]
+        [InlineData("buffer, 0, buffer.Length, New CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), New CancellationToken()",
+                    true, 82)]
+        public Task VB_Analyzer_Diagnostic_AsStream(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
+        {
+            string source = @"
+Imports System
+Imports System.IO
+Imports System.Threading
+Public Module C
+    Public Async Sub M()
         Using s As Stream = New FileStream(""file.txt"", FileMode.Create)
-            Await s.WriteAsync(buffer, 0, buffer.Length)
+            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
+            Await {0}
         End Using
     End Sub
-End Class
-            ", GetVBResult(9, 19, 9, 57));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_CancellationToken()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length, New CancellationToken())
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(9, 19, 9, 83));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_InlineBuffer()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8)
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(8, 19, 8, 99));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_InlineBuffer_CancellationToken()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8, New CancellationToken())
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(8, 19, 8, 124));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_ConfigureAwait()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(False)
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(9, 19, 9, 80));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_CancellationToken_ConfigureAwait()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(buffer, 0, buffer.Length, New CancellationToken()).ConfigureAwait(False)
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(9, 19, 9, 105));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_InlineBuffer_ConfigureAwait()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8).ConfigureAwait(False)
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(8, 19, 8, 121));
-        }
-
-        [Fact]
-        public Task VB_Analyzer_Diagnostic_InlineBuffer_CancellationToken_ConfigureAwait()
-        {
-            return AnalyzeVBAsync(@"
-Imports System
-Imports System.IO
-Imports System.Threading
-Class C
-    Public Async Sub M()
-        Using fs As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Await fs.WriteAsync(New Byte() {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}, 0, 8, New CancellationToken()).ConfigureAwait(False)
-        End Using
-    End Sub
-End Class
-            ", GetVBResult(8, 19, 8, 146));
+End Module
+            ";
+            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
         }
 
         #endregion
 
         #region Helpers
+
+        private const string AsyncMethodName = "Write";
+
+        private Task GetCSWriteAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return FixCSAsync(
+                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.CSharp),
+                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.CSharp),
+                GetCSResult(startLine, startColumn, endLine, endColumn));
+        }
+
+        private Task GetVBWriteAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return FixVBAsync(
+                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.VisualBasic),
+                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.VisualBasic),
+                GetVBResult(startLine, startColumn, endLine, endColumn));
+        }
 
         protected static DiagnosticResult GetCSResult(int startLine, int startColumn, int endLine, int endColumn)
             => GetCSResultForRule(startLine, startColumn, endLine, endColumn,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -585,39 +585,39 @@ End Module
         [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
         public Task VB_Analyzer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
-            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: true);
+            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
         [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
         public Task VB_Analyzer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
-            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: false);
+            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
         [Theory]
         [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
         public Task VB_Analyzer_Diagnostic_AsStream(string originalArgs, string fixedArgs) =>
-            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: true);
+            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
         [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
         public Task VB_Analyzer_Diagnostic_AsStream_WithConfigureAwait(string originalArgs, string fixedArgs) =>
-            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: false);
+            VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
 
         [Theory]
         [MemberData(nameof(VisualBasicInlinedByteArrayTestData))]
         public Task VB_Analyzer_Diagnostic_InlineByteArray(string originalArgs, string fixedArgs)
-            => VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
+            => VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: true);
 
         [Theory]
         [MemberData(nameof(VisualBasicInlinedByteArrayTestData))]
         public Task VB_Analyzer_Diagnostic_InlineByteArray_WithConfigureAwait(string originalArgs, string fixedArgs)
-            => VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
+            => VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: true, isEmptyConfigureAwait: false);
 
         #endregion
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
@@ -14,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Write()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -35,7 +36,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_WriteAsync_ByteMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -57,7 +58,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_WriteAsync_AsMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -78,7 +79,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_NoAwait_SaveAsTask()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -100,7 +101,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_FileStream_NoAwait_ReturnMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -118,7 +119,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -136,7 +137,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod_InvokeGetBufferMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -158,7 +159,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_NoAwait_ExpressionBodyMethod()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -173,7 +174,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -194,7 +195,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_ContinueWith_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -215,7 +216,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -236,7 +237,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory_CancellationToken()
         {
-            return AnalyzeCSAsync(@"
+            return CSharpVerifyAnalyzerAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -257,7 +258,7 @@ class C
         [Fact]
         public Task CS_Analyzer_NoDiagnostic_UnsupportedVersion()
         {
-            return AnalyzeCSUnsupportedAsync(@"
+            return CSharpVerifyAnalyzerForUnsupportedVersionAsync(@"
 using System;
 using System.IO;
 using System.Threading;
@@ -282,7 +283,7 @@ class C
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Write()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -300,7 +301,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_WriteAsync_AsMemory()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -318,7 +319,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_NoAwait_SaveAsTask()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -337,7 +338,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_FileStream_NoAwait_ReturnMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -353,7 +354,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -369,7 +370,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_Stream_NoAwait_VoidMethod_InvokeGetBufferMethod()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -385,13 +386,13 @@ End Class
             ");
         }
 
-        // The method VB_Analyzer_NoDiagnostic_NoAwait_ExpressionBodyMethod()
-        // is skipped because VB does not support expression bodies for methods
+        // The method VB_Analyzer_NoDiagnostic_NoAwait_ExpressionBodyMethod() is
+        // skipped because VB does not support expression bodies for methods.
 
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -410,7 +411,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_ContinueWith_ContinueWith_ConfigureAwait()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -430,7 +431,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -449,7 +450,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_AutoCastedToReadOnlyMemory_CancellationToken()
         {
-            return AnalyzeVBAsync(@"
+            return VisualBasicVerifyAnalyzerAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -468,7 +469,7 @@ End Class
         [Fact]
         public Task VB_Analyzer_NoDiagnostic_UnsupportedVersion()
         {
-            return AnalyzeVBUnsupportedAsync(@"
+            return VisualBasicVerifyAnalyzerForUnsupportedVersionAsync(@"
 Imports System
 Imports System.IO
 Imports System.Threading
@@ -487,22 +488,7 @@ End Class
 
         #region C# - Diagnostic - Analyzer
 
-        [Theory]
-        [InlineData("buffer, 0, buffer.Length",
-                    "buffer.AsMemory(0, buffer.Length)",
-                    false, 57)]
-        [InlineData("buffer, 0, buffer.Length",
-                    "buffer.AsMemory(0, buffer.Length)",
-                    true, 57)]
-        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
-                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
-                    false, 82)]
-        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
-                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
-                    true, 82)]
-        public Task CS_Analyzer_Diagnostic_VarByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
-        {
-            string source = @"
+        private const string _sourceWithPredeclaredByteArrayCSharp = @"
 using System;
 using System.IO;
 using System.Threading;
@@ -518,7 +504,23 @@ class C
     }}
 }}
             ";
-            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
+
+        [Theory]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    false, 57)]
+        [InlineData("buffer, 0, buffer.Length",
+                    "buffer.AsMemory(0, buffer.Length)",
+                    true, 57)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    false, 82)]
+        [InlineData("buffer, 0, buffer.Length, new CancellationToken()",
+                    "buffer.AsMemory(0, buffer.Length), new CancellationToken()",
+                    true, 82)]
+        public Task CS_Analyzer_Diagnostic_VarByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
+        {
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
         }
 
         [Theory]
@@ -551,7 +553,7 @@ class C
     }}
 }}
             ";
-            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 11, 19, 11, endColumn);
+            return CSharpVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 11, 19, 11, endColumn);
         }
 
         [Theory]
@@ -569,28 +571,137 @@ class C
                     true, 82)]
         public Task CS_Analyzer_Diagnostic_AsStream(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            string source = @"
-using System;
-using System.IO;
-using System.Threading;
-class C
-{{
-    public async void M()
-    {{
-        using (Stream s = new FileStream(""path.txt"", FileMode.Create))
-        {{
-            byte[] buffer = {{ 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 }};
-            await {0};
-        }}
-    }}
-}}
-            ";
-            return GetCSWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait, 12, 19, 12, endColumn);
+        }
+
+        public static IEnumerable<object[]> NamedArgumentsTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count)
+            yield return new object[] { "buffer: buffer, offset: 0, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0)" };
+            yield return new object[] { "count: buffer.Length, offset: 0, buffer: buffer",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0)" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0)" };
+            yield return new object[] { "offset: 0, buffer: buffer, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length)" };
+            yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length)" };
+        }
+
+        public static IEnumerable<object[]> NamedArgumentsWithCancellationTokenTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            // Cancellation token as fourth argument
+            yield return new object[] { "buffer: buffer, offset: 0, count: buffer.Length, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 0, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, offset: 0, buffer: buffer, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 0, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            // Cancellation token as third argument
+            yield return new object[] { "buffer: buffer, offset: 0, cancellationToken: new CancellationToken(), count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken(), offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, offset: 0, cancellationToken: new CancellationToken(), buffer: buffer",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken(), offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            // Cancellation token as second argument
+            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), offset: 0, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), offset: 0, buffer: buffer",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 0, cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            // Cancellation token as first argument
+            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, offset: 0, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, offset: 0, buffer: buffer",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer, offset: 0",
+                                        "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 0, buffer: buffer, count: buffer.Length",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 0, count: buffer.Length, buffer: buffer",
+                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+        }
+
+        [Fact]
+        public Task Test()
+        {
+            string originalArgs = "count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer, offset: 0";
+            string fixedArgs = "buffer.AsMemory(length: buffer.Length, start: 0), cancellationToken: new CancellationToken()";
+
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait: false, 12, 19, 12, 80);
+        }
+
+        [Theory]
+        [MemberData(nameof(NamedArgumentsTestData))]
+        public Task CS_Analyzer_Diagnostic_NamedArguments(string originalArgs, string fixedArgs)
+        {
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait: false, 12, 19, 12, 80);
+        }
+
+        [Theory]
+        [MemberData(nameof(NamedArgumentsTestData))]
+        public Task CS_Analyzer_Diagnostic_NamedArguments_WithConfigureAwait(string originalArgs, string fixedArgs)
+        {
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait: true, 12, 19, 12, 80);
+        }
+
+        [Theory]
+        [MemberData(nameof(NamedArgumentsWithCancellationTokenTestData))]
+        public Task CS_Analyzer_Diagnostic_NamedArguments_CancellationToken(string originalArgs, string fixedArgs)
+        {
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait: false, 12, 19, 12, 124);
+        }
+
+        [Theory]
+        [MemberData(nameof(NamedArgumentsWithCancellationTokenTestData))]
+        public Task CS_Analyzer_Diagnostic_NamedArguments_CancellationToken_WithConfigureAwait(string originalArgs, string fixedArgs)
+        {
+            return CSharpVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayCSharp, originalArgs, fixedArgs, withConfigureAwait: true, 12, 19, 12, 124);
         }
 
         #endregion
 
         #region VB - Diagnostic - Analyzer
+
+        private const string _sourceWithPredeclaredByteArrayVisualBasic = @"
+Imports System
+Imports System.IO
+Imports System.Threading
+Public Module C
+    Public Async Sub M()
+        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
+            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
+            Await {0}
+        End Using
+    End Sub
+End Module
+            ";
 
         [Theory]
         [InlineData("buffer, 0, buffer.Length",
@@ -607,20 +718,7 @@ class C
                     true, 82)]
         public Task VB_Analyzer_Diagnostic_VarByteArray(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            string source = @"
-Imports System
-Imports System.IO
-Imports System.Threading
-Public Module C
-    Public Async Sub M()
-        Using s As FileStream = New FileStream(""file.txt"", FileMode.Create)
-            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
-            Await {0}
-        End Using
-    End Sub
-End Module
-            ";
-            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
+            return VisualBasicVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayVisualBasic, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
         }
 
         [Theory]
@@ -650,7 +748,7 @@ Public Module C
     End Sub
 End Module
             ";
-            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 8, 19, 8, endColumn);
+            return VisualBasicVerifyCodeFixAsync(source, originalArgs, fixedArgs, withConfigureAwait, 8, 19, 8, endColumn);
         }
 
         [Theory]
@@ -668,20 +766,7 @@ End Module
                     true, 82)]
         public Task VB_Analyzer_Diagnostic_AsStream(string originalArgs, string fixedArgs, bool withConfigureAwait, int endColumn)
         {
-            string source = @"
-Imports System
-Imports System.IO
-Imports System.Threading
-Public Module C
-    Public Async Sub M()
-        Using s As Stream = New FileStream(""file.txt"", FileMode.Create)
-            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
-            Await {0}
-        End Using
-    End Sub
-End Module
-            ";
-            return GetVBWriteAsyncDiagnostic(source, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
+            return VisualBasicVerifyCodeFixAsync(_sourceWithPredeclaredByteArrayVisualBasic, originalArgs, fixedArgs, withConfigureAwait, 9, 19, 9, endColumn);
         }
 
         #endregion
@@ -690,27 +775,31 @@ End Module
 
         private const string AsyncMethodName = "Write";
 
-        private Task GetCSWriteAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        // Verifies that the fixer generates the fixes for the specified C# diagnostic result configuration for the WriteAsync method.
+        private Task CSharpVerifyCodeFixAsync(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
         {
-            return FixCSAsync(
-                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.CSharp),
-                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.CSharp),
+            return CSharpVerifyCodeFixAsync(
+                GetSourceCodeForInvocation(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.CSharp),
+                GetSourceCodeForInvocation(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.CSharp),
                 GetCSResult(startLine, startColumn, endLine, endColumn));
         }
 
-        private Task GetVBWriteAsyncDiagnostic(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
+        // Verifies that the fixer generates the fixes for the specified VB diagnostic result configuration for the WriteAsync method.
+        private Task VisualBasicVerifyCodeFixAsync(string source, string originalArgs, string fixedArgs, bool withConfigureAwait, int startLine, int startColumn, int endLine, int endColumn)
         {
-            return FixVBAsync(
-                GetFormattedSourceCode(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.VisualBasic),
-                GetFormattedSourceCode(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.VisualBasic),
+            return VisualBasicVerifyCodeFixAsync(
+                GetSourceCodeForInvocation(source, AsyncMethodName, originalArgs, withConfigureAwait, LanguageNames.VisualBasic),
+                GetSourceCodeForInvocation(source, AsyncMethodName, fixedArgs, withConfigureAwait, LanguageNames.VisualBasic),
                 GetVBResult(startLine, startColumn, endLine, endColumn));
         }
 
+        // Returns a C# diagnostic result using the specified rule, lines, columns and preferred method signature for the WriteAsync method.
         protected static DiagnosticResult GetCSResult(int startLine, int startColumn, int endLine, int endColumn)
             => GetCSResultForRule(startLine, startColumn, endLine, endColumn,
                 PreferStreamAsyncMemoryOverloads.PreferStreamWriteAsyncMemoryOverloadsRule,
                 "WriteAsync", "System.IO.Stream.WriteAsync(System.ReadOnlyMemory<byte>, System.Threading.CancellationToken)");
 
+        // Returns a VB diagnostic result using the specified rule, lines, columns and preferred method signature for the WriteAsync method.
         protected static DiagnosticResult GetVBResult(int startLine, int startColumn, int endLine, int endColumn)
             => GetVBResultForRule(startLine, startColumn, endLine, endColumn,
                 PreferStreamAsyncMemoryOverloads.PreferStreamWriteAsyncMemoryOverloadsRule,

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -27,10 +27,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                     Return args.FirstOrDefault(
                         Function(argOperation)
                             argNode = TryCast(argOperation.Syntax, SimpleArgumentSyntax)
-                            Return argNode.NameColonEquals IsNot Nothing AndAlso
-                                    argNode.NameColonEquals.Name IsNot Nothing AndAlso
-                                    argNode.NameColonEquals.Name.Identifier <> Nothing AndAlso
-                                    argNode.NameColonEquals.Name.Identifier.ValueText = name
+                            Return argNode.NameColonEquals?.Name?.Identifier.ValueText = name
                         End Function)
                 End If
             End If

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -1,0 +1,39 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Collections.Immutable
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Operations
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+Imports Microsoft.NetCore.Analyzers.Runtime
+
+Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
+
+    <ExportCodeFixProvider(LanguageNames.VisualBasic)>
+    Public NotInheritable Class PreferStreamAsyncMemoryOverloadsVisualBasicFixer
+
+        Inherits PreferStreamAsyncMemoryOverloadsFixer
+
+        Protected Overrides Function GetArgumentByPositionOrName(args As ImmutableArray(Of IArgumentOperation), index As Integer, name As String, ByRef isNamed As Boolean) As IArgumentOperation
+            isNamed = False
+            If index >= args.Length Then
+                Return Nothing
+            Else
+                Dim argNode = TryCast(args(index).Syntax, SimpleArgumentSyntax)
+                If argNode IsNot Nothing AndAlso argNode.NameColonEquals Is Nothing Then
+                    Return args(index)
+                Else
+                    isNamed = True
+                    Return args.FirstOrDefault(
+                        Function(argOperation)
+                            argNode = TryCast(argOperation.Syntax, SimpleArgumentSyntax)
+                            Return argNode.NameColonEquals IsNot Nothing AndAlso
+                                    argNode.NameColonEquals.Name IsNot Nothing AndAlso
+                                    argNode.NameColonEquals.Name.Identifier <> Nothing AndAlso
+                                    argNode.NameColonEquals.Name.Identifier.ValueText = name
+                        End Function)
+                End If
+            End If
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Fixes dotnet/runtime#33790

### Summary
If the user invokes any of these methods from an object that is or inherits from Stream:

```cs
ReadAsync(byte[] buffer, int offset, int count)
ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
WriteAsync(byte[] buffer, int offset, int count)
WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
```

We should suggest to instead use:
```cs
ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
```

Works for both C# and VB.
All unit tests are passing locally.