### PR TITLE
Fixer for https://github.com/dotnet/runtime/issues/33785

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1306,13 +1306,13 @@
     <value>Remove the ToString call</value>
   </data>
   <data name="PreferStringContainsOverIndexOfDescription" xml:space="preserve">
-    <value>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</value>
+    <value>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</value>
   </data>
   <data name="PreferStringContainsOverIndexOfMessage" xml:space="preserve">
-    <value>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</value>
+    <value>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</value>
   </data>
   <data name="PreferStringContainsOverIndexOfTitle" xml:space="preserve">
-    <value>Consider using 'String.Contains' instead of 'String.IndexOf'</value>
+    <value>Consider using 'string.Contains' instead of 'string.IndexOf'</value>
   </data>
   <data name="PreferConstCharOverConstUnitStringInStringBuilderDescription" xml:space="preserve">
     <value>'StringBuilder.Append(char)' is more efficient than 'StringBuilder.Append(string)' when the string is a single character. When calling 'Append' with a constant, prefer using a constant char rather than a constant string containing one character.</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Analyzer.Utilities;
@@ -79,7 +78,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     int numberOfArguments = indexOfMethodArguments.Length;
                     if (numberOfArguments == 1)
                     {
-                        var firstArgument = indexOfMethodArguments.First();
+                        var firstArgument = indexOfMethodArguments[0];
                         if (firstArgument.Parameter.Type.Equals(charType))
                         {
                             containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -27,99 +27,107 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             Document doc = context.Document;
             CancellationToken cancellationToken = context.CancellationToken;
             SyntaxNode root = await doc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            if (root.FindNode(context.Span) is SyntaxNode expression)
+            if (!(root.FindNode(context.Span) is SyntaxNode expression))
             {
-                SemanticModel semanticModel = await doc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-                var compilation = semanticModel.Compilation;
-                if (!compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemString, out INamedTypeSymbol? stringType) ||
-                    !compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemChar, out INamedTypeSymbol? charType) ||
-                    !compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison, out INamedTypeSymbol? stringComparisonType))
-                {
-                    return;
-                }
-
-                var operation = semanticModel.GetOperation(expression, cancellationToken);
-                // Not offering a code-fix for the variable declaration case
-                if (!(operation is IBinaryOperation binaryOperation))
-                {
-                    return;
-                }
-
-                IInvocationOperation invocationOperation;
-                IOperation otherOperation;
-                if (binaryOperation.LeftOperand is IInvocationOperation invocationOperationOperand)
-                {
-                    invocationOperation = invocationOperationOperand;
-                    otherOperation = binaryOperation.RightOperand;
-                }
-                else
-                {
-                    invocationOperation = (IInvocationOperation)binaryOperation.RightOperand;
-                    otherOperation = binaryOperation.LeftOperand;
-                }
-
-                var instanceOperation = invocationOperation.Instance;
-
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        title: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfTitle,
-                        createChangedDocument: c => ReplaceBinaryOperationWithContains(doc, instanceOperation.Syntax, root, invocationOperation.Arguments, binaryOperation, c),
-                        equivalenceKey: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfMessage),
-                    context.Diagnostics);
                 return;
+            }
 
-                async Task<Document?> ReplaceBinaryOperationWithContains(Document document, SyntaxNode syntaxNode, SyntaxNode treeRoot, ImmutableArray<IArgumentOperation> indexOfMethodArguments, IBinaryOperation binaryOperation, CancellationToken cancellationToken)
+            SemanticModel semanticModel = await doc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var operation = semanticModel.GetOperation(expression, cancellationToken);
+
+            // Not offering a code-fix for the variable declaration case
+            if (!(operation is IBinaryOperation binaryOperation))
+            {
+                return;
+            }
+
+            IInvocationOperation invocationOperation;
+            IOperation otherOperation;
+            if (binaryOperation.LeftOperand is IInvocationOperation invocationOperationOperand)
+            {
+                invocationOperation = invocationOperationOperand;
+                otherOperation = binaryOperation.RightOperand;
+            }
+            else
+            {
+                invocationOperation = (IInvocationOperation)binaryOperation.RightOperand;
+                otherOperation = binaryOperation.LeftOperand;
+            }
+
+            switch (invocationOperation.Arguments.Length)
+            {
+                case 1:
+                case 2:
+                    break;
+                default:
+                    return;
+            }
+
+            var instanceOperation = invocationOperation.Instance;
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfTitle,
+                    createChangedDocument: c => ReplaceBinaryOperationWithContains(doc, instanceOperation.Syntax, invocationOperation.Arguments, binaryOperation, c),
+                    equivalenceKey: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfTitle),
+                context.Diagnostics);
+            return;
+
+            async Task<Document?> ReplaceBinaryOperationWithContains(Document document, SyntaxNode syntaxNode, ImmutableArray<IArgumentOperation> indexOfMethodArguments, IBinaryOperation binaryOperation, CancellationToken cancellationToken)
+            {
+                DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+                SyntaxGenerator generator = editor.Generator;
+                var containsExpression = generator.MemberAccessExpression(syntaxNode, "Contains");
+                SyntaxNode? containsInvocation = null;
+                int numberOfArguments = indexOfMethodArguments.Length;
+                if (numberOfArguments == 1)
                 {
-                    DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-                    SyntaxEditor syntaxEditor = new SyntaxEditor(treeRoot, document.Project.Solution.Workspace);
-                    SyntaxGenerator generator = editor.Generator;
-                    var containsExpression = generator.MemberAccessExpression(syntaxNode, "Contains");
-                    SyntaxNode? containsInvocation = null;
-                    int numberOfArguments = indexOfMethodArguments.Length;
-                    if (numberOfArguments == 1)
+                    var firstArgument = indexOfMethodArguments[0];
+                    if (firstArgument.Parameter.Type.SpecialType == SpecialType.System_Char)
                     {
-                        var firstArgument = indexOfMethodArguments[0];
-                        if (firstArgument.Parameter.Type.Equals(charType))
-                        {
-                            containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax);
-                        }
-                        else
-                        {
-                            var systemNode = generator.IdentifierName("System");
-                            var argument = generator.MemberAccessExpression(generator.MemberAccessExpression(systemNode, "StringComparison"), "CurrentCulture");
-                            containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax, argument);
-                        }
+                        containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax);
                     }
                     else
                     {
-                        IArgumentOperation secondArgument = indexOfMethodArguments[1];
-                        if (secondArgument.Value.ConstantValue.HasValue && secondArgument.Value.ConstantValue.Value is int intValue)
-                        {
-                            if ((StringComparison)intValue == StringComparison.Ordinal)
-                            {
-                                containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax);
-                            }
-                            else
-                            {
-                                containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax, indexOfMethodArguments[1].Syntax);
-                            }
-                        }
-                        else
-                        {
-                            containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax, indexOfMethodArguments[1].Syntax);
-                        }
+                        var systemNode = generator.IdentifierName("System");
+                        var argument = generator.MemberAccessExpression(generator.MemberAccessExpression(systemNode, "StringComparison"), "CurrentCulture");
+                        containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax, argument);
                     }
-                    SyntaxNode newIfCondition = containsInvocation;
-                    int rightValue = (int)otherOperation.ConstantValue.Value;
-                    if (rightValue == -1)
-                    {
-                        newIfCondition = generator.LogicalNotExpression(containsInvocation);
-                    }
-                    newIfCondition = newIfCondition.WithTriviaFrom(binaryOperation.Syntax);
-                    syntaxEditor.ReplaceNode(binaryOperation.Syntax, newIfCondition);
-                    var newRoot = syntaxEditor.GetChangedRoot();
-                    return document.WithSyntaxRoot(newRoot);
                 }
+                else
+                {
+                    int stringOrCharArgumentIndex, ordinalArgumentIndex;
+                    if (indexOfMethodArguments[0].Value.Type.SpecialType == SpecialType.System_String || indexOfMethodArguments[0].Value.Type.SpecialType == SpecialType.System_Char)
+                    {
+                        stringOrCharArgumentIndex = 0;
+                        ordinalArgumentIndex = 1;
+                    }
+                    else
+                    {
+                        stringOrCharArgumentIndex = 1;
+                        ordinalArgumentIndex = 0;
+                    }
+
+                    var ordinalArgumentValue = indexOfMethodArguments[ordinalArgumentIndex].Value;
+                    if (ordinalArgumentValue.ConstantValue.HasValue &&
+                        ordinalArgumentValue.ConstantValue.Value is int intValue &&
+                        (StringComparison)intValue == StringComparison.Ordinal)
+                    {
+                        containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[stringOrCharArgumentIndex].Syntax);
+                    }
+                    else
+                    {
+                        containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax, indexOfMethodArguments[1].Syntax);
+                    }
+                }
+
+                SyntaxNode newIfCondition = (int)otherOperation.ConstantValue.Value != -1 ?
+                                            containsInvocation :
+                                            generator.LogicalNotExpression(containsInvocation);
+                newIfCondition = newIfCondition.WithTriviaFrom(binaryOperation.Syntax);
+                editor.ReplaceNode(binaryOperation.Syntax, newIfCondition);
+                var newRoot = editor.GetChangedRoot();
+                return document.WithSyntaxRoot(newRoot);
             }
         }
     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Runtime
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic), Shared]
+    public sealed class PreferStringContainsOverIndexOfFixer : CodeFixProvider
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PreferStringContainsOverIndexOfAnalyzer.RuleId);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            Document doc = context.Document;
+            CancellationToken cancellationToken = context.CancellationToken;
+            SyntaxNode root = await doc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root.FindNode(context.Span) is SyntaxNode expression)
+            {
+                SemanticModel semanticModel = await doc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var compilation = semanticModel.Compilation;
+                if (!compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemString, out INamedTypeSymbol? stringType) ||
+                    !compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemChar, out INamedTypeSymbol? charType) ||
+                    !compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison, out INamedTypeSymbol? stringComparisonType))
+                {
+                    return;
+                }
+
+                var operation = semanticModel.GetOperation(expression, cancellationToken);
+                // Not offering a code-fix for the variable declaration case
+                if (!(operation is IBinaryOperation binaryOperation))
+                {
+                    return;
+                }
+
+                IInvocationOperation invocationOperation;
+                IOperation otherOperation;
+                if (binaryOperation.LeftOperand is IInvocationOperation)
+                {
+                    invocationOperation = (IInvocationOperation)binaryOperation.LeftOperand;
+                    otherOperation = binaryOperation.RightOperand;
+                }
+                else
+                {
+                    invocationOperation = (IInvocationOperation)binaryOperation.RightOperand;
+                    otherOperation = binaryOperation.LeftOperand;
+                }
+
+                var instanceOperation = invocationOperation.Instance;
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfTitle,
+                        createChangedDocument: c => ReplaceBinaryOperationWithContains(doc, instanceOperation.Syntax, root, invocationOperation.Arguments, binaryOperation, c),
+                        equivalenceKey: MicrosoftNetCoreAnalyzersResources.PreferStringContainsOverIndexOfMessage),
+                    context.Diagnostics);
+                return;
+
+                async Task<Document?> ReplaceBinaryOperationWithContains(Document document, SyntaxNode syntaxNode, SyntaxNode treeRoot, ImmutableArray<IArgumentOperation> indexOfMethodArguments, IBinaryOperation binaryOperation, CancellationToken cancellationToken)
+                {
+                    DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+                    SyntaxEditor syntaxEditor = new SyntaxEditor(treeRoot, document.Project.Solution.Workspace);
+                    SyntaxGenerator generator = editor.Generator;
+                    var containsExpression = generator.MemberAccessExpression(syntaxNode, "Contains");
+                    SyntaxNode? containsInvocation = null;
+                    int numberOfArguments = indexOfMethodArguments.Length;
+                    if (numberOfArguments == 1)
+                    {
+                        var firstArgument = indexOfMethodArguments.First();
+                        if (firstArgument.Parameter.Type.Equals(charType))
+                        {
+                            containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax);
+                        }
+                        else
+                        {
+                            var systemNode = generator.IdentifierName("System");
+                            var argument = generator.MemberAccessExpression(generator.MemberAccessExpression(systemNode, "StringComparison"), "CurrentCulture");
+                            containsInvocation = generator.InvocationExpression(containsExpression, firstArgument.Syntax, argument);
+                        }
+                    }
+                    else
+                    {
+                        IArgumentOperation secondArgument = indexOfMethodArguments[1];
+                        if (secondArgument.Value.ConstantValue.HasValue && secondArgument.Value.ConstantValue.Value is int intValue)
+                        {
+                            if ((StringComparison)intValue == StringComparison.Ordinal)
+                            {
+                                containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax);
+                            }
+                            else
+                            {
+                                containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax, indexOfMethodArguments[1].Syntax);
+                            }
+                        }
+                        else
+                        {
+                            containsInvocation = generator.InvocationExpression(containsExpression, indexOfMethodArguments[0].Syntax, indexOfMethodArguments[1].Syntax);
+                        }
+                    }
+                    SyntaxNode newIfCondition = containsInvocation;
+                    int rightValue = (int)otherOperation.ConstantValue.Value;
+                    if (rightValue == -1)
+                    {
+                        newIfCondition = generator.LogicalNotExpression(containsInvocation);
+                    }
+                    syntaxEditor.ReplaceNode(binaryOperation.Syntax, newIfCondition);
+                    var newRoot = syntaxEditor.GetChangedRoot();
+                    return document.WithSyntaxRoot(newRoot);
+                }
+            }
+        }
+    }
+}

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -5,8 +5,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Analyzer.Utilities;
-using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -47,9 +47,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 IInvocationOperation invocationOperation;
                 IOperation otherOperation;
-                if (binaryOperation.LeftOperand is IInvocationOperation)
+                if (binaryOperation.LeftOperand is IInvocationOperation invocationOperationOperand)
                 {
-                    invocationOperation = (IInvocationOperation)binaryOperation.LeftOperand;
+                    invocationOperation = invocationOperationOperand;
                     otherOperation = binaryOperation.RightOperand;
                 }
                 else
@@ -115,6 +115,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         newIfCondition = generator.LogicalNotExpression(containsInvocation);
                     }
+                    newIfCondition = newIfCondition.WithTriviaFrom(binaryOperation.Syntax);
                     syntaxEditor.ReplaceNode(binaryOperation.Syntax, newIfCondition);
                     var newRoot = syntaxEditor.GetChangedRoot();
                     return document.WithSyntaxRoot(newRoot);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="translated">Volání metody String.IndexOf, kde se pomocí výsledku kontroluje přítomnost nebo nepřítomnost podřetězce, se dá nahradit metodou String.Contains.</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="needs-review-translation">Volání metody String.IndexOf, kde se pomocí výsledku kontroluje přítomnost nebo nepřítomnost podřetězce, se dá nahradit metodou String.Contains.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="translated">Pro lepší čitelnost použijte místo String.IndexOf metodu String.Contains.</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="needs-review-translation">Pro lepší čitelnost použijte místo String.IndexOf metodu String.Contains.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="translated">Zvážit možnost místo String.IndexOf použít String.Contains</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="needs-review-translation">Zvážit možnost místo String.IndexOf použít String.Contains</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1394,18 +1394,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="translated">Wywołania elementu „String.IndexOf”, w przypadku których wynik jest używany do sprawdzania obecności/nieobecności podciągu, mogą zostać zastąpione przez wyrażenie „String.Contains”</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="needs-review-translation">Wywołania elementu „String.IndexOf”, w przypadku których wynik jest używany do sprawdzania obecności/nieobecności podciągu, mogą zostać zastąpione przez wyrażenie „String.Contains”</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="translated">Użyj ciągu „String.Contains” zamiast ciągu „String.IndexOf”, aby zwiększyć czytelność</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="needs-review-translation">Użyj ciągu „String.Contains” zamiast ciągu „String.IndexOf”, aby zwiększyć czytelność</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="translated">Rozważ użycie ciągu „String.Contains” zamiast „String.IndexOf”</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="needs-review-translation">Rozważ użycie ciągu „String.Contains” zamiast „String.IndexOf”</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="translated">Chamadas para 'String.IndexOf' em que o resultado é usado para verificar a presença/ausência de uma substring podem ser substituídas por 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="needs-review-translation">Chamadas para 'String.IndexOf' em que o resultado é usado para verificar a presença/ausência de uma substring podem ser substituídas por 'String.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="translated">Use 'String.Contains' em vez de 'String.IndexOf' para melhorar a legibilidade</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="needs-review-translation">Use 'String.Contains' em vez de 'String.IndexOf' para melhorar a legibilidade</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="translated">Considere usar 'String.Contains' em vez de 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="needs-review-translation">Considere usar 'String.Contains' em vez de 'String.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1393,18 +1393,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfDescription">
-        <source>Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</source>
-        <target state="new">Calls to 'String.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'String.Contains'</target>
+        <source>Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</source>
+        <target state="new">Calls to 'string.IndexOf' where the result is used to check for the presence/absence of a substring can be replaced by 'string.Contains'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfMessage">
-        <source>Use 'String.Contains' instead of 'String.IndexOf' to improve readability</source>
-        <target state="new">Use 'String.Contains' instead of 'String.IndexOf' to improve readability</target>
+        <source>Use 'string.Contains' instead of 'string.IndexOf' to improve readability</source>
+        <target state="new">Use 'string.Contains' instead of 'string.IndexOf' to improve readability</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferStringContainsOverIndexOfTitle">
-        <source>Consider using 'String.Contains' instead of 'String.IndexOf'</source>
-        <target state="new">Consider using 'String.Contains' instead of 'String.IndexOf'</target>
+        <source>Consider using 'string.Contains' instead of 'string.IndexOf'</source>
+        <target state="new">Consider using 'string.Contains' instead of 'string.IndexOf'</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferTypedStringBuilderAppendOverloadsDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
@@ -391,6 +391,301 @@ End Class
         }
 
         [Theory]
+        [InlineData("This", false)]
+        [InlineData("a", true)]
+        public async Task TestStringAndCharNamedArgumentCombinationVB(string input, bool isCharTest)
+        {
+            string startQuote = "\"";
+            string vbCharLiteral = isCharTest ? "c" : "";
+            string vbInput = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If [|Str.IndexOf(value:= " + startQuote + input + startQuote + vbCharLiteral + @", System.StringComparison.Ordinal) = -1|] Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            string vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If Not Str.Contains(value:= " + startQuote + input + startQuote + vbCharLiteral + @") Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            var testOrdinal_vb = new VerifyVB.Test
+            {
+                TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal_vb.RunAsync();
+
+            vbInput = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If [|Str.IndexOf(value:= " + startQuote + input + startQuote + vbCharLiteral + @", comparisonType:= System.StringComparison.OrdinalIgnoreCase) = -1|] Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If Not Str.Contains(value:= " + startQuote + input + startQuote + vbCharLiteral + @", comparisonType:= System.StringComparison.OrdinalIgnoreCase) Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            testOrdinal_vb = new VerifyVB.Test
+            {
+                TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal_vb.RunAsync();
+
+            vbInput = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If [|Str.IndexOf(" + startQuote + input + startQuote + vbCharLiteral + @", comparisonType:= System.StringComparison.OrdinalIgnoreCase) = -1|] Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If Not Str.Contains(" + startQuote + input + startQuote + vbCharLiteral + @", comparisonType:= System.StringComparison.OrdinalIgnoreCase) Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            testOrdinal_vb = new VerifyVB.Test
+            {
+                TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal_vb.RunAsync();
+
+            vbInput = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If [|Str.IndexOf(comparisonType:= System.StringComparison.OrdinalIgnoreCase, value:= " + startQuote + input + startQuote + vbCharLiteral + @") = -1|] Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If Not Str.Contains(value:= " + startQuote + input + startQuote + vbCharLiteral + @", comparisonType:= System.StringComparison.OrdinalIgnoreCase) Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
+            testOrdinal_vb = new VerifyVB.Test
+            {
+                TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal_vb.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("This", false)]
+        [InlineData("a", true)]
+        public async Task TestStringAndCharNamedArgumentCombinationsCS(string input, bool isCharTest)
+        {
+            string startQuote = isCharTest ? "'" : "\"";
+            string csInput = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if ([|str.IndexOf(value: " + startQuote + input + startQuote + @", System.StringComparison.Ordinal) == -1|])
+            {
+
+            }
+        } 
+    } 
+}";
+            string csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if (!str.Contains(value: " + startQuote + input + startQuote + @"))
+            {
+
+            }
+        } 
+    } 
+}";
+            var testOrdinal = new VerifyCS.Test
+            {
+                TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal.RunAsync();
+
+            csInput = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if ([|str.IndexOf(value: " + startQuote + input + startQuote + @", comparisonType: System.StringComparison.OrdinalIgnoreCase) == -1|])
+            {
+
+            }
+        } 
+    } 
+}";
+            csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if (!str.Contains(value: " + startQuote + input + startQuote + @", comparisonType: System.StringComparison.OrdinalIgnoreCase))
+            {
+
+            }
+        } 
+    } 
+}";
+            testOrdinal = new VerifyCS.Test
+            {
+                TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal.RunAsync();
+
+            csInput = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if ([|str.IndexOf(" + startQuote + input + startQuote + @", comparisonType: System.StringComparison.OrdinalIgnoreCase) == -1|])
+            {
+
+            }
+        } 
+    } 
+}";
+            csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if (!str.Contains(" + startQuote + input + startQuote + @", comparisonType: System.StringComparison.OrdinalIgnoreCase))
+            {
+
+            }
+        } 
+    } 
+}";
+            testOrdinal = new VerifyCS.Test
+            {
+                TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal.RunAsync();
+
+            csInput = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if ([|str.IndexOf(comparisonType: System.StringComparison.OrdinalIgnoreCase, value: " + startQuote + input + startQuote + @") == -1|])
+            {
+
+            }
+        } 
+    } 
+}";
+            csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if (!str.Contains(comparisonType: System.StringComparison.OrdinalIgnoreCase, value: " + startQuote + input + startQuote + @"))
+            {
+
+            }
+        } 
+    } 
+}";
+            testOrdinal = new VerifyCS.Test
+            {
+                TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+            };
+            await testOrdinal.RunAsync();
+        }
+
+        [Theory]
         [InlineData("This", false, ", 1")]
         [InlineData("a", true, ", 1")]
         [InlineData("This", false, ", 1", ", 2")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
@@ -6,27 +6,21 @@ using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStringContainsOverIndexOfAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+    Microsoft.NetCore.Analyzers.Runtime.PreferStringContainsOverIndexOfFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStringContainsOverIndexOfAnalyzer,
-    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
-
-// The following pragmas should be removed when the fixer is implemented. 
-#pragma warning disable IDE0060 // Remove unused parameter
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
-#pragma warning disable CA1801 // Unused parameter
+    Microsoft.NetCore.Analyzers.Runtime.PreferStringContainsOverIndexOfFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class PreferStringContainsOverIndexOfTests
     {
         [Theory]
-        [InlineData("This", "This", false, " == ", " -1", "!")]
-        [InlineData("a", "a", true, " == ", " -1", "!")]
-        [InlineData("This", "This", false, " >= ", " 0", "")]
-        [InlineData("a", "a", true, " >= ", " 0", "")]
-        public async Task TestStringAndChar(string input, string fix, bool isCharTest, string operatorKind, string value, string notString)
+        [InlineData("This", false, " == ", " -1")]
+        [InlineData("a", true, " == ", " -1")]
+        [InlineData("This", false, " >= ", " 0")]
+        [InlineData("a", true, " >= ", " 0")]
+        public async Task TestStringAndChar(string input, bool isCharTest, string operatorKind, string value)
         {
             string startQuote = isCharTest ? "'" : "\"";
             string endQuote = isCharTest ? "'" : "\", System.StringComparison.Ordinal";
@@ -50,7 +44,6 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
@@ -58,7 +51,6 @@ namespace TestNamespace
             string vbCharLiteral = isCharTest ? "c" : "";
             string stringComparison = isCharTest ? "" : ", System.StringComparison.Ordinal";
             operatorKind = operatorKind == " == " ? " = " : operatorKind;
-            notString = notString == "!" ? " Not" : notString;
 
             string vbInput = @"
 Public Class StringOf
@@ -83,9 +75,9 @@ End Class
         }
 
         [Theory]
-        [InlineData(" == ", " -1", "!")]
-        [InlineData(" >= ", " 0", "")]
-        public async Task TestStringNoComparisonArgument(string operatorKind, string value, string notString)
+        [InlineData(" == ", " -1")]
+        [InlineData(" >= ", " 0")]
+        public async Task TestStringNoComparisonArgument(string operatorKind, string value)
         {
             string csInput = @"
 namespace TestNamespace 
@@ -107,12 +99,10 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
             operatorKind = operatorKind == " == " ? " = " : operatorKind;
-            notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -136,9 +126,9 @@ End Class
         }
 
         [Theory]
-        [InlineData(" == ", " -1", "!")]
-        [InlineData(" >= ", " 0", "")]
-        public async Task TestCharAndOrdinal(string operatorKind, string value, string notString)
+        [InlineData(" == ", " -1")]
+        [InlineData(" >= ", " 0")]
+        public async Task TestCharAndOrdinal(string operatorKind, string value)
         {
             string csInput = @"
 namespace TestNamespace 
@@ -160,12 +150,10 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
             operatorKind = operatorKind == " == " ? " = " : operatorKind;
-            notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -189,9 +177,9 @@ End Class
         }
 
         [Theory]
-        [InlineData("This", "This", false)]
-        [InlineData("a", "a", true)]
-        public async Task TestStringAndCharWithMultipleDiagnostics(string input, string fix, bool isCharTest)
+        [InlineData("This", false)]
+        [InlineData("a", true)]
+        public async Task TestStringAndCharWithMultipleDiagnostics(string input, bool isCharTest)
         {
             string startQuote = isCharTest ? "'" : "\"";
             string endQuote = isCharTest ? "'" : "\", System.StringComparison.Ordinal";
@@ -221,7 +209,6 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
@@ -255,9 +242,9 @@ End Class
         }
 
         [Theory]
-        [InlineData("This", "This", false)]
-        [InlineData("a", "a", true)]
-        public async Task TestStringAndCharWithComparison(string input, string fix, bool isCharTest)
+        [InlineData("This", false)]
+        [InlineData("a", true)]
+        public async Task TestStringAndCharWithComparison(string input, bool isCharTest)
         {
             string quotes = isCharTest ? "'" : "\"";
             string csInput = @" 
@@ -281,7 +268,6 @@ namespace TestNamespace
             {
                 TestCode = csInput,
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await test.RunAsync();
 
@@ -310,9 +296,9 @@ End Class
         }
 
         [Theory]
-        [InlineData("This", "This", false)]
-        [InlineData("a", "a", true)]
-        public async Task TestLeftAndRightOperandInvocations(string input, string fix, bool isCharTest)
+        [InlineData("This", false)]
+        [InlineData("a", true)]
+        public async Task TestLeftAndRightOperandInvocations(string input, bool isCharTest)
         {
             string startQuote = isCharTest ? "'" : "\"";
             string endQuote = isCharTest ? "'" : "\", System.StringComparison.Ordinal";
@@ -335,11 +321,30 @@ namespace TestNamespace
         } 
     } 
 }";
+            string csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod() 
+        { 
+            const string str = ""This is a string"";
+            if (!str.Contains(" + startQuote + input + startQuote + @"))
+            {
+
+            }
+            if (!str.Contains(" + startQuote + input + startQuote + @"))
+            {
+
+            }
+        } 
+    } 
+}";
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
@@ -361,10 +366,25 @@ Public Class StringOf
     End Class
 End Class
 ";
+            string vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub Main()
+            Dim Str As String = ""This is a statement""
+            If Not Str.Contains(" + startQuote + input + startQuote + vbCharLiteral + @") Then
 
+            End If
+            If Not Str.Contains(" + startQuote + input + startQuote + vbCharLiteral + @") Then
+
+            End If
+        End Sub
+    End Class
+End Class
+";
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
             };
             await testOrdinal_vb.RunAsync();
@@ -681,11 +701,24 @@ namespace TestNamespace
         } 
     } 
 }";
+            string csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod(string str) 
+        { 
+            if (" + notString + @"str.Contains(""This"", System.StringComparison.CurrentCulture)" + @")
+            {
+            }
+        } 
+    } 
+}";
             var testCulture = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testCulture.RunAsync();
 
@@ -702,10 +735,21 @@ Public Class StringOf
     End Class
 End Class
 ";
+            string vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub AMethod(arg As String)
+            If" + notString + @" arg.Contains(""This"", System.StringComparison.CurrentCulture)" + @" Then
 
+            End If
+        End Sub
+    End Class
+End Class
+";
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
             };
             await testOrdinal_vb.RunAsync();
@@ -729,11 +773,24 @@ namespace TestNamespace
         } 
     } 
 }";
+            string csFix = @"
+namespace TestNamespace 
+{ 
+    class TestClass 
+    { 
+        private void TestMethod(string str, System.StringComparison comparison) 
+        { 
+            if (" + notString + @"str.Contains(""This"", comparison)" + @")
+            {
+            }
+        } 
+    } 
+}";
             var testCulture = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
+                FixedState = { Sources = { csFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testCulture.RunAsync();
 
@@ -750,19 +807,30 @@ Public Class StringOf
     End Class
 End Class
 ";
+            string vbFix = @"
+Public Class StringOf
+    Class TestClass
+        Public Sub AMethod(arg As String, comparison As System.StringComparison)
+            If" + notString + @" arg.Contains(""This"", comparison)" + @" Then
 
+            End If
+        End Sub
+    End Class
+End Class
+";
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
+                FixedState = { Sources = { vbFix } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
             };
             await testOrdinal_vb.RunAsync();
         }
 
         [Theory]
-        [InlineData(" == ", " -1", "!")]
-        [InlineData(" >= ", " 0", "")]
-        public async Task TestReversedMultipleDeclarations(string operatorKind, string value, string notString)
+        [InlineData(" == ", " -1")]
+        [InlineData(" >= ", " 0")]
+        public async Task TestReversedMultipleDeclarations(string operatorKind, string value)
         {
             string csInput = @"
 namespace TestNamespace 
@@ -784,12 +852,10 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
             operatorKind = operatorKind == " == " ? " = " : operatorKind;
-            notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -813,9 +879,9 @@ End Class
         }
 
         [Theory]
-        [InlineData(" == ", " -1", "!")]
-        [InlineData(" >= ", " 0", "")]
-        public async Task TestMultipleDeclarations(string operatorKind, string value, string notString)
+        [InlineData(" == ", " -1")]
+        [InlineData(" >= ", " 0")]
+        public async Task TestMultipleDeclarations(string operatorKind, string value)
         {
             string csInput = @"
 namespace TestNamespace 
@@ -837,12 +903,10 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
             };
             await testOrdinal.RunAsync();
 
             operatorKind = operatorKind == " == " ? " = " : operatorKind;
-            notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
     Class TestClass


### PR DESCRIPTION
Offers a code-fix for the following cases when they appear inside a binary expression such as `if (string.IndexOf() == -1)`:

``` csharp
String.IndexOf(char) -> string.Contains(char)
String.IndexOf(string) -> string.Contains(string, StringComparison.CurrentCulture)
String.IndexOf(string/char, StringComparison.Ordinal) -> string.Contains(string/char)
String.IndexOf(string/char, NON StringComparison.Ordinal) -> string.Contains(string/char, NON StringComparison.Ordinal)
```

The analyzer also tags the following case, but @mavasani recommended against offering a code-fix here(since it involves more data flow analysis than roslyn provides currently). Note: The analyzer will still fire:
``` csharp
int index = str.IndexOf("AString");
if (index == -1)
```