### PR TITLE
publish our nuget package to the azure blob feed so the .NET Core SDK can consume them

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -7,6 +7,7 @@ queue:
 variables:
   BuildConfiguration: Release
   TeamName: Roslyn
+  _DotNetArtifactsCategory: .NETCore
 
 steps:
 - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@1
@@ -22,6 +23,12 @@ steps:
             /p:DotNetSignType=$(SignType)
             /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
             /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+            /p:PublishToSymbolServer=true
+            /p:DotNetPublishToBlobFeed=true
+            /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
+            /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
+            /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+            /p:DotnetPublishUsingPipelines=true
   displayName: Build
 
 - task: NuGetPublisher@0

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Dependencies>
+  <ProductDependencies>
+  </ProductDependencies>
+  <ToolsetDependencies>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.20230.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>5fd50687c9a9f39bd2ee8221165ea9c1b3f565d9</Sha>
+    </Dependency>
+  </ToolsetDependencies>
+</Dependencies>

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "vswhere": "2.2.7"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20221.2"
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.20230.5"
   }
 }


### PR DESCRIPTION
This is the first part of a set of changes that will allot the roslyn-analyzers repo to be consumed from the .NET Core SDK