### PR TITLE
Fix handling of successor.Destination in UseValueTasksCorrectly

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -273,7 +273,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                     // If there's a conditional successor, we not only need to follow it, we need to evaluate the
                     // condition. That condition might be something like "if (vt.IsCompleted)", in which case
                     // we need to flow that completion knowledge (just as with asserts) into the relevant branch.
-                    if (block.ConditionalSuccessor != null)
+                    if (block.ConditionalSuccessor?.Destination is BasicBlock conditional)
                     {
                         if (!(setFallthroughKnownCompletion | setConditionalKnownCompletion) ||
                             block.BranchValue != null)
@@ -292,14 +292,14 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                             }
                         }
 
-                        HandleSuccessor(block.ConditionalSuccessor.Destination, setConditionalKnownCompletion);
+                        HandleSuccessor(conditional, setConditionalKnownCompletion);
                     }
 
                     // If there's a fallback successor, follow it as well. We computed any necessary completion
                     // value previously, so just pass that along.
-                    if (block.FallThroughSuccessor != null)
+                    if (block.FallThroughSuccessor?.Destination is BasicBlock fallthrough)
                     {
-                        HandleSuccessor(block.FallThroughSuccessor.Destination, setFallthroughKnownCompletion);
+                        HandleSuccessor(fallthrough, setFallthroughKnownCompletion);
                     }
 
                     // Processes a successor, determining whether to push it onto the evaluation stack or update

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
@@ -887,6 +887,51 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
         }
 
         [Fact]
+        public async Task NoDiagnostics_StoreLocalUnused()
+        {
+            // NOTE: This is a false negative.  Ideally the analyzer would catch
+            // this case, but the validation to ensure the local is properly consumed
+            // is challenging and we prefer false negatives over false positives.
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public void StoreLocalUnused()
+                    {
+                        ValueTask vt0 = Helpers.ReturnsValueTask();
+                        ValueTask<string> vt1 = Helpers.ReturnsValueTaskOfT<string>();
+                        ValueTask<int> vt2 = Helpers.ReturnsValueTaskOfInt();
+                    }
+                }")
+            );
+        }
+
+        [Fact]
+        public async Task NoDiagnostics_StoreLocalUnused_Guarded()
+        {
+            // NOTE: This is a false negative.  Ideally the analyzer would catch
+            // this case, but the validation to ensure the local is properly consumed
+            // is challenging and we prefer false negatives over false positives.
+            await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"
+                using System;
+                using System.Threading.Tasks;
+
+                class C
+                {
+                    public void StoreLocalUnused(bool guard)
+                    {
+                        if (guard) throw new Exception();
+                        ValueTask vt0 = Helpers.ReturnsValueTask();
+                        ValueTask<string> vt1 = Helpers.ReturnsValueTaskOfT<string>();
+                        ValueTask<int> vt2 = Helpers.ReturnsValueTaskOfInt();
+                    }
+                }")
+            );
+        }
+
+        [Fact]
         public async Task Diagnostics_PassAsGeneric()
         {
             await VerifyCS.VerifyAnalyzerAsync(CSBoilerplate(@"


### PR DESCRIPTION
I didn't realize Destination could be null: IntelliSense lied to me again ;-) ("'Destination' is not null here.)

Fixes https://github.com/dotnet/roslyn-analyzers/issues/3642