### PR TITLE
CA1043: Allow System.Index and System.Range for indexers

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             });
         }
 
-        private void AnalyzeSymbol(SymbolAnalysisContext context, ImmutableHashSet<INamedTypeSymbol> allowedTypes)
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, ImmutableHashSet<INamedTypeSymbol> allowedTypes)
         {
             var symbol = (IPropertySymbol)context.Symbol;
             if (!symbol.IsIndexer || symbol.IsOverride)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexers.cs
@@ -31,16 +31,17 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                              isPortedFxCopRule: true,
                                                                              isDataflowRule: false);
 
-        private static readonly SpecialType[] s_allowedSpecialTypes = new[] {
-                        SpecialType.System_String,
-                        SpecialType.System_Int16,
-                        SpecialType.System_Int32,
-                        SpecialType.System_Int64,
-                        SpecialType.System_Object,
-                        SpecialType.System_UInt16,
-                        SpecialType.System_UInt32,
-                        SpecialType.System_UInt64
-                        };
+        private static readonly ImmutableHashSet<SpecialType> s_allowedSpecialTypes =
+            ImmutableHashSet.Create(
+                SpecialType.System_String,
+                SpecialType.System_Int16,
+                SpecialType.System_Int32,
+                SpecialType.System_Int64,
+                SpecialType.System_Object,
+                SpecialType.System_UInt16,
+                SpecialType.System_UInt32,
+                SpecialType.System_UInt64
+            );
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -70,30 +71,36 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         private void AnalyzeSymbol(SymbolAnalysisContext context, ImmutableHashSet<INamedTypeSymbol> allowedTypes)
         {
             var symbol = (IPropertySymbol)context.Symbol;
-            if (symbol.IsIndexer &&
-                !symbol.IsOverride &&
-                symbol.MatchesConfiguredVisibility(context.Options, Rule, context.Compilation, context.CancellationToken))
+            if (!symbol.IsIndexer || symbol.IsOverride)
             {
-                if (symbol.GetParameters().Length == 1)
-                {
-                    ITypeSymbol paramType = symbol.GetParameters()[0].Type;
+                return;
+            }
 
-                    if (paramType.TypeKind == TypeKind.TypeParameter)
-                    {
-                        return;
-                    }
+            if (symbol.Parameters.Length != 1)
+            {
+                return;
+            }
 
-                    if (paramType.TypeKind == TypeKind.Enum)
-                    {
-                        paramType = ((INamedTypeSymbol)paramType).EnumUnderlyingType;
-                    }
+            ITypeSymbol paramType = symbol.Parameters[0].Type;
 
-                    if (!s_allowedSpecialTypes.Contains(paramType.SpecialType) &&
-                        !allowedTypes.Contains(paramType))
-                    {
-                        context.ReportDiagnostic(symbol.CreateDiagnostic(Rule));
-                    }
-                }
+            if (paramType.TypeKind == TypeKind.TypeParameter)
+            {
+                return;
+            }
+
+            if (paramType.TypeKind == TypeKind.Enum)
+            {
+                paramType = ((INamedTypeSymbol)paramType).EnumUnderlyingType;
+            }
+
+            if (s_allowedSpecialTypes.Contains(paramType.SpecialType) || allowedTypes.Contains(paramType))
+            {
+                return;
+            }
+
+            if (symbol.MatchesConfiguredVisibility(context.Options, Rule, context.Compilation, context.CancellationToken))
+            {
+                context.ReportDiagnostic(symbol.CreateDiagnostic(Rule));
             }
         }
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseIntegralOrStringArgumentForIndexersTests.cs
@@ -200,6 +200,66 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
     End Class");
         }
 
+        [Fact, WorkItem(3638, "https://github.com/dotnet/roslyn-analyzers/issues/3638")]
+        public async Task CA1043_IndexerOfTypeSystemIndex_NoDiagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp30,
+                TestCode = @"
+public class C
+{
+    public string this[System.Index index]
+    {
+        get => null;
+    }
+}",
+            }.RunAsync();
+
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp30,
+                TestCode = @"
+Public Class Months
+    Default ReadOnly Property Item(index As System.Index) As String
+        Get
+            Return Nothing
+        End Get
+    End Property
+End Class",
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3638, "https://github.com/dotnet/roslyn-analyzers/issues/3638")]
+        public async Task CA1043_IndexerOfTypeSystemRange_NoDiagnostic()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp30,
+                TestCode = @"
+public class C
+{
+    public string this[System.Range range]
+    {
+        get => null;
+    }
+}",
+            }.RunAsync();
+
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp30,
+                TestCode = @"
+Public Class Months
+    Default ReadOnly Property Item(index As System.Range) As String
+        Get
+            Return Nothing
+        End Get
+    End Property
+End Class",
+            }.RunAsync();
+        }
+
         private static DiagnosticResult CreateCSharpResult(int line, int col)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, col);

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -173,6 +173,7 @@ namespace Analyzer.Utilities
         public const string SystemIDisposable = "System.IDisposable";
         public const string SystemIEquatable1 = "System.IEquatable`1";
         public const string SystemIFormatProvider = "System.IFormatProvider";
+        public const string SystemIndex = "System.Index";
         public const string SystemInt16 = "System.Int16";
         public const string SystemInt32 = "System.Int32";
         public const string SystemInt64 = "System.Int64";


### PR DESCRIPTION
Fix #3638 for the original 2 points but there are still some open questions (they might deserve a separate thread).

The first commit of the PR is the actual fix, the second is a code refactoring to reduce nesting, improve performance by checking the `api_surface` later in the code and also by using `ImmutableHashSet` instead of `array` for the contains check. Please feel free to push a revert for the second commit if you prefer not to have it.