### PR TITLE
CA2241: AutoDetectStringFormattingMethods

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -239,6 +239,16 @@ Examples:
 |`dotnet_code_quality.additional_string_formatting_methods = NS.MyType.MyFormat(ParamType)` | Matches specific method 'MyFormat' with given fully qualified signature
 |`dotnet_code_quality.additional_string_formatting_methods = NS1.MyType1.MyFormat1(ParamType)\|NS2.MyType2.MyFormat2(ParamType)` | Matches specific methods 'MyFormat1' and 'MyFormat2' with respective fully qualified signature
 
+Option Name: `try_determine_additional_string_formatting_methods_automatically`
+
+Configurable Rules: [CA2241](https://docs.microsoft.com/visualstudio/code-quality/ca2241)
+
+Option Values: Boolean values
+
+Default Value: `false`
+
+Example: `dotnet_code_quality.try_determine_additional_string_formatting_methods_automatically = true`
+
 ### Excluded symbol names
 
 Option Name: `excluded_symbol_names`

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -241,6 +241,9 @@ Examples:
 
 Option Name: `try_determine_additional_string_formatting_methods_automatically`
 
+Boolean option to enable heuristically detecting of additional string formatting methods
+A method is considered a string formatting method if it has a 'string format' parameter followed by a 'params object[]' parameter.
+
 Configurable Rules: [CA2241](https://docs.microsoft.com/visualstudio/code-quality/ca2241)
 
 Option Values: Boolean values

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -67,7 +67,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     var stringFormat = (string)formatStringArgument.Value.ConstantValue.Value;
                     int expectedStringFormatArgumentCount = GetFormattingArguments(stringFormat);
 
-                    // explict parameter case
+                    // explicit parameter case
                     if (info.ExpectedStringFormatArgumentCount >= 0)
                     {
                         // __arglist is not supported here
@@ -351,6 +351,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 var additionalStringFormatMethodsOption = context.Options.GetAdditionalStringFormattingMethodsOption(Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, context.CancellationToken);
                 if (additionalStringFormatMethodsOption.Contains(method.OriginalDefinition) &&
                     TryGetFormatInfo(method, out info))
+                {
+                    return info;
+                }
+
+                // Check if method could be a string formatting method.
+                // This is defined as a method with a 'format' argument followed by an 'params object[]'.
+                if (TryGetFormatInfo(method, out info))
                 {
                     return info;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -355,9 +355,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return info;
                 }
 
+                var heuristicDetermineAdditionalStringFormatMethodsOption = context.Options.GetBoolOptionValue(EditorConfigOptionNames.HeuristicDetermineAdditionalStringFormattingMethods, Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, false, context.CancellationToken);
                 // Check if method could be a string formatting method.
                 // This is defined as a method with a 'format' argument followed by an 'params object[]'.
-                if (TryGetFormatInfo(method, out info))
+                if (heuristicDetermineAdditionalStringFormatMethodsOption &&
+                    TryGetFormatInfo(method, out info) && info.ExpectedStringFormatArgumentCount == -1)
                 {
                     return info;
                 }
@@ -387,6 +389,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 int formatIndex = FindParameterIndexOfName(method.Parameters, Format);
                 if (formatIndex < 0 || formatIndex == method.Parameters.Length - 1)
+                {
+                    // no valid format string
+                    return false;
+                }
+
+                if (method.Parameters[formatIndex].Type.SpecialType != SpecialType.System_String)
                 {
                     // no valid format string
                     return false;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -357,11 +357,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 // Check if the user configured automatic determination of formatting methods.
                 // If so, check if the method called has a 'string format' parameter followed by an params array.
-                bool defaultTryDetermineAdditionalStringFormattingMethodsAutomatically = false;
-                var canTryDetermineAdditionalStringFormattingMethodsAutomatically = context.Options.GetBoolOptionValue(EditorConfigOptionNames.TryDetermineAdditionalStringFormattingMethodsAutomatically,
-                        Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, defaultTryDetermineAdditionalStringFormattingMethodsAutomatically, context.CancellationToken);
-                if (canTryDetermineAdditionalStringFormattingMethodsAutomatically &&
-                    TryGetFormatInfo(method, out info) && info.ExpectedStringFormatArgumentCount == -1)
+                var determineAdditionalStringFormattingMethodsAutomatically = context.Options.GetBoolOptionValue(EditorConfigOptionNames.TryDetermineAdditionalStringFormattingMethodsAutomatically,
+                        Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, defaultValue: false, context.CancellationToken);
+                if (determineAdditionalStringFormattingMethodsAutomatically &&
+                    TryGetFormatInfo(method, out info) &&
+                    info.ExpectedStringFormatArgumentCount == -1)
                 {
                     return info;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -355,10 +355,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return info;
                 }
 
-                var heuristicDetermineAdditionalStringFormatMethodsOption = context.Options.GetBoolOptionValue(EditorConfigOptionNames.HeuristicDetermineAdditionalStringFormattingMethods, Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, false, context.CancellationToken);
-                // Check if method could be a string formatting method.
-                // This is defined as a method with a 'format' argument followed by an 'params object[]'.
-                if (heuristicDetermineAdditionalStringFormatMethodsOption &&
+                // Check if the user configured automatic determination of formatting methods.
+                // If so, check if the method called has a 'string format' parameter followed by an params array.
+                bool defaultTryDetermineAdditionalStringFormattingMethodsAutomatically = false;
+                var canTryDetermineAdditionalStringFormattingMethodsAutomatically = context.Options.GetBoolOptionValue(EditorConfigOptionNames.TryDetermineAdditionalStringFormattingMethodsAutomatically,
+                        Rule, context.Operation.Syntax.SyntaxTree, context.Compilation, defaultTryDetermineAdditionalStringFormattingMethodsAutomatically, context.CancellationToken);
+                if (canTryDetermineAdditionalStringFormattingMethodsAutomatically &&
                     TryGetFormatInfo(method, out info) && info.ExpectedStringFormatArgumentCount == -1)
                 {
                     return info;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -335,9 +335,19 @@ public class C
 ");
         }
 
-        [Fact]
-        public async Task CA2241AutoDetectStringFormattingMethods()
+        [Theory]
+        [WorkItem(2799, "https://github.com/dotnet/roslyn-analyzers/issues/2799")]
+        // No configuration - validate no diagnostics in default configuration
+        [InlineData(null)]
+        // Configured but disabled
+        [InlineData(false)]
+        // Configured and enabled
+        [InlineData(true)]
+        public async Task EditorConfigConfiguration_HeuristicAdditionalStringFormattingMethods(bool? editorConfig)
         {
+            string editorConfigText = editorConfig == null ? string.Empty :
+                "dotnet_code_quality.heuristic_determine_additional_string_formatting_methods = " + editorConfig.Value;
+
             var csharpTest = new VerifyCS.Test
             {
                 TestState =
@@ -355,13 +365,17 @@ class Test
     }
 }"
                     },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
                 }
             };
 
 
-            csharpTest.ExpectedDiagnostics.Add(
-                // Test0.cs(8,17): warning CA2241: Provide correct arguments to formatting methods
-                GetCSharpResultAt(8, 17));
+            if (editorConfig == true)
+            {
+                csharpTest.ExpectedDiagnostics.Add(
+                    // Test0.cs(8,17): warning CA2241: Provide correct arguments to formatting methods
+                    GetCSharpResultAt(8, 17));
+            }
 
             await csharpTest.RunAsync();
 
@@ -382,16 +396,21 @@ Class Test
     End Sub
 End Class"
 },
+                    AdditionalFiles = { (".editorconfig", editorConfigText) }
                 }
             };
 
 
-            basicTest.ExpectedDiagnostics.Add(
-                // Test0.vb(8,17): warning CA2241: Provide correct arguments to formatting methods
-                GetBasicResultAt(8, 17));
+            if (editorConfig == true)
+            {
+                basicTest.ExpectedDiagnostics.Add(
+                    // Test0.vb(8,17): warning CA2241: Provide correct arguments to formatting methods
+                    GetBasicResultAt(8, 17));
+            }
 
             await basicTest.RunAsync();
         }
+
 
         [Theory]
         [WorkItem(2799, "https://github.com/dotnet/roslyn-analyzers/issues/2799")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -335,6 +335,64 @@ public class C
 ");
         }
 
+        [Fact]
+        public async Task CA2241AutoDetectStringFormattingMethods()
+        {
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+class Test
+{
+    public static string MyFormat(string format, params object[] args) => format;
+
+    void M1(string param)
+    {
+        var a = MyFormat("""", 1);
+    }
+}"
+                    },
+                }
+            };
+
+
+            csharpTest.ExpectedDiagnostics.Add(
+                // Test0.cs(8,17): warning CA2241: Provide correct arguments to formatting methods
+                GetCSharpResultAt(8, 17));
+
+            await csharpTest.RunAsync();
+
+            var basicTest = new VerifyVB.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+Class Test
+    Public Shared Function MyFormat(format As String, ParamArray args As Object()) As String
+        Return format
+    End Function
+
+    Private Sub M1(ByVal param As String)
+        Dim a = MyFormat("""", 1)
+    End Sub
+End Class"
+},
+                }
+            };
+
+
+            basicTest.ExpectedDiagnostics.Add(
+                // Test0.vb(8,17): warning CA2241: Provide correct arguments to formatting methods
+                GetBasicResultAt(8, 17));
+
+            await basicTest.RunAsync();
+        }
+
         [Theory]
         [WorkItem(2799, "https://github.com/dotnet/roslyn-analyzers/issues/2799")]
         // No configuration - validate no diagnostics in default configuration

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -346,7 +346,7 @@ public class C
         public async Task EditorConfigConfiguration_HeuristicAdditionalStringFormattingMethods(bool? editorConfig)
         {
             string editorConfigText = editorConfig == null ? string.Empty :
-                "dotnet_code_quality.heuristic_determine_additional_string_formatting_methods = " + editorConfig.Value;
+                "dotnet_code_quality.try_determine_additional_string_formatting_methods_automatically = " + editorConfig.Value;
 
             var csharpTest = new VerifyCS.Test
             {
@@ -410,7 +410,6 @@ End Class"
 
             await basicTest.RunAsync();
         }
-
 
         [Theory]
         [WorkItem(2799, "https://github.com/dotnet/roslyn-analyzers/issues/2799")]

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -68,7 +68,7 @@ namespace Analyzer.Utilities
         public const string AdditionalStringFormattingMethods = "additional_string_formatting_methods";
 
         /// <summary>
-        /// String option to enable heuristically detecting of additional string formatting methods for CA2241 (https://docs.microsoft.com/visualstudio/code-quality/ca2241).
+        /// Boolean option to enable heuristically detecting of additional string formatting methods for CA2241 (https://docs.microsoft.com/visualstudio/code-quality/ca2241).
         /// A method is considered a string formatting method if it has a '<see cref="string"/> <c>format</c>' parameter followed by a <see langword="params"/> <see cref="object"/>[]' parameter.
         /// The default value of this is <c>false</c>.
         /// </summary>

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -68,10 +68,11 @@ namespace Analyzer.Utilities
         public const string AdditionalStringFormattingMethods = "additional_string_formatting_methods";
 
         /// <summary>
-        /// String option to heuristically determine additional string formatting methods for CA2241 (https://docs.microsoft.com/visualstudio/code-quality/ca2241).
-        /// A method is considered a string formatting method if it has a 'string format' parameter followed by a 'params object[]' parameter.
+        /// String option to enable heuristically detecting of additional string formatting methods for CA2241 (https://docs.microsoft.com/visualstudio/code-quality/ca2241).
+        /// A method is considered a string formatting method if it has a '<see cref="string"/> <c>format</c>' parameter followed by a <see langword="params"/> <see cref="object"/>[]' parameter.
+        /// The default value of this is <c>false</c>.
         /// </summary>
-        public const string HeuristicDetermineAdditionalStringFormattingMethods = "heuristic_determine_additional_string_formatting_methods";
+        public const string TryDetermineAdditionalStringFormattingMethodsAutomatically = "try_determine_additional_string_formatting_methods_automatically";
 
         /// <summary>
         /// String option to configure names of symbols (separated by '|') that are excluded for analysis.

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -68,6 +68,12 @@ namespace Analyzer.Utilities
         public const string AdditionalStringFormattingMethods = "additional_string_formatting_methods";
 
         /// <summary>
+        /// String option to heuristically determine additional string formatting methods for CA2241 (https://docs.microsoft.com/visualstudio/code-quality/ca2241).
+        /// A method is considered a string formatting method if it has a 'string format' parameter followed by a 'params object[]' parameter.
+        /// </summary>
+        public const string HeuristicDetermineAdditionalStringFormattingMethods = "heuristic_determine_additional_string_formatting_methods";
+
+        /// <summary>
         /// String option to configure names of symbols (separated by '|') that are excluded for analysis.
         /// Configurable rules: CA1303 (https://docs.microsoft.com/visualstudio/code-quality/ca1303).
         /// Allowed method name formats:


### PR DESCRIPTION
In the end this was very simple as the method to detect a Format method already existed.

We could completely delete the existing configuration and simply check if the called method has a format parameter followed by a params parameter. This can not be much more expensive than checking the configuration.
