### PR TITLE
Check for constructor with parameterName parameter

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -86,14 +86,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             ITypeSymbol argumentExceptionType)
         {
             var creation = (IObjectCreationOperation)context.Operation;
-            if (!creation.Type.Inherits(argumentExceptionType) || !MatchesConfiguredVisibility(owningSymbol, context))
+            if (!creation.Type.Inherits(argumentExceptionType) || !MatchesConfiguredVisibility(owningSymbol, context) || !HasParameterNameConstructor(creation.Type))
             {
                 return;
             }
 
             if (creation.Arguments.Length == 0)
             {
-                if (HasParameters(owningSymbol) && HasMessageOrParameterNameConstructor(creation.Type))
+                if (HasParameters(owningSymbol))
                 {
                     // Call the {0} constructor that contains a message and/ or paramName parameter
                     context.ReportDiagnostic(context.Operation.Syntax.CreateDiagnostic(RuleNoArguments, creation.Type.Name));
@@ -174,7 +174,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             return parameter.Name == "paramName" || parameter.Name == "parameterName";
         }
 
-        private static bool HasMessageOrParameterNameConstructor(ITypeSymbol type)
+        private static bool HasParameterNameConstructor(ITypeSymbol type)
         {
             foreach (ISymbol member in type.GetMembers())
             {
@@ -186,7 +186,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 foreach (IParameterSymbol parameter in member.GetParameters())
                 {
                     if (parameter.Type.SpecialType == SpecialType.System_String
-                        && (IsMessage(parameter) || IsParameterName(parameter)))
+                        && IsParameterName(parameter))
                     {
                         return true;
                     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -915,6 +915,46 @@ public class C
                End Class");
         }
 
+        [Fact]
+        public async Task ArgumentExceptionType_NotHavingConstructorWithParameterName_NoArgument_DoesNotWarn()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test(string first)
+                    {
+                        throw new System.Text.DecoderFallbackException ();
+                    }
+                }");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
+                       Throw New System.Text.DecoderFallbackException ()
+                   End Sub
+               End Class");
+        }
+
+        [Fact]
+        public async Task ArgumentExceptionType_NotHavingConstructor_WithParameterName_WithArgument_DoesNotWarn()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test(string first)
+                    {
+                        throw new System.Text.DecoderFallbackException (""first"");
+                    }
+                }");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+               Public Class [MyClass]
+                   Public Sub Test(first As String)
+                       Throw New System.Text.DecoderFallbackException (""first"")
+                   End Sub
+               End Class");
+        }
+
         [Fact, WorkItem(1824, "https://github.com/dotnet/roslyn-analyzers/issues/1824")]
         public async Task ArgumentNullException_LocalFunctionParameter_DoesNotWarn()
         {


### PR DESCRIPTION
Fixes last comment for  https://github.com/dotnet/runtime/issues/33763
Related to PR comment `apply the rule to the all ArgumentException-derived types (including itself) that have a constructor accepting a paramName parameter, including user-defined types.`  https://github.com/dotnet/runtime/pull/35717#discussion_r424655024