### PR TITLE
Cleanup props and targets files generated for analyzer packages in th…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,9 @@
     <AssetsDir>$(MSBuildThisFileDirectory)assets\</AssetsDir>
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <NoWarn>$(NoWarn);NU5119</NoWarn>
+
+    <!-- Set 'NoDefaultExcludes' to ensure that we can package .editorconfig files into our analyzer NuGet packages -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />


### PR DESCRIPTION
…e repo

Fixes #3670
Also sets "NoDefaultExcludes" to true to enable packaging .editorconfig files into the NuGet package.