### PR TITLE
Fix CodeMetrics source "LineCount" metric to not include leading and …

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
@@ -2126,14 +2126,25 @@ namespace N1
         {
         }
     }
+
+    class C9_10_lines
+    {
+
+        // Leading Comment1
+
+        // Leading Comment2
+        void M10_6_lines_blank_lines_between_leading_comments_are_counted()
+        {
+        }
+    }
 }
 
 
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 95, ExecutableLines: 0, MntIndex: 100, CycCxty: 9, DepthInherit: 1)
-    N1: (Lines: 95, ExecutableLines: 0, MntIndex: 100, CycCxty: 9, DepthInherit: 1)
+Assembly: (Lines: 106, ExecutableLines: 0, MntIndex: 100, CycCxty: 10, DepthInherit: 1)
+    N1: (Lines: 106, ExecutableLines: 0, MntIndex: 100, CycCxty: 10, DepthInherit: 1)
         C1_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             N1.C1_10_lines.M1_3_lines_has_leading_and_trailing_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
         C2_13_lines: (Lines: 13, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
@@ -2151,6 +2162,8 @@ Assembly: (Lines: 95, ExecutableLines: 0, MntIndex: 100, CycCxty: 9, DepthInheri
             N1.C7_9_lines.M8_5_lines_has_doc_comment(): (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
         C8_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             N1.C8_10_lines.M9_6_lines_has_leading_block_comment(): (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C9_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C9_10_lines.M10_6_lines_blank_lines_between_leading_comments_are_counted(): (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
 ";
 
             VerifyCSharp(source, expectedMetricsText);

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
@@ -103,10 +103,10 @@ namespace N2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
-   N1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
+   N1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-   N2: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
+   N2: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
       C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C3: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
@@ -127,10 +127,10 @@ namespace N1.N2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
-   N1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
+   N1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-   N2: (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+   N2: (Lines: 4, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
 
@@ -155,10 +155,10 @@ namespace N2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
-   N1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
+   N1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-   N2: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
+   N2: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
       C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
       C3: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
@@ -188,8 +188,8 @@ partial class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 16, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
-    C1: (Lines: 16, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
+Assembly: (Lines: 14, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
+    C1: (Lines: 14, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
         C1.M1(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
         C1.M2(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
 ";
@@ -221,8 +221,8 @@ partial class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 16, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
-    C1: (Lines: 16, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
+Assembly: (Lines: 14, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
+    C1: (Lines: 14, ExecutableLines: 2, MntIndex: 95, CycCxty: 2, DepthInherit: 1)
         C1.M1(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
         C1.M2(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
 ";
@@ -250,8 +250,8 @@ namespace N1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 14, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
-    N1: (Lines: 14, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
+Assembly: (Lines: 13, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
+    N1: (Lines: 13, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
         C1: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
         NestedType: (Lines: 7, ExecutableLines: 1, MntIndex: 97, CycCxty: 1, DepthInherit: 1)
             N1.C1.NestedType.M1(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
@@ -295,8 +295,8 @@ class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 11, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
-    C1: (Lines: 11, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 1, MntIndex: 98, CycCxty: 2, DepthInherit: 1)
+    C1: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     NestedType: (Lines: 7, ExecutableLines: 1, MntIndex: 97, CycCxty: 1, DepthInherit: 1)
         C1.NestedType.M1(int): (Lines: 4, ExecutableLines: 1, MntIndex: 97, CycCxty: 1)
 ";
@@ -319,7 +319,7 @@ namespace N1
 Assembly: (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, CoupledTypes: {N1.C1}, DepthInherit: 2)
    N1: (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, CoupledTypes: {N1.C1}, DepthInherit: 2)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-      C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1}, DepthInherit: 2)
+      C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1}, DepthInherit: 2)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -342,8 +342,8 @@ namespace N1
 Assembly: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, CoupledTypes: {N1.C1, N1.C2<T>}, DepthInherit: 2)
    N1: (Lines: 8, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, CoupledTypes: {N1.C1, N1.C2<T>}, DepthInherit: 2)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-      C2<T>: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-      C3: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1, N1.C2<T>}, DepthInherit: 2)
+      C2<T>: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+      C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1, N1.C2<T>}, DepthInherit: 2)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -365,7 +365,7 @@ namespace N1
 Assembly: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, CoupledTypes: {N1.C1, System.Attribute}, DepthInherit: 2)
    N1: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, CoupledTypes: {N1.C1, System.Attribute}, DepthInherit: 2)
       C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.Attribute}, DepthInherit: 2)
-      C2: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1}, DepthInherit: 1)
+      C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {N1.C1}, DepthInherit: 1)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -444,10 +444,10 @@ class C3 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 12, ExecutableLines: 1, MntIndex: 100, CycCxty: 4, CoupledTypes: {C1, C2, C3}, DepthInherit: 1)
-    C: (Lines: 8, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2, C3}, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 1, MntIndex: 100, CycCxty: 4, CoupledTypes: {C1, C2, C3}, DepthInherit: 1)
+    C: (Lines: 7, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2, C3}, DepthInherit: 1)
         C.M(C2, C3): (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2, C3})
-    C1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
@@ -473,10 +473,10 @@ class C2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 12, ExecutableLines: 2, MntIndex: 93, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
-    C1: (Lines: 7, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 2, MntIndex: 93, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
+    C1: (Lines: 6, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
         C1.M(int): (Lines: 3, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2})
-    C2: (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
         C2.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
 ";
 
@@ -503,10 +503,10 @@ class C4 { public static C2 MyC2 = null; }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 14, ExecutableLines: 3, MntIndex: 95, CycCxty: 5, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 2)
-    C: (Lines: 9, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 1)
+Assembly: (Lines: 12, ExecutableLines: 3, MntIndex: 95, CycCxty: 5, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 2)
+    C: (Lines: 8, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 1)
         C.M(C1): (Lines: 5, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C1, C2, C3, C4})
-    C1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
     C4: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
@@ -539,13 +539,13 @@ class C2 : C1 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 17, ExecutableLines: 2, MntIndex: 100, CycCxty: 5, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
-    C: (Lines: 13, ExecutableLines: 2, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
+Assembly: (Lines: 15, ExecutableLines: 2, MntIndex: 100, CycCxty: 5, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
+    C: (Lines: 12, ExecutableLines: 2, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
         C.M1(C1): (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, I})
-        C.M2(C1): (Lines: 5, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2})
+        C.M2(C1): (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2})
     C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {I}, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
-    I: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
+    I: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -565,8 +565,8 @@ class C
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 8, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, DepthInherit: 1)
-   C: (Lines: 8, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 7, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, DepthInherit: 1)
+   C: (Lines: 7, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, DepthInherit: 1)
       C.M1(): (Lines: 4, ExecutableLines: 1, MntIndex: 94, CycCxty: 1)
 ";
 
@@ -594,8 +594,8 @@ class C2 {}
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 15, ExecutableLines: 5, MntIndex: 93, CycCxty: 4, CoupledTypes: {C1, C2, G<T>}, DepthInherit: 1)
-   C: (Lines: 12, ExecutableLines: 5, MntIndex: 73, CycCxty: 1, CoupledTypes: {C1, C2, G<T>}, DepthInherit: 1)
+Assembly: (Lines: 14, ExecutableLines: 5, MntIndex: 93, CycCxty: 4, CoupledTypes: {C1, C2, G<T>}, DepthInherit: 1)
+   C: (Lines: 11, ExecutableLines: 5, MntIndex: 73, CycCxty: 1, CoupledTypes: {C1, C2, G<T>}, DepthInherit: 1)
       C.M1(): (Lines: 8, ExecutableLines: 5, MntIndex: 73, CycCxty: 1, CoupledTypes: {C1, C2, G<T>})
    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
@@ -625,8 +625,8 @@ public class C
 }";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 12, ExecutableLines: 3, MntIndex: 93, CycCxty: 3, CoupledTypes: {A, B, System.Collections.Generic.IEnumerable<T>}, DepthInherit: 1)
-    A: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 11, ExecutableLines: 3, MntIndex: 93, CycCxty: 3, CoupledTypes: {A, B, System.Collections.Generic.IEnumerable<T>}, DepthInherit: 1)
+    A: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     B: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C: (Lines: 9, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, CoupledTypes: {A, B, System.Collections.Generic.IEnumerable<T>}, DepthInherit: 1)
         C.M1(): (Lines: 6, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, CoupledTypes: {A, B, System.Collections.Generic.IEnumerable<T>})
@@ -656,9 +656,9 @@ public class C
 }";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 15, ExecutableLines: 5, MntIndex: 93, CycCxty: 3, CoupledTypes: {System.CodeDom.Compiler.GeneratedCodeAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute}, DepthInherit: 1)
-    A: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.Runtime.CompilerServices.CompilerGeneratedAttribute}, DepthInherit: 1)
-    B: (Lines: 3, ExecutableLines: 2, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.CodeDom.Compiler.GeneratedCodeAttribute}, DepthInherit: 1)
+Assembly: (Lines: 13, ExecutableLines: 5, MntIndex: 93, CycCxty: 3, CoupledTypes: {System.CodeDom.Compiler.GeneratedCodeAttribute, System.Runtime.CompilerServices.CompilerGeneratedAttribute}, DepthInherit: 1)
+    A: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.Runtime.CompilerServices.CompilerGeneratedAttribute}, DepthInherit: 1)
+    B: (Lines: 2, ExecutableLines: 2, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.CodeDom.Compiler.GeneratedCodeAttribute}, DepthInherit: 1)
     C: (Lines: 9, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, DepthInherit: 1)
         C.M1(): (Lines: 6, ExecutableLines: 3, MntIndex: 80, CycCxty: 1)
 ";
@@ -683,8 +683,8 @@ class C2{ public C2(C1 a) {} }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 11, ExecutableLines: 3, MntIndex: 93, CycCxty: 3, CoupledTypes: {C1, C2, System.Action}, DepthInherit: 1)
-   C: (Lines: 9, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, CoupledTypes: {C1, C2, System.Action}, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 3, MntIndex: 93, CycCxty: 3, CoupledTypes: {C1, C2, System.Action}, DepthInherit: 1)
+   C: (Lines: 8, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, CoupledTypes: {C1, C2, System.Action}, DepthInherit: 1)
       C.M1(): (Lines: 5, ExecutableLines: 3, MntIndex: 80, CycCxty: 1, CoupledTypes: {C1, C2, System.Action})
    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 1)
@@ -813,16 +813,16 @@ class C4
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 26, ExecutableLines: 5, MntIndex: 92, CycCxty: 5, CoupledTypes: {C2, C3, CAttr, System.Attribute}, DepthInherit: 2)
-    C1: (Lines: 9, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2, C3, CAttr}, DepthInherit: 1)
+Assembly: (Lines: 21, ExecutableLines: 5, MntIndex: 92, CycCxty: 5, CoupledTypes: {C2, C3, CAttr, System.Attribute}, DepthInherit: 2)
+    C1: (Lines: 8, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2, C3, CAttr}, DepthInherit: 1)
         C1.M(int): (Lines: 5, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2, C3, CAttr})
-    C2: (Lines: 5, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
         C2.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 90, CycCxty: 0)
-    C3: (Lines: 5, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
+    C3: (Lines: 4, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
         C3.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 90, CycCxty: 0)
-    C4: (Lines: 5, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
+    C4: (Lines: 4, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
         C4.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 90, CycCxty: 0)
-    CAttr: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.Attribute}, DepthInherit: 2)
+    CAttr: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.Attribute}, DepthInherit: 2)
         CAttr.CAttr(string): (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
 ";
 
@@ -860,10 +860,10 @@ class C2 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 7, ExecutableLines: 1, MntIndex: 96, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
-    C1: (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
+Assembly: (Lines: 5, ExecutableLines: 1, MntIndex: 96, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
+    C1: (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
         C1.f: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2})
-    C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -882,10 +882,10 @@ class C2 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 7, ExecutableLines: 1, MntIndex: 96, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
-    C1: (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
+Assembly: (Lines: 5, ExecutableLines: 1, MntIndex: 96, CycCxty: 2, CoupledTypes: {C2}, DepthInherit: 1)
+    C1: (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
         C1.f: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2})
-    C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -906,10 +906,10 @@ class C4 { public static C2 MyC2 = null; }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 9, ExecutableLines: 2, MntIndex: 96, CycCxty: 4, CoupledTypes: {C2, C3, C4}, DepthInherit: 2)
-    C1: (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
+Assembly: (Lines: 7, ExecutableLines: 2, MntIndex: 96, CycCxty: 4, CoupledTypes: {C2, C3, C4}, DepthInherit: 2)
+    C1: (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
         C1.f: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2, C3, C4})
-    C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 2)
     C4: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
         C4.MyC2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2})
@@ -939,11 +939,11 @@ class C4 { public static C2 MyC2 = null; }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 15, ExecutableLines: 4, MntIndex: 95, CycCxty: 4, CoupledTypes: {C2, C3, C4}, DepthInherit: 2)
-    C1: (Lines: 11, ExecutableLines: 3, MntIndex: 87, CycCxty: 1, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
+Assembly: (Lines: 13, ExecutableLines: 4, MntIndex: 95, CycCxty: 4, CoupledTypes: {C2, C3, C4}, DepthInherit: 2)
+    C1: (Lines: 10, ExecutableLines: 3, MntIndex: 87, CycCxty: 1, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
         C1.f: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2, C3, C4})
-        C1.M(C1): (Lines: 6, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C2, C3, C4})
-    C2: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+        C1.M(C1): (Lines: 5, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C2, C3, C4})
+    C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 2)
     C4: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
         C4.MyC2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2})
@@ -991,8 +991,8 @@ public class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 33, ExecutableLines: 7, MntIndex: 77, CycCxty: 15, DepthInherit: 1)
-    C1: (Lines: 33, ExecutableLines: 7, MntIndex: 77, CycCxty: 15, DepthInherit: 1)
+Assembly: (Lines: 32, ExecutableLines: 7, MntIndex: 77, CycCxty: 15, DepthInherit: 1)
+    C1: (Lines: 32, ExecutableLines: 7, MntIndex: 77, CycCxty: 15, DepthInherit: 1)
         C1.f1: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
         C1.f2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
         C1.f3: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
@@ -1013,7 +1013,7 @@ Assembly: (Lines: 33, ExecutableLines: 7, MntIndex: 77, CycCxty: 15, DepthInheri
         C1.f18: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
         C1.f19: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
         C1.f20: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
-        C1.MultipleLogicals(bool, bool, bool, bool, bool): (Lines: 9, ExecutableLines: 5, MntIndex: 67, CycCxty: 15)
+        C1.MultipleLogicals(bool, bool, bool, bool, bool): (Lines: 8, ExecutableLines: 5, MntIndex: 67, CycCxty: 15)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1035,13 +1035,13 @@ class C2 : C1 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 10, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
-    C: (Lines: 6, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
+Assembly: (Lines: 8, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
+    C: (Lines: 5, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
         C.f1: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C1, I})
         C.f2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C1, C2})
     C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {I}, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
-    I: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
+    I: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1062,13 +1062,13 @@ class C2 : C1 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 9, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
-    C: (Lines: 5, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
+Assembly: (Lines: 7, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
+    C: (Lines: 4, ExecutableLines: 2, MntIndex: 93, CycCxty: 1, CoupledTypes: {C1, C2, I}, DepthInherit: 1)
         C.f1: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C1, I})
         C.f2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C1, C2})
     C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {I}, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
-    I: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
+    I: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
     
 ";
 
@@ -1092,10 +1092,10 @@ public class C2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 11, ExecutableLines: 3, MntIndex: 88, CycCxty: 2, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
-    C1: (Lines: 6, ExecutableLines: 2, MntIndex: 87, CycCxty: 1, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
+Assembly: (Lines: 9, ExecutableLines: 3, MntIndex: 88, CycCxty: 2, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
+    C1: (Lines: 5, ExecutableLines: 2, MntIndex: 87, CycCxty: 1, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
         C1.f: (Lines: 1, ExecutableLines: 2, MntIndex: 87, CycCxty: 0, CoupledTypes: {C2, System.ObsoleteAttribute})
-    C2: (Lines: 5, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
         C2.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 90, CycCxty: 0)
 ";
 
@@ -1221,12 +1221,12 @@ class C2 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 8, ExecutableLines: 1, MntIndex: 100, CycCxty: 4, CoupledTypes: {C1, C2}, DepthInherit: 1)
-    C: (Lines: 5, ExecutableLines: 1, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2}, DepthInherit: 1)
+Assembly: (Lines: 6, ExecutableLines: 1, MntIndex: 100, CycCxty: 4, CoupledTypes: {C1, C2}, DepthInherit: 1)
+    C: (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2}, DepthInherit: 1)
         C.this[C2]: (Lines: 1, ExecutableLines: 1, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2})
             C.this[C2].get: (Lines: 1, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2})
             C.this[C2].set: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1, C2})
-    C1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
 ";
 
@@ -1252,13 +1252,13 @@ class C2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 13, ExecutableLines: 4, MntIndex: 97, CycCxty: 4, CoupledTypes: {C1, C2}, DepthInherit: 1)
-    C: (Lines: 6, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2}, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 4, MntIndex: 97, CycCxty: 4, CoupledTypes: {C1, C2}, DepthInherit: 1)
+    C: (Lines: 5, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2}, DepthInherit: 1)
         C.this[int]: (Lines: 2, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C1, C2})
             C.this[int].get: (Lines: 1, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1})
             C.this[int].set: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1})
-    C1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
-    C2: (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
         C2.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
 ";
 
@@ -1293,12 +1293,12 @@ class C4 { public static C2 MyC2 = null; }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 22, ExecutableLines: 5, MntIndex: 95, CycCxty: 6, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 3)
-    C: (Lines: 17, ExecutableLines: 4, MntIndex: 86, CycCxty: 2, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
+Assembly: (Lines: 20, ExecutableLines: 5, MntIndex: 95, CycCxty: 6, CoupledTypes: {C1, C2, C3, C4}, DepthInherit: 3)
+    C: (Lines: 16, ExecutableLines: 4, MntIndex: 86, CycCxty: 2, CoupledTypes: {C2, C3, C4}, DepthInherit: 1)
         C.P: (Lines: 13, ExecutableLines: 4, MntIndex: 86, CycCxty: 2, CoupledTypes: {C2, C3, C4})
             C.P.get: (Lines: 5, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C2, C3, C4})
             C.P.set: (Lines: 5, ExecutableLines: 2, MntIndex: 86, CycCxty: 1, CoupledTypes: {C2, C3, C4})
-    C1: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C3}, DepthInherit: 3)
     C3: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
     C4: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, CoupledTypes: {C2}, DepthInherit: 1)
@@ -1333,14 +1333,14 @@ class C2 : C1 { }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 19, ExecutableLines: 2, MntIndex: 99, CycCxty: 5, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
-    C: (Lines: 15, ExecutableLines: 2, MntIndex: 98, CycCxty: 2, CoupledTypes: {C2, I}, DepthInherit: 1)
+Assembly: (Lines: 17, ExecutableLines: 2, MntIndex: 99, CycCxty: 5, CoupledTypes: {C1, C2, I}, DepthInherit: 2)
+    C: (Lines: 14, ExecutableLines: 2, MntIndex: 98, CycCxty: 2, CoupledTypes: {C2, I}, DepthInherit: 1)
         C.P: (Lines: 11, ExecutableLines: 2, MntIndex: 98, CycCxty: 2, CoupledTypes: {C2, I})
             C.P.get: (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 1, CoupledTypes: {I})
             C.P.set: (Lines: 4, ExecutableLines: 1, MntIndex: 96, CycCxty: 1, CoupledTypes: {C2})
     C1: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {I}, DepthInherit: 1)
     C2: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C1}, DepthInherit: 2)
-    I: (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
+    I: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 0)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1372,12 +1372,12 @@ class C2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 20, ExecutableLines: 4, MntIndex: 95, CycCxty: 3, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
-    C1: (Lines: 15, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
+Assembly: (Lines: 18, ExecutableLines: 4, MntIndex: 95, CycCxty: 3, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
+    C1: (Lines: 14, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C2, System.ObsoleteAttribute}, DepthInherit: 1)
         C1.P: (Lines: 11, ExecutableLines: 3, MntIndex: 100, CycCxty: 2, CoupledTypes: {C2, System.ObsoleteAttribute})
             C1.P.get: (Lines: 4, ExecutableLines: 1, MntIndex: 100, CycCxty: 1)
             C1.P.set: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
-    C2: (Lines: 5, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 1, MntIndex: 90, CycCxty: 1, DepthInherit: 1)
         C2.MyConst: (Lines: 1, ExecutableLines: 1, MntIndex: 90, CycCxty: 0)
 ";
 
@@ -1404,11 +1404,11 @@ class C2
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 12, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, CoupledTypes: {C.SampleEventHandler, C2, System.EventArgs}, DepthInherit: 1)
-   C: (Lines: 7, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C.SampleEventHandler, C2}, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 3, CoupledTypes: {C.SampleEventHandler, C2, System.EventArgs}, DepthInherit: 1)
+   C: (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {C.SampleEventHandler, C2}, DepthInherit: 1)
       C.SampleEvent: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0, CoupledTypes: {C.SampleEventHandler, C2})
    SampleEventHandler: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventArgs}, DepthInherit: 1)
-   C2: (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventArgs}, DepthInherit: 1)
+   C2: (Lines: 4, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventArgs}, DepthInherit: 1)
       C2.MyHandler(object, System.EventArgs): (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventArgs})
 ";
 
@@ -1442,14 +1442,14 @@ class C3
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 19, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C2, C3, System.EventHandler}, DepthInherit: 1)
-    C: (Lines: 9, ExecutableLines: 2, MntIndex: 94, CycCxty: 2, CoupledTypes: {C2, C3, System.EventHandler}, DepthInherit: 1)
+Assembly: (Lines: 16, ExecutableLines: 2, MntIndex: 98, CycCxty: 4, CoupledTypes: {C2, C3, System.EventHandler}, DepthInherit: 1)
+    C: (Lines: 8, ExecutableLines: 2, MntIndex: 94, CycCxty: 2, CoupledTypes: {C2, C3, System.EventHandler}, DepthInherit: 1)
         C.ExplicitEvent: (Lines: 5, ExecutableLines: 2, MntIndex: 94, CycCxty: 2, CoupledTypes: {C2, C3, System.EventHandler})
             C.ExplicitEvent.add: (Lines: 1, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, CoupledTypes: {C2, System.EventHandler})
             C.ExplicitEvent.remove: (Lines: 1, ExecutableLines: 1, MntIndex: 94, CycCxty: 1, CoupledTypes: {C3, System.EventHandler})
-    C2: (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventHandler}, DepthInherit: 1)
+    C2: (Lines: 4, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventHandler}, DepthInherit: 1)
         C2.ExplicitEvent: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0, CoupledTypes: {System.EventHandler})
-    C3: (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventHandler}, DepthInherit: 1)
+    C3: (Lines: 4, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, CoupledTypes: {System.EventHandler}, DepthInherit: 1)
         C3.ExplicitEvent: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0, CoupledTypes: {System.EventHandler})
 ";
 
@@ -1525,13 +1525,13 @@ class C
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 63, ExecutableLines: 11, MntIndex: 87, CycCxty: 16, DepthInherit: 1)
-    C: (Lines: 63, ExecutableLines: 11, MntIndex: 87, CycCxty: 16, DepthInherit: 1)
+Assembly: (Lines: 62, ExecutableLines: 11, MntIndex: 87, CycCxty: 16, DepthInherit: 1)
+    C: (Lines: 62, ExecutableLines: 11, MntIndex: 87, CycCxty: 16, DepthInherit: 1)
         C.SimpleIf(bool): (Lines: 6, ExecutableLines: 1, MntIndex: 100, CycCxty: 2)
-        C.SimpleIfElse(bool): (Lines: 10, ExecutableLines: 1, MntIndex: 100, CycCxty: 2)
-        C.NestedIf(bool, bool): (Lines: 10, ExecutableLines: 2, MntIndex: 91, CycCxty: 3)
-        C.ElseIf(bool, bool): (Lines: 10, ExecutableLines: 2, MntIndex: 91, CycCxty: 3)
-        C.MultipleIfs(bool, bool): (Lines: 23, ExecutableLines: 5, MntIndex: 79, CycCxty: 6)
+        C.SimpleIfElse(bool): (Lines: 9, ExecutableLines: 1, MntIndex: 100, CycCxty: 2)
+        C.NestedIf(bool, bool): (Lines: 9, ExecutableLines: 2, MntIndex: 91, CycCxty: 3)
+        C.ElseIf(bool, bool): (Lines: 9, ExecutableLines: 2, MntIndex: 91, CycCxty: 3)
+        C.MultipleIfs(bool, bool): (Lines: 22, ExecutableLines: 5, MntIndex: 79, CycCxty: 6)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1565,11 +1565,11 @@ class C
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 22, ExecutableLines: 8, MntIndex: 81, CycCxty: 11, DepthInherit: 1)
-    C: (Lines: 22, ExecutableLines: 8, MntIndex: 81, CycCxty: 11, DepthInherit: 1)
+Assembly: (Lines: 21, ExecutableLines: 8, MntIndex: 81, CycCxty: 11, DepthInherit: 1)
+    C: (Lines: 21, ExecutableLines: 8, MntIndex: 81, CycCxty: 11, DepthInherit: 1)
         C.SimpleConditional(bool): (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 2)
-        C.NestedConditional(bool, bool, bool, bool): (Lines: 5, ExecutableLines: 2, MntIndex: 84, CycCxty: 3)
-        C.MultipleConditionals(bool, bool, bool, bool, bool): (Lines: 9, ExecutableLines: 5, MntIndex: 70, CycCxty: 6)
+        C.NestedConditional(bool, bool, bool, bool): (Lines: 4, ExecutableLines: 2, MntIndex: 84, CycCxty: 3)
+        C.MultipleConditionals(bool, bool, bool, bool, bool): (Lines: 8, ExecutableLines: 5, MntIndex: 70, CycCxty: 6)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1603,11 +1603,11 @@ class C
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 22, ExecutableLines: 7, MntIndex: 79, CycCxty: 22, DepthInherit: 1)
-    C: (Lines: 22, ExecutableLines: 7, MntIndex: 79, CycCxty: 22, DepthInherit: 1)
+Assembly: (Lines: 21, ExecutableLines: 7, MntIndex: 79, CycCxty: 22, DepthInherit: 1)
+    C: (Lines: 21, ExecutableLines: 7, MntIndex: 79, CycCxty: 22, DepthInherit: 1)
         C.SimpleLogical(bool, bool, bool, bool): (Lines: 4, ExecutableLines: 1, MntIndex: 91, CycCxty: 3)
-        C.NestedLogical(bool, bool, bool, bool): (Lines: 5, ExecutableLines: 1, MntIndex: 89, CycCxty: 4)
-        C.MultipleLogicals(bool, bool, bool, bool, bool): (Lines: 9, ExecutableLines: 5, MntIndex: 67, CycCxty: 15)
+        C.NestedLogical(bool, bool, bool, bool): (Lines: 4, ExecutableLines: 1, MntIndex: 89, CycCxty: 4)
+        C.MultipleLogicals(bool, bool, bool, bool, bool): (Lines: 8, ExecutableLines: 5, MntIndex: 67, CycCxty: 15)
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1655,16 +1655,16 @@ class C2 { public readonly bool B = false; }
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 36, ExecutableLines: 11, MntIndex: 90, CycCxty: 26, CoupledTypes: {C2, System.Nullable<T>}, DepthInherit: 1)
-   C: (Lines: 34, ExecutableLines: 10, MntIndex: 87, CycCxty: 25, CoupledTypes: {C2, System.Nullable<T>}, DepthInherit: 1)
+Assembly: (Lines: 34, ExecutableLines: 11, MntIndex: 90, CycCxty: 26, CoupledTypes: {C2, System.Nullable<T>}, DepthInherit: 1)
+   C: (Lines: 33, ExecutableLines: 10, MntIndex: 87, CycCxty: 25, CoupledTypes: {C2, System.Nullable<T>}, DepthInherit: 1)
       C.c2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0, CoupledTypes: {C2})
       C.b: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
-      C.SimpleCoalesce(bool?): (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 2, CoupledTypes: {System.Nullable<T>})
-      C.SimpleConditionalAccess(C): (Lines: 5, ExecutableLines: 1, MntIndex: 93, CycCxty: 2, CoupledTypes: {System.Nullable<T>})
-      C.NestedCoalesce(bool?, bool?): (Lines: 5, ExecutableLines: 1, MntIndex: 92, CycCxty: 3, CoupledTypes: {System.Nullable<T>})
-      C.NestedConditionalAccess(C): (Lines: 5, ExecutableLines: 1, MntIndex: 91, CycCxty: 3, CoupledTypes: {C2, System.Nullable<T>})
-      C.MultipleCoalesceAndConditionalAccess(C, C, C, C, C): (Lines: 8, ExecutableLines: 4, MntIndex: 69, CycCxty: 15, CoupledTypes: {C2, System.Nullable<T>})
-   C2: (Lines: 2, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
+      C.SimpleCoalesce(bool?): (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 2, CoupledTypes: {System.Nullable<T>})
+      C.SimpleConditionalAccess(C): (Lines: 4, ExecutableLines: 1, MntIndex: 93, CycCxty: 2, CoupledTypes: {System.Nullable<T>})
+      C.NestedCoalesce(bool?, bool?): (Lines: 4, ExecutableLines: 1, MntIndex: 92, CycCxty: 3, CoupledTypes: {System.Nullable<T>})
+      C.NestedConditionalAccess(C): (Lines: 4, ExecutableLines: 1, MntIndex: 91, CycCxty: 3, CoupledTypes: {C2, System.Nullable<T>})
+      C.MultipleCoalesceAndConditionalAccess(C, C, C, C, C): (Lines: 7, ExecutableLines: 4, MntIndex: 69, CycCxty: 15, CoupledTypes: {C2, System.Nullable<T>})
+   C2: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 1, DepthInherit: 1)
       C2.B: (Lines: 1, ExecutableLines: 1, MntIndex: 93, CycCxty: 0)
 ";
 
@@ -1753,13 +1753,13 @@ class C
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 76, ExecutableLines: 23, MntIndex: 74, CycCxty: 17, CoupledTypes: {System.Collections.IEnumerable, System.Console}, DepthInherit: 1)
-    C: (Lines: 76, ExecutableLines: 23, MntIndex: 74, CycCxty: 17, CoupledTypes: {System.Collections.IEnumerable, System.Console}, DepthInherit: 1)
+Assembly: (Lines: 75, ExecutableLines: 23, MntIndex: 74, CycCxty: 17, CoupledTypes: {System.Collections.IEnumerable, System.Console}, DepthInherit: 1)
+    C: (Lines: 75, ExecutableLines: 23, MntIndex: 74, CycCxty: 17, CoupledTypes: {System.Collections.IEnumerable, System.Console}, DepthInherit: 1)
         C.SimpleWhileLoop(bool, int): (Lines: 7, ExecutableLines: 2, MntIndex: 90, CycCxty: 2)
-        C.SimpleForLoop(): (Lines: 8, ExecutableLines: 2, MntIndex: 84, CycCxty: 2, CoupledTypes: {System.Console})
-        C.SimpleForEachLoop(int[]): (Lines: 8, ExecutableLines: 2, MntIndex: 90, CycCxty: 2, CoupledTypes: {System.Collections.IEnumerable, System.Console})
-        C.NestedLoops(bool, int[]): (Lines: 16, ExecutableLines: 5, MntIndex: 73, CycCxty: 4, CoupledTypes: {System.Collections.IEnumerable, System.Console})
-        C.MultipleLoops(bool, int[], int): (Lines: 33, ExecutableLines: 12, MntIndex: 61, CycCxty: 7, CoupledTypes: {System.Collections.IEnumerable, System.Console})
+        C.SimpleForLoop(): (Lines: 7, ExecutableLines: 2, MntIndex: 84, CycCxty: 2, CoupledTypes: {System.Console})
+        C.SimpleForEachLoop(int[]): (Lines: 7, ExecutableLines: 2, MntIndex: 90, CycCxty: 2, CoupledTypes: {System.Collections.IEnumerable, System.Console})
+        C.NestedLoops(bool, int[]): (Lines: 15, ExecutableLines: 5, MntIndex: 73, CycCxty: 4, CoupledTypes: {System.Collections.IEnumerable, System.Console})
+        C.MultipleLoops(bool, int[], int): (Lines: 32, ExecutableLines: 12, MntIndex: 61, CycCxty: 7, CoupledTypes: {System.Collections.IEnumerable, System.Console})
 ";
 
             VerifyCSharp(source, expectedMetricsText);
@@ -1782,8 +1782,8 @@ class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 11, ExecutableLines: 4, MntIndex: 76, CycCxty: 1, DepthInherit: 1)
-    C1: (Lines: 11, ExecutableLines: 4, MntIndex: 76, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 10, ExecutableLines: 4, MntIndex: 76, CycCxty: 1, DepthInherit: 1)
+    C1: (Lines: 10, ExecutableLines: 4, MntIndex: 76, CycCxty: 1, DepthInherit: 1)
         C1.M(): (Lines: 7, ExecutableLines: 4, MntIndex: 76, CycCxty: 1)
 ";
 
@@ -1953,8 +1953,8 @@ class C1
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 157, ExecutableLines: 123, MntIndex: 27, CycCxty: 4, DepthInherit: 1)
-    C1: (Lines: 157, ExecutableLines: 123, MntIndex: 27, CycCxty: 4, DepthInherit: 1)
+Assembly: (Lines: 156, ExecutableLines: 123, MntIndex: 27, CycCxty: 4, DepthInherit: 1)
+    C1: (Lines: 156, ExecutableLines: 123, MntIndex: 27, CycCxty: 4, DepthInherit: 1)
         C1.M(int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int): (Lines: 153, ExecutableLines: 123, MntIndex: 27, CycCxty: 4)
 ";
 
@@ -1979,8 +1979,8 @@ End Class
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 12, ExecutableLines: 3, MntIndex: 81, CycCxty: 4, DepthInherit: 1)
-    C: (Lines: 12, ExecutableLines: 3, MntIndex: 81, CycCxty: 4, DepthInherit: 1)
+Assembly: (Lines: 11, ExecutableLines: 3, MntIndex: 81, CycCxty: 4, DepthInherit: 1)
+    C: (Lines: 11, ExecutableLines: 3, MntIndex: 81, CycCxty: 4, DepthInherit: 1)
         Public Sub M(i As Integer): (Lines: 9, ExecutableLines: 3, MntIndex: 81, CycCxty: 4)
 ";
 
@@ -2010,19 +2010,79 @@ End Class
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 16, ExecutableLines: 2, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
-    TopLevel: (Lines: 4, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+Assembly: (Lines: 14, ExecutableLines: 2, MntIndex: 100, CycCxty: 3, DepthInherit: 1)
+    TopLevel: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
         Public ReadOnly Property P As Integer: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0)
-    N1: (Lines: 12, ExecutableLines: 2, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
+    N1: (Lines: 11, ExecutableLines: 2, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
         C: (Lines: 9, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             Public Sub M(Of T)(i As Integer): (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
-        NestedClass(Of U): (Lines: 5, ExecutableLines: 2, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+        NestedClass(Of U): (Lines: 4, ExecutableLines: 2, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             Public Field0 As Integer: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0)
             Public Field1 As Integer: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0)
             Public Field2 As Integer: (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 0)
 ";
 
             VerifyBasic(source, expectedMetricsText);
+        }
+
+        [Fact]
+        public void EmptyLinesAreNotCounted()
+        {
+            var source = @"
+
+
+
+namespace N1
+{
+
+
+
+    class C1_10_lines
+    {
+
+    
+        void M1_3_lines_has_leading_and_trailing_newlines()
+        {
+        }
+
+
+    }
+
+    class C2_13_lines {
+
+
+
+        void M2_2_lines_has_leading_newlines()
+        { }
+        void M3_3_lines_has_trailing_newlines()
+        {
+        }
+
+
+
+    }
+
+    class C3_3_lines
+    {   void M4_1_lines_has_no_newlines() { }
+    }
+}
+
+
+";
+
+            var expectedMetricsText = @"
+Assembly: (Lines: 34, ExecutableLines: 0, MntIndex: 100, CycCxty: 4, DepthInherit: 1)
+    N1: (Lines: 34, ExecutableLines: 0, MntIndex: 100, CycCxty: 4, DepthInherit: 1)
+        C1_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C1_10_lines.M1_3_lines_has_leading_and_trailing_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C2_13_lines: (Lines: 13, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
+            N1.C2_13_lines.M2_2_lines_has_leading_newlines(): (Lines: 2, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+            N1.C2_13_lines.M3_3_lines_has_trailing_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C3_3_lines: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C3_3_lines.M4_1_lines_has_no_newlines(): (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+";
+
+            VerifyCSharp(source, expectedMetricsText);
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsComputationTests.cs
@@ -2065,14 +2065,75 @@ namespace N1
     class C3_3_lines
     {   void M4_1_lines_has_no_newlines() { }
     }
+
+    class C4_14_lines
+    {
+
+
+        // Leading Comment
+
+        void M5_5_lines_has_leading_trailing_newlines_and_comments()
+        {
+        }
+
+        // Trailing Comment does not count for method above
+
+
+    }
+
+    class C5_12_lines
+    {
+
+
+        // Leading Comment1
+        // Leading Comment2
+        void M6_5_lines_has_leading_comments_trailing_newlines()
+        {
+        }
+
+
+    }
+
+    class C6_11_lines
+    {
+
+
+        void M7_3_lines_has_trailing_comments_leading_newlines()
+        {
+        }
+
+        // Trailing Comment1 does not count for method above
+        // Trailing Comment2 does not count for method above
+    }
+
+    class C7_9_lines
+    {
+
+        /// <summary>
+        /// </summary>
+        void M8_5_lines_has_doc_comment()
+        {
+        }
+    }
+
+    class C8_10_lines
+    {
+
+        /*
+            Block comment
+        */
+        void M9_6_lines_has_leading_block_comment()
+        {
+        }
+    }
 }
 
 
 ";
 
             var expectedMetricsText = @"
-Assembly: (Lines: 34, ExecutableLines: 0, MntIndex: 100, CycCxty: 4, DepthInherit: 1)
-    N1: (Lines: 34, ExecutableLines: 0, MntIndex: 100, CycCxty: 4, DepthInherit: 1)
+Assembly: (Lines: 95, ExecutableLines: 0, MntIndex: 100, CycCxty: 9, DepthInherit: 1)
+    N1: (Lines: 95, ExecutableLines: 0, MntIndex: 100, CycCxty: 9, DepthInherit: 1)
         C1_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             N1.C1_10_lines.M1_3_lines_has_leading_and_trailing_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
         C2_13_lines: (Lines: 13, ExecutableLines: 0, MntIndex: 100, CycCxty: 2, DepthInherit: 1)
@@ -2080,6 +2141,16 @@ Assembly: (Lines: 34, ExecutableLines: 0, MntIndex: 100, CycCxty: 4, DepthInheri
             N1.C2_13_lines.M3_3_lines_has_trailing_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
         C3_3_lines: (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
             N1.C3_3_lines.M4_1_lines_has_no_newlines(): (Lines: 1, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C4_14_lines: (Lines: 14, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C4_14_lines.M5_5_lines_has_leading_trailing_newlines_and_comments(): (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C5_12_lines: (Lines: 12, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C5_12_lines.M6_5_lines_has_leading_comments_trailing_newlines(): (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C6_11_lines: (Lines: 11, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C6_11_lines.M7_3_lines_has_trailing_comments_leading_newlines(): (Lines: 3, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C7_9_lines: (Lines: 9, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C7_9_lines.M8_5_lines_has_doc_comment(): (Lines: 5, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
+        C8_10_lines: (Lines: 10, ExecutableLines: 0, MntIndex: 100, CycCxty: 1, DepthInherit: 1)
+            N1.C8_10_lines.M9_6_lines_has_leading_block_comment(): (Lines: 6, ExecutableLines: 0, MntIndex: 100, CycCxty: 1)
 ";
 
             VerifyCSharp(source, expectedMetricsText);

--- a/src/Utilities/Compiler/CodeMetrics/MetricsHelper.cs
+++ b/src/Utilities/Compiler/CodeMetrics/MetricsHelper.cs
@@ -109,11 +109,10 @@ namespace Microsoft.CodeAnalysis.CodeMetrics
                     var loopCondition = leading ? LoopConditionForLeading : (Func<int, int, bool>)LoopConditionForTrailing;
                     var incrementOrDecrement = leading ? 1 : -1;
                     var count = 0;
-                    for (; loopCondition(index, triviaParts.Length); index += incrementOrDecrement, count++)
+                    while (loopCondition(index, triviaParts.Length) && string.IsNullOrWhiteSpace(triviaParts[index]))
                     {
-                        var trivia = triviaParts[index].Trim();
-                        if (trivia.Length != 0)
-                            break;
+                        index += incrementOrDecrement;
+                        count++;
                     }
 
                     return count;


### PR DESCRIPTION
…trailing empty newlines.

Fixes customer feedback from https://developercommunity.visualstudio.com/content/problem/1014036/code-metrics-lines-of-source-code-off-by-one.html