### PR TITLE
Chloduan/ca3075 xml document secure default xml resolver after net452

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -352,7 +352,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                 xmlDocumentEnvironment.XmlDocumentDefinition = objCreation.Syntax;
                 SyntaxNode node = objCreation.Syntax;
-                bool isXmlDocumentSecureResolver = xmlDocumentEnvironment.IsSecureResolver;
+                bool isXmlDocumentSecureResolver = _isFrameworkSecure;
 
                 // if XmlSecureResolver declared as XmlResolver by constructor
                 // or if IsSecureResolver set to true by _isFrameworkSecure == true; version > 4.5.2

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -348,7 +348,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                 // initial XmlResolver secure value dependent on whether framework version secure
                 // < .NET 4.5.2 insecure - XmlDocument would set XmlResolver as XmlUrlResolver
-                // > .NET 4.5.2 secure - XmlDocument would set XmlResolver as null
+                // >= .NET 4.5.2 secure - XmlDocument would set XmlResolver as null
                 bool isXmlDocumentSecureResolver = _isFrameworkSecure;
 
                 if (!Equals(objCreation.Constructor.ContainingType, _xmlTypes.XmlDocument))

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -197,7 +197,13 @@ namespace Microsoft.NetFramework.Analyzers
 
                     // secure 4.5.2 version not being checked for secure
                     // if Version > 4.5.2 => XmlDocument = secure!!
-                    if (!(env.IsXmlResolverSet | env.IsSecureResolver))
+                    // Before 4.5.2, insecure if XmlResolver set as null for XmlUrlResolver
+                    // After 4.5.2, insecure only if XmlResolver set as XmlUrlResolver
+                    if ((!_isFrameworkSecure &&
+                            (!(env.IsXmlResolverSet | env.IsSecureResolver))) ||
+                        (_isFrameworkSecure &&
+                            !env.IsXmlResolverSet && !env.IsSecureResolver)
+                        )
                     {
                         context.ReportDiagnostic(env.XmlDocumentDefinition.CreateDiagnostic(RuleXmlDocumentWithNoSecureResolver));
                     }

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -405,7 +405,7 @@ namespace Microsoft.NetFramework.Analyzers
 
                 xmlDocumentEnvironment.IsSecureResolver = isXmlDocumentSecureResolver;
 
-                // if XmlDocument object not temporary (variable not null), add environment to dictionary
+                // if XmlDocument object not temporary, add environment to dictionary
                 if (variable != null)
                 {
                     _xmlDocumentEnvironments[variable] = xmlDocumentEnvironment;

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -193,10 +193,6 @@ namespace Microsoft.NetFramework.Analyzers
                 {
                     XmlDocumentEnvironment env = p.Value;
 
-                    // secure 4.5.2 version not being checked for secure
-                    // if Version > 4.5.2 => XmlDocument = secure!!
-                    // Before 4.5.2, insecure if XmlResolver set as null for XmlUrlResolver
-                    // After 4.5.2, insecure only if XmlResolver set as XmlUrlResolver
                     if (!(env.IsXmlResolverSet | env.IsSecureResolver))
                     {
                         context.ReportDiagnostic(env.XmlDocumentDefinition.CreateDiagnostic(RuleXmlDocumentWithNoSecureResolver));

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessing.cs
@@ -123,14 +123,7 @@ namespace Microsoft.NetFramework.Analyzers
                 internal XmlDocumentEnvironment(bool isTargetFrameworkSecure)
                 {
                     IsXmlResolverSet = false;
-                    if (isTargetFrameworkSecure)
-                    {
-                        IsSecureResolver = true;
-                    }
-                    else
-                    {
-                        IsSecureResolver = false;
-                    }
+                    IsSecureResolver = isTargetFrameworkSecure;
                 }
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -456,7 +456,7 @@ End Namespace");
         }
 
         [Fact]
-        public async Task RealCodeSnippitFromCustomerPre452ShouldGenerateDiagnostic()
+        public async Task RealCodeSnippetFromCustomerPre452ShouldGenerateDiagnostic()
         {
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net451.Default,
@@ -554,7 +554,7 @@ End Namespace",
         }
 
         [Fact]
-        public async Task RealCodeSnippitFromCustomerPost452ShouldNotGenerateDiagnostic()
+        public async Task RealCodeSnippetFromCustomerPost452ShouldNotGenerateDiagnostic()
         {
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net452.Default,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -510,8 +510,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System
 Imports System.IO
 Imports System.Xml
@@ -582,7 +582,7 @@ namespace TestNamespace
                 XmlReaderSettings settings = new XmlReaderSettings
                 {
                     ConformanceLevel = ConformanceLevel.Auto,
-                    IgnoreComments = true,
+                    IgnoreComments = true,            await VerifyVisualBasicAnalyzerAsync(
                     DtdProcessing = DtdProcessing.Ignore,
                     XmlResolver = null
                 };
@@ -607,8 +607,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System
 Imports System.IO
 Imports System.Xml

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -509,46 +509,48 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(15, 38)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System
-//Imports System.IO
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System
+Imports System.IO
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public Shared Function TestMethod(inputRule As String) As String
-//            Dim outputRule As String
-//            Try
-//                Dim xmlDoc As New XmlDocument()
-//                ' CA3075 for not setting secure Xml resolver
-//                Dim stringReader As New StringReader(inputRule)
-//                Dim textReader As New XmlTextReader(stringReader) With { _
-//                    .DtdProcessing = DtdProcessing.Ignore, _
-//                    .XmlResolver = Nothing _
-//                }
-//                Dim settings As New XmlReaderSettings() With { _
-//                    .ConformanceLevel = ConformanceLevel.Auto, _
-//                    .IgnoreComments = True, _
-//                    .DtdProcessing = DtdProcessing.Ignore, _
-//                    .XmlResolver = Nothing _
-//                }
-//                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
-//                xmlDoc.Load(reader)
-//                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
-//                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
-//                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
-//                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
-//                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
-//                outputRule = xmlDoc.OuterXml
-//            Catch e As XmlException
-//                Throw New Exception(""Compliance policy parsing error"", e)
-//            End Try
-//            Return outputRule
-//        End Function
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public Shared Function TestMethod(inputRule As String) As String
+            Dim outputRule As String
+            Try
+                Dim xmlDoc As New XmlDocument()
+                ' CA3075 for not setting secure Xml resolver
+                Dim stringReader As New StringReader(inputRule)
+                Dim textReader As New XmlTextReader(stringReader) With { _
+                    .DtdProcessing = DtdProcessing.Ignore, _
+                    .XmlResolver = Nothing _
+                }
+                Dim settings As New XmlReaderSettings() With { _
+                    .ConformanceLevel = ConformanceLevel.Auto, _
+                    .IgnoreComments = True, _
+                    .DtdProcessing = DtdProcessing.Ignore, _
+                    .XmlResolver = Nothing _
+                }
+                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
+                xmlDoc.Load(reader)
+                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
+                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
+                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
+                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
+                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
+                outputRule = xmlDoc.OuterXml
+            Catch e As XmlException
+                Throw New Exception(""Compliance policy parsing error"", e)
+            End Try
+            Return outputRule
+        End Function
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
+            );
         }
 
         [Fact]
@@ -604,46 +606,47 @@ namespace TestNamespace
 "
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System
-//Imports System.IO
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+Imports System
+Imports System.IO
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public Shared Function TestMethod(inputRule As String) As String
-//            Dim outputRule As String
-//            Try
-//                Dim xmlDoc As New XmlDocument()
-//                ' CA3075 for not setting secure Xml resolver
-//                Dim stringReader As New StringReader(inputRule)
-//                Dim textReader As New XmlTextReader(stringReader) With { _
-//                    .DtdProcessing = DtdProcessing.Ignore, _
-//                    .XmlResolver = Nothing _
-//                }
-//                Dim settings As New XmlReaderSettings() With { _
-//                    .ConformanceLevel = ConformanceLevel.Auto, _
-//                    .IgnoreComments = True, _
-//                    .DtdProcessing = DtdProcessing.Ignore, _
-//                    .XmlResolver = Nothing _
-//                }
-//                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
-//                xmlDoc.Load(reader)
-//                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
-//                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
-//                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
-//                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
-//                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
-//                outputRule = xmlDoc.OuterXml
-//            Catch e As XmlException
-//                Throw New Exception(""Compliance policy parsing error"", e)
-//            End Try
-//            Return outputRule
-//        End Function
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public Shared Function TestMethod(inputRule As String) As String
+            Dim outputRule As String
+            Try
+                Dim xmlDoc As New XmlDocument()
+                ' ok
+                Dim stringReader As New StringReader(inputRule)
+                Dim textReader As New XmlTextReader(stringReader) With { _
+                    .DtdProcessing = DtdProcessing.Ignore, _
+                    .XmlResolver = Nothing _
+                }
+                Dim settings As New XmlReaderSettings() With { _
+                    .ConformanceLevel = ConformanceLevel.Auto, _
+                    .IgnoreComments = True, _
+                    .DtdProcessing = DtdProcessing.Ignore, _
+                    .XmlResolver = Nothing _
+                }
+                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
+                xmlDoc.Load(reader)
+                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
+                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
+                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
+                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
+                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
+                outputRule = xmlDoc.OuterXml
+            Catch e As XmlException
+                Throw New Exception(""Compliance policy parsing error"", e)
+            End Try
+            Return outputRule
+        End Function
+    End Class
+End Namespace"
+            );
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -582,7 +582,7 @@ namespace TestNamespace
                 XmlReaderSettings settings = new XmlReaderSettings
                 {
                     ConformanceLevel = ConformanceLevel.Auto,
-                    IgnoreComments = true,            await VerifyVisualBasicAnalyzerAsync(
+                    IgnoreComments = true,
                     DtdProcessing = DtdProcessing.Ignore,
                     XmlResolver = null
                 };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingCreateUsingInsecureInputXmlReaderSettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetFramework.Analyzers.DoNotUseInsecureDtdProcessingAnalyzer,
@@ -455,9 +456,11 @@ End Namespace");
         }
 
         [Fact]
-        public async Task RealCodeSnippitFromCustomerShouldGenerateDiagnostic()
+        public async Task RealCodeSnippitFromCustomerPre452ShouldGenerateDiagnostic()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System;
 using System.IO;
 using System.Xml;
@@ -506,46 +509,141 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(15, 38)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System
-Imports System.IO
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System
+//Imports System.IO
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Public Shared Function TestMethod(inputRule As String) As String
-            Dim outputRule As String
-            Try
-                Dim xmlDoc As New XmlDocument()
-                ' CA3075 for not setting secure Xml resolver
-                Dim stringReader As New StringReader(inputRule)
-                Dim textReader As New XmlTextReader(stringReader) With { _
-                    .DtdProcessing = DtdProcessing.Ignore, _
-                    .XmlResolver = Nothing _
-                }
-                Dim settings As New XmlReaderSettings() With { _
-                    .ConformanceLevel = ConformanceLevel.Auto, _
-                    .IgnoreComments = True, _
-                    .DtdProcessing = DtdProcessing.Ignore, _
-                    .XmlResolver = Nothing _
-                }
-                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
-                xmlDoc.Load(reader)
-                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
-                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
-                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
-                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
-                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
-                outputRule = xmlDoc.OuterXml
-            Catch e As XmlException
-                Throw New Exception(""Compliance policy parsing error"", e)
-            End Try
-            Return outputRule
-        End Function
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
+//Namespace TestNamespace
+//    Class TestClass
+//        Public Shared Function TestMethod(inputRule As String) As String
+//            Dim outputRule As String
+//            Try
+//                Dim xmlDoc As New XmlDocument()
+//                ' CA3075 for not setting secure Xml resolver
+//                Dim stringReader As New StringReader(inputRule)
+//                Dim textReader As New XmlTextReader(stringReader) With { _
+//                    .DtdProcessing = DtdProcessing.Ignore, _
+//                    .XmlResolver = Nothing _
+//                }
+//                Dim settings As New XmlReaderSettings() With { _
+//                    .ConformanceLevel = ConformanceLevel.Auto, _
+//                    .IgnoreComments = True, _
+//                    .DtdProcessing = DtdProcessing.Ignore, _
+//                    .XmlResolver = Nothing _
+//                }
+//                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
+//                xmlDoc.Load(reader)
+//                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
+//                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
+//                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
+//                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
+//                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
+//                outputRule = xmlDoc.OuterXml
+//            Catch e As XmlException
+//                Throw New Exception(""Compliance policy parsing error"", e)
+//            End Try
+//            Return outputRule
+//        End Function
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
+//            );
+        }
+
+        [Fact]
+        public async Task RealCodeSnippitFromCustomerPost452ShouldNotGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System;
+using System.IO;
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {         
+        public static string TestMethod(string inputRule)
+        {
+            string outputRule;
+            try
+            {
+                XmlDocument xmlDoc = new XmlDocument();         // ok
+                StringReader stringReader = new StringReader(inputRule);
+                XmlTextReader textReader = new XmlTextReader(stringReader)
+                {
+                    DtdProcessing = DtdProcessing.Ignore,
+                    XmlResolver = null
+                };
+                XmlReaderSettings settings = new XmlReaderSettings
+                {
+                    ConformanceLevel = ConformanceLevel.Auto,
+                    IgnoreComments = true,
+                    DtdProcessing = DtdProcessing.Ignore,
+                    XmlResolver = null
+                };
+                XmlReader reader = XmlReader.Create(textReader, settings);
+                xmlDoc.Load(reader);
+                XmlAttribute enabledAttribute = xmlDoc.CreateAttribute(""enabled"");
+                XmlAttributeCollection ruleAttrColl = xmlDoc.DocumentElement.Attributes;
+                XmlAttribute nameAttribute = (XmlAttribute)ruleAttrColl.GetNamedItem(""name"");
+                ruleAttrColl.Remove(ruleAttrColl[""enabled""]);
+                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute);
+                outputRule = xmlDoc.OuterXml;
+            }
+            catch (XmlException e)
+            {
+                throw new Exception(""Compliance policy parsing error"", e);
+            }
+            return outputRule;
+        }
+    }
+}
+"
             );
+
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System
+//Imports System.IO
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Public Shared Function TestMethod(inputRule As String) As String
+//            Dim outputRule As String
+//            Try
+//                Dim xmlDoc As New XmlDocument()
+//                ' CA3075 for not setting secure Xml resolver
+//                Dim stringReader As New StringReader(inputRule)
+//                Dim textReader As New XmlTextReader(stringReader) With { _
+//                    .DtdProcessing = DtdProcessing.Ignore, _
+//                    .XmlResolver = Nothing _
+//                }
+//                Dim settings As New XmlReaderSettings() With { _
+//                    .ConformanceLevel = ConformanceLevel.Auto, _
+//                    .IgnoreComments = True, _
+//                    .DtdProcessing = DtdProcessing.Ignore, _
+//                    .XmlResolver = Nothing _
+//                }
+//                Dim reader As XmlReader = XmlReader.Create(textReader, settings)
+//                xmlDoc.Load(reader)
+//                Dim enabledAttribute As XmlAttribute = xmlDoc.CreateAttribute(""enabled"")
+//                Dim ruleAttrColl As XmlAttributeCollection = xmlDoc.DocumentElement.Attributes
+//                Dim nameAttribute As XmlAttribute = DirectCast(ruleAttrColl.GetNamedItem(""name""), XmlAttribute)
+//                ruleAttrColl.Remove(ruleAttrColl(""enabled""))
+//                ruleAttrColl.InsertAfter(enabledAttribute, nameAttribute)
+//                outputRule = xmlDoc.OuterXml
+//            Catch e As XmlException
+//                Throw New Exception(""Compliance policy parsing error"", e)
+//            End Try
+//            Return outputRule
+//        End Function
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(11, 31)
+//            );
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -152,9 +152,11 @@ End Namespace",
         }
 
         [Fact]
-        public async Task XmlDocumentAsFieldNoResolverShouldGenerateDiagnostic()
+        public async Task XmlDocumentAsFieldNoResolverPre452ShouldGenerateDiagnostic()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -167,16 +169,45 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(8, 34)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Public doc As XmlDocument = New XmlDocument()
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentAsFieldNoResolverPost452ShouldNotGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        public XmlDocument doc = new XmlDocument();
+    }
+}"
             );
+
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+//            );
         }
 
         [Fact]
@@ -343,9 +374,12 @@ End Namespace"
         }
 
         [Fact]
-        public async Task XmlDocumentNoResolverShouldGenerateDiagnostic()
+        public async Task XmlDocumentNoResolverPre452ShouldGenerateDiagnostic()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            // TODO: line 202
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -361,18 +395,52 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(10, 31)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Private Shared Sub TestMethod()
-            Dim doc As New XmlDocument()
-        End Sub
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
+//Namespace TestNamespace
+//    Class TestClass
+//        Private Shared Sub TestMethod()
+//            Dim doc As New XmlDocument()
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentNoResolverPost452ShouldNotGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XmlDocument doc = new XmlDocument();
+        }
+    }
+}"
             );
+
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Private Shared Sub TestMethod()
+//            Dim doc As New XmlDocument()
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
+            //);
         }
 
         [Fact]
@@ -494,9 +562,11 @@ End Namespace"
         }
 
         [Fact]
-        public async Task XmlDocumentReassignmentDefaultShouldGenerateDiagnostic()
+        public async Task XmlDocumentReassignmentDefaultTargetPre452ShouldGenerateDiagnostic()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -516,6 +586,48 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(14, 19)
             );
 
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Private Shared Sub TestMethod()
+//            Dim doc As New XmlDocument() With { _
+//                .XmlResolver = Nothing _
+//            }
+//            doc = New XmlDocument()
+//            ' warn
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(10, 19)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentReassignmentDefaultTargetPost452ShouldNotGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XmlDocument doc = new XmlDocument()
+            {
+                XmlResolver = null
+            };
+            doc = new XmlDocument();    // ok
+        }
+    }
+}"
+            );
+
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
 
@@ -526,11 +638,9 @@ Namespace TestNamespace
                 .XmlResolver = Nothing _
             }
             doc = New XmlDocument()
-            ' warn
         End Sub
     End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(10, 19)
+End Namespace"
             );
         }
 
@@ -580,9 +690,11 @@ End Namespace",
         }
 
         [Fact]
-        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInOnlyMethodShouldGenerateDiagnostics()
+        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInOnlyMethodPre452ShouldGenerateDiagnostics()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -601,27 +713,69 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(12, 13)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Public doc As XmlDocument = New XmlDocument()
-        ' warn
-        Public Sub Method1()
-            Me.doc.XmlResolver = New XmlUrlResolver()
-        End Sub
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
-            );
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+//        ' warn
+//        Public Sub Method1()
+//            Me.doc.XmlResolver = New XmlUrlResolver()
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
+//            );
         }
 
         [Fact]
-        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInSomeMethodShouldGenerateDiagnostics()
+        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInOnlyMethodPost452ShouldGenerateDiagnostics()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        public XmlDocument doc = new XmlDocument(); // ok
+
+        public void Method1()
+        {
+            this.doc.XmlResolver = new XmlUrlResolver(); // warn
+        }
+    }
+}",
+                GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(12, 13)
+            );
+
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+//        ' warn
+//        Public Sub Method1()
+//            Me.doc.XmlResolver = New XmlUrlResolver()
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInSomeMethodPre452ShouldGenerateDiagnostics()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -645,32 +799,35 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(17, 13)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Public doc As XmlDocument = New XmlDocument()
-        ' warn
-        Public Sub Method1()
-            Me.doc.XmlResolver = Nothing
-        End Sub
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+//        ' warn
+//        Public Sub Method1()
+//            Me.doc.XmlResolver = Nothing
+//        End Sub
 
-        Public Sub Method2()
-            Me.doc.XmlResolver = New XmlUrlResolver()
-            ' warn
-        End Sub
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
-            );
+//        Public Sub Method2()
+//            Me.doc.XmlResolver = New XmlUrlResolver()
+//            ' warn
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
+//            );
         }
 
         [Fact]
-        public async Task XmlDocumentAsFieldSetResolverToNullInSomeMethodShouldGenerateDiagnostics()
+        public async Task XmlDocumentAsFieldSetResolverToNullInSomeMethodPre452ShouldGenerateDiagnostics()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            //TODO: why?
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -693,6 +850,103 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(8, 34)
             );
 
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Public doc As XmlDocument = New XmlDocument()
+
+//        Public Sub Method1()
+//            Me.doc.XmlResolver = Nothing
+//        End Sub
+
+//        Public Sub Method2(reader As XmlReader)
+//            Me.doc.Load(reader)
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentAsFieldSetResolverToInsecureResolverInSomeMethodPost452ShouldGenerateDiagnostics()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        public XmlDocument doc = new XmlDocument();     // ok
+
+        public void Method1()
+        {
+            this.doc.XmlResolver = null;
+        }
+
+        public void Method2()
+        {
+            this.doc.XmlResolver = new XmlUrlResolver();    // warn
+        }
+    }
+}",
+                GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(17, 13)
+            );
+
+            //            await VerifyVB.VerifyAnalyzerAsync(@"
+            //Imports System.Xml
+
+            //Namespace TestNamespace
+            //    Class TestClass
+            //        Public doc As XmlDocument = New XmlDocument()
+            //        ' warn
+            //        Public Sub Method1()
+            //            Me.doc.XmlResolver = Nothing
+            //        End Sub
+
+            //        Public Sub Method2()
+            //            Me.doc.XmlResolver = New XmlUrlResolver()
+            //            ' warn
+            //        End Sub
+            //    End Class
+            //End Namespace",
+            //                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+            //                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
+            //            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentAsFieldSetResolverToNullInSomeMethodPost452ShouldNotGenerateDiagnostics()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        public XmlDocument doc = new XmlDocument();
+
+        public void Method1()
+        {
+            this.doc.XmlResolver = null;
+        }
+
+        public void Method2(XmlReader reader)
+        {
+            this.doc.Load(reader);
+        }
+    }
+}"
+            );
+
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
 
@@ -708,15 +962,16 @@ Namespace TestNamespace
             Me.doc.Load(reader)
         End Sub
     End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+End Namespace"
             );
         }
 
         [Fact]
-        public async Task XmlDocumentCreatedAsTempNotSetResolverShouldGenerateDiagnostics()
+        public async Task XmlDocumentCreatedAsTempNotSetResolverPre452ShouldGenerateDiagnostics()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -735,6 +990,47 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(11, 21)
             );
 
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+
+//        Public Sub Method1()
+//            Method2(New XmlDocument())
+//        End Sub
+
+//        Public Sub Method2(doc As XmlDocument)
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 21)
+//            );
+        }
+
+        [Fact]
+        public async Task XmlDocumentCreatedAsTempNotSetResolverPost452ShouldNotGenerateDiagnostics()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+
+        public void Method1()
+        {
+            Method2(new XmlDocument());
+        }
+
+        public void Method2(XmlDocument doc){}
+    }
+}"
+            );
+
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System.Xml
 
@@ -748,8 +1044,7 @@ Namespace TestNamespace
         Public Sub Method2(doc As XmlDocument)
         End Sub
     End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 21)
+End Namespace"
             );
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -169,16 +169,18 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(8, 34)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+            );
         }
 
         [Fact]
@@ -198,16 +200,17 @@ namespace TestNamespace
 }"
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
+    End Class
+End Namespace"
+            );
         }
 
         [Fact]
@@ -395,18 +398,20 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(10, 31)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Private Shared Sub TestMethod()
-//            Dim doc As New XmlDocument()
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Private Shared Sub TestMethod()
+            Dim doc As New XmlDocument()
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
+            );
         }
 
         [Fact]
@@ -429,18 +434,19 @@ namespace TestNamespace
 }"
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Private Shared Sub TestMethod()
-//            Dim doc As New XmlDocument()
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(7, 24)
-            //);
+Namespace TestNamespace
+    Class TestClass
+        Private Shared Sub TestMethod()
+            Dim doc As New XmlDocument()
+        End Sub
+    End Class
+End Namespace"
+            );
         }
 
         [Fact]
@@ -586,22 +592,24 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(14, 19)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Private Shared Sub TestMethod()
-//            Dim doc As New XmlDocument() With { _
-//                .XmlResolver = Nothing _
-//            }
-//            doc = New XmlDocument()
-//            ' warn
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(10, 19)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Private Shared Sub TestMethod()
+            Dim doc As New XmlDocument() With { _
+                .XmlResolver = Nothing _
+            }
+            doc = New XmlDocument()
+            ' warn
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(10, 19)
+            );
         }
 
         [Fact]
@@ -628,7 +636,9 @@ namespace TestNamespace
 }"
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -671,24 +681,26 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(11, 35)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Private Shared Sub TestMethod()
-//            If True Then
-//                Dim doc As New XmlDocument()
-//            End If
-//            If True Then
-//                Dim doc As New XmlDocument()
-//                doc.XmlResolver = Nothing
-//            End If
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Private Shared Sub TestMethod()
+            If True Then
+                Dim doc As New XmlDocument()
+            End If
+            If True Then
+                Dim doc As New XmlDocument()
+                doc.XmlResolver = Nothing
+            End If
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
+            );
         }
 
         [Fact]
@@ -717,24 +729,25 @@ namespace TestNamespace
 }"
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Private Shared Sub TestMethod()
-//            If True Then
-//                Dim doc As New XmlDocument()
-//            End If
-//            If True Then
-//                Dim doc As New XmlDocument()
-//                doc.XmlResolver = Nothing
-//            End If
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Private Shared Sub TestMethod()
+            If True Then
+                Dim doc As New XmlDocument()
+            End If
+            If True Then
+                Dim doc As New XmlDocument()
+                doc.XmlResolver = Nothing
+            End If
+        End Sub
+    End Class
+End Namespace"
+            );
         }
 
         [Fact]
@@ -761,21 +774,23 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(12, 13)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
-//        ' warn
-//        Public Sub Method1()
-//            Me.doc.XmlResolver = New XmlUrlResolver()
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
+        ' warn
+        Public Sub Method1()
+            Me.doc.XmlResolver = New XmlUrlResolver()
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
+            );
         }
 
         [Fact]
@@ -801,21 +816,23 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(12, 13)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
-//        ' warn
-//        Public Sub Method1()
-//            Me.doc.XmlResolver = New XmlUrlResolver()
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
-//            );
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
+        ' ok
+        Public Sub Method1()
+            Me.doc.XmlResolver = New XmlUrlResolver()
+        ' warn
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(9, 13)
+            );
         }
 
         [Fact]
@@ -847,26 +864,28 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(17, 13)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
-//        ' warn
-//        Public Sub Method1()
-//            Me.doc.XmlResolver = Nothing
-//        End Sub
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
+        ' warn
+        Public Sub Method1()
+            Me.doc.XmlResolver = Nothing
+        End Sub
 
-//        Public Sub Method2()
-//            Me.doc.XmlResolver = New XmlUrlResolver()
-//            ' warn
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
-//            );
+        Public Sub Method2()
+            Me.doc.XmlResolver = New XmlUrlResolver()
+            ' warn
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
+            );
         }
 
         [Fact]
@@ -898,24 +917,26 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(8, 34)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
-//        Public doc As XmlDocument = New XmlDocument()
+Namespace TestNamespace
+    Class TestClass
+        Public doc As XmlDocument = New XmlDocument()
 
-//        Public Sub Method1()
-//            Me.doc.XmlResolver = Nothing
-//        End Sub
+        Public Sub Method1()
+            Me.doc.XmlResolver = Nothing
+        End Sub
 
-//        Public Sub Method2(reader As XmlReader)
-//            Me.doc.Load(reader)
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
-//            );
+        Public Sub Method2(reader As XmlReader)
+            Me.doc.Load(reader)
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37)
+            );
         }
 
         [Fact]
@@ -946,26 +967,27 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(17, 13)
             );
 
-            //            await VerifyVB.VerifyAnalyzerAsync(@"
-            //Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
+            Imports System.Xml
 
-            //Namespace TestNamespace
-            //    Class TestClass
-            //        Public doc As XmlDocument = New XmlDocument()
-            //        ' warn
-            //        Public Sub Method1()
-            //            Me.doc.XmlResolver = Nothing
-            //        End Sub
+            Namespace TestNamespace
+                Class TestClass
+                    Public doc As XmlDocument = New XmlDocument()
+                    ' ok
+                    Public Sub Method1()
+                        Me.doc.XmlResolver = Nothing
+                    End Sub
 
-            //        Public Sub Method2()
-            //            Me.doc.XmlResolver = New XmlUrlResolver()
-            //            ' warn
-            //        End Sub
-            //    End Class
-            //End Namespace",
-            //                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(6, 37),
-            //                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 13)
-            //            );
+                    Public Sub Method2()
+                        Me.doc.XmlResolver = New XmlUrlResolver()
+                        ' warn
+                    End Sub
+                End Class
+            End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(13, 25)
+            );
         }
 
         [Fact]
@@ -995,7 +1017,9 @@ namespace TestNamespace
 }"
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -1038,22 +1062,24 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(11, 21)
             );
 
-//            await VerifyVB.VerifyAnalyzerAsync(@"
-//Imports System.Xml
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net451.Default,
+    @"
+Imports System.Xml
 
-//Namespace TestNamespace
-//    Class TestClass
+Namespace TestNamespace
+    Class TestClass
 
-//        Public Sub Method1()
-//            Method2(New XmlDocument())
-//        End Sub
+        Public Sub Method1()
+            Method2(New XmlDocument())
+        End Sub
 
-//        Public Sub Method2(doc As XmlDocument)
-//        End Sub
-//    End Class
-//End Namespace",
-//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 21)
-//            );
+        Public Sub Method2(doc As XmlDocument)
+        End Sub
+    End Class
+End Namespace",
+                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 21)
+            );
         }
 
         [Fact]
@@ -1079,7 +1105,9 @@ namespace TestNamespace
 }"
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
+            await VerifyVisualBasicAnalyzerAsync(
+    ReferenceAssemblies.NetFramework.Net452.Default,
+    @"
 Imports System.Xml
 
 Namespace TestNamespace

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -170,8 +170,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -201,8 +201,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -398,8 +398,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -434,8 +434,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -592,8 +592,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -636,8 +636,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -703,7 +703,7 @@ End Namespace",
         }
 
         [Fact]
-        public async Task XmlDocumentSetResolversInDifferentBlockPost452ShouldGenerateDiagnostic()
+        public async Task XmlDocumentSetResolversInDifferentBlockPost452ShouldNotGenerateDiagnostic()
         {
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net452.Default,
@@ -729,8 +729,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -774,8 +774,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -816,8 +816,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -864,8 +864,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -916,8 +916,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -966,8 +966,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
             Imports System.Xml
 
             Namespace TestNamespace
@@ -1016,8 +1016,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -1061,8 +1061,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net451.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace
@@ -1104,8 +1104,8 @@ namespace TestNamespace
             );
 
             await VerifyVisualBasicAnalyzerAsync(
-    ReferenceAssemblies.NetFramework.Net452.Default,
-    @"
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
 Imports System.Xml
 
 Namespace TestNamespace

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -671,24 +671,24 @@ namespace TestNamespace
                 GetCA3075XmlDocumentWithNoSecureResolverCSharpResultAt(11, 35)
             );
 
-            await VerifyVB.VerifyAnalyzerAsync(@"
-Imports System.Xml
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
 
-Namespace TestNamespace
-    Class TestClass
-        Private Shared Sub TestMethod()
-            If True Then
-                Dim doc As New XmlDocument()
-            End If
-            If True Then
-                Dim doc As New XmlDocument()
-                doc.XmlResolver = Nothing
-            End If
-        End Sub
-    End Class
-End Namespace",
-                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
-            );
+//Namespace TestNamespace
+//    Class TestClass
+//        Private Shared Sub TestMethod()
+//            If True Then
+//                Dim doc As New XmlDocument()
+//            End If
+//            If True Then
+//                Dim doc As New XmlDocument()
+//                doc.XmlResolver = Nothing
+//            End If
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
+//            );
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -379,7 +379,6 @@ End Namespace"
         [Fact]
         public async Task XmlDocumentNoResolverPre452ShouldGenerateDiagnostic()
         {
-            // TODO: line 202
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net451.Default,
                 @"
@@ -891,7 +890,6 @@ End Namespace",
         [Fact]
         public async Task XmlDocumentAsFieldSetResolverToNullInSomeMethodPre452ShouldGenerateDiagnostics()
         {
-            //TODO: why?
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net451.Default,
                 @"
@@ -901,7 +899,7 @@ namespace TestNamespace
 {
     class TestClass
     {
-        public XmlDocument doc = new XmlDocument();
+        public XmlDocument doc = new XmlDocument(); // warn
 
         public void Method1()
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentConstructedWithNoSecureResolverTests.cs
@@ -645,9 +645,11 @@ End Namespace"
         }
 
         [Fact]
-        public async Task XmlDocumentSetResolversInDifferentBlock()
+        public async Task XmlDocumentSetResolversInDifferentBlockPre452ShouldGenerateDiagnostic()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
 using System.Xml;
 
 namespace TestNamespace
@@ -657,7 +659,7 @@ namespace TestNamespace
         private static void TestMethod()
         {
             {
-                XmlDocument doc = new XmlDocument();
+                XmlDocument doc = new XmlDocument(); //warn
             }
             {
                 XmlDocument doc = new XmlDocument();
@@ -687,6 +689,52 @@ Namespace TestNamespace
 End Namespace",
                 GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
             );
+        }
+
+        [Fact]
+        public async Task XmlDocumentSetResolversInDifferentBlockPost452ShouldGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System.Xml;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            {
+                XmlDocument doc = new XmlDocument(); //ok in 4.5.2
+            }
+            {
+                XmlDocument doc = new XmlDocument();
+                doc.XmlResolver = null;
+            }
+        }
+    }
+}"
+            );
+
+//            await VerifyVB.VerifyAnalyzerAsync(@"
+//Imports System.Xml
+
+//Namespace TestNamespace
+//    Class TestClass
+//        Private Shared Sub TestMethod()
+//            If True Then
+//                Dim doc As New XmlDocument()
+//            End If
+//            If True Then
+//                Dim doc As New XmlDocument()
+//                doc.XmlResolver = Nothing
+//            End If
+//        End Sub
+//    End Class
+//End Namespace",
+//                GetCA3075XmlDocumentWithNoSecureResolverBasicResultAt(8, 28)
+//            );
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
+    Microsoft.NetFramework.Analyzers.DoNotUseInsecureDtdProcessingAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.NetFramework.Analyzers.UnitTests
+{
+    public partial class DoNotUseInsecureDtdProcessingAnalyzerTests
+    {
+        private static DiagnosticResult GetCSharpResultAt(int line, int column)
+        => VerifyCS.Diagnostic(DoNotUseInsecureDtdProcessingAnalyzer.RuleXmlDocumentWithNoSecureResolver).WithLocation(line, column);
+
+        [Fact]
+        public async Task XmlDocument_TargetFx451_ShouldGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net451.Default,
+                @"
+using System;
+using System.Reflection;               
+using System.Xml;   
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(string path)
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            XmlReader reader = XmlReader.Create(path, settings);
+            XmlDocument doc = new XmlDocument();
+            doc.Load(reader);
+        }
+    }
+}
+",
+            GetCSharpResultAt(14, 31)
+            );
+
+        }
+
+        [Fact]
+        public async Task XmlDocument_TargetFx452_ShouldNotGenerateDiagnostic()
+        {
+            await VerifyCSharpAnalyzerAsync(
+                ReferenceAssemblies.NetFramework.Net452.Default,
+                @"
+using System;
+using System.Reflection;               
+using System.Xml;   
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(string path)
+        {
+            XmlReaderSettings settings = new XmlReaderSettings();
+            XmlReader reader = XmlReader.Create(path, settings);
+            XmlDocument doc = new XmlDocument();
+            doc.Load(reader);
+        }
+    }
+}
+"
+            );
+        }
+    }
+}

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
         	=> VerifyCS.Diagnostic(DoNotUseInsecureDtdProcessingAnalyzer.RuleXmlDocumentWithNoSecureResolver).WithLocation(line, column);
 
         [Fact]
-        public async Task XmlDocument_TargetFx451_ShouldGenerateDiagnostic()
+        public async Task XmlDocumentDefaultResolversInXmlReaderSettingsPre452ShouldGenerateDiagnostic()
         {
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net451.Default,
@@ -44,7 +44,7 @@ namespace TestNamespace
         }
 
         [Fact]
-        public async Task XmlDocument_TargetFx452_ShouldNotGenerateDiagnostic()
+        public async Task XmlDocumentDefaultResolversInXmlReaderSettingsPre452ShouldNotGenerateDiagnostic()
         {
             await VerifyCSharpAnalyzerAsync(
                 ReferenceAssemblies.NetFramework.Net452.Default,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureDtdProcessingXmlDocumentSecureDefaultXmlResolverAnalyzerTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
     public partial class DoNotUseInsecureDtdProcessingAnalyzerTests
     {
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
-        => VerifyCS.Diagnostic(DoNotUseInsecureDtdProcessingAnalyzer.RuleXmlDocumentWithNoSecureResolver).WithLocation(line, column);
+        	=> VerifyCS.Diagnostic(DoNotUseInsecureDtdProcessingAnalyzer.RuleXmlDocumentWithNoSecureResolver).WithLocation(line, column);
 
         [Fact]
         public async Task XmlDocument_TargetFx451_ShouldGenerateDiagnostic()
@@ -21,8 +21,8 @@ namespace Microsoft.NetFramework.Analyzers.UnitTests
                 ReferenceAssemblies.NetFramework.Net451.Default,
                 @"
 using System;
-using System.Reflection;               
-using System.Xml;   
+using System.Reflection;
+using System.Xml;
 
 namespace TestNamespace
 {
@@ -50,8 +50,8 @@ namespace TestNamespace
                 ReferenceAssemblies.NetFramework.Net452.Default,
                 @"
 using System;
-using System.Reflection;               
-using System.Xml;   
+using System.Reflection;
+using System.Xml;
 
 namespace TestNamespace
 {


### PR DESCRIPTION
Fixes #1150

This change is made to account for the false positives created by analyzer CA3075 for XmlDocument after .NET version 4.5.2.

Before .NET 4.5.2, XmlDocument creates a new XmlUrlResolver object as XmlResolver if no object is provided as the default behaviour. After .NET 4.5.2, XmlDocument defaults XmlResolver as null.

This check for warning is done in DoNotUseInsecureDtdProcessing.cs, indicated by variables XmlDocumentEnvironment.IsXmlResolverSet and XmlDocumentEnvironment.IsSecureResolver.

Unit tests for XmlDocument is split into pre/post version 4.5.2 to test for CA3075 warning variations. Helper methods for .NET version variation (VerifyCSharpAnalyzerAsync, VerifyVisualBasicAnalyzerAsync) are added.

