### PR TITLE
Apply CA2016 - Forward CancellationToken to methods that can take it

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             var generator = editor.Generator;
 
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var typeIsSealed = ((INamedTypeSymbol)model.GetDeclaredSymbol(classDecl)).IsSealed;
+            var typeIsSealed = ((INamedTypeSymbol)model.GetDeclaredSymbol(classDecl, cancellationToken)).IsSealed;
 
             INamedTypeSymbol? codeFixProviderSymbol = model.Compilation.GetOrCreateTypeByMetadataName(FixerWithFixAllAnalyzer.CodeFixProviderMetadataName);
             IMethodSymbol? getFixAllProviderMethod = codeFixProviderSymbol?.GetMembers(FixerWithFixAllAnalyzer.GetFixAllProviderMethodName).OfType<IMethodSymbol>().FirstOrDefault();

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementStandardExceptionConstructors.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementStandardExceptionConstructors.Fixer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             CodeAnalysis.Text.TextSpan diagnosticSpan = diagnostics.First().Location.SourceSpan; // All the diagnostics are reported at the same location -- the name of the declared class -- so it doesn't matter which one we pick
             SyntaxNode node = root.FindNode(diagnosticSpan);
             SyntaxNode targetNode = editor.Generator.GetDeclaration(node, DeclarationKind.Class);
-            if (!(model.GetDeclaredSymbol(targetNode) is INamedTypeSymbol typeSymbol))
+            if (!(model.GetDeclaredSymbol(targetNode, cancellationToken) is INamedTypeSymbol typeSymbol))
             {
                 return document;
             }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             editor.AddInterfaceType(declaration, interfaceType);
 
             // Find a Dispose method. If one exists make that implement IDisposable, else generate a new method.
-            var typeSymbol = model.GetDeclaredSymbol(declaration) as INamedTypeSymbol;
+            var typeSymbol = model.GetDeclaredSymbol(declaration, cancellationToken) as INamedTypeSymbol;
             IMethodSymbol? disposeMethod = (typeSymbol?.GetMembers("Dispose"))?.OfType<IMethodSymbol>()?.Where(m => m.Parameters.Length == 0).FirstOrDefault();
             if (disposeMethod != null && disposeMethod.DeclaringSyntaxReferences.Length == 1)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var generator = editor.Generator;
 
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(methodNode);
+            var methodSymbol = (IMethodSymbol)model.GetDeclaredSymbol(methodNode, cancellationToken);
 
             var parameterIndex = GetParameterIndex(methodSymbol, model.SyntaxTree, span);
             if (parameterIndex < 0)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParameters.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParameters.Fixer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             SyntaxNode declarationNode = GetParameterDeclarationNode(diagnosticNode);
 
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            ISymbol parameterSymbol = editor.SemanticModel.GetDeclaredSymbol(declarationNode);
+            ISymbol parameterSymbol = editor.SemanticModel.GetDeclaredSymbol(declarationNode, cancellationToken);
             ISymbol methodDeclarationSymbol = parameterSymbol.ContainingSymbol;
 
             if (!IsSafeMethodToRemoveParameter(methodDeclarationSymbol))
@@ -138,7 +138,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     foreach (var referenceLocation in referencedSymbol.Locations)
                     {
                         Location location = referenceLocation.Location;
-                        var referenceRoot = location.SourceTree.GetRoot();
+                        var referenceRoot = location.SourceTree.GetRoot(cancellationToken);
                         var referencedSymbolNode = referenceRoot.FindNode(location.SourceSpan);
                         DocumentEditor localEditor = await DocumentEditor.CreateAsync(referenceLocation.Document, cancellationToken).ConfigureAwait(false);
                         var arguments = GetOperationArguments(referencedSymbolNode, localEditor.SemanticModel, cancellationToken);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
@@ -101,7 +101,7 @@ namespace Microsoft.NetCore.Analyzers.Resources
                 return false;
             }
 
-            Optional<object> constValue = model.GetConstantValue(argument);
+            Optional<object> constValue = model.GetConstantValue(argument, cancellationToken);
             if (!constValue.HasValue)
             {
                 return false;


### PR DESCRIPTION
This PR applies Roslyn analyzer CA2016: It identified methods that had a CancellationToken parameter, and then looked inside its method body for any method invocations that could accept a token as an argument, but weren't taking it yet.

The Roslyn analyzer/fixer is up for review here: dotnet/roslyn-analyzers#3641
Original issue here: #33774

@mavasani the rule behaved strange in all the `model.GetDeclaredSymbol(classDecl)` invocations - The method overload that takes a `CancellationToken` is located in an extension class, which I wasn't expecting to diagnose, but it was diagnosed and an incorrect fix was offered, because the object was being substituted by the class name.