### PR TITLE
Rename CA1835 C#/VB specific classes

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -11,7 +11,7 @@ using Microsoft.NetCore.Analyzers.Runtime;
 namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 {
     [ExportCodeFixProvider(LanguageNames.CSharp)]
-    public sealed class PreferStreamAsyncMemoryOverloadsCSharpFixer : PreferStreamAsyncMemoryOverloadsFixer
+    public sealed class CSharpPreferStreamAsyncMemoryOverloadsFixer : PreferStreamAsyncMemoryOverloadsFixer
     {
         protected override IArgumentOperation? GetArgumentByPositionOrName(ImmutableArray<IArgumentOperation> args, int index, string name, out bool isNamed)
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -6,10 +6,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsCSharpFixer>;
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpPreferStreamAsyncMemoryOverloadsFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.PreferStreamAsyncMemoryOverloads,
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.PreferStreamAsyncMemoryOverloadsVisualBasicFixer>;
+    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicPreferStreamAsyncMemoryOverloadsFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -10,7 +10,7 @@ Imports Microsoft.NetCore.Analyzers.Runtime
 Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
     <ExportCodeFixProvider(LanguageNames.VisualBasic)>
-    Public NotInheritable Class PreferStreamAsyncMemoryOverloadsVisualBasicFixer
+    Public NotInheritable Class BasicPreferStreamAsyncMemoryOverloadsFixer
 
         Inherits PreferStreamAsyncMemoryOverloadsFixer
 


### PR DESCRIPTION
Small fix. I realized I didn't name the classes and files properly.