### PR TITLE
Update fixer title, update getting started doc

### DIFF
--- a/docs/NetCore_GettingStarted.md
+++ b/docs/NetCore_GettingStarted.md
@@ -34,7 +34,6 @@
 - Document for review: severity, default, categorization, numbering, titles, messages, and descriptions.
 - Create the appropriate documentation for [docs.microsoft.com](https://github.com/MicrosoftDocs/visualstudio-docs-pr/tree/master/docs/code-quality) within **ONE WEEK**, instructions available on OneNote. External contributors should create an issue at https://github.com/microsoftDocs/visualstudio-docs/issues with a subject `Add documentation for analyzer rule [Your Rule ID]`. 
 - PR merged into `dotnet/roslyn-analyzers`. 
- 
 
 ## Testing against the Runtime and Roslyn-analyzers repo 
 
@@ -45,7 +44,7 @@
 	- `cd artifacts\bin\Microsoft.NetCore.CSharp.Analyzers\Debug\netstandard2.0` 
 2. Copy the two DLLs and replace the NuGet cache entries used by `dotnet/runtime`. They might be in `"runtime/.packages/..."` or `"%USERPROFILE%/.nuget/packages/... "`. You can check the exact path by building something in runtime with /bl and checking the binlog file. Example: 
 	- `copy /y *.dll %USERPROFILE%\.nuget\packages\Microsoft.NetCore.Analyzers\%RUNTIMEPACKAGEVERSION%\analyzers\dotnet\cs`
-3. Build the rolsyn-analyzers with just `build.cmd`, now new analyzers will be used from nuget packages and you would see warnings if it found diagnostics.
+3. Build the rolsyn-analyzers with `build.cmd`, now new analyzers will be used from updated nuget packages and you would see the warnings if diagnostics found.
 4. If failures found, review each of the failures and determine the course of action for each. 
 	- Improve analyzer to reduce false positives, fix valid warnings, in a very rare edge cases suppress them.
 5. Make sure all failures addressed and corresponding PR(s) merged.	
@@ -54,7 +53,6 @@
 8. In case no any failure introduce an error somewhere to prove that the rule ran. 
 	- Be careful about in which project you are producing an error, choose an API not having reference from other APIs, else all dependent API's will fail.
 9. If failures found, repeat step 4-5 to evaluate and address all warnings. 
- 
 
 ## Testing against the Roslyn repo 
 

--- a/docs/NetCore_GettingStarted.md
+++ b/docs/NetCore_GettingStarted.md
@@ -25,17 +25,18 @@
 	- Do not separate analyzer tests from code fix tests. If the analyzer has a code fix, then write all your tests as code fix tests.
 		- Calling `VerifyCodeFixAsync(source, source)` verifies that the analyzer either does not produce diagnostics, or produces diagnostics where no code fix is offered.
 		- Calling `VerifyCodeFixAsync(source, fixedSource)` verifies the diagnostics (analyzer testing) and verifies that the code fix on source produces the expected output.
-- Run the analyzer locally against `dotnet/runtime` [instructions](#Testing-against-the-Runtime-repo). 
-	- Use the failures to discover nuance and guide the implementation details. 
-	- Run the analyzer against `dotnet/roslyn` [instruction](#Testing-against-the-Roslyn-repo), and with `dotnet/aspnetcore` if feasable. 
-	- Review each of the failures in those repositories and determine the course of action for each. 
+- Run the analyzer locally against `dotnet/runtime` and `dotnet/roslyn-analyzers` [instructions](#Testing-against-the-Runtime-and-Roslyn-analyzers-repo).
+	- Review each of the failures in those repositories and determine the course of action for each.
+	- Use the failures to discover nuance and guide the implementation details.
+	- Run the analyzer against `dotnet/roslyn` [instruction](#Testing-against-the-Roslyn-repo), and if feasable with `dotnet/aspnetcore` repos.
+	- Document for review: matching and non-matching scenarios, including any discovered nuance.
+	- Failures in all `dotnet` repos are addressed.
 - Document for review: severity, default, categorization, numbering, titles, messages, and descriptions.
-- Document for review: matching and non-matching scenarios, including any discovered nuance. 
 - Create the appropriate documentation for [docs.microsoft.com](https://github.com/MicrosoftDocs/visualstudio-docs-pr/tree/master/docs/code-quality) within **ONE WEEK**, instructions available on OneNote. External contributors should create an issue at https://github.com/microsoftDocs/visualstudio-docs/issues with a subject `Add documentation for analyzer rule [Your Rule ID]`. 
 - PR merged into `dotnet/roslyn-analyzers`. 
-- Failures in `dotnet/runtime` addressed. 
+ 
 
-## Testing against the Runtime repo 
+## Testing against the Runtime and Roslyn-analyzers repo 
 
 1. Navigate to the root of the Roslyn-analyzers repo and run these commands: 
 	- `cd roslyn-analyzers` 
@@ -43,11 +44,17 @@
 	- `build.cmd -ci /p:AssemblyVersion=%RUNTIMEPACKAGEVERSION% /p:AutoGenerateAssemblyVersion=false /p:OfficialBuild=true`
 	- `cd artifacts\bin\Microsoft.NetCore.CSharp.Analyzers\Debug\netstandard2.0` 
 2. Copy the two DLLs and replace the NuGet cache entries used by `dotnet/runtime`. They might be in `"runtime/.packages/..."` or `"%USERPROFILE%/.nuget/packages/... "`. You can check the exact path by building something in runtime with /bl and checking the binlog file. Example: 
-	- `copy /y *.dll %USERPROFILE%\.nuget\packages\Microsoft.NetCore.Analyzers\%RUNTIMEPACKAGEVERSION%\analyzers\dotnet\cs` 
-3.    Switch to the runtime project. 
-4.    Introduce an error somewhere to prove that the rule ran. 
-	- Be careful about in which project you are producing an error, choose an API not having reference from other APIs, else all dependent API's will fail. 
-5. Build the runtime repo, either do a complete build or build each repo separately (coreclr, libraries, mono). 
+	- `copy /y *.dll %USERPROFILE%\.nuget\packages\Microsoft.NetCore.Analyzers\%RUNTIMEPACKAGEVERSION%\analyzers\dotnet\cs`
+3. Build the rolsyn-analyzers with just `build.cmd`, now new analyzers will be used from nuget packages and you would see warnings if it found diagnostics.
+4. If failures found, review each of the failures and determine the course of action for each. 
+	- Improve analyzer to reduce false positives, fix valid warnings, in a very rare edge cases suppress them.
+5. Make sure all failures addressed and corresponding PR(s) merged.	
+6. Switch to the runtime repo. 
+7. Build the runtime repo, either do a complete build or build each repo separately (coreclr, libraries, mono). 
+8. In case no any failure introduce an error somewhere to prove that the rule ran. 
+	- Be careful about in which project you are producing an error, choose an API not having reference from other APIs, else all dependent API's will fail.
+9. If failures found, repeat step 4-5 to evaluate and address all warnings. 
+ 
 
 ## Testing against the Roslyn repo 
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1344,4 +1344,7 @@
   <data name="PreferIsEmptyOverCountTitle" xml:space="preserve">
     <value>Prefer IsEmpty over Count</value>
   </data>
+  <data name="UseAsSpanInsteadOfRangeIndexerCodeFixTitle" xml:space="preserve">
+    <value>Use {0} instead of Range-based indexers on {1}</value>
+  </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1345,9 +1345,9 @@
     <value>Prefer IsEmpty over Count</value>
   </data>
   <data name="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle" xml:space="preserve">
-    <value>Use {0} instead of Range-based indexers on a string</value>
+    <value>Use `{0}` instead of Range-based indexers on a string</value>
   </data>
   <data name="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle" xml:space="preserve">
-    <value>Use {0} instead of Range-based indexers on an array</value>
+    <value>Use `{0}` instead of Range-based indexers on an array</value>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1344,7 +1344,10 @@
   <data name="PreferIsEmptyOverCountTitle" xml:space="preserve">
     <value>Prefer IsEmpty over Count</value>
   </data>
-  <data name="UseAsSpanInsteadOfRangeIndexerCodeFixTitle" xml:space="preserve">
-    <value>Use {0} instead of Range-based indexers on {1}</value>
+  <data name="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle" xml:space="preserve">
+    <value>Use {0} instead of Range-based indexers on a string</value>
+  </data>
+  <data name="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle" xml:space="preserve">
+    <value>Use {0} instead of Range-based indexers on an array</value>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.Fixer.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -75,8 +77,10 @@ namespace Microsoft.NetCore.Analyzers.Performance
             private readonly SyntaxNode _toReplace;
             private readonly SyntaxNode _methodTarget;
             private readonly IEnumerable<SyntaxNode> _rangeArguments;
+            private const string aString = "a string";
+            private const string anArray = "an array";
 
-            public override string Title { get; } = MicrosoftNetCoreAnalyzersResources.UseAsSpanInsteadOfRangeIndexerTitle;
+            public override string Title { get; }
 
             public override string EquivalenceKey { get; }
 
@@ -94,6 +98,8 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 _methodTarget = methodTarget;
                 _rangeArguments = rangeArguments;
                 EquivalenceKey = ruleId;
+                Title = string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.UseAsSpanInsteadOfRangeIndexerCodeFixTitle, targetMethod,
+                    ruleId.Equals(UseAsSpanInsteadOfRangeIndexerAnalyzer.StringRuleId, StringComparison.InvariantCulture) ? aString : anArray);
             }
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.Fixer.cs
@@ -77,8 +77,6 @@ namespace Microsoft.NetCore.Analyzers.Performance
             private readonly SyntaxNode _toReplace;
             private readonly SyntaxNode _methodTarget;
             private readonly IEnumerable<SyntaxNode> _rangeArguments;
-            private const string aString = "a string";
-            private const string anArray = "an array";
 
             public override string Title { get; }
 
@@ -98,8 +96,9 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 _methodTarget = methodTarget;
                 _rangeArguments = rangeArguments;
                 EquivalenceKey = ruleId;
-                Title = string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.UseAsSpanInsteadOfRangeIndexerCodeFixTitle, targetMethod,
-                    ruleId.Equals(UseAsSpanInsteadOfRangeIndexerAnalyzer.StringRuleId, StringComparison.InvariantCulture) ? aString : anArray);
+                Title = ruleId.Equals(UseAsSpanInsteadOfRangeIndexerAnalyzer.StringRuleId, StringComparison.InvariantCulture) ?
+                    string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle, targetMethod) :
+                    string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle, targetMethod);
             }
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">Indexer hodnot pole založený na rozsahu vytváří kopii požadované části pole. Když se implicitně používá jako hodnota Span nebo Memory, je tato kopie často nežádoucí. Pokud se jí chcete vyhnout, použijte metodu AsSpan.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">V {2} místo indexeru založeného na {1} použijte {0}, nebudou se tak vytvářet nepotřebné kopie dat.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">Indexer hodnot pole založený na rozsahu vytváří kopii požadované části pole. Když se implicitně používá jako hodnota Span nebo Memory, je tato kopie často nežádoucí. Pokud se jí chcete vyhnout, použijte metodu AsSpan.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">V {2} místo indexeru založeného na {1} použijte {0}, nebudou se tak vytvářet nepotřebné kopie dat.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">Der Range-basierte Indexer für Arraywerte erzeugt eine Kopie des angeforderten Bereichs des Arrays. Diese Kopie ist bei einer impliziten Verwendung als Span- oder Memory-Wert häufig unerwünscht. Verwenden Sie die Span-Methode, um die Kopie zu vermeiden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Verwenden Sie "{0}" anstelle des {1}-basierten Indexers für "{2}", um das Erstellen nicht erforderlicher Datenkopien zu vermeiden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">Der Range-basierte Indexer für Arraywerte erzeugt eine Kopie des angeforderten Bereichs des Arrays. Diese Kopie ist bei einer impliziten Verwendung als Span- oder Memory-Wert häufig unerwünscht. Verwenden Sie die Span-Methode, um die Kopie zu vermeiden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Verwenden Sie "{0}" anstelle des {1}-basierten Indexers für "{2}", um das Erstellen nicht erforderlicher Datenkopien zu vermeiden.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">El indizador basado en intervalos en los valores de matriz genera una copia de la parte solicitada de la matriz. Esta copia suele ser no deseada cuando se usa implícitamente como valor Span o Memory. Use el método AsSpan para evitar la copia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Use "{0}" en lugar del indizador basado en "{1}" en "{2}" para evitar la creación de copias de datos innecesarias.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">El indizador basado en intervalos en los valores de matriz genera una copia de la parte solicitada de la matriz. Esta copia suele ser no deseada cuando se usa implícitamente como valor Span o Memory. Use el método AsSpan para evitar la copia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Use "{0}" en lugar del indizador basado en "{1}" en "{2}" para evitar la creación de copias de datos innecesarias.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">L'indexeur basé sur Range pour les valeurs de tableau produit une copie de la partie demandée du tableau. Cette copie est souvent indésirable quand elle est implicitement utilisée en tant que valeur Span ou Memory. Utilisez la méthode AsSpan pour éviter la copie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Utilisez '{0}' à la place de l'indexeur basé sur '{1}' pour '{2}' afin d'éviter la création de copies de données inutiles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">L'indexeur basé sur Range pour les valeurs de tableau produit une copie de la partie demandée du tableau. Cette copie est souvent indésirable quand elle est implicitement utilisée en tant que valeur Span ou Memory. Utilisez la méthode AsSpan pour éviter la copie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Utilisez '{0}' à la place de l'indexeur basé sur '{1}' pour '{2}' afin d'éviter la création de copies de données inutiles.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">Con l'indicizzatore basato su Range su valori di matrice viene prodotta una copia della porzione richiesta della matrice. Questa copia è spesso indesiderata quando viene usata in modo implicito come valore di Span o Memory. Per evitare la copia, usare il metodo AsSpan.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Per evitare la creazione di copie di dati non necessarie, usare '{0}' invece dell'indicizzatore basato su '{1}' su '{2}'.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">Con l'indicizzatore basato su Range su valori di matrice viene prodotta una copia della porzione richiesta della matrice. Questa copia è spesso indesiderata quando viene usata in modo implicito come valore di Span o Memory. Per evitare la copia, usare il metodo AsSpan.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Per evitare la creazione di copie di dati non necessarie, usare '{0}' invece dell'indicizzatore basato su '{1}' su '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">配列の値に対して範囲ベースのインデクサーを使用すると、要求された配列の部分のコピーが作成されます。Span または Memory 値として暗黙的に使用される場合、このコピーは不要であることが少なくありません。このコピーを回避するには、AsSpan メソッドをご使用ください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">不要なデータ コピーが作成されないようにするには、'{2}' で '{1}' ベースのインデクサーの代わりに '{0}' をお使いください。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">配列の値に対して範囲ベースのインデクサーを使用すると、要求された配列の部分のコピーが作成されます。Span または Memory 値として暗黙的に使用される場合、このコピーは不要であることが少なくありません。このコピーを回避するには、AsSpan メソッドをご使用ください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">不要なデータ コピーが作成されないようにするには、'{2}' で '{1}' ベースのインデクサーの代わりに '{0}' をお使いください。</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">배열 값에 대한 범위 기반 인덱서는 배열의 요청된 부분의 복사본을 생성합니다. 이 복사본은 암시적으로 범위 또는 메모리 값으로 사용될 경우 대개 필요하지 않습니다. 복사본이 생성되지 않도록 하려면 AsSpan 메서드를 사용하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">불필요한 데이터 복사본이 만들어지지 않도록 하려면 '{2}'에서 '{1}' 기반 인덱서 대신 '{0}'을(를) 사용하세요.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">배열 값에 대한 범위 기반 인덱서는 배열의 요청된 부분의 복사본을 생성합니다. 이 복사본은 암시적으로 범위 또는 메모리 값으로 사용될 경우 대개 필요하지 않습니다. 복사본이 생성되지 않도록 하려면 AsSpan 메서드를 사용하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">불필요한 데이터 복사본이 만들어지지 않도록 하려면 '{2}'에서 '{1}' 기반 인덱서 대신 '{0}'을(를) 사용하세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1834,13 +1834,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1828,14 +1828,19 @@
         <target state="translated">Użycie indeksatora opartego na zakresie w przypadku wartości tablicy powoduje utworzenie kopii żądanej części tablicy. Ta kopia jest często niechciana, gdy jest niejawnie używana jako wartość Span lub Memory. Użyj metody AsSpan, aby uniknąć kopiowania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Użyj metody „{0}” zamiast indeksatora opartego na „{1}” w przypadku wartości „{2}”, aby uniknąć tworzenia niepotrzebnych kopii danych.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1828,6 +1828,11 @@
         <target state="translated">Użycie indeksatora opartego na zakresie w przypadku wartości tablicy powoduje utworzenie kopii żądanej części tablicy. Ta kopia jest często niechciana, gdy jest niejawnie używana jako wartość Span lub Memory. Użyj metody AsSpan, aby uniknąć kopiowania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Użyj metody „{0}” zamiast indeksatora opartego na „{1}” w przypadku wartości „{2}”, aby uniknąć tworzenia niepotrzebnych kopii danych.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">O Indexador baseado em intervalo em valores de matriz produz uma cópia da porção solicitada da matriz. Essa cópia costuma ser indesejada quando é usada implicitamente como um valor de Span ou de Memory. Use o método AsSpan para evitar a cópia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Use '{0}' em vez do indexador baseado em '{1}' em '{2}' para evitar a criação de cópias de dados desnecessárias.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">O Indexador baseado em intervalo em valores de matriz produz uma cópia da porção solicitada da matriz. Essa cópia costuma ser indesejada quando é usada implicitamente como um valor de Span ou de Memory. Use o método AsSpan para evitar a cópia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Use '{0}' em vez do indexador baseado em '{1}' em '{2}' para evitar a criação de cópias de dados desnecessárias.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">Основанный на диапазонах индексатор для значений массива создает копию запрошенной части массива. Эта копия часто нежелательна, если она неявно используется в качестве значения Span или Memory. Используйте метод AsSpan, чтобы избежать копирования.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Используйте "{0}" вместо индексатора на основе "{1}" в "{2}", чтобы избежать создания ненужных копий данных.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">Основанный на диапазонах индексатор для значений массива создает копию запрошенной части массива. Эта копия часто нежелательна, если она неявно используется в качестве значения Span или Memory. Используйте метод AsSpan, чтобы избежать копирования.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Используйте "{0}" вместо индексатора на основе "{1}" в "{2}", чтобы избежать создания ненужных копий данных.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">Dizi değerleri üzerindeki Aralık tabanlı dizin oluşturucu, dizinin istenen kısmının bir kopyasını üretir. Bu kopya, örtük olarak bir Yayılma veya Bellek değeri olarak kullanıldığında genellikle istenmez. Kopya oluşturmamak için AsSpan metodunu kullanın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Gereksiz veri kopyaları oluşturmamak için '{2}' üzerinde '{0}' yerine '{1}' tabanlı dizin oluşturucu kullanın.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">Dizi değerleri üzerindeki Aralık tabanlı dizin oluşturucu, dizinin istenen kısmının bir kopyasını üretir. Bu kopya, örtük olarak bir Yayılma veya Bellek değeri olarak kullanıldığında genellikle istenmez. Kopya oluşturmamak için AsSpan metodunu kullanın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">Gereksiz veri kopyaları oluşturmamak için '{2}' üzerinde '{0}' yerine '{1}' tabanlı dizin oluşturucu kullanın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">数组值的基于范围的索引器生成数组所请求部分的副本。此副本在隐式用作 Span 或 Memory 值时常常是不需要的。使用 AsSpan 方法可避免此副本。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">请使用 "{0}" 代替 "{2}" 上的基于 "{1}" 的索引器，以避免创建不必要的数据副本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">数组值的基于范围的索引器生成数组所请求部分的副本。此副本在隐式用作 Span 或 Memory 值时常常是不需要的。使用 AsSpan 方法可避免此副本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">请使用 "{0}" 代替 "{2}" 上的基于 "{1}" 的索引器，以避免创建不必要的数据副本。</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1833,13 +1833,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on a string</source>
-        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <source>Use `{0}` instead of Range-based indexers on a string</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on a string</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on an array</source>
-        <target state="new">Use {0} instead of Range-based indexers on an array</target>
+        <source>Use `{0}` instead of Range-based indexers on an array</source>
+        <target state="new">Use `{0}` instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1827,14 +1827,19 @@
         <target state="translated">陣列值中以 Range 為基礎的索引子會產生陣列中要求部分的複本。隱含使用此複本作為 Span 或 Memory 值時，通常不需此複本。請使用 AsSpan 方法來避免使用此複本。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
-        <source>Use {0} instead of Range-based indexers on {1}</source>
-        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">在 '{2}' 上使用 '{0}' 代替以 '{1}' 為基礎的索引子，以避免建立不必要的資料複本。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAStringCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on a string</source>
+        <target state="new">Use {0} instead of Range-based indexers on a string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on an array</source>
+        <target state="new">Use {0} instead of Range-based indexers on an array</target>
         <note />
       </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1827,6 +1827,11 @@
         <target state="translated">陣列值中以 Range 為基礎的索引子會產生陣列中要求部分的複本。隱含使用此複本作為 Span 或 Memory 值時，通常不需此複本。請使用 AsSpan 方法來避免使用此複本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseAsSpanInsteadOfRangeIndexerCodeFixTitle">
+        <source>Use {0} instead of Range-based indexers on {1}</source>
+        <target state="new">Use {0} instead of Range-based indexers on {1}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseAsSpanInsteadOfRangeIndexerMessage">
         <source>Use '{0}' instead of the '{1}'-based indexer on '{2}' to avoid creating unnecessary data copies.</source>
         <target state="translated">在 '{2}' 上使用 '{0}' 代替以 '{1}' 為基礎的索引子，以避免建立不必要的資料複本。</target>


### PR DESCRIPTION
1. Updated getting started: "Definition of done" to test roslyn-analyzers repo same as runtime
2. As per VS doc [PR feedback](https://github.com/MicrosoftDocs/visualstudio-docs-pr/pull/6679#discussion_r437781158) updated UseAsSpanInsteadOfRangeIndexer Fixer title