### PR TITLE
Add non-generic TCS support to CA2247

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.Fixer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                 CodeFixContext context, SyntaxNode root, SemanticModel model, CancellationToken cancellationToken)
             {
                 if (// If we can get all the necessary types,
-                    model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSource, out var tcsType) &&
+                    model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSourceGeneric, out _) &&
                     model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskContinuationOptions, out var taskContinutationOptionsType) &&
                     model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCreationOptions, out INamedTypeSymbol? taskCreationOptionsType) &&
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.Fixer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                 CodeFixContext context, SyntaxNode root, SemanticModel model, CancellationToken cancellationToken)
             {
                 if (// If we can get all the necessary types,
-                    model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSourceGeneric, out _) &&
+                    model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksGenericTaskCompletionSource, out _) &&
                     model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskContinuationOptions, out var taskContinutationOptionsType) &&
                     model.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCreationOptions, out INamedTypeSymbol? taskCreationOptionsType) &&
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             context.RegisterCompilationStartAction(compilationContext =>
             {
                 // Only analyze if we can find TCS<T> and TaskContinuationOptions
-                if (compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSourceGeneric, out var tcsGenericType) &&
+                if (compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksGenericTaskCompletionSource, out var tcsGenericType) &&
                     compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskContinuationOptions, out var taskContinutationOptionsType))
                 {
                     // Also optionally look for the non-generic TCS, but don't require it.

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
@@ -32,14 +32,18 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.RegisterCompilationStartAction(compilationContext =>
             {
-                if (compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSource, out var tcsType) &&
+                // Only analyze if we can find TCS<T> and TaskContinuationOptions
+                if (compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSourceGeneric, out var tcsGenericType) &&
                     compilationContext.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskContinuationOptions, out var taskContinutationOptionsType))
                 {
+                    // Also optionally look for the non-generic TCS, but don't require it.
+                    var tcsType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskCompletionSource);
+
                     compilationContext.RegisterOperationAction(operationContext =>
                     {
                         // Warn if this is `new TCS(object ...)` with an expression of type `TaskContinuationOptions` as the argument.
                         var objectCreation = (IObjectCreationOperation)operationContext.Operation;
-                        if (objectCreation.Type.OriginalDefinition.Equals(tcsType) &&
+                        if ((objectCreation.Type.OriginalDefinition.Equals(tcsGenericType) || (tcsType != null && objectCreation.Type.OriginalDefinition.Equals(tcsType))) &&
                             objectCreation.Constructor.Parameters.Length != 0 && objectCreation.Constructor.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
                             objectCreation.Arguments.Length != 0 && objectCreation.Arguments[0].Value is IConversionOperation conversionOperation &&
                             conversionOperation.Operand.Type.Equals(taskContinutationOptionsType))

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArgumentsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArgumentsTests.cs
@@ -115,6 +115,58 @@ class C
         }
 
         [Fact]
+        public async Task Diagnostics_FixApplies_CSharp_NonGeneric()
+        {
+            await VerifyCS.VerifyCodeFixAsync(
+@"
+using System.Threading.Tasks;
+
+namespace System.Threading.Tasks
+{
+    public class TaskCompletionSource // added in .NET 5
+    {
+        public TaskCompletionSource(TaskCreationOptions options) { }
+        public TaskCompletionSource(object state) { }
+    }
+}
+
+class C
+{
+    void M()
+    {
+        new TaskCompletionSource([|TaskContinuationOptions.None|]);
+        new TaskCompletionSource([|TaskContinuationOptions.RunContinuationsAsynchronously|]);
+        var tcs = new TaskCompletionSource([|TaskContinuationOptions.AttachedToParent|]);
+    }
+    TaskContinuationOptions MyProperty { get; set; }
+}
+",
+@"
+using System.Threading.Tasks;
+
+namespace System.Threading.Tasks
+{
+    public class TaskCompletionSource // added in .NET 5
+    {
+        public TaskCompletionSource(TaskCreationOptions options) { }
+        public TaskCompletionSource(object state) { }
+    }
+}
+
+class C
+{
+    void M()
+    {
+        new TaskCompletionSource(TaskCreationOptions.None);
+        new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.AttachedToParent);
+    }
+    TaskContinuationOptions MyProperty { get; set; }
+}
+");
+        }
+
+        [Fact]
         public async Task Diagnostics_FixApplies_Basic()
         {
             await VerifyVB.VerifyCodeFixAsync(

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -282,7 +282,8 @@ namespace Analyzer.Utilities
         public const string SystemThreadingTasksGenericTask = "System.Threading.Tasks.Task`1";
         public const string SystemThreadingTasksGenericValueTask = "System.Threading.Tasks.ValueTask`1";
         public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";
-        public const string SystemThreadingTasksTaskCompletionSource = "System.Threading.Tasks.TaskCompletionSource`1";
+        public const string SystemThreadingTasksTaskCompletionSource = "System.Threading.Tasks.TaskCompletionSource";
+        public const string SystemThreadingTasksTaskCompletionSourceGeneric = "System.Threading.Tasks.TaskCompletionSource`1";
         public const string SystemThreadingTasksTaskContinuationOptions = "System.Threading.Tasks.TaskContinuationOptions";
         public const string SystemThreadingTasksTaskCreationOptions = "System.Threading.Tasks.TaskCreationOptions";
         public const string SystemThreadingTasksTaskFactory = "System.Threading.Tasks.TaskFactory";

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -283,7 +283,7 @@ namespace Analyzer.Utilities
         public const string SystemThreadingTasksGenericValueTask = "System.Threading.Tasks.ValueTask`1";
         public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";
         public const string SystemThreadingTasksTaskCompletionSource = "System.Threading.Tasks.TaskCompletionSource";
-        public const string SystemThreadingTasksTaskCompletionSourceGeneric = "System.Threading.Tasks.TaskCompletionSource`1";
+        public const string SystemThreadingTasksGenericTaskCompletionSource = "System.Threading.Tasks.TaskCompletionSource`1";
         public const string SystemThreadingTasksTaskContinuationOptions = "System.Threading.Tasks.TaskContinuationOptions";
         public const string SystemThreadingTasksTaskCreationOptions = "System.Threading.Tasks.TaskCreationOptions";
         public const string SystemThreadingTasksTaskFactory = "System.Threading.Tasks.TaskFactory";


### PR DESCRIPTION
A non-generic TaskCompletionSource was added in .NET 5.  Add checking for it in addition to the generic in CA2247.