### PR TITLE
Add support to read in MSBuild property values required by analyzers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
-    <MicrosoftCodeAnalysisForShippedApisVersion>3.5.0-beta2-20056-01</MicrosoftCodeAnalysisForShippedApisVersion>
+    <MicrosoftCodeAnalysisForShippedApisVersion>3.7.0-2.final</MicrosoftCodeAnalysisForShippedApisVersion>
     <DogfoodAnalyzersVersion>3.0.0</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyersVersion>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHavePluralNames.cs
@@ -135,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            bool hasFlagsAttribute = symbol.GetAttributes().Any(a => a.AttributeClass.Equals(flagsAttribute));
+            bool hasFlagsAttribute = symbol.GetAttributes().Any(a => flagsAttribute.Equals(a.AttributeClass));
             if (hasFlagsAttribute)
             {
                 if (reportCA1714 && !IsPlural(symbol.Name)) // Checking Rule CA1714

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -30,7 +30,7 @@ namespace Test.Utilities
                     var parseOptions = (CSharpParseOptions)project.ParseOptions!;
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
 
-                    var compilationOptions = project!.CompilationOptions!;
+                    var compilationOptions = project.CompilationOptions!;
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(NullableWarnings));
                     solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
 

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Test.Utilities
 {
@@ -25,12 +26,21 @@ namespace Test.Utilities
 
                 SolutionTransforms.Add((solution, projectId) =>
                 {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (CSharpParseOptions)project.ParseOptions!;
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
 
-                    var compilationOptions = solution.GetProject(projectId)!.CompilationOptions!;
+                    var compilationOptions = project!.CompilationOptions!;
                     compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(compilationOptions.SpecificDiagnosticOptions.SetItems(NullableWarnings));
                     solution = solution.WithProjectCompilationOptions(projectId, compilationOptions);
+
+                    if (AnalyzerConfigDocument != null)
+                    {
+                        solution = project.AddAnalyzerConfigDocument(
+                            ".editorconfig",
+                            SourceText.From($"is_global = true" + Environment.NewLine + AnalyzerConfigDocument),
+                            filePath: @"z:\.editorconfig").Project.Solution;
+                    }
 
                     return solution;
                 });
@@ -51,6 +61,8 @@ namespace Test.Utilities
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp7_3;
+
+            public string? AnalyzerConfigDocument { get; set; }
         }
     }
 }

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Testing;
 
@@ -20,14 +22,25 @@ namespace Test.Utilities
 
                 SolutionTransforms.Add((solution, projectId) =>
                 {
-                    var parseOptions = (VisualBasicParseOptions)solution.GetProject(projectId)!.ParseOptions!;
+                    var project = solution.GetProject(projectId)!;
+                    var parseOptions = (VisualBasicParseOptions)project.ParseOptions!;
                     solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion));
+
+                    if (AnalyzerConfigDocument != null)
+                    {
+                        solution = project.AddAnalyzerConfigDocument(
+                            ".editorconfig",
+                            SourceText.From($"is_global = true" + Environment.NewLine + AnalyzerConfigDocument),
+                            filePath: @"z:\.editorconfig").Project.Solution;
+                    }
 
                     return solution;
                 });
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.VisualBasic15_5;
+
+            public string? AnalyzerConfigDocument { get; set; }
         }
     }
 }

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -10,6 +10,7 @@
     <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />
     <Compile Include="..\..\Utilities\Compiler\Debug.cs" Link="Debug.cs" />
     <Compile Include="..\..\Utilities\Compiler\Extensions\PooledHashSetExtensions.cs" Link="PooledHashSetExtensions.cs" />
+    <Compile Include="..\..\Utilities\Compiler\Options\MSBuildPropertyOptionNames.cs" Link="MSBuildPropertyOptionNames.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ArrayBuilder.cs" Link="ArrayBuilder.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ArrayBuilder.Enumerator.cs" Link="ArrayBuilder.Enumerator.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ObjectPool.cs" Link="ObjectPool.cs" />

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -59,6 +59,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\NullableContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\NullableContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\SemanticModelExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OptionKind.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\MSBuildPropertyOptionNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\SyntaxTreeCategorizedAnalyzerConfigOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\ICategorizedAnalyzerConfigOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\AggregateCategorizedAnalyzerConfigOptions.cs" />

--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -98,7 +98,9 @@ namespace Analyzer.Utilities
             {
                 if (TryGetOptionValue(optionKeyPrefix, specificOptionKey, optionName, out var valueString))
                 {
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'specificOptionValue'.
                     return tryParseValue(valueString, out specificOptionValue);
+#pragma warning restore CS8601 // Possible null reference assignment.
                 }
 
                 specificOptionValue = defaultValue;
@@ -123,7 +125,9 @@ namespace Analyzer.Utilities
             {
                 if (TryGetOptionValue(optionKeyPrefix, optionKeySuffix: null, optionName, out var valueString))
                 {
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'specificOptionValue'.
                     return tryParseValue(valueString, out generalOptionValue);
+#pragma warning restore CS8601 // Possible null reference assignment.
                 }
 
                 generalOptionValue = defaultValue;

--- a/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -84,9 +85,10 @@ namespace Analyzer.Utilities
             }
         }
 
-        public T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, T defaultValue)
+        [return: MaybeNull]
+        public T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
-            if (TryGetOptionValue(optionName, tree, rule, tryParseValue, defaultValue, out var value))
+            if (TryGetOptionValue(optionName, kind, tree, rule, tryParseValue, defaultValue, out var value))
             {
                 return value;
             }
@@ -94,7 +96,7 @@ namespace Analyzer.Utilities
             return defaultValue;
         }
 
-        private bool TryGetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, T defaultValue, out T value)
+        private bool TryGetOptionValue<T>(string optionName, OptionKind kind, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, [MaybeNull] out T value)
         {
             if (ReferenceEquals(this, Empty))
             {
@@ -103,13 +105,13 @@ namespace Analyzer.Utilities
             }
 
             // Prefer additional file based options for back compat.
-            if (_additionalFileBasedOptions.TryGetOptionValue(optionName, rule, tryParseValue, defaultValue, out value))
+            if (_additionalFileBasedOptions.TryGetOptionValue(optionName, kind, rule, tryParseValue, defaultValue, out value))
             {
                 return true;
             }
 
             return _perTreeOptions.TryGetValue(tree, out var lazyTreeOptions) &&
-                lazyTreeOptions.Value.TryGetOptionValue(optionName, rule, tryParseValue, defaultValue, out value);
+                lazyTreeOptions.Value.TryGetOptionValue(optionName, kind, rule, tryParseValue, defaultValue, out value);
         }
     }
 }

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -484,7 +484,7 @@ namespace Analyzer.Utilities
             }
         }
 
-        public static string? GetMSBuildPropertyOptionValue(
+        public static string? GetMSBuildPropertyValue(
             this AnalyzerOptions options,
             string optionName,
             DiagnosticDescriptor rule,
@@ -492,10 +492,10 @@ namespace Analyzer.Utilities
             Compilation compilation,
             CancellationToken cancellationToken)
         => TryGetSyntaxTreeForOption(symbol, out var tree)
-            ? options.GetMSBuildPropertyOptionValue(optionName, rule, tree, compilation, cancellationToken)
+            ? options.GetMSBuildPropertyValue(optionName, rule, tree, compilation, cancellationToken)
             : null;
 
-        public static string? GetMSBuildPropertyOptionValue(
+        public static string? GetMSBuildPropertyValue(
             this AnalyzerOptions options,
             string optionName,
             DiagnosticDescriptor rule,

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -152,7 +152,7 @@ namespace Analyzer.Utilities
             where TEnum : struct
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
-            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParseValue, defaultValue);
+            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParseValue, defaultValue)!;
             static bool TryParseValue(string value, out ImmutableHashSet<TEnum> result)
             {
                 var builder = ImmutableHashSet.CreateBuilder<TEnum>();
@@ -436,7 +436,7 @@ namespace Analyzer.Utilities
             where TValue : notnull
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
-            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParse, defaultValue: GetDefaultValue());
+            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParse, defaultValue: GetDefaultValue())!;
 
             // Local functions.
             bool TryParse(string s, out SymbolNamesWithValueOption<TValue> option)
@@ -482,6 +482,31 @@ namespace Analyzer.Utilities
                     ? option
                     : SymbolNamesWithValueOption<TValue>.Empty;
             }
+        }
+
+        public static string? GetMSBuildPropertyOptionValue(
+            this AnalyzerOptions options,
+            string optionName,
+            DiagnosticDescriptor rule,
+            ISymbol symbol,
+            Compilation compilation,
+            CancellationToken cancellationToken)
+        => TryGetSyntaxTreeForOption(symbol, out var tree)
+            ? options.GetMSBuildPropertyOptionValue(optionName, rule, tree, compilation, cancellationToken)
+            : null;
+
+        public static string? GetMSBuildPropertyOptionValue(
+            this AnalyzerOptions options,
+            string optionName,
+            DiagnosticDescriptor rule,
+            SyntaxTree tree,
+            Compilation compilation,
+            CancellationToken cancellationToken)
+        {
+            var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
+            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule,
+                tryParseValue: (string value, out string? result) => { result = value; return true; },
+                defaultValue: null, OptionKind.BuildProperty);
         }
 
 #pragma warning disable CA1801 // Review unused parameters - 'compilation' is used conditionally.

--- a/src/Utilities/Compiler/Options/CompilationCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/CompilationCategorizedAnalyzerConfigOptions.cs
@@ -70,12 +70,12 @@ namespace Analyzer.Utilities
                 var key = kvp.Key;
                 var value = kvp.Value;
 
-                if (!key.StartsWith(KeyPrefix, StringComparison.OrdinalIgnoreCase))
+                if (!HasSupportedKeyPrefix(key, out var keyPrefix))
                 {
                     continue;
                 }
 
-                key = key.Substring(KeyPrefix.Length);
+                key = key.Substring(keyPrefix.Length);
                 var keyParts = key.Split('.').Select(s => s.Trim()).ToImmutableArray();
                 switch (keyParts.Length)
                 {

--- a/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities
@@ -27,11 +28,13 @@ namespace Analyzer.Utilities
     internal interface ICategorizedAnalyzerConfigOptions
     {
         bool IsEmpty { get; }
-        T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, T defaultValue);
+
+        [return: MaybeNull]
+        T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
     }
 
     internal static class CategorizedAnalyzerConfigOptionsExtensions
     {
-        public delegate bool TryParseValue<T>(string value, out T parsedValue);
+        public delegate bool TryParseValue<T>(string value, [MaybeNull, NotNullWhen(returnValue: true)] out T parsedValue);
     }
 }

--- a/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// MSBuild property names that are required to be threaded as analyzer config options.
+    /// </summary>
+    internal static partial class MSBuildPropertyOptionNames
+    {
+        public const string TargetFramework = "TargetFramework";
+    }
+}

--- a/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
@@ -8,5 +8,6 @@ namespace Analyzer.Utilities
     internal static partial class MSBuildPropertyOptionNames
     {
         public const string TargetFramework = "TargetFramework";
+        public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
     }
 }

--- a/src/Utilities/Compiler/Options/OptionKind.cs
+++ b/src/Utilities/Compiler/Options/OptionKind.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// Kind of option to fetch from <see cref="AnalyzerOptionsExtensions"/>.
+    /// </summary>
+    internal enum OptionKind
+    {
+        /// <summary>
+        /// Option prefixed with "dotnet_code_quality."
+        /// Used for custom analyzer config options for analyzers in this repo.
+        /// </summary>
+        DotnetCodeQuality,
+
+        /// <summary>
+        /// Option prefixed with "build_property."
+        /// Used for options generated for MSBuild properties.
+        /// </summary>
+        BuildProperty
+    }
+}


### PR DESCRIPTION
Using the new global analyzerconfig feature added by the compiler team, analyzers and end users can now thread in any required MSBuild property values as analyzer options. This change adds the following support:

1. Define a new type `MSBuildPropertyOptionNames` with the names of properties that required to be threaded to analyzers
2. Update the targets file dropped in with our analyzer packages to have the properties defined in the above type to be threaded to the analyzers
3. Add extension method `GetMSBuildPropertyValue` to `AnalyzerOptions` fetch option value inside our analyzers:
```csharp
var optionValue = context.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.TargetFramework, ...);
```