### PR TITLE
Use nameof where appropriate

### DIFF
--- a/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
@@ -5,9 +5,9 @@ namespace Analyzer.Utilities
     /// <summary>
     /// MSBuild property names that are required to be threaded as analyzer config options.
     /// </summary>
-    internal static partial class MSBuildPropertyOptionNames
+    internal static class MSBuildPropertyOptionNames
     {
-        public const string TargetFramework = "TargetFramework";
-        public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
+        public const string TargetFramework = nameof(TargetFramework);
+        public const string TargetPlatformMinVersion = nameof(TargetPlatformMinVersion);
     }
 }


### PR DESCRIPTION
This change codifies our pattern of property names in code matching property names in the project file.