### PR TITLE
Fix nullability attributes

### DIFF
--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -25,8 +25,8 @@ namespace Analyzer.Utilities
         public abstract bool IsEmpty { get; }
         protected abstract bool TryGetOptionValue(string optionKeyPrefix, string? optionKeySuffix, string optionName, [NotNullWhen(returnValue: true)] out string? valueString);
 
-        [return: MaybeNull]
-        public T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
+        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
+        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
             if (TryGetOptionValue(optionName, kind, rule, tryParseValue, defaultValue, out var value))
             {
@@ -62,7 +62,7 @@ namespace Analyzer.Utilities
             return false;
         }
 
-        public bool TryGetOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, [MaybeNull] out T value)
+        public bool TryGetOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, [MaybeNullWhen(false), NotNullIfNotNull("defaultValue")] out T value)
         {
             if (this.IsEmpty)
             {
@@ -73,14 +73,22 @@ namespace Analyzer.Utilities
             var key = $"{rule.Id}.{optionName}";
             if (!_computedOptionValuesMap.TryGetValue(key, out var computedValue))
             {
-                computedValue = _computedOptionValuesMap.GetOrAdd(key, _ => ComputeOptionValue(optionName, kind, rule, tryParseValue, defaultValue));
+                computedValue = _computedOptionValuesMap.GetOrAdd(key, _ => ComputeOptionValue(optionName, kind, rule, tryParseValue));
             }
 
-            value = (T)computedValue.value;
-            return computedValue.found;
+            if (computedValue.found)
+            {
+                value = (T)computedValue.value!;
+                return true;
+            }
+            else
+            {
+                value = defaultValue;
+                return false;
+            }
         }
 
-        private (bool found, object? value) ComputeOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue)
+        private (bool found, object? value) ComputeOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue)
         {
             var optionKeyPrefix = MapOptionKindToKeyPrefix(kind);
             if (TryGetSpecificOptionValue(rule.Id, optionKeyPrefix, out var optionValue) ||
@@ -91,7 +99,7 @@ namespace Analyzer.Utilities
                 return (true, optionValue);
             }
 
-            return (false, defaultValue);
+            return (false, null);
 
             // Local functions.
             bool TryGetSpecificOptionValue(string specificOptionKey, string optionKeyPrefix, out T specificOptionValue)
@@ -103,7 +111,9 @@ namespace Analyzer.Utilities
 #pragma warning restore CS8601 // Possible null reference assignment.
                 }
 
-                specificOptionValue = defaultValue;
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'specificOptionValue'.
+                specificOptionValue = default;
+#pragma warning restore CS8601 // Possible null reference assignment.
                 return false;
             }
 
@@ -117,7 +127,9 @@ namespace Analyzer.Utilities
                     }
                 }
 
-                specificOptionValue = defaultValue;
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'specificOptionValue'.
+                specificOptionValue = default;
+#pragma warning restore CS8601 // Possible null reference assignment.
                 return false;
             }
 
@@ -125,12 +137,14 @@ namespace Analyzer.Utilities
             {
                 if (TryGetOptionValue(optionKeyPrefix, optionKeySuffix: null, optionName, out var valueString))
                 {
-#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'specificOptionValue'.
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'generalOptionValue'.
                     return tryParseValue(valueString, out generalOptionValue);
 #pragma warning restore CS8601 // Possible null reference assignment.
                 }
 
-                generalOptionValue = defaultValue;
+#pragma warning disable CS8601 // Possible null reference assignment - Once local function attributes are supported, add "[MaybeNull]" on 'generalOptionValue'.
+                generalOptionValue = default;
+#pragma warning restore CS8601 // Possible null reference assignment.
                 return false;
             }
         }

--- a/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
@@ -85,8 +85,8 @@ namespace Analyzer.Utilities
             }
         }
 
-        [return: MaybeNull]
-        public T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
+        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
+        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
             if (TryGetOptionValue(optionName, kind, tree, rule, tryParseValue, defaultValue, out var value))
             {
@@ -96,7 +96,7 @@ namespace Analyzer.Utilities
             return defaultValue;
         }
 
-        private bool TryGetOptionValue<T>(string optionName, OptionKind kind, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, [MaybeNull] out T value)
+        private bool TryGetOptionValue<T>(string optionName, OptionKind kind, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, [MaybeNullWhen(false), NotNullIfNotNull("defaultValue")] out T value)
         {
             if (ReferenceEquals(this, Empty))
             {

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -152,7 +152,7 @@ namespace Analyzer.Utilities
             where TEnum : struct
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
-            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParseValue, defaultValue)!;
+            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParseValue, defaultValue);
             static bool TryParseValue(string value, out ImmutableHashSet<TEnum> result)
             {
                 var builder = ImmutableHashSet.CreateBuilder<TEnum>();
@@ -436,7 +436,7 @@ namespace Analyzer.Utilities
             where TValue : notnull
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
-            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParse, defaultValue: GetDefaultValue())!;
+            return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParse, defaultValue: GetDefaultValue());
 
             // Local functions.
             bool TryParse(string s, out SymbolNamesWithValueOption<TValue> option)

--- a/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
@@ -29,12 +29,12 @@ namespace Analyzer.Utilities
     {
         bool IsEmpty { get; }
 
-        [return: MaybeNull]
-        T GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
+        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
+        T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
     }
 
     internal static class CategorizedAnalyzerConfigOptionsExtensions
     {
-        public delegate bool TryParseValue<T>(string value, [MaybeNull, NotNullWhen(returnValue: true)] out T parsedValue);
+        public delegate bool TryParseValue<T>(string value, [MaybeNullWhen(returnValue: false)] out T parsedValue);
     }
 }


### PR DESCRIPTION
:memo: Instances of `[MaybeNull] T` that can be converted to `T??` later have been indicated with `/*??*/`.