### PR TITLE
Don't warn CA1805 for default struct ctors with initializers

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                 // If this is default(T) or new ValueType(), it's the default.
                 if (value is IDefaultValueOperation ||
-                    (type.IsValueType && value is IObjectCreationOperation oco && oco.Arguments.Length == 0))
+                    (type.IsValueType && value is IObjectCreationOperation oco && oco.Arguments.Length == 0 && oco.Initializer is null))
                 {
                     return !IsNullSuppressed(value);
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
@@ -61,6 +61,7 @@ public class C
     public System.DayOfWeek Week2 = System.DayOfWeek.Sunday;
 
     public int SomeIntProp { get; } = 42;
+    public System.ValueTuple<int, int> SomeTuple = new System.ValueTuple<int, int>() { Item1 = 42, Item2 = 84 };
 }");
         }
 


### PR DESCRIPTION
Found this case when analyzing dotnet/runtime