### PR TITLE
Fix CA1805 handling of nullable attributes

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
@@ -37,7 +37,11 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             {
                 var init = (IFieldInitializerOperation)context.Operation;
                 IFieldSymbol? field = init.InitializedFields.FirstOrDefault();
-                if (field != null && !field.IsConst && init.Value != null && UsesKnownDefaultValue(init.Value, field.Type))
+                if (field != null &&
+                    !field.IsConst &&
+                    init.Value != null &&
+                    field.GetAttributes().Length == 0 && // in case of attributes that impact nullability analysis
+                    UsesKnownDefaultValue(init.Value, field.Type))
                 {
                     context.ReportDiagnostic(init.CreateDiagnostic(DefaultRule, field.Name));
                 }
@@ -47,7 +51,10 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             {
                 var init = (IPropertyInitializerOperation)context.Operation;
                 IPropertySymbol? prop = init.InitializedProperties.FirstOrDefault();
-                if (prop != null && init.Value != null && UsesKnownDefaultValue(init.Value, prop.Type))
+                if (prop != null &&
+                    init.Value != null &&
+                    prop.GetAttributes().Length == 0 && // in case of attributes that impact nullability analysis
+                    UsesKnownDefaultValue(init.Value, prop.Type))
                 {
                     context.ReportDiagnostic(init.CreateDiagnostic(DefaultRule, prop.Name));
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
@@ -117,13 +117,25 @@ End Class
             {
                 TestCode = @"
 #nullable enable
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 public class C
 {
     private static object s_obj1 = null!;
+    [AllowNull] private object _obj2 = null;
 }
+
 public class G<T>
 {
-    private T _value = default!;
+    private T _value1 = default!;
+    [AllowNull] private T _value2 = default;
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute { }
 }
 ",
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8,


### PR DESCRIPTION
Or, rather, punt.  If fields are annotated with nullable attributes, it's possible you end up in a situation like:
```C#
[AllowNull] private T _value = default;
```
where for whatever reason (https://github.com/dotnet/roslyn/issues/37138), the compiler won't warn on the above, but will warn on:
```C#
[AllowNull] private T _value;
```