### PR TITLE
Fix CA1062 for untracked interprocedural calls

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -4577,7 +4577,7 @@ public class C<T> where T : class
     {
         o = o ?? new object();
         AllocateSlow(s);
-        var x = s.Length;
+        var x = [|s|].Length;
     }
 
     private T AllocateSlow(string s)
@@ -5464,7 +5464,7 @@ namespace MyComments
                             new
                             {
                                 id = id,
-                                returnUrl = httpContext.Request.Url
+                                returnUrl = [|httpContext|].Request.Url
                             });
                 }
 
@@ -5481,7 +5481,7 @@ namespace MyComments
                 }
             }
 
-            Output.Write(text);
+            [|Output|].Write(text);
         }
     }
 }
@@ -6221,6 +6221,44 @@ End Module"
             };
             vbTest.ExpectedDiagnostics.AddRange(expected);
             await vbTest.RunAsync();
+        }
+
+        [Fact, WorkItem(2919, "https://github.com/dotnet/roslyn-analyzers/issues/2919")]
+        public async Task Interprocedural_DelegateInvocation_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+namespace ReproCA1062
+{
+    public static class Repro
+    {
+        public static void Test(string foo)
+        {
+            NotNull(foo, nameof(foo));
+            int x = foo.Length; // no warning
+            Bar();
+            x = foo.Length; // CA1062 on foo
+        }
+
+        public static void Bar()
+        {
+            Action<int> a = x => { };
+            a(0);
+        }
+
+        public static void NotNull([ValidatedNotNull] object param, string paramName)
+        {
+            if (param == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+
+    [System.AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    public sealed class ValidatedNotNullAttribute : Attribute { }
+}");
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ParameterValidationAnalysis/ParameterValidationAnalysis.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             CancellationToken cancellationToken,
             InterproceduralAnalysisKind interproceduralAnalysisKind = InterproceduralAnalysisKind.ContextSensitive,
             uint defaultMaxInterproceduralMethodCallChain = 1, // By default, we only want to track method calls one level down.
-            bool pessimisticAnalysis = true)
+            bool pessimisticAnalysis = false)
         {
             Debug.Assert(!owningSymbol.IsConfiguredToSkipAnalysis(analyzerOptions, rule, compilation, cancellationToken));
 
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ParameterValidationAnalys
             SymbolNamesWithValueOption<Unit> nullCheckValidationMethods,
             InterproceduralAnalysisConfiguration interproceduralAnalysisConfig,
             bool performCopyAnalysis,
-            bool pessimisticAnalysis = true)
+            bool pessimisticAnalysis)
         {
             var cfg = topmostBlock.GetEnclosingControlFlowGraph();
             if (cfg == null)


### PR DESCRIPTION
Fixes #2919

Switch parameter validation analysis from pessimistic to optimistic - if we encounter a call that cannot be analyzed interprocedurally, we don't reset analysis data, which would nullify all the prior validations in the method.