### PR TITLE
Fix CA1805 for boxed value types

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
@@ -62,6 +62,9 @@ public class C
 
     public int SomeIntProp { get; } = 42;
     public System.ValueTuple<int, int> SomeTuple = new System.ValueTuple<int, int>() { Item1 = 42, Item2 = 84 };
+
+    public static readonly object BoxedInt32Default = default(int);
+    public static readonly object BoxedInt32Value = 0;
 }");
         }
 


### PR DESCRIPTION
The rule is currently warning on fields like:
```C#
private static readonly object s_boxedDefaultInt = default(int);
```
but that's not actually setting the field to its default value.