### PR TITLE
Fix CA1805 assignment of default to nullable

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarily.cs
@@ -67,8 +67,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     value = conversion.Operand;
                 }
 
-                // If this might box, don't warn, as we don't want to warn for something like `object o = default(int);`.
-                if (value.Type != null && value.Type.IsReferenceType != type.IsReferenceType)
+                // If this might box or assign a value to a nullable, don't warn, as we don't want to warn for
+                // something like `object o = default(int);` or `int? i = 0;`.
+                if (value.Type != null && value.Type.IsReferenceTypeOrNullableValueType() != type.IsReferenceTypeOrNullableValueType())
                 {
                     return false;
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotInitializeUnnecessarilyTests.cs
@@ -65,6 +65,8 @@ public class C
 
     public static readonly object BoxedInt32Default = default(int);
     public static readonly object BoxedInt32Value = 0;
+    public static int? NullableInt32Default = default(int);
+    public static int? NullableInt32Value = 0;
 }");
         }
 


### PR DESCRIPTION
One more case found from dotnet/runtime.  Code like:
```C#
private int? _value = 0;
```
shouldn't warn, but it currently does.

This is the last issue discovered in running the rule over dotnet/runtime:
https://github.com/dotnet/runtime/pull/38410