### PR TITLE
Increase test timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
   pool:
     name: NetCorePublic-Pool
     queue: BuildPool.Windows.10.Amd64.VS2019.Open
-  timeoutInMinutes: 30
+  timeoutInMinutes: 40
 
   steps:
     - checkout: self
@@ -54,7 +54,7 @@ jobs:
   pool:
     name: NetCorePublic-Pool
     queue: BuildPool.Windows.Amd64.VS2019.Pre.ES.Open
-  timeoutInMinutes: 30
+  timeoutInMinutes: 40
 
   steps:
     - checkout: self


### PR DESCRIPTION
Tests are completing at 28-29 mins, and occasionally timing out at 30 mins.