### PR TITLE
Fix null reference exception in DoNotCreateTaskCompletionSourceWithWrongArguments

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArguments.cs
@@ -41,11 +41,14 @@ namespace Microsoft.NetCore.Analyzers.Tasks
 
                     compilationContext.RegisterOperationAction(operationContext =>
                     {
-                        // Warn if this is `new TCS(object ...)` with an expression of type `TaskContinuationOptions` as the argument.
+                        // Warn if this is `new TCS(object)` with an expression of type `TaskContinuationOptions` as the argument.
                         var objectCreation = (IObjectCreationOperation)operationContext.Operation;
                         if ((objectCreation.Type.OriginalDefinition.Equals(tcsGenericType) || (tcsType != null && objectCreation.Type.OriginalDefinition.Equals(tcsType))) &&
-                            !objectCreation.Constructor.Parameters.IsEmpty && objectCreation.Constructor.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
-                            !objectCreation.Arguments.IsEmpty && objectCreation.Arguments[0].Value is IConversionOperation conversionOperation &&
+                            objectCreation.Constructor.Parameters.Length == 1 &&
+                            objectCreation.Constructor.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
+                            objectCreation.Arguments.Length == 1 &&
+                            objectCreation.Arguments[0].Value is IConversionOperation conversionOperation &&
+                            conversionOperation.Operand.Type != null &&
                             conversionOperation.Operand.Type.Equals(taskContinutationOptionsType))
                         {
                             operationContext.ReportDiagnostic(conversionOperation.CreateDiagnostic(Rule));

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArgumentsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/DoNotCreateTaskCompletionSourceWithWrongArgumentsTests.cs
@@ -23,11 +23,23 @@ class C
 {
     void M()
     {
+        // Use TCS correctly without options
+        new TaskCompletionSource<int>(null);
+        new TaskCompletionSource<int>(""hello"");
+        new TaskCompletionSource<int>(new object());
+        new TaskCompletionSource<int>(42);
+
         // Uses TaskCreationOptions correctly
-        new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         var validEnum = TaskCreationOptions.RunContinuationsAsynchronously;
         new TaskCompletionSource<int>(validEnum);
+        new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
         new TaskCompletionSource<int>(this.MyProperty);
+        new TaskCompletionSource<int>(new object(), validEnum);
+        new TaskCompletionSource<int>(new object(), TaskCreationOptions.RunContinuationsAsynchronously);
+        new TaskCompletionSource<int>(new object(), this.MyProperty);
+        new TaskCompletionSource<int>(null, validEnum);
+        new TaskCompletionSource<int>(null, TaskCreationOptions.RunContinuationsAsynchronously);
+        new TaskCompletionSource<int>(null, this.MyProperty);
 
         // We only pay attention to things of type TaskContinuationOptions
         new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously.ToString());


### PR DESCRIPTION
IConversionOperation.Operand.Type can return null.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/3811

cc: @jonasric, @madenwala, @mavasani 