### PR TITLE
Update CA1012: Reword title and message

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
@@ -217,13 +217,13 @@
     <value>Add a member to {0} that has a value of zero with a suggested name of 'None'.</value>
   </data>
   <data name="AbstractTypesShouldNotHaveConstructorsTitle" xml:space="preserve">
-    <value>Abstract types should not have constructors</value>
+    <value>Abstract types should not have public constructors</value>
   </data>
   <data name="AbstractTypesShouldNotHaveConstructorsDescription" xml:space="preserve">
     <value>Constructors on abstract types can be called only by derived types. Because public constructors create instances of a type, and you cannot create instances of an abstract type, an abstract type that has a public constructor is incorrectly designed.</value>
   </data>
   <data name="AbstractTypesShouldNotHaveConstructorsMessage" xml:space="preserve">
-    <value>Abstract type {0} should not have constructors</value>
+    <value>Abstract type '{0}' should not have public constructors</value>
   </data>
   <data name="MarkAssembliesWithClsCompliantTitle" xml:space="preserve">
     <value>Mark assemblies with CLSCompliant</value>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Abstraktní typy nemají mít konstruktory.</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Abstraktní typy nemají mít konstruktory.</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Abstraktní typ {0} nemá mít konstruktory.</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Abstraktní typ {0} nemá mít konstruktory.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Abstrakte Typen dürfen keine Konstruktoren aufweisen</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Abstrakte Typen dürfen keine Konstruktoren aufweisen</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Der abstrakte Typ "{0}" darf keine Konstruktoren aufweisen.</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Der abstrakte Typ "{0}" darf keine Konstruktoren aufweisen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Los tipos abstractos no deben tener constructores</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Los tipos abstractos no deben tener constructores</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">El tipo abstracto {0} no debe tener constructores</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">El tipo abstracto {0} no debe tener constructores</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Les types abstract ne doivent pas avoir de constructeurs</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Les types abstract ne doivent pas avoir de constructeurs</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Le type abstract {0} ne doit pas avoir de constructeurs</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Le type abstract {0} ne doit pas avoir de constructeurs</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">I tipi astratti non devono includere costruttori</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">I tipi astratti non devono includere costruttori</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Il tipo astratto {0} non deve avere costruttori</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Il tipo astratto {0} non deve avere costruttori</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">抽象型はコンストラクターを含むことはできません</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">抽象型はコンストラクターを含むことはできません</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">抽象型 {0} はコンストラクターを含むことはできません</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">抽象型 {0} はコンストラクターを含むことはできません</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">추상 형식에는 생성자를 사용하지 않아야 합니다.</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">추상 형식에는 생성자를 사용하지 않아야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">{0} 추상 형식에는 생성자를 사용하지 않아야 합니다.</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">{0} 추상 형식에는 생성자를 사용하지 않아야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Typy abstrakcyjne nie powinny mieć konstruktorów</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Typy abstrakcyjne nie powinny mieć konstruktorów</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Typ abstrakcyjny {0} nie powinien mieć konstruktorów</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Typ abstrakcyjny {0} nie powinien mieć konstruktorów</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Tipos abstratos não devem ter construtores</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Tipos abstratos não devem ter construtores</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">O tipo abstrato {0} não deve ter construtores</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">O tipo abstrato {0} não deve ter construtores</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Абстрактные типы не должны иметь конструкторы</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Абстрактные типы не должны иметь конструкторы</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">Абстрактный тип {0} не должен иметь конструкторы</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">Абстрактный тип {0} не должен иметь конструкторы</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">Soyut türlerin oluşturucuları olmamalıdır</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">Soyut türlerin oluşturucuları olmamalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">{0} soyut türünün oluşturucuları olmamalıdır</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">{0} soyut türünün oluşturucuları olmamalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">抽象类型不应具有构造函数</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">抽象类型不应具有构造函数</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">抽象类型 {0} 不应具有构造函数</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">抽象类型 {0} 不应具有构造函数</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
@@ -378,8 +378,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
-        <source>Abstract types should not have constructors</source>
-        <target state="translated">抽象類型不應有建構函式</target>
+        <source>Abstract types should not have public constructors</source>
+        <target state="needs-review-translation">抽象類型不應有建構函式</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsDescription">
@@ -388,8 +388,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsMessage">
-        <source>Abstract type {0} should not have constructors</source>
-        <target state="translated">抽象類型 {0} 不應有建構函式</target>
+        <source>Abstract type '{0}' should not have public constructors</source>
+        <target state="needs-review-translation">抽象類型 {0} 不應有建構函式</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantTitle">


### PR DESCRIPTION
Refactor title and message to add a mention to public constructors to avoid confusion for end-users.

Fix #3632 

@mavasani I haven't renamed the class, is it mandatory to allow renaming the documentation header?