### PR TITLE
Remove invalid attribute on abstract type - we already have the attri…

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferIsEmptyOverCount.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferIsEmptyOverCount.Fixer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Composition;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferIsEmptyOverCount.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferIsEmptyOverCount.Fixer.cs
@@ -13,7 +13,6 @@ namespace Microsoft.NetCore.Analyzers.Performance
     /// <summary>
     /// CA1836: Prefer IsEmpty over Count when available.
     /// </summary>
-    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic), Shared]
     public abstract class PreferIsEmptyOverCountFixer : CodeFixProvider
     {
         public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(UseCountProperlyAnalyzer.CA1836);


### PR DESCRIPTION
…bute on non-abstract sub-types

Also filed https://github.com/dotnet/roslyn/issues/45851 as FxCopAnalyzers VSIX with this fixer was causing VS crash. We should also write a meta-analyzer that flags such an invalid export attribute.