### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.0.1-beta1.20374.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -32,7 +32,7 @@
     <CodeStyleAnalyersVersion>3.8.0-1.20330.5</CodeStyleAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <!-- Roslyn Testing -->
-    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20214.2</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20374.2</MicrosoftCodeAnalysisTestingVersion>
     <!-- Libs -->
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemComponentModelCompositionVersion>4.7.0</SystemComponentModelCompositionVersion>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/UpgradeMSBuildWorkspaceAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/UpgradeMSBuildWorkspaceAnalyzer.cs
@@ -39,11 +39,10 @@ namespace Microsoft.CodeAnalysis.Analyzers
             _performAssemblyChecks = performAssemblyChecks;
         }
 
-#pragma warning disable RS1025 // Configure generated code analysis
         public override void Initialize(AnalysisContext context)
-#pragma warning restore RS1025 // Configure generated code analysis
         {
             context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
 
             if (_performAssemblyChecks)
             {

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzerTests.cs
@@ -1220,28 +1220,28 @@ class MyAnalyzer : DiagnosticAnalyzer
 # 'Category': Comma separate list of 'StartId-EndId' or 'Id' or 'Prefix'
 
 # Illegal: spaces in category name
-Category with spaces
-Category with spaces and range: Prefix100-Prefix199
+{|#6:Category with spaces|}
+{|#7:Category with spaces and range: Prefix100-Prefix199|}
 
 # Illegal: Multiple colons
-CategoryMultipleColons: IdWithColon:100
+{|#8:CategoryMultipleColons: IdWithColon:100|}
 
 # Illegal: Duplicate category
 DuplicateCategory1
-DuplicateCategory1
+{|#9:DuplicateCategory1|}
 DuplicateCategory2: Prefix100-Prefix199
-DuplicateCategory2: Prefix200-Prefix299
+{|#10:DuplicateCategory2: Prefix200-Prefix299|}
 
 # Illegal: ID cannot be non-alphanumeric
-CategoryWithBadId1: Prefix_100
-CategoryWithBadId2: Prefix_100-Prefix_199
+{|#11:CategoryWithBadId1: Prefix_100|}
+{|#12:CategoryWithBadId2: Prefix_100-Prefix_199|}
 
 # Illegal: Id cannot have letters after number
-CategoryWithBadId3: Prefix000NotAllowed
-CategoryWithBadId4: Prefix000NotAllowed-Prefix099NotAllowed
+{|#13:CategoryWithBadId3: Prefix000NotAllowed|}
+{|#14:CategoryWithBadId4: Prefix000NotAllowed-Prefix099NotAllowed|}
 
 # Illegal: Different prefixes in ID range
-CategoryWithBadId5: Prefix000-DifferentPrefix099
+{|#15:CategoryWithBadId5: Prefix000-DifferentPrefix099|}
 ";
 
             await new VerifyCS.Test
@@ -1252,16 +1252,16 @@ CategoryWithBadId5: Prefix000-DifferentPrefix099
                     AdditionalFiles = { (AdditionalFileName, additionalText) },
                     ExpectedDiagnostics =
                     {
-                        GetRS1021ExpectedDiagnostic(6, 1, "Category with spaces", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(7, 1, "Category with spaces and range: Prefix100-Prefix199", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(10, 1, "CategoryMultipleColons: IdWithColon:100", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(14, 1, "DuplicateCategory1", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(16, 1, "DuplicateCategory2: Prefix200-Prefix299", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(19, 1, "CategoryWithBadId1: Prefix_100", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(20, 1, "CategoryWithBadId2: Prefix_100-Prefix_199", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(23, 1, "CategoryWithBadId3: Prefix000NotAllowed", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(24, 1, "CategoryWithBadId4: Prefix000NotAllowed-Prefix099NotAllowed", AdditionalFileName),
-                        GetRS1021ExpectedDiagnostic(27, 1, "CategoryWithBadId5: Prefix000-DifferentPrefix099", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(6, "Category with spaces", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(7, "Category with spaces and range: Prefix100-Prefix199", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(8, "CategoryMultipleColons: IdWithColon:100", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(9, "DuplicateCategory1", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(10, "DuplicateCategory2: Prefix200-Prefix299", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(11, "CategoryWithBadId1: Prefix_100", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(12, "CategoryWithBadId2: Prefix_100-Prefix_199", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(13, "CategoryWithBadId3: Prefix000NotAllowed", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(14, "CategoryWithBadId4: Prefix000NotAllowed-Prefix099NotAllowed", AdditionalFileName),
+                        GetRS1021ExpectedDiagnostic(15, "CategoryWithBadId5: Prefix000-DifferentPrefix099", AdditionalFileName),
                         GetRS1028ResultAt(0),
                         GetRS1028ResultAt(1),
                         GetRS1028ResultAt(2),
@@ -2426,9 +2426,9 @@ End Class
         /// <summary>
         /// Creates an expected diagnostic for <inheritdoc cref="DiagnosticDescriptorCreationAnalyzer.AnalyzerCategoryAndIdRangeFileInvalidRule"/>
         /// </summary>
-        private static DiagnosticResult GetRS1021ExpectedDiagnostic(int line, int column, string invalidEntry, string additionalFile) =>
+        private static DiagnosticResult GetRS1021ExpectedDiagnostic(int markupKey, string invalidEntry, string additionalFile) =>
             new DiagnosticResult(DiagnosticDescriptorCreationAnalyzer.AnalyzerCategoryAndIdRangeFileInvalidRule)
-                .WithLocation(AdditionalFileName, line, column)
+                .WithLocation(markupKey)
                 .WithArguments(invalidEntry, additionalFile);
 
         /// <summary>
@@ -2448,7 +2448,6 @@ End Class
                     Sources = { source },
                 },
                 ReferenceAssemblies = AdditionalMetadataReferences.Default,
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
             };
 
             test.SolutionTransforms.Add(WithoutEnableReleaseTrackingWarning);
@@ -2465,7 +2464,6 @@ End Class
                     Sources = { source },
                 },
                 ReferenceAssemblies = AdditionalMetadataReferences.Default,
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
             };
 
             test.SolutionTransforms.Add(WithoutEnableReleaseTrackingWarning);

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -977,7 +977,6 @@ class MyAnalyzer : DiagnosticAnalyzer
                     AdditionalFiles = { },
                 },
                 ReferenceAssemblies = AdditionalMetadataReferences.Default,
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             if (shippedText != null)
@@ -1014,7 +1013,6 @@ class MyAnalyzer : DiagnosticAnalyzer
                 : (CodeFixTest<XUnitVerifier>)new VisualBasicCodeFixTest<DiagnosticDescriptorCreationAnalyzer, AnalyzerReleaseTrackingFix, XUnitVerifier>();
 
             test.ReferenceAssemblies = AdditionalMetadataReferences.Default;
-            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
             test.SolutionTransforms.Add(DisableNonReleaseTrackingWarnings);
 
             test.TestState.Sources.Add(source);

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/StartActionWithNoRegisteredActionsRuleTests.cs
@@ -268,12 +268,17 @@ class MyAnalyzer2 : DiagnosticAnalyzer
                     Sources = { source },
                     ExpectedDiagnostics =
                     {
+#if !NETCOREAPP
                         // Test0.cs(3,26): error CS0234: The type or namespace name 'Immutable' does not exist in the namespace 'System.Collections' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(3, 26, 3, 35).WithArguments("Immutable", "System.Collections"),
                         // Test0.cs(4,17): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(4, 17, 4, 29).WithArguments("CodeAnalysis", "Microsoft"),
                         // Test0.cs(5,17): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(5, 17, 5, 29).WithArguments("CodeAnalysis", "Microsoft"),
+#else
+                        // Test0.cs(5,30): error CS0234: The type or namespace name 'Diagnostics' does not exist in the namespace 'Microsoft.CodeAnalysis' (are you missing an assembly reference?)
+                        DiagnosticResult.CompilerError("CS0234").WithSpan(5, 30, 5, 41).WithArguments("Diagnostics", "Microsoft.CodeAnalysis"),
+#endif
                         // Test0.cs(7,2): error CS0246: The type or namespace name 'DiagnosticAnalyzer' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(7, 2, 7, 20).WithArguments("DiagnosticAnalyzer"),
                         // Test0.cs(7,2): error CS0246: The type or namespace name 'DiagnosticAnalyzerAttribute' could not be found (are you missing a using directive or an assembly reference?)
@@ -282,8 +287,10 @@ class MyAnalyzer2 : DiagnosticAnalyzer
                         DiagnosticResult.CompilerError("CS0103").WithSpan(7, 21, 7, 34).WithArguments("LanguageNames"),
                         // Test0.cs(8,20): error CS0246: The type or namespace name 'DiagnosticAnalyzer' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(8, 20, 8, 38).WithArguments("DiagnosticAnalyzer"),
+#if !NETCOREAPP
                         // Test0.cs(10,21): error CS0246: The type or namespace name 'ImmutableArray<>' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(10, 21, 10, 57).WithArguments("ImmutableArray<>"),
+#endif
                         // Test0.cs(10,36): error CS0246: The type or namespace name 'DiagnosticDescriptor' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(10, 36, 10, 56).WithArguments("DiagnosticDescriptor"),
                         // Test0.cs(10,58): error CS0115: 'MyAnalyzer.SupportedDiagnostics': no suitable method found to override
@@ -302,8 +309,10 @@ class MyAnalyzer2 : DiagnosticAnalyzer
                         DiagnosticResult.CompilerError("CS0103").WithSpan(28, 21, 28, 34).WithArguments("LanguageNames"),
                         // Test0.cs(29,21): error CS0246: The type or namespace name 'DiagnosticAnalyzer' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(29, 21, 29, 39).WithArguments("DiagnosticAnalyzer"),
+#if !NETCOREAPP
                         // Test0.cs(31,21): error CS0246: The type or namespace name 'ImmutableArray<>' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(31, 21, 31, 57).WithArguments("ImmutableArray<>"),
+#endif
                         // Test0.cs(31,36): error CS0246: The type or namespace name 'DiagnosticDescriptor' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(31, 36, 31, 56).WithArguments("DiagnosticDescriptor"),
                         // Test0.cs(31,58): error CS0115: 'MyAnalyzer2.SupportedDiagnostics': no suitable method found to override
@@ -380,12 +389,17 @@ class MyAnalyzer : DiagnosticAnalyzer
                     Sources = { source },
                     ExpectedDiagnostics =
                     {
+#if !NETCOREAPP
                         // Test0.cs(3,26): error CS0234: The type or namespace name 'Immutable' does not exist in the namespace 'System.Collections' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(3, 26, 3, 35).WithArguments("Immutable", "System.Collections"),
                         // Test0.cs(4,17): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(4, 17, 4, 29).WithArguments("CodeAnalysis", "Microsoft"),
                         // Test0.cs(5,17): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
                         DiagnosticResult.CompilerError("CS0234").WithSpan(5, 17, 5, 29).WithArguments("CodeAnalysis", "Microsoft"),
+#else
+                        // Test0.cs(5,30): error CS0234: The type or namespace name 'Diagnostics' does not exist in the namespace 'Microsoft.CodeAnalysis' (are you missing an assembly reference?)
+                        DiagnosticResult.CompilerError("CS0234").WithSpan(5, 30, 5, 41).WithArguments("Diagnostics", "Microsoft.CodeAnalysis"),
+#endif
                         // Test0.cs(7,2): error CS0246: The type or namespace name 'DiagnosticAnalyzer' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(7, 2, 7, 20).WithArguments("DiagnosticAnalyzer"),
                         // Test0.cs(7,2): error CS0246: The type or namespace name 'DiagnosticAnalyzerAttribute' could not be found (are you missing a using directive or an assembly reference?)
@@ -394,8 +408,10 @@ class MyAnalyzer : DiagnosticAnalyzer
                         DiagnosticResult.CompilerError("CS0103").WithSpan(7, 21, 7, 34).WithArguments("LanguageNames"),
                         // Test0.cs(8,20): error CS0246: The type or namespace name 'DiagnosticAnalyzer' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(8, 20, 8, 38).WithArguments("DiagnosticAnalyzer"),
+#if !NETCOREAPP
                         // Test0.cs(10,21): error CS0246: The type or namespace name 'ImmutableArray<>' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(10, 21, 10, 57).WithArguments("ImmutableArray<>"),
+#endif
                         // Test0.cs(10,36): error CS0246: The type or namespace name 'DiagnosticDescriptor' could not be found (are you missing a using directive or an assembly reference?)
                         DiagnosticResult.CompilerError("CS0246").WithSpan(10, 36, 10, 56).WithArguments("DiagnosticDescriptor"),
                         // Test0.cs(10,58): error CS0115: 'MyAnalyzer.SupportedDiagnostics': no suitable method found to override
@@ -558,8 +574,10 @@ End Class
                         DiagnosticResult.CompilerError("BC30002").WithSpan(9, 11, 9, 29).WithArguments("DiagnosticAnalyzer"),
                         // Test0.vb(10) : error BC30284: property 'SupportedDiagnostics' cannot be declared 'Overrides' because it does not override a property in a base class.
                         DiagnosticResult.CompilerError("BC30284").WithSpan(10, 37, 10, 57).WithArguments("property", "SupportedDiagnostics"),
+#if !NETCOREAPP
                         // Test0.vb(10) : error BC30002: Type 'ImmutableArray' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(10, 63, 10, 102).WithArguments("ImmutableArray"),
+#endif
                         // Test0.vb(10) : error BC30002: Type 'DiagnosticDescriptor' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(10, 81, 10, 101).WithArguments("DiagnosticDescriptor"),
                         // Test0.vb(16) : error BC30284: sub 'Initialize' cannot be declared 'Overrides' because it does not override a sub in a base class.
@@ -578,8 +596,10 @@ End Class
                         DiagnosticResult.CompilerError("BC30002").WithSpan(26, 11, 26, 29).WithArguments("DiagnosticAnalyzer"),
                         // Test0.vb(27) : error BC30284: property 'SupportedDiagnostics' cannot be declared 'Overrides' because it does not override a property in a base class.
                         DiagnosticResult.CompilerError("BC30284").WithSpan(27, 37, 27, 57).WithArguments("property", "SupportedDiagnostics"),
+#if !NETCOREAPP
                         // Test0.vb(27) : error BC30002: Type 'ImmutableArray' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(27, 63, 27, 102).WithArguments("ImmutableArray"),
+#endif
                         // Test0.vb(27) : error BC30002: Type 'DiagnosticDescriptor' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(27, 81, 27, 101).WithArguments("DiagnosticDescriptor"),
                         // Test0.vb(33) : error BC30284: sub 'Initialize' cannot be declared 'Overrides' because it does not override a sub in a base class.
@@ -655,8 +675,10 @@ End Class
                         DiagnosticResult.CompilerError("BC30002").WithSpan(9, 11, 9, 29).WithArguments("DiagnosticAnalyzer"),
                         // Test0.vb(10) : error BC30284: property 'SupportedDiagnostics' cannot be declared 'Overrides' because it does not override a property in a base class.
                         DiagnosticResult.CompilerError("BC30284").WithSpan(10, 37, 10, 57).WithArguments("property", "SupportedDiagnostics"),
+#if !NETCOREAPP
                         // Test0.vb(10) : error BC30002: Type 'ImmutableArray' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(10, 63, 10, 102).WithArguments("ImmutableArray"),
+#endif
                         // Test0.vb(10) : error BC30002: Type 'DiagnosticDescriptor' is not defined.
                         DiagnosticResult.CompilerError("BC30002").WithSpan(10, 81, 10, 101).WithArguments("DiagnosticDescriptor"),
                         // Test0.vb(16) : error BC30284: sub 'Initialize' cannot be declared 'Overrides' because it does not override a sub in a base class.

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UpgradeMSBuildWorkspaceAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UpgradeMSBuildWorkspaceAnalyzerTests.cs
@@ -57,22 +57,13 @@ class Usage
     }
 }";
 
-            await new VerifyCS.Test
-            {
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics =
-                    {
-                        // Test0.cs(2,30): error CS0234: The type or namespace name 'MSBuild' does not exist in the namespace 'Microsoft.CodeAnalysis' (are you missing an assembly reference?)
-                        DiagnosticResult.CompilerError("CS0234").WithSpan(2, 30, 2, 37).WithArguments("MSBuild", "Microsoft.CodeAnalysis"),
-                        // Test0.cs(8,25): error CS0103: The name 'MSBuildWorkspace' does not exist in the current context
-                        DiagnosticResult.CompilerError("CS0103").WithSpan(8, 25, 8, 41).WithArguments("MSBuildWorkspace"),
-                        GetCSharpExpectedDiagnostic(8, 25),
-                    },
-                },
-            }.RunAsync();
+            await VerifyCS.VerifyAnalyzerAsync(
+                source,
+                // Test0.cs(2,30): error CS0234: The type or namespace name 'MSBuild' does not exist in the namespace 'Microsoft.CodeAnalysis' (are you missing an assembly reference?)
+                DiagnosticResult.CompilerError("CS0234").WithSpan(2, 30, 2, 37).WithArguments("MSBuild", "Microsoft.CodeAnalysis"),
+                // Test0.cs(8,25): error CS0103: The name 'MSBuildWorkspace' does not exist in the current context
+                DiagnosticResult.CompilerError("CS0103").WithSpan(8, 25, 8, 41).WithArguments("MSBuildWorkspace"),
+                GetCSharpExpectedDiagnostic(8, 25));
         }
 
         [Fact]
@@ -111,20 +102,11 @@ Class Usage
     End Sub
 End Class";
 
-            await new VerifyVB.Test
-            {
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
-                TestState =
-                {
-                    Sources = { source },
-                    ExpectedDiagnostics =
-                    {
-                        // Test0.vb(6) : error BC30451: 'MSBuildWorkspace' is not declared. It may be inaccessible due to its protection level.
-                        DiagnosticResult.CompilerError("BC30451").WithSpan(6, 25, 6, 41).WithArguments("MSBuildWorkspace"),
-                        GetBasicExpectedDiagnostic(6, 25),
-                    },
-                },
-            }.RunAsync();
+            await VerifyVB.VerifyAnalyzerAsync(
+                source,
+                // Test0.vb(6) : error BC30451: 'MSBuildWorkspace' is not declared. It may be inaccessible due to its protection level.
+                DiagnosticResult.CompilerError("BC30451").WithSpan(6, 25, 6, 41).WithArguments("MSBuildWorkspace"),
+                GetBasicExpectedDiagnostic(6, 25));
         }
 
         private static DiagnosticResult GetCSharpExpectedDiagnostic(int line, int column) =>

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/RestrictedInternalsVisibleToAnalyzerTests.cs
@@ -78,7 +78,6 @@ End Namespace";
                 {
                     (solution, projectId) => ApplySolutionTransforms(solution, projectId, apiProviderSource, LanguageNames.CSharp),
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);
@@ -97,7 +96,6 @@ End Namespace";
                 {
                     (solution, projectId) => ApplySolutionTransforms(solution, projectId, apiProviderSource, LanguageNames.VisualBasic),
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
                     Sources = { source },
                     AdditionalFiles = { (SymbolIsBannedAnalyzer.BannedSymbolsFileName, bannedApiText) },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);
@@ -54,7 +53,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests
                     Sources = { source },
                     AdditionalFiles = { (SymbolIsBannedAnalyzer.BannedSymbolsFileName, bannedApiText) },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.Fixer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -241,7 +242,7 @@ public class C
     public async Task M()
     {
         Task<Task> t = null;
-        await (await t.ConfigureAwait(false)).ConfigureAwait(false).{|CS1061:ConfigureAwait|}(false); // both have warnings.
+        await {|#1:(await t.ConfigureAwait(false)).ConfigureAwait(false)|}.{|#0:ConfigureAwait|}(false); // both have warnings.
         await (await t.ConfigureAwait(false)).ConfigureAwait(false); // outer await is wrong.
         await (await t.ConfigureAwait(false)).ConfigureAwait(false); // inner await is wrong.
     }
@@ -252,7 +253,20 @@ public class C
             {
                 TestState = { Sources = { code } },
                 FixedState = { Sources = { fixedCode } },
-                BatchFixedState = { Sources = { fixAllCode } },
+                BatchFixedState =
+                {
+                    Sources = { fixAllCode },
+                    ExpectedDiagnostics =
+                    {
+#if !NETCOREAPP
+                        // /0/Test0.cs(9,69): error CS1061: 'ConfiguredTaskAwaitable' does not contain a definition for 'ConfigureAwait' and no accessible extension method 'ConfigureAwait' accepting a first argument of type 'ConfiguredTaskAwaitable' could be found (are you missing a using directive or an assembly reference?)
+                        DiagnosticResult.CompilerError("CS1061").WithLocation(0).WithArguments("System.Runtime.CompilerServices.ConfiguredTaskAwaitable", "ConfigureAwait"),
+#else
+                        // /0/Test0.cs(9,15): error CS1929: 'ConfiguredTaskAwaitable' does not contain a definition for 'ConfigureAwait' and the best extension method overload 'TaskAsyncEnumerableExtensions.ConfigureAwait(IAsyncDisposable, bool)' requires a receiver of type 'IAsyncDisposable'
+                        DiagnosticResult.CompilerError("CS1929").WithLocation(1).WithArguments("System.Runtime.CompilerServices.ConfiguredTaskAwaitable", "ConfigureAwait", "System.Threading.Tasks.TaskAsyncEnumerableExtensions.ConfigureAwait(System.IAsyncDisposable, bool)", "System.IAsyncDisposable"),
+#endif
+                    },
+                },
                 NumberOfFixAllIterations = 2,
             }.RunAsync();
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.Fixer.cs
@@ -205,7 +205,6 @@ class E
                         anotherCodeFix,
                     },
                 },
-                NumberOfFixAllInDocumentIterations = 2,
             }.RunAsync();
         }
 
@@ -671,7 +670,6 @@ End Class
                         anotherCodeFix,
                     },
                 },
-                NumberOfFixAllInDocumentIterations = 2,
             }.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1647,10 +1647,16 @@ public class Test
 
             if (string.IsNullOrEmpty(editorConfigText))
             {
+#if !NETCOREAPP
+                const string StringArgType = "string";
+#else
+                const string StringArgType = "string?";
+#endif
+
                 csharpTest.ExpectedDiagnostics.AddRange(new[]
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a")
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", $"Exception.Exception({StringArgType} message)", "a")
                 });
             }
 
@@ -1697,14 +1703,20 @@ public class Test
 
             if (string.IsNullOrEmpty(editorConfigText))
             {
+#if !NETCOREAPP
+                const string StringArgType = "string";
+#else
+                const string StringArgType = "string?";
+#endif
+
                 csharpTest.ExpectedDiagnostics.AddRange(new[]
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
-                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
-                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", $"Exception.Exception({StringArgType} message)", "a"),
+                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", $"ArgumentException.ArgumentException({StringArgType} message)", "a"),
+                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", $"InvalidOperationException.InvalidOperationException({StringArgType} message)", "a")
                 });
             }
 
@@ -1747,14 +1759,20 @@ public class Test
 
             if (string.IsNullOrEmpty(editorConfigText))
             {
+#if !NETCOREAPP
+                const string StringArgType = "string";
+#else
+                const string StringArgType = "string?";
+#endif
+
                 csharpTest.ExpectedDiagnostics.AddRange(new[]
                 {
-                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", "Exception.Exception(string message)", "a"),
-                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", "ArgumentException.ArgumentException(string message)", "a"),
-                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string message)'. Retrieve the following string(s) from a resource table instead: "a".
-                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", "InvalidOperationException.InvalidOperationException(string message)", "a")
+                    // Test0.cs(9,31): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'Exception.Exception(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(9, 31, "void Test.M1()", "message", $"Exception.Exception({StringArgType} message)", "a"),
+                    // Test0.cs(10,39): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'ArgumentException.ArgumentException(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(10, 39, "void Test.M1()", "message", $"ArgumentException.ArgumentException({StringArgType} message)", "a"),
+                    // Test0.cs(11,47): warning CA1303: Method 'void Test.M1()' passes a literal string as parameter 'message' of a call to 'InvalidOperationException.InvalidOperationException(string? message)'. Retrieve the following string(s) from a resource table instead: "a".
+                    GetCSharpResultAt(11, 47, "void Test.M1()", "message", $"InvalidOperationException.InvalidOperationException({StringArgType} message)", "a")
                 });
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparisonTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparisonTests.cs
@@ -17,6 +17,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [Fact]
         public async Task CA1307_StringCompareTests_CSharp()
         {
+#if !NETCOREAPP
+            const string StringArgType = "string";
+#else
+            const string StringArgType = "string?";
+#endif
+
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
@@ -34,18 +40,18 @@ public class StringComparisonTests
         return 0;
     }
 }",
-GetCA1307CSharpResultsAt(11, 18, "string.Compare(string, string)",
+GetCA1307CSharpResultsAt(11, 18, $"string.Compare({StringArgType}, {StringArgType})",
                                  "StringComparisonTests.StringCompare()",
-                                 "string.Compare(string, string, System.StringComparison)"),
-GetCA1307CSharpResultsAt(12, 18, "string.Compare(string, string, bool)",
+                                 $"string.Compare({StringArgType}, {StringArgType}, System.StringComparison)"),
+GetCA1307CSharpResultsAt(12, 18, $"string.Compare({StringArgType}, {StringArgType}, bool)",
                                  "StringComparisonTests.StringCompare()",
-                                 "string.Compare(string, string, System.StringComparison)"),
-GetCA1307CSharpResultsAt(13, 18, "string.Compare(string, int, string, int, int)",
+                                 $"string.Compare({StringArgType}, {StringArgType}, System.StringComparison)"),
+GetCA1307CSharpResultsAt(13, 18, $"string.Compare({StringArgType}, int, {StringArgType}, int, int)",
                                  "StringComparisonTests.StringCompare()",
-                                 "string.Compare(string, int, string, int, int, System.StringComparison)"),
-GetCA1307CSharpResultsAt(14, 18, "string.Compare(string, int, string, int, int, bool)",
+                                 $"string.Compare({StringArgType}, int, {StringArgType}, int, int, System.StringComparison)"),
+GetCA1307CSharpResultsAt(14, 18, $"string.Compare({StringArgType}, int, {StringArgType}, int, int, bool)",
                                  "StringComparisonTests.StringCompare()",
-                                 "string.Compare(string, int, string, int, int, System.StringComparison)"));
+                                 $"string.Compare({StringArgType}, int, {StringArgType}, int, int, System.StringComparison)"));
         }
 
         [Fact]
@@ -104,6 +110,14 @@ GetCA1307CSharpResultsAt(12, 16, "string.IndexOf(string, int, int)",
         [Fact]
         public async Task CA1307_StringCompareToTests_CSharp()
         {
+#if !NETCOREAPP
+            const string ObjectArgType = "object";
+            const string StringArgType = "string";
+#else
+            const string ObjectArgType = "object?";
+            const string StringArgType = "string?";
+#endif
+
             await VerifyCS.VerifyAnalyzerAsync(@"
 using System;
 using System.Globalization;
@@ -118,12 +132,12 @@ public class StringComparisonTests
             return """".CompareTo(new object());
     }
 }",
-GetCA1307CSharpResultsAt(11, 22, "string.CompareTo(string)",
+GetCA1307CSharpResultsAt(11, 22, $"string.CompareTo({StringArgType})",
                                  "StringComparisonTests.StringCompareTo()",
-                                 "string.Compare(string, string, System.StringComparison)"),
-GetCA1307CSharpResultsAt(12, 20, "string.CompareTo(object)",
+                                 $"string.Compare({StringArgType}, {StringArgType}, System.StringComparison)"),
+GetCA1307CSharpResultsAt(12, 20, $"string.CompareTo({ObjectArgType})",
                                  "StringComparisonTests.StringCompareTo()",
-                                 "string.Compare(string, string, System.StringComparison)"));
+                                 $"string.Compare({StringArgType}, {StringArgType}, System.StringComparison)"));
         }
 
         [Fact]

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CSharpPerformanceCodeFixVerifier`2.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CSharpPerformanceCodeFixVerifier`2.cs
@@ -62,7 +62,6 @@ namespace Roslyn.Utilities
                         ("PerformanceSensitiveAttribute.cs", PerformanceSensitiveAttributeSource)
                     },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);
@@ -88,7 +87,6 @@ namespace Roslyn.Utilities
                     },
                 },
                 FixedCode = fixedSource,
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -86,7 +86,6 @@ public class MyClass
                         VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(10, 9),
                     },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             }.RunAsync();
         }
 

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/VisualBasicPerformanceCodeFixVerifier`2.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/VisualBasicPerformanceCodeFixVerifier`2.cs
@@ -2,10 +2,10 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.VisualBasic.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.VisualBasic.Testing;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -62,7 +62,6 @@ End Namespace
                         ("PerformanceSensitiveAttribute.vb", PerformanceSensitiveAttributeSource)
                     },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);
@@ -88,7 +87,6 @@ End Namespace
                     },
                 },
                 FixedCode = fixedSource,
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/AnnotatePublicApiAnalyzerTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                     Sources = { source },
                     AdditionalFiles = { },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             if (shippedApiText != null)
@@ -47,8 +46,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
         private async Task VerifyAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newShippedApiText, string newUnshippedApiText)
         {
             var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, AnnotatePublicApiFix, XUnitVerifier>();
-
-            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
 
             test.TestState.Sources.Add(source);
             test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, oldShippedApiText));

--- a/src/PublicApiAnalyzers/UnitTests/NullableEnablePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/NullableEnablePublicApiAnalyzerTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                     Sources = { source },
                     AdditionalFiles = { },
                 },
-                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck,
             };
 
             if (shippedApiText != null)
@@ -47,8 +46,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
         private async Task VerifyAdditionalFileFixAsync(string source, string oldShippedApiText, string oldUnshippedApiText, string newSource, string newShippedApiText, string newUnshippedApiText)
         {
             var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, NullableEnablePublicApiFix, XUnitVerifier>();
-
-            test.TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
 
             test.TestState.Sources.Add(source);
             test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, oldShippedApiText));

--- a/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
@@ -6,7 +6,6 @@ using System.Net;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 
 namespace Test.Utilities
 {
@@ -32,8 +31,6 @@ namespace Test.Utilities
 
             public Test()
             {
-                // These analyzers run on generated code by default.
-                TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
             }
 
             protected override Project ApplyCompilationOptions(Project project)

--- a/src/Test.Utilities/VisualBasicSecurityCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/VisualBasicSecurityCodeFixVerifier`2+Test.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 
 namespace Test.Utilities
 {
@@ -17,8 +16,6 @@ namespace Test.Utilities
         {
             public Test()
             {
-                // These analyzers run on generated code by default.
-                TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
             }
 
             protected override Project ApplyCompilationOptions(Project project)


### PR DESCRIPTION
* Infer Fix All in Document iteration counts
* Infer generated code analysis configuration
* Use markup keys for locations in additional files when the same test uses markup keys for locations in source
