### PR TITLE
CA1835 fix - Automatically add using/imports System if not yet included

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -40,9 +40,9 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             }
         }
 
-        protected override bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> imports)
+        protected override bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> importList)
         {
-            foreach (SyntaxNode import in imports)
+            foreach (SyntaxNode import in importList)
             {
                 if (import is UsingDirectiveSyntax usingDirective &&
                     usingDirective.Name is IdentifierNameSyntax identifierName &&

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -44,9 +44,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         {
             foreach (SyntaxNode import in importList)
             {
-                if (import is UsingDirectiveSyntax usingDirective &&
-                    usingDirective.Name is IdentifierNameSyntax identifierName &&
-                    identifierName.Identifier.Text == "System")
+                if (import is UsingDirectiveSyntax { Name: IdentifierNameSyntax { Identifier: { Text: nameof(System) } } })
                 {
                     return true;
                 }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -37,6 +38,20 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                            argNode.NameColon?.Name?.Identifier.ValueText == name;
                 });
             }
+        }
+
+        protected override bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> imports)
+        {
+            foreach (SyntaxNode import in imports)
+            {
+                if (import is UsingDirectiveSyntax usingDirective &&
+                    usingDirective.Name is IdentifierNameSyntax identifierName &&
+                    identifierName.Identifier.Text == "System")
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -34,8 +34,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         // Checks if the argument in the specified index has a name. If it doesn't, returns that arguments. If it does, then looks for the argument using the specified name, and returns it, or null if not found.
         protected abstract IArgumentOperation? GetArgumentByPositionOrName(ImmutableArray<IArgumentOperation> args, int index, string name, out bool isNamed);
 
-        // 
-        protected abstract bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> imports);
+        // Verifies if a namespace has already been added to the usings/imports list.
+        protected abstract bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> importList);
 
         public sealed override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(PreferStreamAsyncMemoryOverloads.RuleId);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -153,12 +153,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             // The invocation needs to be replaced before adding the import/using, it won't work the other way around
             SyntaxNode newRoot = generator.ReplaceNode(root, invocation.Syntax, newInvocationExpression.WithTriviaFrom(invocation.Syntax));
-            SyntaxNode newRootWithImports = containsSystemImport ? newRoot : generator.AddNamespaceImports(newRoot, generator.NamespaceImportDeclaration("System"));
+            SyntaxNode newRootWithImports = containsSystemImport ? newRoot : generator.AddNamespaceImports(newRoot, generator.NamespaceImportDeclaration(nameof(System)));
 
             return Task.FromResult(doc.WithSyntaxRoot(newRootWithImports));
         }
 
-        // Needed for Telemetry (https://github.com/dotnet/roslyn-analyzers/issues/192) 
+        // Needed for Telemetry (https://github.com/dotnet/roslyn-analyzers/issues/192)
         private class MyCodeAction : DocumentChangeAction
         {
             public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -582,12 +582,11 @@ class C
             string originalCode = @"
 using System.IO;
 using System.Threading;
-
 class C
 {
     public async void M()
     {
-        using (FileStream s = File.Open(""path.txt"", FileMode.Open))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
             await s.ReadAsync(new byte[s.Length], 0, (int)s.Length);
@@ -603,26 +602,14 @@ class C
 {
     public async void M()
     {
-        using (FileStream s = File.Open(""path.txt"", FileMode.Open))
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
             await s.ReadAsync((new byte[s.Length]).AsMemory(0, (int)s.Length));
         }
     }
 }";
-            var test = new Test.Utilities.CSharpCodeFixVerifier<
-    PreferStreamAsyncMemoryOverloads,
-    CSharp.Analyzers.Runtime.CSharpPreferStreamAsyncMemoryOverloadsFixer>.Test
-            {
-                TestCode = originalCode,
-                FixedCode = fixedCode,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
-                CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne
-            };
-            test.ExpectedDiagnostics.Add(GetCSharpResult(12, 19, 12, 68));
-            return test.RunAsync();
-
-            // return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(12, 19, 12, 68));
+            return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(11, 19, 11, 68));
         }
 
         [Theory]
@@ -813,10 +800,9 @@ End Module
             string originalCode = @"
 Imports System.IO
 Imports System.Threading
-
 Class C
     Public Async Sub M()
-        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
             Dim buffer As Byte() = New Byte(s.Length - 1) {}
             Await s.ReadAsync(New Byte(s.Length - 1) {}, 0, s.Length)
         End Using
@@ -830,14 +816,14 @@ Imports System
 
 Class C
     Public Async Sub M()
-        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
             Dim buffer As Byte() = New Byte(s.Length - 1) {}
             Await s.ReadAsync((New Byte(s.Length - 1) {}).AsMemory(0, s.Length))
         End Using
     End Sub
 End Class
 ";
-            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(9, 19, 9, 70));
+            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(8, 19, 8, 70));
         }
 
         [Theory]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -610,7 +610,19 @@ class C
         }
     }
 }";
-            return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(12, 19, 12, 68));
+            var test = new Test.Utilities.CSharpCodeFixVerifier<
+    PreferStreamAsyncMemoryOverloads,
+    CSharp.Analyzers.Runtime.CSharpPreferStreamAsyncMemoryOverloadsFixer>.Test
+            {
+                TestCode = originalCode,
+                FixedCode = fixedCode,
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne
+            };
+            test.ExpectedDiagnostics.Add(GetCSharpResult(12, 19, 12, 68));
+            return test.RunAsync();
+
+            // return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(12, 19, 12, 68));
         }
 
         [Theory]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -572,15 +572,14 @@ class C
             string originalCode = @"
 using System.IO;
 using System.Threading;
-
 class C
 {
     public async void M()
     {
-        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            await s.WriteAsync(buffer, 0, 8);
+            await s.WriteAsync(buffer, 0, buffer.Length);
         }
     }
 }";
@@ -593,14 +592,14 @@ class C
 {
     public async void M()
     {
-        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            await s.WriteAsync(buffer.AsMemory(0, 8));
+            await s.WriteAsync(buffer.AsMemory(0, buffer.Length));
         }
     }
 }";
-            return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(12, 19, 12, 68));
+            return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(11, 19, 11, 57));
         }
 
         [Theory]
@@ -761,12 +760,11 @@ End Module
             string originalCode = @"
 Imports System.IO
 Imports System.Threading
-
 Class C
     Public Async Sub M()
-        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
             Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-            Await s.WriteAsync(buffer, 0, 8)
+            Await s.WriteAsync(buffer, 0, buffer.Length)
         End Using
     End Sub
 End Class
@@ -778,14 +776,14 @@ Imports System
 
 Class C
     Public Async Sub M()
-        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
             Dim buffer As Byte() = {&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}
-            Await s.WriteAsync(buffer.AsMemory(0, 8))
+            Await s.WriteAsync(buffer.AsMemory(0, buffer.Length))
         End Using
     End Sub
 End Class
 ";
-            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(9, 19, 9, 70));
+            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(8, 19, 8, 57));
         }
 
         [Theory]

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -33,9 +33,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             End If
         End Function
 
-        Protected Overrides Function IsSystemNamespaceImported([imports] As IReadOnlyList(Of SyntaxNode)) As Boolean
+        Protected Overrides Function IsSystemNamespaceImported(importList As IReadOnlyList(Of SyntaxNode)) As Boolean
 
-            For Each import As SyntaxNode In [imports]
+            For Each import As SyntaxNode In importList
 
                 Dim importsStatement As ImportsStatementSyntax = TryCast(import, ImportsStatementSyntax)
                 If importsStatement IsNot Nothing Then
@@ -51,11 +51,8 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                             End If
 
                         End If
-
                     Next
-
                 End If
-
             Next
 
             Return False

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -32,5 +32,35 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                 End If
             End If
         End Function
+
+        Protected Overrides Function IsSystemNamespaceImported([imports] As IReadOnlyList(Of SyntaxNode)) As Boolean
+
+            For Each import As SyntaxNode In [imports]
+
+                Dim importsStatement As ImportsStatementSyntax = TryCast(import, ImportsStatementSyntax)
+                If importsStatement IsNot Nothing Then
+
+                    For Each clause As ImportsClauseSyntax In importsStatement.ImportsClauses
+
+                        Dim simpleClause As SimpleImportsClauseSyntax = TryCast(clause, SimpleImportsClauseSyntax)
+                        If simpleClause IsNot Nothing Then
+
+                            Dim identifier As IdentifierNameSyntax = TryCast(simpleClause.Name, IdentifierNameSyntax)
+                            If identifier IsNot Nothing AndAlso identifier.Identifier.Text = "System" Then
+                                Return True
+                            End If
+
+                        End If
+
+                    Next
+
+                End If
+
+            Next
+
+            Return False
+
+        End Function
+
     End Class
 End Namespace

--- a/src/Utilities/Workspaces/SyntaxNodeExtensions.cs
+++ b/src/Utilities/Workspaces/SyntaxNodeExtensions.cs
@@ -24,6 +24,11 @@ namespace Analyzer.Utilities
             }
         }
 
+        /// <summary>
+        /// Annotates a syntax node representing a type so that any missing imports get automatically added. Does not work in any other kinds of nodes.
+        /// </summary>
+        /// <param name="syntaxNode">The type node to annotate.</param>
+        /// <returns>The annotated type node.</returns>
         public static SyntaxNode WithAddImportsAnnotation(this SyntaxNode syntaxNode)
         {
             if (AddImportsAnnotation is null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/3827

If rule CA1835 finds a diagnostic and applies a fix, but the `System` namespace has not yet been added (which contains the `AsMemory()` method for byte arrays), then the compilation can fail.
With this change, the `System` namespace should be added if the user has not added it yet.