### PR TITLE
Allow tainting function arguments

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
@@ -144,7 +144,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 operationAnalysisContext =>
                                 {
                                     IParameterReferenceOperation parameterReferenceOperation = (IParameterReferenceOperation)operationAnalysisContext.Operation;
-                                    if (sourceInfoSymbolMap.IsSourceParameter(parameterReferenceOperation.Parameter))
+                                    if (sourceInfoSymbolMap.IsSourceParameter(parameterReferenceOperation.Parameter, wellKnownTypeProvider))
                                     {
                                         lock (rootOperationsNeedingAnalysis)
                                         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
@@ -143,6 +143,20 @@ namespace Microsoft.NetCore.Analyzers.Security
                             operationBlockStartContext.RegisterOperationAction(
                                 operationAnalysisContext =>
                                 {
+                                    IParameterReferenceOperation parameterReferenceOperation = (IParameterReferenceOperation)operationAnalysisContext.Operation;
+                                    if (sourceInfoSymbolMap.IsSourceParameter(parameterReferenceOperation.Parameter))
+                                    {
+                                        lock (rootOperationsNeedingAnalysis)
+                                        {
+                                            rootOperationsNeedingAnalysis.Add(parameterReferenceOperation.GetRoot());
+                                        }
+                                    }
+                                },
+                                OperationKind.ParameterReference);
+
+                            operationBlockStartContext.RegisterOperationAction(
+                                operationAnalysisContext =>
+                                {
                                     IInvocationOperation invocationOperation = (IInvocationOperation)operationAnalysisContext.Operation;
                                     if (sourceInfoSymbolMap.IsSourceMethod(
                                             invocationOperation.TargetMethod,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
@@ -3253,5 +3253,23 @@ namespace TestNamespace
     }
 }");
         }
+
+        [Fact]
+        public async Task TaintFunctionArguments()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.Data.SqlClient;
+using Microsoft.AspNetCore.Mvc;
+
+public class MyController : Controller
+{
+    public string DoSomething(string input)
+    {
+        new SqlCommand(input);
+        return null;
+    }
+}",
+                GetCSharpResultAt(9, 9, 9, 24, "SqlCommand.SqlCommand(string cmdText)", "string MyController.DoSomething(string input)", "string input", "string MyController.DoSomething(string input)"));
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -705,6 +705,76 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
+        /// Returns a value indicating whether the specified or inherited symbol has the specified
+        /// attribute.
+        /// </summary>
+        /// <param name="symbol">
+        /// The symbol being examined.
+        /// </param>
+        /// <param name="attribute">
+        /// The attribute in question.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="symbol"/> has an attribute of type
+        /// <paramref name="attribute"/>; otherwise <see langword="false"/>.
+        /// </returns>
+        public static bool HasDerivedTypeAttribute(this ITypeSymbol symbol, [NotNullWhen(returnValue: true)] INamedTypeSymbol? attribute)
+        {
+            if (attribute == null)
+            {
+                return false;
+            }
+
+            while (symbol != null)
+            {
+                if (symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute)))
+                    return true;
+
+                if (symbol.BaseType == null)
+                    return false;
+
+                symbol = symbol.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified or inherited method symbol has the specified
+        /// attribute.
+        /// </summary>
+        /// <param name="symbol">
+        /// The symbol being examined.
+        /// </param>
+        /// <param name="attribute">
+        /// The attribute in question.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="symbol"/> has an attribute of type
+        /// <paramref name="attribute"/>; otherwise <see langword="false"/>.
+        /// </returns>
+        public static bool HasDerivedMethodAttribute(this IMethodSymbol symbol, [NotNullWhen(returnValue: true)] INamedTypeSymbol? attribute)
+        {
+            if (attribute == null)
+            {
+                return false;
+            }
+
+            while (symbol != null)
+            {
+                if (symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute)))
+                    return true;
+
+                if (symbol.OverriddenMethod == null)
+                    return false;
+
+                symbol = symbol.OverriddenMethod;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Determines if the given symbol has the specified attributes.
         /// </summary>
         /// <param name="symbol">Symbol to examine.</param>

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -24,6 +24,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftAspNetCoreMvcHttpPostAttribute = "Microsoft.AspNetCore.Mvc.HttpPostAttribute";
         public const string MicrosoftAspNetCoreMvcHttpPutAttribute = "Microsoft.AspNetCore.Mvc.HttpPutAttribute";
         public const string MicrosoftAspNetCoreMvcNonActionAttribute = "Microsoft.AspNetCore.Mvc.NonActionAttribute";
+        public const string MicrosoftAspNetCoreMvcNonControllerAttribute = "Microsoft.AspNetCore.Mvc.NonControllerAttribute";
         public const string MicrosoftAspNetCoreMvcRouteAttribute = "Microsoft.AspNetCore.Mvc.RouteAttribute";
         public const string MicrosoftAspNetCoreMvcRoutingHttpMethodAttribute = "Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute";
         public const string MicrosoftAspNetCoreRazorHostingRazorCompiledItemAttribute = "Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute";

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -10,6 +10,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftAspNetCoreHttpInternalResponseCookies = "Microsoft.AspNetCore.Http.Internal.ResponseCookies";
         public const string MicrosoftAspNetCoreHttpIResponseCookies = "Microsoft.AspNetCore.Http.IResponseCookies";
         public const string MicrosoftAspNetCoreMvcController = "Microsoft.AspNetCore.Mvc.Controller";
+        public const string MicrosoftAspNetCoreMvcControllerAttribute = "Microsoft.AspNetCore.Mvc.ControllerAttribute";
         public const string MicrosoftAspNetCoreMvcControllerBase = "Microsoft.AspNetCore.Mvc.ControllerBase";
         public const string MicrosoftAspNetCoreMvcFiltersAuthorizationFilterContext = "Microsoft.AspNetCore.Mvc.Filters.AuthorizationFilterContext";
         public const string MicrosoftAspNetCoreMvcFiltersFilterCollection = "Microsoft.AspNetCore.Mvc.Filters.FilterCollection";
@@ -212,6 +213,7 @@ namespace Analyzer.Utilities
         public const string SystemNotSupportedException = "System.NotSupportedException";
         public const string SystemNullable1 = "System.Nullable`1";
         public const string SystemNumber = "System.Number";
+        public const string SystemObject = "System.Object";
         public const string SystemObsoleteAttribute = "System.ObsoleteAttribute";
         public const string SystemOutOfMemoryException = "System.OutOfMemoryException";
         public const string SystemRandom = "System.Random";

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
@@ -17,7 +17,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Qualified name of the optional dependency type.
         /// </summary>
-        string? FullDependencyTypeName { get; }
+        string? DependencyFullTypeName { get; }
 
         /// <summary>
         /// Indicates that the type is an interface, rather than a concrete type.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/ITaintedDataInfo.cs
@@ -15,6 +15,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         string FullTypeName { get; }
 
         /// <summary>
+        /// Qualified name of the optional dependency type.
+        /// </summary>
+        string? FullDependencyTypeName { get; }
+
+        /// <summary>
         /// Indicates that the type is an interface, rather than a concrete type.
         /// </summary>
         bool IsInterface { get; }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -79,13 +79,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
         public static void AddSourceInfo(
             this PooledHashSet<SourceInfo> builder,
-            string fullDependencyTypeName,
+            string dependencyFullTypeName,
             string fullTypeName,
             IEnumerable<ParameterMatcher> taintedArguments)
         {
             SourceInfo metadata = new SourceInfo(
                 fullTypeName,
-                fullDependencyTypeName: fullDependencyTypeName,
+                dependencyFullTypeName: dependencyFullTypeName,
                 isInterface: false,
                 taintedProperties: ImmutableHashSet<string>.Empty,
                 taintedArguments:

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -77,6 +77,31 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             builder.Add(metadata);
         }
 
+        public static void AddSourceInfo(
+            this PooledHashSet<SourceInfo> builder,
+            string fullDependencyTypeName,
+            string fullTypeName,
+            IEnumerable<ParameterMatcher> taintedArguments)
+        {
+            SourceInfo metadata = new SourceInfo(
+                fullTypeName,
+                fullDependencyTypeName: fullDependencyTypeName,
+                isInterface: false,
+                taintedProperties: ImmutableHashSet<string>.Empty,
+                taintedArguments:
+                    taintedArguments.ToImmutableHashSet(),
+                taintedMethods:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<string>)>.Empty,
+                taintedMethodsNeedsPointsToAnalysis:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(PointsToCheck, string)>)>.Empty,
+                taintedMethodsNeedsValueContentAnalysis:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(ValueContentCheck, string)>)>.Empty,
+                transferMethods:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)>.Empty,
+                taintConstantArray: false);
+            builder.Add(metadata);
+        }
+
         // Just to make hardcoding SourceInfos more convenient.
         public static void AddSourceInfo(
             this PooledHashSet<SourceInfo> builder,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -54,6 +54,29 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             builder.Add(sinkInfo);
         }
 
+        public static void AddSourceInfo(
+            this PooledHashSet<SourceInfo> builder,
+            string fullTypeName,
+            IEnumerable<ParameterMatcher> taintedArguments)
+        {
+            SourceInfo metadata = new SourceInfo(
+                fullTypeName,
+                isInterface: false,
+                taintedProperties: ImmutableHashSet<string>.Empty,
+                taintedArguments:
+                    taintedArguments.ToImmutableHashSet(),
+                taintedMethods:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<string>)>.Empty,
+                taintedMethodsNeedsPointsToAnalysis:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(PointsToCheck, string)>)>.Empty,
+                taintedMethodsNeedsValueContentAnalysis:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(ValueContentCheck, string)>)>.Empty,
+                transferMethods:
+                    ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)>.Empty,
+                taintConstantArray: false);
+            builder.Add(metadata);
+        }
+
         // Just to make hardcoding SourceInfos more convenient.
         public static void AddSourceInfo(
             this PooledHashSet<SourceInfo> builder,
@@ -67,6 +90,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isInterface: isInterface,
                 taintedProperties: taintedProperties?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
+                taintedArguments:
+                    ImmutableHashSet<ParameterMatcher>.Empty,
                 taintedMethods:
                     taintedMethods
                         ?.Select<string, (MethodMatcher, ImmutableHashSet<string>)>(o =>
@@ -111,6 +136,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isInterface: isInterface,
                 taintedProperties: taintedProperties?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
+                taintedArguments:
+                    ImmutableHashSet<ParameterMatcher>.Empty,
                 taintedMethods:
                     ImmutableHashSet<(MethodMatcher, ImmutableHashSet<string>)>.Empty,
                 taintedMethodsNeedsPointsToAnalysis:
@@ -162,6 +189,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 isInterface: isInterface,
                 taintedProperties: taintedProperties?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty,
+                taintedArguments:
+                    ImmutableHashSet<ParameterMatcher>.Empty,
                 taintedMethods:
                     ImmutableHashSet<(MethodMatcher, ImmutableHashSet<string>)>.Empty,
                 taintedMethodsNeedsPointsToAnalysis:

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -50,7 +50,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public bool RequiresValueContentAnalysis => false;
 
-        public string? FullDependencyTypeName => null;
+        public string? DependencyFullTypeName => null;
 
         public override int GetHashCode()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -50,6 +50,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public bool RequiresValueContentAnalysis => false;
 
+        public string? FullDependencyTypeName => null;
+
         public override int GetHashCode()
         {
             return HashUtilities.Combine(this.SanitizingMethods,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkInfo.cs
@@ -57,7 +57,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public bool RequiresValueContentAnalysis => false;
 
-        public string? FullDependencyTypeName => null;
+        public string? DependencyFullTypeName => null;
 
         public override int GetHashCode()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SinkInfo.cs
@@ -57,6 +57,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public bool RequiresValueContentAnalysis => false;
 
+        public string? FullDependencyTypeName => null;
+
         public override int GetHashCode()
         {
             return HashUtilities.Combine(this.SinkProperties,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
@@ -40,7 +40,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(ValueContentCheck, string)>)> taintedMethodsNeedsValueContentAnalysis,
             ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)> transferMethods,
             bool taintConstantArray,
-            string? fullDependencyTypeName = null)
+            string? dependencyFullTypeName = null)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
@@ -51,7 +51,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             TaintedMethodsNeedsValueContentAnalysis = taintedMethodsNeedsValueContentAnalysis ?? throw new ArgumentNullException(nameof(taintedMethodsNeedsValueContentAnalysis));
             TransferMethods = transferMethods ?? throw new ArgumentNullException(nameof(transferMethods));
             TaintConstantArray = taintConstantArray;
-            FullDependencyTypeName = fullDependencyTypeName;
+            DependencyFullTypeName = dependencyFullTypeName;
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Full type name of the optional dependency referenced type that should be resolved.
         /// </summary>
-        public string? FullDependencyTypeName { get; }
+        public string? DependencyFullTypeName { get; }
 
         /// <summary>
         /// Indicates this type is an interface.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
@@ -39,7 +39,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(PointsToCheck, string)>)> taintedMethodsNeedsPointsToAnalysis,
             ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(ValueContentCheck, string)>)> taintedMethodsNeedsValueContentAnalysis,
             ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)> transferMethods,
-            bool taintConstantArray)
+            bool taintConstantArray,
+            string? fullDependencyTypeName = null)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
@@ -50,12 +51,18 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             TaintedMethodsNeedsValueContentAnalysis = taintedMethodsNeedsValueContentAnalysis ?? throw new ArgumentNullException(nameof(taintedMethodsNeedsValueContentAnalysis));
             TransferMethods = transferMethods ?? throw new ArgumentNullException(nameof(transferMethods));
             TaintConstantArray = taintConstantArray;
+            FullDependencyTypeName = fullDependencyTypeName;
         }
 
         /// <summary>
         /// Full type name of the...type (namespace + type).
         /// </summary>
         public string FullTypeName { get; }
+
+        /// <summary>
+        /// Full type name of the optional dependency referenced type that should be resolved.
+        /// </summary>
+        public string? FullDependencyTypeName { get; }
 
         /// <summary>
         /// Indicates this type is an interface.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
@@ -13,7 +13,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     internal delegate bool PointsToCheck(ImmutableArray<PointsToAbstractValue> pointsTos);
     internal delegate bool ValueContentCheck(ImmutableArray<PointsToAbstractValue> pointsTos, ImmutableArray<ValueContentAbstractValue> valueContents);
     internal delegate bool MethodMatcher(string methodName, ImmutableArray<IArgumentOperation> arguments);
-    internal delegate bool ParameterMatcher(IParameterSymbol parameter);
+    internal delegate bool ParameterMatcher(IParameterSymbol parameter, WellKnownTypeProvider wellKnownTypeProvider);
 
     /// <summary>
     /// Info for tainted data sources, which generate tainted data.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -181,11 +181,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
             protected override TaintedDataAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, TaintedDataAbstractValue defaultValue)
             {
-                // If the property reference itself is a tainted data source
+                // If the property or parameter reference itself is a tainted data source
                 if (operation is IPropertyReferenceOperation propertyReferenceOperation
                     && this.DataFlowAnalysisContext.SourceInfos.IsSourceProperty(propertyReferenceOperation.Property))
                 {
                     return TaintedDataAbstractValue.CreateTainted(propertyReferenceOperation.Member, propertyReferenceOperation.Syntax, this.OwningSymbol);
+                }
+                else if (operation is IParameterReferenceOperation parameterReferenceOperation
+                    && this.DataFlowAnalysisContext.SourceInfos.IsSourceParameter(parameterReferenceOperation.Parameter))
+                {
+                    return TaintedDataAbstractValue.CreateTainted(parameterReferenceOperation.Parameter, parameterReferenceOperation.Syntax, this.OwningSymbol);
                 }
 
                 if (AnalysisEntityFactory.TryCreate(operation, out AnalysisEntity? analysisEntity))

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -188,7 +188,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                     return TaintedDataAbstractValue.CreateTainted(propertyReferenceOperation.Member, propertyReferenceOperation.Syntax, this.OwningSymbol);
                 }
                 else if (operation is IParameterReferenceOperation parameterReferenceOperation
-                    && this.DataFlowAnalysisContext.SourceInfos.IsSourceParameter(parameterReferenceOperation.Parameter))
+                    && this.DataFlowAnalysisContext.SourceInfos.IsSourceParameter(parameterReferenceOperation.Parameter, WellKnownTypeProvider))
                 {
                     return TaintedDataAbstractValue.CreateTainted(parameterReferenceOperation.Parameter, parameterReferenceOperation.Syntax, this.OwningSymbol);
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
@@ -33,6 +33,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
             foreach (TInfo info in taintedDataInfos)
             {
+                if (info.FullDependencyTypeName != null
+                    && !wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(info.FullDependencyTypeName, out INamedTypeSymbol? _))
+                {
+                    continue;
+                }
+
                 if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(info.FullTypeName, out INamedTypeSymbol? namedTypeSymbol))
                 {
                     if (info.IsInterface)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
@@ -33,8 +33,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
             foreach (TInfo info in taintedDataInfos)
             {
-                if (info.FullDependencyTypeName != null
-                    && !wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(info.FullDependencyTypeName, out INamedTypeSymbol? _))
+                if (info.DependencyFullTypeName != null
+                    && !wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(info.DependencyFullTypeName, out INamedTypeSymbol? _))
                 {
                     continue;
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
@@ -131,6 +131,24 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         }
 
         /// <summary>
+        /// Determines if the given parameter is a tainted data source.
+        /// </summary>
+        /// <param name="sourceSymbolMap"></param>
+        /// <param name="parameterSymbol"></param>
+        /// <returns></returns>
+        public static bool IsSourceParameter(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IParameterSymbol parameterSymbol)
+        {
+            ISymbol containingSymbol = parameterSymbol.ContainingSymbol;
+            foreach (SourceInfo sourceInfo in sourceSymbolMap.GetInfosForType(containingSymbol.ContainingType))
+            {
+                if (sourceInfo.TaintedArguments.Any(match => match(parameterSymbol)))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Determines if the given array can be a tainted data source when its elements are all constant.
         /// </summary>
         /// <param name="sourceSymbolMap"></param>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
@@ -136,13 +136,15 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <param name="sourceSymbolMap"></param>
         /// <param name="parameterSymbol"></param>
         /// <returns></returns>
-        public static bool IsSourceParameter(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IParameterSymbol parameterSymbol)
+        public static bool IsSourceParameter(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IParameterSymbol parameterSymbol, WellKnownTypeProvider wellKnownTypeProvider)
         {
             ISymbol containingSymbol = parameterSymbol.ContainingSymbol;
             foreach (SourceInfo sourceInfo in sourceSymbolMap.GetInfosForType(containingSymbol.ContainingType))
             {
-                if (sourceInfo.TaintedArguments.Any(match => match(parameterSymbol)))
+                if (sourceInfo.TaintedArguments.Any(match => match(parameterSymbol, wellKnownTypeProvider)))
+                {
                     return true;
+                }
             }
 
             return false;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities.Extensions;
@@ -15,6 +16,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         public static ImmutableHashSet<SourceInfo> SourceInfos { get; }
 
+        private static readonly BoundedCacheWithFactory<Compilation, ConcurrentDictionary<ISymbol, bool>> s_sourceArgumentCacheByCompilation = new BoundedCacheWithFactory<Compilation, ConcurrentDictionary<ISymbol, bool>>();
+
         /// <summary>
         /// Statically constructs.
         /// </summary>
@@ -23,12 +26,20 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             var sourceInfosBuilder = PooledHashSet<SourceInfo>.GetInstance();
 
             sourceInfosBuilder.AddSourceInfo(
-                WellKnownTypeNames.SystemObject,
+                WellKnownTypeNames.MicrosoftAspNetCoreMvcControllerBase,
+                WellKnownTypeNames.SystemObject, // checking all System.Object derived types is expensive, so it first check if MicrosoftAspNetCoreMvcControllerBase is resolvable
                  new ParameterMatcher[]{
                     (parameter, wellKnownTypeProvider) => {
+                        // it can be expensive to do all the machinery on every parameter reference access
+                        // since it ultimately boils down to if the method is an Action, we cache the containing symbol
+                        var cache = s_sourceArgumentCacheByCompilation.GetOrCreateValue(wellKnownTypeProvider.Compilation, (compilation) => new ConcurrentDictionary<ISymbol, bool>());
+                        if (cache.TryGetValue(parameter.ContainingSymbol, out bool ret))
+                            return ret;
+
                         if (!(parameter.ContainingSymbol is IMethodSymbol containingSymbol)
                             || !(containingSymbol.ContainingSymbol is INamedTypeSymbol typeSymbol))
                         {
+                            cache.TryAdd(parameter.ContainingSymbol, false);
                             return false;
                         }
 
@@ -36,6 +47,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                             && (!wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcControllerAttribute, out var controllerAttributeTypeSymbol)
                                 || !typeSymbol.HasDerivedTypeAttribute(controllerAttributeTypeSymbol)))
                         {
+                            cache.TryAdd(parameter.ContainingSymbol, false);
                             return false;
                         }
 
@@ -47,9 +59,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                             || !wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcNonControllerAttribute, out var nonControllerAttributeTypeSymbol)
                             || typeSymbol.HasDerivedTypeAttribute(nonControllerAttributeTypeSymbol))
                         {
+                            cache.TryAdd(parameter.ContainingSymbol, false);
                             return false;
                         }
 
+                        cache.TryAdd(parameter.ContainingSymbol, true);
                         return true;
                     }
                  });

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
+using Microsoft.CodeAnalysis;
 
 namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 {
@@ -19,6 +21,21 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         {
             var sourceInfosBuilder = PooledHashSet<SourceInfo>.GetInstance();
 
+            sourceInfosBuilder.AddSourceInfo(
+                WellKnownTypeNames.MicrosoftAspNetCoreMvcControllerBase,
+                 new ParameterMatcher[]{
+                    (parameter) => {
+                        ISymbol containingSymbol = parameter.ContainingSymbol;
+
+                        if (containingSymbol.DeclaredAccessibility != Accessibility.Public)
+                            return false;
+
+                        if (containingSymbol.IsConstructor())
+                            return false;
+
+                        return true;
+                    }
+                 });
             sourceInfosBuilder.AddSourceInfo(
                 WellKnownTypeNames.SystemWebHttpCookie,
                 isInterface: false,


### PR DESCRIPTION
This pull request allows tainting method arguments itself that is a common case in MVC pattern, like:
```cs
public class MyController : Controller
{
    public string DoSomething(string input) // << input is tainted argument
    {
        new SqlCommand(input);
        return null;
    }
}
```