### PR TITLE
Fix false positive for PointsToAnalysisKind.PartialWithoutTrackingFie…

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/DefaultPointsToValueGenerator.cs
@@ -35,16 +35,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 {
                     return PointsToAbstractValue.NoLocation;
                 }
-                else if (analysisEntity.HasUnknownInstanceLocation ||
-                    PointsToAnalysisKind != PointsToAnalysisKind.Complete &&
-                    analysisEntity.IsChildOrInstanceMemberNeedingCompletePointsToAnalysis())
+                else if (analysisEntity.HasUnknownInstanceLocation)
                 {
                     return PointsToAbstractValue.Unknown;
                 }
 
                 value = PointsToAbstractValue.Create(AbstractLocation.CreateAnalysisEntityDefaultLocation(analysisEntity), mayBeNull: true);
-                _trackedEntitiesBuilder.AddEntityAndPointsToValue(analysisEntity, value);
-                _defaultPointsToValueMapBuilder.Add(analysisEntity, value);
+
+                // PERF: Do not track entity and its points to value for partial analysis for entities requiring complete analysis.
+                if (PointsToAnalysisKind == PointsToAnalysisKind.Complete ||
+                    !analysisEntity.IsChildOrInstanceMemberNeedingCompletePointsToAnalysis())
+                {
+                    _trackedEntitiesBuilder.AddEntityAndPointsToValue(analysisEntity, value);
+                    _defaultPointsToValueMapBuilder.Add(analysisEntity, value);
+                }
             }
 
             return value;


### PR DESCRIPTION
…ldsAndProperties

Fixes #3873
This regressed with my recent change to add PointsToAnalysisKind for partial analysis support. We no longer track points to values for fields and properties for `PointsToAnalysisKind.PartialWithoutTrackingFieldsAndProperties`. However, we should still use the default points to value for such entities for the analysis, instead of unknown points to value to ensure that merging values coming from tracked and untracked entities is correct