### PR TITLE
CA2012 change severity from Hidden to Info

### DIFF
--- a/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
+++ b/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
@@ -24,7 +24,7 @@ CA1836 | Performance | Info | PreferIsEmptyOverCountAnalyzer, [Documentation](ht
 CA1837 | Performance | Info | UseEnvironmentProcessId, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca1837)
 CA1838 | Performance | Hidden | AvoidStringBuilderPInvokeParametersAnalyzer, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca1838)
 CA2011 | Reliability | Info | AvoidInfiniteRecursion, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2011)
-CA2012 | Reliability | Hidden | UseValueTasksCorrectlyAnalyzer, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2012)
+CA2012 | Reliability | Info | UseValueTasksCorrectlyAnalyzer, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2012)
 CA2013 | Reliability | Warning | DoNotUseReferenceEqualsWithValueTypesAnalyzer, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2013)
 CA2014 | Reliability | Warning | DoNotUseStackallocInLoopsAnalyzer, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2014)
 CA2015 | Reliability | Warning | DoNotDefineFinalizersForTypesDerivedFromMemoryManager, [Documentation](https://docs.microsoft.com/visualstudio/code-quality/ca2015)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             s_localizableTitle,
             new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValueTasksCorrectlyMessage_General), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources)),
             DiagnosticCategory.Reliability,
-            RuleLevel.IdeHidden_BulkConfigurable,
+            RuleLevel.IdeSuggestion,
             s_localizableDescription,
             isPortedFxCopRule: false,
             isDataflowRule: false);
@@ -37,7 +37,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             s_localizableTitle,
             new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValueTasksCorrectlyMessage_Unconsumed), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources)),
             DiagnosticCategory.Reliability,
-            RuleLevel.IdeHidden_BulkConfigurable,
+            RuleLevel.IdeSuggestion,
             s_localizableDescription,
             isPortedFxCopRule: false,
             isDataflowRule: false);
@@ -46,7 +46,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             s_localizableTitle,
             new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValueTasksCorrectlyMessage_DoubleConsumption), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources)),
             DiagnosticCategory.Reliability,
-            RuleLevel.IdeHidden_BulkConfigurable,
+            RuleLevel.IdeSuggestion,
             s_localizableDescription,
             isPortedFxCopRule: false,
             isDataflowRule: false);
@@ -55,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             s_localizableTitle,
             new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValueTasksCorrectlyMessage_AccessingIncompleteResult), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources)),
             DiagnosticCategory.Reliability,
-            RuleLevel.IdeHidden_BulkConfigurable,
+            RuleLevel.IdeSuggestion,
             s_localizableDescription,
             isPortedFxCopRule: false,
             isDataflowRule: false);


### PR DESCRIPTION
As requested by @stephentoub, this rule was initially merged with severity Hidden and we want it to be Info instead.