### PR TITLE
Add support for threading MSBuild item metadata to analyzer options

### DIFF
--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -10,6 +10,7 @@
     <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />
     <Compile Include="..\..\Utilities\Compiler\Debug.cs" Link="Debug.cs" />
     <Compile Include="..\..\Utilities\Compiler\Extensions\PooledHashSetExtensions.cs" Link="PooledHashSetExtensions.cs" />
+    <Compile Include="..\..\Utilities\Compiler\Options\MSBuildItemOptionNames.cs" Link="MSBuildItemOptionNames.cs" />
     <Compile Include="..\..\Utilities\Compiler\Options\MSBuildPropertyOptionNames.cs" Link="MSBuildPropertyOptionNames.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ArrayBuilder.cs" Link="ArrayBuilder.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ArrayBuilder.Enumerator.cs" Link="ArrayBuilder.Enumerator.cs" />

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -324,13 +324,14 @@ $@"<Project>{GetCommonContents(packageName)}{GetPackageSpecificContents(packageN
             File.WriteAllText(fileWithPath, fileContents);
 
             static string GetCommonContents(string packageName)
-                => GetGlobalAnalyzerConfigTargetContents(packageName) + GetMSBuildPropertyOptionItemGroup();
+                => GetGlobalAnalyzerConfigTargetContents(packageName) + GetMSBuildContentForPropertyAndItemOptions();
 
             static string GetGlobalAnalyzerConfigTargetContents(string packageName)
             {
-                string packageVersionPropName = packageName.Replace(".", string.Empty, StringComparison.Ordinal) + "RulesVersion";
+                var trimmedPackageName = packageName.Replace(".", string.Empty, StringComparison.Ordinal);
+                string packageVersionPropName = trimmedPackageName + "RulesVersion";
                 return $@"
-  <Target Name=""AddGlobalAnalyzerConfigForPackage"" BeforeTargets=""CoreCompile"" Condition=""'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'"">
+  <Target Name=""AddGlobalAnalyzerConfigForPackage_{trimmedPackageName}"" BeforeTargets=""CoreCompile"" Condition=""'$(SkipGlobalAnalyzerConfigForPackage)' != 'true'"">
     <!-- PropertyGroup to compute global analyzer config file to be used -->
     <PropertyGroup>
       <!-- GlobalAnalyzerConfig folder name based on user specified package version '{packageVersionPropName}', if any. We replace '.' with '_' to map the version string to file name suffix. -->
@@ -347,22 +348,67 @@ $@"<Project>{GetCommonContents(packageName)}{GetPackageSpecificContents(packageN
 ";
             }
 
-            static string GetMSBuildPropertyOptionItemGroup()
+            static string GetMSBuildContentForPropertyAndItemOptions()
             {
                 var builder = new StringBuilder();
 
-                builder.Append($@"
-  <!-- MSBuild properties to thread to the analyzers as options --> 
-  <ItemGroup>
-");
-                foreach (var field in typeof(MSBuildPropertyOptionNames).GetFields())
-                {
-                    builder.AppendLine($@"    <CompilerVisibleProperty Include=""{field.Name}"" />");
-                }
-
-                builder.AppendLine($@"  </ItemGroup>");
+                AddMSBuildContentForPropertyOptions(builder);
+                AddMSBuildContentForItemOptions(builder);
 
                 return builder.ToString();
+
+                static void AddMSBuildContentForPropertyOptions(StringBuilder builder)
+                {
+                    var compilerVisibleProperties = new List<string>();
+                    foreach (var field in typeof(MSBuildPropertyOptionNames).GetFields())
+                    {
+                        compilerVisibleProperties.Add(field.Name);
+                    }
+
+                    // Add ItemGroup for MSBuild property names that are required to be threaded as analyzer config options.
+                    AddItemGroupForCompilerVisibleProperties(compilerVisibleProperties, builder);
+                }
+
+                static void AddItemGroupForCompilerVisibleProperties(List<string> compilerVisibleProperties, StringBuilder builder)
+                {
+                    builder.AppendLine($@"
+  <!-- MSBuild properties to thread to the analyzers as options --> 
+  <ItemGroup>");
+                    foreach (var compilerVisibleProperty in compilerVisibleProperties)
+                    {
+                        builder.AppendLine($@"    <CompilerVisibleProperty Include=""{compilerVisibleProperty}"" />");
+                    }
+
+                    builder.AppendLine($@"  </ItemGroup>");
+                }
+
+                static void AddMSBuildContentForItemOptions(StringBuilder builder)
+                {
+                    // Add ItemGroup and PropertyGroup for MSBuild item names that are required to be threaded as analyzer config options.
+                    // The analyzer config option will have the following key/value:
+                    // - Key: Item name prefixed with an '_' and suffixed with a 'List' to reduce chances of conflicts with any existing project property.
+                    // - Value: Concatenated item metadata values, separate by a ';' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
+
+                    builder.Append($@"
+  <!-- MSBuild item metadata to thread to the analyzers as options -->
+  <PropertyGroup>
+");
+                    var compilerVisibleProperties = new List<string>();
+                    foreach (var field in typeof(MSBuildItemOptionNames).GetFields())
+                    {
+                        // Item option name: "SupportedPlatform"
+                        // Generated MSBuild property: "<_SupportedPlatformList>@(SupportedPlatform, '<separator>')</_SupportedPlatformList>"
+
+                        var itemOptionName = field.Name;
+                        var propertyName = MSBuildItemOptionNamesHelpers.GetPropertyNameForItemOptionName(itemOptionName);
+                        compilerVisibleProperties.Add(propertyName);
+                        builder.AppendLine($@"    <{propertyName}>@({itemOptionName}, '{MSBuildItemOptionNamesHelpers.ValuesSeparator}')</{propertyName}>");
+                    }
+
+                    builder.AppendLine($@"  </PropertyGroup>");
+
+                    AddItemGroupForCompilerVisibleProperties(compilerVisibleProperties, builder);
+                }
             }
 
             static string GetPackageSpecificContents(string packageName)

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -384,10 +384,10 @@ $@"<Project>{GetCommonContents(packageName)}{GetPackageSpecificContents(packageN
 
                 static void AddMSBuildContentForItemOptions(StringBuilder builder)
                 {
-                    // Add ItemGroup and PropertyGroup for MSBuild item names that are required to be threaded as analyzer config options.
+                    // Add ItemGroup and PropertyGroup for MSBuild item names that are required to be treated as analyzer config options.
                     // The analyzer config option will have the following key/value:
                     // - Key: Item name prefixed with an '_' and suffixed with a 'List' to reduce chances of conflicts with any existing project property.
-                    // - Value: Concatenated item metadata values, separate by a ';' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
+                    // - Value: Concatenated item metadata values, separated by a ',' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
 
                     builder.Append($@"
   <!-- MSBuild item metadata to thread to the analyzers as options -->

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\NullableContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\NullableContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\SemanticModelExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\MSBuildItemOptionNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\OptionKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\MSBuildPropertyOptionNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\SyntaxTreeCategorizedAnalyzerConfigOptions.cs" />

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -508,6 +508,8 @@ namespace Analyzer.Utilities
             Compilation compilation,
             CancellationToken cancellationToken)
         {
+            MSBuildPropertyOptionNamesHelpers.VerifySupportedPropertyOptionName(optionName);
+
             // MSBuild property values should be set at compilation level, and cannot have different values per-tree.
             // So, we default to first syntax tree.
             if (!(compilation.SyntaxTrees.FirstOrDefault() is { } tree))
@@ -519,6 +521,29 @@ namespace Analyzer.Utilities
             return analyzerConfigOptions.GetOptionValue(optionName, tree, rule: null,
                 tryParseValue: (string value, out string? result) => { result = value; return true; },
                 defaultValue: null, OptionKind.BuildProperty);
+        }
+
+        public static ImmutableArray<string> GetMSBuildItemMetadataValues(
+            this AnalyzerOptions options,
+            string itemOptionName,
+            Compilation compilation,
+            CancellationToken cancellationToken)
+        {
+            MSBuildItemOptionNamesHelpers.VerifySupportedItemOptionName(itemOptionName);
+
+            // MSBuild property values should be set at compilation level, and cannot have different values per-tree.
+            // So, we default to first syntax tree.
+            if (!(compilation.SyntaxTrees.FirstOrDefault() is { } tree))
+            {
+                return ImmutableArray<string>.Empty;
+            }
+
+            var propertyOptionName = MSBuildItemOptionNamesHelpers.GetPropertyNameForItemOptionName(itemOptionName);
+            var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
+            var propertyValue = analyzerConfigOptions.GetOptionValue(propertyOptionName, tree, rule: null,
+                tryParseValue: (string value, out string? result) => { result = value; return true; },
+                defaultValue: null, OptionKind.BuildProperty);
+            return MSBuildItemOptionNamesHelpers.ParseItemOptionValue(propertyValue);
         }
 
 #pragma warning disable CA1801 // Review unused parameters - 'compilation' is used conditionally.

--- a/src/Utilities/Compiler/Options/MSBuildItemOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildItemOptionNames.cs
@@ -14,7 +14,7 @@ namespace Analyzer.Utilities
     /// MSBuild item names that are required to be threaded as analyzer config options.
     /// The analyzer config option will have the following key/value:
     /// - Key: Item name prefixed with an '_' and suffixed with a 'List' to reduce chances of conflicts with any existing project property.
-    /// - Value: Concatenated item metadata values, separate by a ';' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
+    /// - Value: Concatenated item metadata values, separated by a ',' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
     /// </summary>
     internal static class MSBuildItemOptionNames
     {

--- a/src/Utilities/Compiler/Options/MSBuildItemOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildItemOptionNames.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+#if CODEANALYSIS_V3_OR_BETTER
+using System.Linq;
+#endif
+
+namespace Analyzer.Utilities
+{
+    /// <summary>
+    /// MSBuild item names that are required to be threaded as analyzer config options.
+    /// The analyzer config option will have the following key/value:
+    /// - Key: Item name prefixed with an '_' and suffixed with a 'List' to reduce chances of conflicts with any existing project property.
+    /// - Value: Concatenated item metadata values, separate by a ';' character. See https://github.com/dotnet/sdk/issues/12706#issuecomment-668219422 for details.
+    /// </summary>
+    internal static class MSBuildItemOptionNames
+    {
+        public const string SupportedPlatform = nameof(SupportedPlatform);
+    }
+
+    internal static class MSBuildItemOptionNamesHelpers
+    {
+        public const char ValuesSeparator = ',';
+        private static readonly char[] s_itemMetadataValuesSeparators = new[] { ValuesSeparator };
+
+        public static string GetPropertyNameForItemOptionName(string itemOptionName)
+        {
+            VerifySupportedItemOptionName(itemOptionName);
+            return $"_{itemOptionName}List";
+        }
+
+        [Conditional("DEBUG")]
+        public static void VerifySupportedItemOptionName(string itemOptionName)
+        {
+#if CODEANALYSIS_V3_OR_BETTER
+            Debug.Assert(typeof(MSBuildItemOptionNames).GetFields().Single(f => f.Name == itemOptionName) != null);
+#endif
+        }
+
+        public static ImmutableArray<string> ParseItemOptionValue(string? itemOptionValue)
+        {
+            if (itemOptionValue == null)
+            {
+                return ImmutableArray<string>.Empty;
+            }
+
+            return itemOptionValue.Split(s_itemMetadataValuesSeparators, StringSplitOptions.RemoveEmptyEntries).ToImmutableArray();
+        }
+    }
+}

--- a/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
@@ -1,5 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
+
+#if CODEANALYSIS_V3_OR_BETTER
+using System.Linq;
+#endif
+
 namespace Analyzer.Utilities
 {
     /// <summary>
@@ -13,5 +19,16 @@ namespace Analyzer.Utilities
         public const string ProjectTypeGuids = nameof(ProjectTypeGuids);
         public const string PublishSingleFile = nameof(PublishSingleFile);
         public const string IncludeAllContentForSelfExtract = nameof(IncludeAllContentForSelfExtract);
+    }
+
+    internal static class MSBuildPropertyOptionNamesHelpers
+    {
+        [Conditional("DEBUG")]
+        public static void VerifySupportedPropertyOptionName(string propertyOptionName)
+        {
+#if CODEANALYSIS_V3_OR_BETTER
+            Debug.Assert(typeof(MSBuildPropertyOptionNames).GetFields().Single(f => f.Name == propertyOptionName) != null);
+#endif
+        }
     }
 }


### PR DESCRIPTION
Addresses analyzer part of https://github.com/dotnet/sdk/issues/12706
Adds support for platform compat check analyzer to be able to read `SupportedPlatform` items.

Analyzers should invoke `context.Options.GetMSBuildItemMetadataValues` extension method to query this option.

## User project file
![image](https://user-images.githubusercontent.com/10605811/89332033-90e26680-d647-11ea-86b9-10987d7ec77a.png)

## Analyzer options with item metadata
![image](https://user-images.githubusercontent.com/10605811/89332219-def76a00-d647-11ea-974a-dcff7193168e.png)

