### PR TITLE
Support sanitizers that write the sanitized value into output parameter

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
@@ -3253,5 +3253,25 @@ namespace TestNamespace
     }
 }");
         }
+
+        [Fact]
+        public async Task HttpServerUtility_HtmlEncode_StringWriterOverload_WrongSanitizer()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultForTaintedDataAnalysis,
+                TestState =
+                {
+                    Sources =
+                    {
+                        SharedCode.WrongSanitizer,
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(16, 33, 11, 24, "SqlCommand.SqlCommand(string cmdText)", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)")
+                    },
+                },
+            }.RunAsync();
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForXssVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForXssVulnerabilitiesTests.cs
@@ -213,5 +213,55 @@ public partial class WebForm : System.Web.UI.Page
                 },
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task HttpServerUtility_HtmlEncode_StringWriterOverload_NoDiagnostic()
+        {
+            const string code = @"
+using System;
+using System.Data.SqlClient;
+using System.IO;
+using System.Web;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        StringWriter w = new StringWriter();
+        Server.HtmlEncode(input, w);
+        Response.Write(""<HTML>"" + w.ToString() + ""</HTML>"");
+        // make sure it is not like any unknown method breaks the taint path, it should warn about sql injection
+        SqlCommand sqlCommand = new SqlCommand(w.ToString());
+    }
+}";
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultForTaintedDataAnalysis,
+                TestState =
+                {
+                    Sources =
+                    {
+                        code,
+                    }
+                },
+            }.RunAsync();
+
+            await new CSharpSecurityCodeFixVerifier<Microsoft.NetCore.Analyzers.Security.ReviewCodeForSqlInjectionVulnerabilities, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultForTaintedDataAnalysis,
+                TestState =
+                {
+                    Sources =
+                    {
+                        code,
+                    },
+                    ExpectedDiagnostics =
+                    {
+                        GetCSharpResultAt(16, 33, 11, 24, "SqlCommand.SqlCommand(string cmdText)", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)", ReviewCodeForSqlInjectionVulnerabilities.Rule)
+                    },
+                },
+            }.RunAsync();
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/TaintedDataAnalyzerTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/TaintedDataAnalyzerTestBase.cs
@@ -21,9 +21,9 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 
         protected virtual IEnumerable<string> AdditionalVisualBasicSources { get; }
 
-        protected DiagnosticResult GetCSharpResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod)
+        protected DiagnosticResult GetCSharpResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod, DiagnosticDescriptor rule = null)
         {
-            return new DiagnosticResult(Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
+            return new DiagnosticResult(rule ?? Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
                 .WithLocation(sinkLine, sinkColumn)
                 .WithLocation(sourceLine, sourceColumn);
         }
@@ -72,9 +72,9 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
             await test.RunAsync();
         }
 
-        protected DiagnosticResult GetBasicResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod)
+        protected DiagnosticResult GetBasicResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod, DiagnosticDescriptor rule = null)
         {
-            return new DiagnosticResult(Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
+            return new DiagnosticResult(rule ?? Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
                 .WithLocation(sinkLine, sinkColumn)
                 .WithLocation(sourceLine, sourceColumn);
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/TaintedDataAnalyzerTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/TaintedDataAnalyzerTestBase.cs
@@ -21,9 +21,9 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 
         protected virtual IEnumerable<string> AdditionalVisualBasicSources { get; }
 
-        protected DiagnosticResult GetCSharpResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod, DiagnosticDescriptor rule = null)
+        protected DiagnosticResult GetCSharpResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod)
         {
-            return new DiagnosticResult(rule ?? Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
+            return new DiagnosticResult(Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
                 .WithLocation(sinkLine, sinkColumn)
                 .WithLocation(sourceLine, sourceColumn);
         }
@@ -72,9 +72,9 @@ namespace Microsoft.NetCore.Analyzers.Security.UnitTests
             await test.RunAsync();
         }
 
-        protected DiagnosticResult GetBasicResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod, DiagnosticDescriptor rule = null)
+        protected DiagnosticResult GetBasicResultAt(int sinkLine, int sinkColumn, int sourceLine, int sourceColumn, string sink, string sinkContainingMethod, string source, string sourceContainingMethod)
         {
-            return new DiagnosticResult(rule ?? Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
+            return new DiagnosticResult(Rule).WithArguments(sink, sinkContainingMethod, source, sourceContainingMethod)
                 .WithLocation(sinkLine, sinkColumn)
                 .WithLocation(sourceLine, sourceColumn);
         }

--- a/src/Test.Utilities/SharedTestCode.cs
+++ b/src/Test.Utilities/SharedTestCode.cs
@@ -1,4 +1,6 @@
-﻿namespace Test.Utilities
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Test.Utilities
 {
     public static class SharedCode
     {

--- a/src/Test.Utilities/SharedTestCode.cs
+++ b/src/Test.Utilities/SharedTestCode.cs
@@ -1,0 +1,25 @@
+﻿namespace Test.Utilities
+{
+    public static class SharedCode
+    {
+        public const string WrongSanitizer = @"
+using System;
+using System.Data.SqlClient;
+using System.IO;
+using System.Web;
+
+public partial class WebForm : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string input = Request.Form[""in""];
+        StringWriter w = new StringWriter();
+        Server.HtmlEncode(input, w);
+        Response.Write(""<HTML>"" + w.ToString() + ""</HTML>"");
+        // make sure it is not like any unknown method breaks the taint path, it should warn about sql injection
+        SqlCommand sqlCommand = new SqlCommand(w.ToString());
+    }
+}
+";
+    }
+}

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/PooledHashSetExtensions.cs
@@ -205,8 +205,41 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 fullTypeName,
                 isInterface: isInterface,
                 isConstructorSanitizing: isConstructorSanitizing,
-                sanitizingMethods: sanitizingMethods?.ToImmutableHashSet(StringComparer.Ordinal)
-                    ?? ImmutableHashSet<string>.Empty,
+                sanitizingMethods:
+                    sanitizingMethods
+                        ?.Select<string, (MethodMatcher, ImmutableHashSet<(string, string)>)>(o =>
+                            (
+                                (methodName, arguments) => methodName == o,
+                                ImmutableHashSet<(string, string)>.Empty))
+                        ?.ToImmutableHashSet()
+                    ?? ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)>.Empty,
+                sanitizingInstanceMethods: sanitizingInstanceMethods?.ToImmutableHashSet(StringComparer.Ordinal)
+                    ?? ImmutableHashSet<string>.Empty);
+            builder.Add(info);
+        }
+
+        public static void AddSanitizerInfo(
+            this PooledHashSet<SanitizerInfo> builder,
+            string fullTypeName,
+            bool isInterface,
+            bool isConstructorSanitizing,
+            IEnumerable<(MethodMatcher methodMatcher, (string str, string sanitizedTargets)[] taintedArgumentToSanized)>? sanitizingMethods,
+            string[]? sanitizingInstanceMethods = null)
+        {
+            SanitizerInfo info = new SanitizerInfo(
+                fullTypeName,
+                isInterface: isInterface,
+                isConstructorSanitizing: isConstructorSanitizing,
+                sanitizingMethods:
+                    sanitizingMethods
+                        ?.Select(o =>
+                            (
+                                o.methodMatcher,
+                                o.taintedArgumentToSanized
+                                    ?.ToImmutableHashSet()
+                                ?? ImmutableHashSet<(string, string)>.Empty))
+                        ?.ToImmutableHashSet()
+                    ?? ImmutableHashSet<(MethodMatcher, ImmutableHashSet<(string, string)>)>.Empty,
                 sanitizingInstanceMethods: sanitizingInstanceMethods?.ToImmutableHashSet(StringComparer.Ordinal)
                     ?? ImmutableHashSet<string>.Empty);
             builder.Add(info);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -11,7 +11,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
     /// </summary>
     internal sealed class SanitizerInfo : ITaintedDataInfo, IEquatable<SanitizerInfo>
     {
-        public SanitizerInfo(string fullTypeName, bool isInterface, bool isConstructorSanitizing, ImmutableHashSet<string> sanitizingMethods, ImmutableHashSet<string> sanitizingInstanceMethods)
+        public SanitizerInfo(
+            string fullTypeName,
+            bool isInterface,
+            bool isConstructorSanitizing,
+            ImmutableHashSet<(MethodMatcher methodMatcher, ImmutableHashSet<(string IfTaintedParameter, string ThenUnTaintedTarget)>)> sanitizingMethods,
+            ImmutableHashSet<string> sanitizingInstanceMethods)
         {
             FullTypeName = fullTypeName ?? throw new ArgumentNullException(nameof(fullTypeName));
             IsInterface = isInterface;
@@ -38,7 +43,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Methods that untaint tainted data.
         /// </summary>
-        public ImmutableHashSet<string> SanitizingMethods { get; }
+        public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(string IfTaintedParameter, string ThenUnTaintedTarget)>)> SanitizingMethods { get; }
 
         /// <summary>
         /// Methods that untaint tainted instance.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -43,6 +43,20 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Methods that untaint tainted data.
         /// </summary>
+        /// <remarks>
+        /// MethodMatcher determines if the outermost tuple applies, based on the method names and arguments.
+        /// (IfTaintedParameter, ThenUnTaintedTarget) determines if the ThenUnTaintedTarget is untainted, based on if the IfTaintedParameter is tainted.
+        ///
+        /// Example:
+        /// (
+        ///   (methodName, argumentOperations) => methodName == "Bar",  // MethodMatcher
+        ///   {
+        ///      ("a", "b")
+        ///   }
+        /// )
+        ///
+        /// will treat the parameter "b" as untainted when parameter "a" is tainted of the "Bar" method.
+        /// </remarks>
         public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(string IfTaintedParameter, string ThenUnTaintedTarget)>)> SanitizingMethods { get; }
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -316,7 +316,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                         }
                         else
                         {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+                            // sanitizedParameterPairs is not null when isSanitizingMethod is true as per IsSanitizingMethod declaration
                             foreach ((string ifTaintedParameter, string thenSanitizedTarget) in sanitizedParameterPairs)
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
                             {
                                 if (thenSanitizedTarget == TaintedTargetValue.Return)
                                 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -242,7 +242,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                             .Where(s => this.GetCachedAbstractValue(s).Kind == TaintedDataAbstractValueKind.Tainted)
                             .Select(s => s.Parameter.Name);
 
-                    var taintedParameterNamesCached = taintedParameterNames.ToImmutableArray();
+                    PooledHashSet<string> taintedParameterNamesCached = PooledHashSet<string>.GetInstance();
+                    if (taintedParameterNames != null)
+                        taintedParameterNamesCached.UnionWith(taintedParameterNames);
 
                     if (this.IsSanitizingMethod(
                         method,
@@ -288,7 +290,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                         }
 
                         if (rebuildTaintedParameterNames)
-                            taintedParameterNamesCached = taintedParameterNames.ToImmutableArray();
+                        {
+                            taintedParameterNamesCached.Clear();
+                            taintedParameterNamesCached.UnionWith(taintedParameterNames);
+                        }
                     }
 
                     if (this.DataFlowAnalysisContext.SourceInfos.IsSourceTransferMethod(
@@ -542,7 +547,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             private bool IsSanitizingMethod(
                 IMethodSymbol method,
                 ImmutableArray<IArgumentOperation> arguments,
-                ImmutableArray<string> taintedParameterNames,
+                ISet<string> taintedParameterNames,
                 [NotNullWhen(returnValue: true)] out PooledHashSet<(string, string)>? taintedParameterPairs)
             {
                 taintedParameterPairs = null;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -543,7 +543,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             /// Determines if the instance method call returns tainted data.
             /// </summary>
             /// <param name="method">Instance method being called.</param>
-            /// <returns>True if the method returns tainted data, false otherwise.</returns>
+            /// <param name="arguments">Arguments passed to the method.</param>
+            /// <param name="taintedParameterNames">Names of the tainted input parameters.</param>
+            /// <param name="taintedParameterPairs">Matched pairs of "tainted parameter name" to "sanitized parameter name".</param>
+            /// <returns>True if the method sanitizes data (returned or as an output parameter), false otherwise.</returns>
             private bool IsSanitizingMethod(
                 IMethodSymbol method,
                 ImmutableArray<IArgumentOperation> arguments,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -236,13 +236,14 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 PooledHashSet<string>? taintedTargets = null;
                 PooledHashSet<(string, string)>? taintedParameterPairs = null;
                 PooledHashSet<(string, string)>? sanitizedParameterPairs = null;
+                PooledHashSet<string>? taintedParameterNamesCached = null;
                 try
                 {
                     var taintedParameterNames = visitedArguments
                             .Where(s => this.GetCachedAbstractValue(s).Kind == TaintedDataAbstractValueKind.Tainted)
                             .Select(s => s.Parameter.Name);
 
-                    PooledHashSet<string> taintedParameterNamesCached = PooledHashSet<string>.GetInstance();
+                    taintedParameterNamesCached = PooledHashSet<string>.GetInstance();
                     if (taintedParameterNames != null)
                         taintedParameterNamesCached.UnionWith(taintedParameterNames);
 
@@ -357,6 +358,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 {
                     taintedTargets?.Free();
                     taintedParameterPairs?.Free();
+                    sanitizedParameterPairs?.Free();
+                    taintedParameterNamesCached?.Free();
                 }
 
                 return result;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
@@ -164,7 +164,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap,
             IMethodSymbol method,
             ImmutableArray<IArgumentOperation> arguments,
-            ImmutableArray<string> taintedParameterNames,
+            ISet<string> taintedParameterNames,
             [NotNullWhen(returnValue: true)] out PooledHashSet<(string, string)>? taintedParameterPairs)
         {
             taintedParameterPairs = null;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -19,6 +19,23 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         {
             var sourceInfosBuilder = PooledHashSet<SourceInfo>.GetInstance();
 
+            sourceInfosBuilder.AddSourceInfoSpecifyingTaintedTargets(
+                WellKnownTypeNames.SystemWebHttpServerUtility,
+                isInterface: false,
+                taintedProperties: null,
+                taintedMethodsNeedsPointsToAnalysis: null,
+                taintedMethodsNeedsValueContentAnalysis: null,
+                transferMethods: new (MethodMatcher, (string, string)[])[]{
+                    (
+                        (methodName, arguments) =>
+                            methodName == "HtmlEncode" &&
+                            arguments.Count() == 2,
+                        new (string, string)[]{
+                            ("s", "output"),
+                        }
+                    )
+                });
+
             sourceInfosBuilder.AddSourceInfo(
                 WellKnownTypeNames.SystemWebHttpCookie,
                 isInterface: false,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XssSanitizers.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/XssSanitizers.cs
@@ -64,8 +64,15 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 WellKnownTypeNames.SystemWebHttpServerUtility,
                 isInterface: false,
                 isConstructorSanitizing: false,
-                sanitizingMethods: new[] {
-                    "HtmlEncode",
+                sanitizingMethods: new (MethodMatcher, (string taintedArgument, string sanitizedArgument)[])[] {
+                    (
+                        (methodName, arguments) => methodName == "HtmlEncode" && arguments.Length == 1,
+                        new[] { ("s", TaintedTargetValue.Return) }
+                    ),
+                    (
+                        (methodName, arguments) => methodName == "HtmlEncode" && arguments.Length == 2,
+                        new[] { ("s", "output") }
+                    ),
                 });
             builder.AddSanitizerInfo(
                 WellKnownTypeNames.SystemWebHttpServerUtilityBase,


### PR DESCRIPTION
This allows defining sanitizers like `void HtmlEncode (string s, System.IO.TextWriter output)` that is neither returning a value nor is an object constructor call.