### PR TITLE
Exclude non-code files from build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ pr:
     exclude:
       - docs/*
       - .github/*
+      - **/*.md
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,15 @@ trigger:
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:
-- master
-- 2.9.x
+  branches:
+    include:
+    - master
+    - 2.9.x
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
+      
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     exclude:
       - docs/*
       - .github/*
-      - **/*.md
+      - '**/*.md'
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ pr:
     exclude:
       - docs/*
       - .github/*
-      - *.md
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ pr:
     exclude:
       - docs/*
       - .github/*
+      - *.md
       
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ pr:
       - docs/*
       - .github/*
       - *.md
-      
 
 jobs:
 - job: Windows


### PR DESCRIPTION
The build was triggered on https://github.com/dotnet/roslyn-analyzers/pull/3597 while it doesn't touch any code files.

This should fix that.