### PR TITLE
Add option for public API analyzer to bail out on missing API files

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -6,6 +6,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
@@ -29,6 +31,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         internal const string InvalidReasonShippedCantHaveRemoved = "The shipped API file can't have removed members";
         internal const string InvalidReasonMisplacedNullableEnable = "The '#nullable enable' marker can only appear as the first line in the shipped API file";
         internal const string PublicApiIsShippedPropertyBagKey = "PublicAPIIsShipped";
+
+        /// <summary>
+        /// Boolean option to configure if public API analyzer should bail out silently if public API files are missing.
+        /// </summary>
+        private const string BailOnMissingPublicApiFilesEditorConfigOptionName = "dotnet_public_api_analyzer.require_api_files";
 
         internal static readonly DiagnosticDescriptor DeclareNewApiRule = new DiagnosticDescriptor(
             id: DiagnosticIds.DeclarePublicApiRuleId,
@@ -205,11 +212,10 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
-            var additionalFiles = compilationContext.Options.AdditionalFiles;
             var errors = new List<Diagnostic>();
 
             // Switch to "RegisterAdditionalFileAction" available in Microsoft.CodeAnalysis "3.8.x" to report additional file diagnostics: https://github.com/dotnet/roslyn-analyzers/issues/3918
-            if (!TryGetApiData(additionalFiles, errors, compilationContext.CancellationToken, out ApiData shippedData, out ApiData unshippedData) ||
+            if (!TryGetApiData(compilationContext.Options, compilationContext.Compilation, errors, compilationContext.CancellationToken, out ApiData shippedData, out ApiData unshippedData) ||
                 !ValidateApiFiles(shippedData, unshippedData, errors))
             {
                 compilationContext.RegisterCompilationEndAction(context =>
@@ -276,12 +282,20 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return new ApiData(apiBuilder.ToImmutable(), removedBuilder.ToImmutable(), maxNullableRank);
         }
 
-        private static bool TryGetApiData(ImmutableArray<AdditionalText> additionalTexts, List<Diagnostic> errors, CancellationToken cancellationToken, out ApiData shippedData, out ApiData unshippedData)
+        private static bool TryGetApiData(AnalyzerOptions analyzerOptions, Compilation compilation, List<Diagnostic> errors, CancellationToken cancellationToken, out ApiData shippedData, out ApiData unshippedData)
         {
-            if (!TryGetApiText(additionalTexts, cancellationToken, out var shippedText, out var unshippedText))
+            if (!TryGetApiText(analyzerOptions.AdditionalFiles, cancellationToken, out var shippedText, out var unshippedText))
             {
                 if (shippedText == null && unshippedText == null)
                 {
+                    if (TryGetEditorConfigOptionForMissingFiles(analyzerOptions, compilation, out var silentlyBailOutOnMissingApiFiles) &&
+                        silentlyBailOutOnMissingApiFiles)
+                    {
+                        shippedData = default;
+                        unshippedData = default;
+                        return false;
+                    }
+
                     // Bootstrapping public API files.
                     (shippedData, unshippedData) = (ApiData.Empty, ApiData.Empty);
                     return true;
@@ -297,6 +311,56 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             shippedData = ReadApiData(shippedText.Path, shippedText.GetText(cancellationToken), isShippedApi: true);
             unshippedData = ReadApiData(unshippedText.Path, unshippedText.GetText(cancellationToken), isShippedApi: false);
             return true;
+        }
+
+        private static bool TryGetEditorConfigOptionForMissingFiles(AnalyzerOptions analyzerOptions, Compilation compilation, out bool optionValue)
+        {
+            optionValue = false;
+            try
+            {
+                var provider = analyzerOptions.GetType().GetRuntimeProperty("AnalyzerConfigOptionsProvider")?.GetValue(analyzerOptions);
+                if (provider == null || !compilation.SyntaxTrees.Any())
+                {
+                    return false;
+                }
+
+                var getOptionsMethod = provider.GetType().GetRuntimeMethods().FirstOrDefault(m => m.Name == "GetOptions");
+                if (getOptionsMethod == null)
+                {
+                    return false;
+                }
+
+                var options = getOptionsMethod.Invoke(provider, new object[] { compilation.SyntaxTrees.First() });
+                var tryGetValueMethod = options.GetType().GetRuntimeMethods().FirstOrDefault(m => m.Name == "TryGetValue");
+                if (tryGetValueMethod == null)
+                {
+                    return false;
+                }
+
+                // bool TryGetValue(string key, out string value);
+                var parameters = new object?[] { BailOnMissingPublicApiFilesEditorConfigOptionName, null };
+                if (!(tryGetValueMethod.Invoke(options, parameters) is bool hasOption) ||
+                    !hasOption)
+                {
+                    return false;
+                }
+
+                if (!(parameters[1] is string value) ||
+                    !bool.TryParse(value, out var boolValue))
+                {
+                    return false;
+                }
+
+                optionValue = boolValue;
+                return true;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // Gracefully handle any exception from reflection.
+                return false;
+            }
         }
 
         private static bool TryGetApiText(

--- a/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
+++ b/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md
@@ -6,6 +6,14 @@ To get started with the Public API Analyzer:
 2. You will have `RS0016` diagnostics on all your public APIs.
 3. Invoke the codefix on any `RS0016` to add the public APIs to the documented set. You can apply the codefix across the entire project or solution to easily document all APIs at once. Text files `PublicAPI.Shipped.txt` and `PublicAPI.Unshipped.txt` will be added to each project in scope, if they do not already exist.
 
+**Configuration:** If you would prefer the public API analyzer to bail out silently for projects with missing public API files, you can do so by setting the following .editorconfig option:
+```ini
+[*.cs]
+dotnet_public_api_analyzer.require_api_files = true
+```
+
+See [Analyzer Configuration.md](.//..//..//docs//Analyzer Configuration.md) for more details on how to setup editorconfig based configuration.
+
 ## Package version earlier then 3.3.x
 
 If you are using a `Microsoft.CodeAnalysis.PublicApiAnalyzers` package with version prior to 3.3.x, then you will need to manually create the following public API files in each project directory that needs to be analyzed. Additionally, you will need to mark the above files as analyzer additional files to enable analysis.

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -3,6 +3,7 @@
 #nullable enable
 #pragma warning disable CA1305
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
@@ -64,15 +65,19 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
             await test.RunAsync();
         }
 
-        private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, params DiagnosticResult[] expected)
+        private Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, params DiagnosticResult[] expected)
+            => VerifyCSharpAsync(source, shippedApiText, unshippedApiText, editorConfigText: null, expected);
+
+        private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, string? editorConfigText, params DiagnosticResult[] expected)
         {
-            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, DeclarePublicApiFix, XUnitVerifier>
+            var test = new CSharpCodeFixVerifier<DeclarePublicApiAnalyzer, DeclarePublicApiFix>.Test
             {
                 TestState =
                 {
                     Sources = { source },
                     AdditionalFiles = { },
                 },
+                AnalyzerConfigDocument = editorConfigText,
             };
 
             if (shippedApiText != null)
@@ -178,9 +183,13 @@ public class C
             await VerifyCSharpAsync(source, shippedText, unshippedText, expected);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("dotnet_public_api_analyzer.require_api_files = false")]
+        [InlineData("dotnet_public_api_analyzer.require_api_files = true")]
         [WorkItem(2622, "https://github.com/dotnet/roslyn-analyzers/issues/2622")]
-        public async Task AnalyzerFileMissing_Both()
+        public async Task AnalyzerFileMissing_Both(string? editorconfigText)
         {
             var source = @"
 public class C
@@ -192,7 +201,14 @@ public class C
             string? shippedText = null;
             string? unshippedText = null;
 
-            await VerifyCSharpAsync(source, shippedText, unshippedText, GetCSharpResultAt(2, 14, DeclarePublicApiAnalyzer.DeclareNewApiRule, "C"));
+            var expectedDiagnostics = Array.Empty<DiagnosticResult>();
+            if (editorconfigText == null ||
+                !editorconfigText.EndsWith("true", StringComparison.OrdinalIgnoreCase))
+            {
+                expectedDiagnostics = new[] { GetCSharpResultAt(2, 14, DeclarePublicApiAnalyzer.DeclareNewApiRule, "C") };
+            }
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText, editorconfigText, expectedDiagnostics);
         }
 
         [Fact]

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -65,8 +65,30 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
             await test.RunAsync();
         }
 
-        private Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, params DiagnosticResult[] expected)
-            => VerifyCSharpAsync(source, shippedApiText, unshippedApiText, editorConfigText: null, expected);
+        private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, params DiagnosticResult[] expected)
+        {
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, DeclarePublicApiFix, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles = { },
+                },
+            };
+
+            if (shippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.ShippedFileName, shippedApiText));
+            }
+
+            if (unshippedApiText != null)
+            {
+                test.TestState.AdditionalFiles.Add((DeclarePublicApiAnalyzer.UnshippedFileName, unshippedApiText));
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync();
+        }
 
         private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, string? editorConfigText, params DiagnosticResult[] expected)
         {


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/pull/3916 added support to public API analyzer to treat missing API files as empty files and report diagnostics. This can be a breaking change for consumers where they relied on old semantics and installed this package or dependent package `Roslyn.Diagnostics.Analyzers` for the whole repo. This change adds an option to fall back the analyzer to old semantics.