### PR TITLE
Fix issues with FixAll application for RS0036 and RS0037 (add #nullab…

### DIFF
--- a/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/NullableEnablePublicApiFix.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
@@ -64,14 +65,14 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private class FixAllAdditionalDocumentChangeAction : CodeAction
         {
-            private readonly List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> _diagnosticsToFix;
+            private readonly List<Project> _projectsToFix;
             private readonly Solution _solution;
 
-            public FixAllAdditionalDocumentChangeAction(string title, Solution solution, List<KeyValuePair<Project, ImmutableArray<Diagnostic>>> diagnosticsToFix)
+            public FixAllAdditionalDocumentChangeAction(string title, Solution solution, List<Project> projectsToFix)
             {
                 this.Title = title;
                 _solution = solution;
-                _diagnosticsToFix = diagnosticsToFix;
+                _projectsToFix = projectsToFix;
             }
 
             public override string Title { get; }
@@ -80,16 +81,21 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             {
                 var updatedPublicSurfaceAreaText = new List<KeyValuePair<DocumentId, SourceText>>();
 
-                foreach (KeyValuePair<Project, ImmutableArray<Diagnostic>> pair in _diagnosticsToFix)
+                using var uniqueShippedDocuments = PooledHashSet<string>.GetInstance();
+                foreach (var project in _projectsToFix)
                 {
-                    Project project = pair.Key;
                     TextDocument? shippedDocument = DeclarePublicApiFix.GetShippedDocument(project);
-                    SourceText? shippedSourceText = shippedDocument is null ? null : await shippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
-                    if (shippedSourceText is object)
+                    if (shippedDocument == null ||
+                        shippedDocument.FilePath != null && !uniqueShippedDocuments.Add(shippedDocument.FilePath))
                     {
-                        SourceText newShippedSourceText = AddNullableEnable(shippedSourceText);
-                        updatedPublicSurfaceAreaText.Add(new KeyValuePair<DocumentId, SourceText>(shippedDocument!.Id, newShippedSourceText));
+                        // Skip past duplicate shipped documents.
+                        // Multi-tfm projects can likely share the same api files, and we want to avoid duplicate code fix application.
+                        continue;
                     }
+
+                    var shippedSourceText = await shippedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+                    SourceText newShippedSourceText = AddNullableEnable(shippedSourceText);
+                    updatedPublicSurfaceAreaText.Add(new KeyValuePair<DocumentId, SourceText>(shippedDocument!.Id, newShippedSourceText));
                 }
 
                 Solution newSolution = _solution;
@@ -106,16 +112,14 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         {
             public override async Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
             {
-                var diagnosticsToFix = new List<KeyValuePair<Project, ImmutableArray<Diagnostic>>>();
+                var projectsToFix = new List<Project>();
                 string? title;
                 switch (fixAllContext.Scope)
                 {
                     case FixAllScope.Document:
                     case FixAllScope.Project:
                         {
-                            Project project = fixAllContext.Project;
-                            ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
-                            diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(fixAllContext.Project, diagnostics));
+                            projectsToFix.Add(fixAllContext.Project);
                             title = string.Format(CultureInfo.InvariantCulture, PublicApiAnalyzerResources.EnableNullableInProjectToThePublicApiTitle, fixAllContext.Project.Name);
                             break;
                         }
@@ -125,7 +129,10 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             foreach (Project project in fixAllContext.Solution.Projects)
                             {
                                 ImmutableArray<Diagnostic> diagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
-                                diagnosticsToFix.Add(new KeyValuePair<Project, ImmutableArray<Diagnostic>>(project, diagnostics));
+                                if (!diagnostics.IsEmpty)
+                                {
+                                    projectsToFix.Add(project);
+                                }
                             }
 
                             title = PublicApiAnalyzerResources.EnableNullableInTheSolutionToThePublicApiTitle;
@@ -140,7 +147,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         return null;
                 }
 
-                return new FixAllAdditionalDocumentChangeAction(title, fixAllContext.Solution, diagnosticsToFix);
+                return new FixAllAdditionalDocumentChangeAction(title, fixAllContext.Solution, projectsToFix);
             }
         }
     }


### PR DESCRIPTION
…le enable to public API files)

Fixes #3965

I was unable to add unit tests as this requires multiple projects with differing contents of input and fixed public API files, I am unable to figure out how to write a unit test with the new test library for this scenario. 