### PR TITLE
Make sure to add as arguments to equal call on comparer

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
@@ -62,19 +62,18 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             var generator = editor.Generator;
 
-            if (invocationOperation.Instance is null)
-            {
-                var replacement = generator.InvocationExpression(
-                                    GetEqualityComparerDefaultEquals(generator),
-                                    invocationOperation.Arguments.Select(argument => argument.Syntax).ToImmutableArray());
+            var arguments = invocationOperation.Arguments.Select(argument => argument.Syntax);
 
-                editor.ReplaceNode(invocationOperation.Syntax, replacement.WithTriviaFrom(invocationOperation.Syntax));
-            }
-            else
+            if (invocationOperation.Instance is not null)
             {
-                var replacement = generator.AddParameters(invocationOperation.Syntax, new[] { GetEqualityComparerDefault(generator) });
-                editor.ReplaceNode(invocationOperation.Syntax, replacement.WithTriviaFrom(invocationOperation.Syntax));
+                arguments = new[] { invocationOperation.Instance.Syntax }.Concat(arguments);
             }
+
+            var replacement = generator.InvocationExpression(
+                                    GetEqualityComparerDefaultEquals(generator),
+                                    arguments);
+
+            editor.ReplaceNode(invocationOperation.Syntax, replacement.WithTriviaFrom(invocationOperation.Syntax));
 
             return editor.GetChangedDocument();
         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -510,6 +510,72 @@ End Class
         }
 
         [Theory]
+        [CombinatorialData]
+        public async Task CompareSymbolFromInstanceEquals_VisualBasic(
+            [CombinatorialValues(nameof(ISymbol), nameof(INamedTypeSymbol))] string symbolType,
+            [CombinatorialValues("", "Not ")] string @operator)
+        {
+            var source = $@"
+Imports Microsoft.CodeAnalysis
+Class TestClass
+    Sub Method1(x As {symbolType}, y As {symbolType})
+        If {@operator}[|x.Equals(y)|] Then Exit Sub
+    End Sub
+End Class
+";
+
+            var fixedSource = $@"
+Imports Microsoft.CodeAnalysis
+Class TestClass
+    Sub Method1(x As {symbolType}, y As {symbolType})
+        If {@operator}SymbolEqualityComparer.Default.Equals(x, y) Then Exit Sub
+    End Sub
+End Class
+";
+
+            await new VerifyVB.Test
+            {
+                TestState = { Sources = { source, SymbolEqualityComparerStubVisualBasic } },
+                FixedState = { Sources = { fixedSource, SymbolEqualityComparerStubVisualBasic } },
+            }.RunAsync();
+        }
+
+        [Theory]
+        [CombinatorialData]
+        public async Task CompareSymbolFromInstanceEquals_CSharp(
+            [CombinatorialValues(nameof(ISymbol), nameof(INamedTypeSymbol))] string symbolType,
+            [CombinatorialValues("", "!")] string @operator)
+        {
+            var source = $@"
+using Microsoft.CodeAnalysis;
+class TestClass
+{{
+    void Method1({symbolType} x , {symbolType} y)
+    {{
+        if ({@operator}[|x.Equals(y)|]) return;
+    }}
+}}
+";
+
+            var fixedSource = $@"
+using Microsoft.CodeAnalysis;
+class TestClass
+{{
+    void Method1({symbolType} x , {symbolType} y)
+    {{
+        if ({@operator}SymbolEqualityComparer.Default.Equals(x, y)) return;
+    }}
+}}
+";
+
+            await new VerifyCS.Test
+            {
+                TestState = { Sources = { source, SymbolEqualityComparerStubCSharp } },
+                FixedState = { Sources = { fixedSource, SymbolEqualityComparerStubCSharp } },
+            }.RunAsync();
+        }
+
+        [Theory]
         [InlineData(nameof(ISymbol))]
         [InlineData(nameof(INamedTypeSymbol))]
         public async Task CompareSymbolImplementationWithInterface_EqualsComparison_CSharp(string symbolType)


### PR DESCRIPTION
Change so we always replace with `SymbolEqualityComparer.Equals` but include the instance variable if it was used 
for the initial equals call. 

Fixes #3975 