### PR TITLE
Use EffectiveAnalysisLevel instead of AnalysisLevel for warning wave mapping

### DIFF
--- a/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/Program.cs
@@ -371,8 +371,8 @@ $@"<Project>{GetCommonContents(packageName)}{GetPackageSpecificContents(packageN
                     if (packageName == "Microsoft.CodeAnalysis.NetAnalyzers")
                     {
                         return $@"
-      <!-- Default '{packageVersionPropName}' to 'AnalysisLevel' -->
-      <{packageVersionPropName} Condition=""'$({packageVersionPropName})' == '' and $(AnalysisLevel) != ''"">$(AnalysisLevel)</{packageVersionPropName}>
+      <!-- Default '{packageVersionPropName}' to 'EffectiveAnalysisLevel' with trimmed trailing '.0' -->
+      <{packageVersionPropName} Condition=""'$({packageVersionPropName})' == '' and $(EffectiveAnalysisLevel) != ''"">$([System.Text.RegularExpressions.Regex]::Replace($(EffectiveAnalysisLevel), '(.0)*$', ''))</{packageVersionPropName}>
 ";
                     }
 


### PR DESCRIPTION
Relates to https://github.com/dotnet/sdk/pull/12898. This allows us to avoid dealing with special values for AnalysisLevel such as 'none', 'preview', 'latest', etc.

Verified that we now correctly handle values such as `5`, `5.0`, `5.0.0.0` and so on to map to `AnalysisLevel_5.editorconfig` for warning wave.