### PR TITLE
Workaround for https://github.com/dotnet/roslyn/issues/46859 

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -342,7 +342,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                             AnalyzeLocalizableStrings(localizableDescriptions, AnalyzeDescriptionCore, symbolToResourceMap, namedType,
                                 resourcesDataValueMap, context.Options, context.ReportDiagnostic, context.CancellationToken);
 
-                            symbolToResourceMap.Free();
+                            symbolToResourceMap.Free(context.CancellationToken);
                         });
                     }, SymbolKind.NamedType);
                 }
@@ -392,7 +392,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         ReportAnalyzerReleaseTrackingDiagnostics(invalidReleaseFileEntryDiagnostics, shippedData, unshippedData, seenRuleIds, compilationEndContext);
                     }
 
-                    seenRuleIds.Free();
+                    seenRuleIds.Free(compilationEndContext.CancellationToken);
                     if (analyzeResourceStrings)
                     {
                         RoslynDebug.Assert(localizableTitles != null);
@@ -400,22 +400,22 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         RoslynDebug.Assert(localizableDescriptions != null);
                         RoslynDebug.Assert(resourcesDataValueMap != null);
 
-                        FreeLocalizableStringsMap(localizableTitles);
-                        FreeLocalizableStringsMap(localizableMessages);
-                        FreeLocalizableStringsMap(localizableDescriptions);
-                        resourcesDataValueMap.Free();
+                        FreeLocalizableStringsMap(localizableTitles, compilationEndContext.CancellationToken);
+                        FreeLocalizableStringsMap(localizableMessages, compilationEndContext.CancellationToken);
+                        FreeLocalizableStringsMap(localizableDescriptions, compilationEndContext.CancellationToken);
+                        resourcesDataValueMap.Free(compilationEndContext.CancellationToken);
                     }
                 });
             });
 
-            static void FreeLocalizableStringsMap(PooledLocalizabeStringsConcurrentDictionary localizableStrings)
+            static void FreeLocalizableStringsMap(PooledLocalizabeStringsConcurrentDictionary localizableStrings, CancellationToken cancellationToken)
             {
                 foreach (var builder in localizableStrings.Values)
                 {
-                    builder.Free();
+                    builder.Free(cancellationToken);
                 }
 
-                localizableStrings.Free();
+                localizableStrings.Free(cancellationToken);
             }
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static IEnumerable<IOperation> GetFilteredDescendants(IOperation operation, Func<IOperation, bool> descendIntoOperation)
         {
-            var stack = ArrayBuilder<IEnumerator<IOperation>>.GetInstance();
+            using var stack = ArrayBuilder<IEnumerator<IOperation>>.GetInstance();
             stack.Add(operation.Children.GetEnumerator());
 
             while (stack.Any())
@@ -180,8 +180,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     }
                 }
             }
-
-            stack.Free();
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     addDiagnostic(symbol.CreateDiagnostic(Rule, Member, GetSymbolDisplayString(membersWithName)));
                 }
 
-                membersWithName.Free();
+                membersWithName.Dispose();
             }
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     context.ReportNoLocationDiagnostic(Rule, Type, GetSymbolDisplayString(typesWithName));
                 }
 
-                typesWithName.Free();
+                typesWithName.Dispose();
             }
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     context.ReportNoLocationDiagnostic(Rule, Namespace, GetSymbolDisplayString(namespacesWithName));
                 }
 
-                namespacesWithName.Free();
+                namespacesWithName.Dispose();
             }
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -179,10 +179,10 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                         }
                     }
 
-                    propertyOrEventCandidates.Free();
-                    accessorCandidates.Free();
-                    methodCandidates.Free();
-                    methodsUsedAsDelegates.Free();
+                    propertyOrEventCandidates.Free(symbolEndContext.CancellationToken);
+                    accessorCandidates.Free(symbolEndContext.CancellationToken);
+                    methodCandidates.Free(symbolEndContext.CancellationToken);
+                    methodsUsedAsDelegates.Free(symbolEndContext.CancellationToken);
                 }
             }
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/RuntimePlatformCheckAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/RuntimePlatformCheckAnalyzer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
                 finally
                 {
-                    platformSpecificOperations.Free();
+                    platformSpecificOperations.Free(context.CancellationToken);
                 }
 
                 return;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposed.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposed.cs
@@ -275,7 +275,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
                 finally
                 {
-                    fieldDisposeValueMap.Free();
+                    fieldDisposeValueMap.Free(symbolEndContext.CancellationToken);
                 }
             }
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -106,54 +106,47 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         operationBlockContext.CancellationToken, out var disposeAnalysisResult, out var pointsToAnalysisResult,
                         interproceduralAnalysisPredicate))
                     {
-                        var notDisposedDiagnostics = ArrayBuilder<Diagnostic>.GetInstance();
-                        var mayBeNotDisposedDiagnostics = ArrayBuilder<Diagnostic>.GetInstance();
-                        try
-                        {
-                            // Compute diagnostics for undisposed objects at exit block for non-exceptional exit paths.
-                            var exitBlock = disposeAnalysisResult.ControlFlowGraph.GetExit();
-                            var disposeDataAtExit = disposeAnalysisResult.ExitBlockOutput.Data;
-                            ComputeDiagnostics(disposeDataAtExit,
-                                notDisposedDiagnostics, mayBeNotDisposedDiagnostics, disposeAnalysisResult, pointsToAnalysisResult,
-                                disposeAnalysisKind, isDisposeDataForExceptionPaths: false);
+                        using var notDisposedDiagnostics = ArrayBuilder<Diagnostic>.GetInstance();
+                        using var mayBeNotDisposedDiagnostics = ArrayBuilder<Diagnostic>.GetInstance();
 
-                            if (trackExceptionPaths)
+                        // Compute diagnostics for undisposed objects at exit block for non-exceptional exit paths.
+                        var exitBlock = disposeAnalysisResult.ControlFlowGraph.GetExit();
+                        var disposeDataAtExit = disposeAnalysisResult.ExitBlockOutput.Data;
+                        ComputeDiagnostics(disposeDataAtExit,
+                            notDisposedDiagnostics, mayBeNotDisposedDiagnostics, disposeAnalysisResult, pointsToAnalysisResult,
+                            disposeAnalysisKind, isDisposeDataForExceptionPaths: false);
+
+                        if (trackExceptionPaths)
+                        {
+                            // Compute diagnostics for undisposed objects at handled exception exit paths.
+                            var disposeDataAtHandledExceptionPaths = disposeAnalysisResult.ExceptionPathsExitBlockOutput!.Data;
+                            ComputeDiagnostics(disposeDataAtHandledExceptionPaths,
+                                notDisposedDiagnostics, mayBeNotDisposedDiagnostics, disposeAnalysisResult, pointsToAnalysisResult,
+                                disposeAnalysisKind, isDisposeDataForExceptionPaths: true);
+
+                            // Compute diagnostics for undisposed objects at unhandled exception exit paths, if any.
+                            var disposeDataAtUnhandledExceptionPaths = disposeAnalysisResult.MergedStateForUnhandledThrowOperations?.Data;
+                            if (disposeDataAtUnhandledExceptionPaths != null)
                             {
-                                // Compute diagnostics for undisposed objects at handled exception exit paths.
-                                var disposeDataAtHandledExceptionPaths = disposeAnalysisResult.ExceptionPathsExitBlockOutput!.Data;
-                                ComputeDiagnostics(disposeDataAtHandledExceptionPaths,
+                                ComputeDiagnostics(disposeDataAtUnhandledExceptionPaths,
                                     notDisposedDiagnostics, mayBeNotDisposedDiagnostics, disposeAnalysisResult, pointsToAnalysisResult,
                                     disposeAnalysisKind, isDisposeDataForExceptionPaths: true);
-
-                                // Compute diagnostics for undisposed objects at unhandled exception exit paths, if any.
-                                var disposeDataAtUnhandledExceptionPaths = disposeAnalysisResult.MergedStateForUnhandledThrowOperations?.Data;
-                                if (disposeDataAtUnhandledExceptionPaths != null)
-                                {
-                                    ComputeDiagnostics(disposeDataAtUnhandledExceptionPaths,
-                                        notDisposedDiagnostics, mayBeNotDisposedDiagnostics, disposeAnalysisResult, pointsToAnalysisResult,
-                                        disposeAnalysisKind, isDisposeDataForExceptionPaths: true);
-                                }
-                            }
-
-                            if (!notDisposedDiagnostics.Any() && !mayBeNotDisposedDiagnostics.Any())
-                            {
-                                return;
-                            }
-
-                            // Report diagnostics preferring *not* disposed diagnostics over may be not disposed diagnostics
-                            // and avoiding duplicates.
-                            foreach (var diagnostic in notDisposedDiagnostics.Concat(mayBeNotDisposedDiagnostics))
-                            {
-                                if (reportedLocations.TryAdd(diagnostic.Location, true))
-                                {
-                                    operationBlockContext.ReportDiagnostic(diagnostic);
-                                }
                             }
                         }
-                        finally
+
+                        if (!notDisposedDiagnostics.Any() && !mayBeNotDisposedDiagnostics.Any())
                         {
-                            notDisposedDiagnostics.Free();
-                            mayBeNotDisposedDiagnostics.Free();
+                            return;
+                        }
+
+                        // Report diagnostics preferring *not* disposed diagnostics over may be not disposed diagnostics
+                        // and avoiding duplicates.
+                        foreach (var diagnostic in notDisposedDiagnostics.Concat(mayBeNotDisposedDiagnostics))
+                        {
+                            if (reportedLocations.TryAdd(diagnostic.Location, true))
+                            {
+                                operationBlockContext.ReportDiagnostic(diagnostic);
+                            }
                         }
                     }
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfAnalyzer.cs
@@ -193,8 +193,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                 context.ReportDiagnostic(variableNameAndLocation.Value.CreateDiagnostic(Rule));
                             }
                         }
-                        variableNameToOperationsMap.Free();
-                        localsToBailOut.Free();
+
+                        variableNameToOperationsMap.Free(context.CancellationToken);
+                        localsToBailOut.Free(context.CancellationToken);
                     }
 
                     bool IsDesiredTargetMethod(IMethodSymbol targetMethod) =>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpClientCRLCheck.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpClientCRLCheck.cs
@@ -237,8 +237,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotInstallRootCert.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotInstallRootCert.cs
@@ -225,8 +225,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseCreateEncryptorWithNonDefaultIV.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseCreateEncryptorWithNonDefaultIV.cs
@@ -200,8 +200,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolver.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolver.cs
@@ -261,8 +261,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinder.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinder.cs
@@ -240,8 +240,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
@@ -232,8 +232,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureSettingsForJsonNet.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureSettingsForJsonNet.cs
@@ -265,8 +265,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFInsufficientIterationCount.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFInsufficientIterationCount.cs
@@ -222,8 +222,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
@@ -190,8 +190,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
@@ -256,7 +256,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     }
                                     finally
                                     {
-                                        rootOperationsNeedingAnalysis.Free();
+                                        rootOperationsNeedingAnalysis.Free(operationBlockAnalysisContext.CancellationToken);
                                     }
                                 });
                         });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSecureCookiesASPNetCore.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSecureCookiesASPNetCore.cs
@@ -220,8 +220,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         }
                     }
 
-                    var symbolNamesToRemove = symbolNamesToRemoveBuilder.ToImmutableAndFree();
+                    var symbolNamesToRemove = symbolNamesToRemoveBuilder.ToImmutableAndFree(cancellationToken);
 
                     // We shouldn't be attempting to remove any symbol name, while also adding it.
                     Debug.Assert(newSymbolNames.All(newSymbolName => !symbolNamesToRemove.Contains(newSymbolName)));

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/BracePlacement/CSharpBracePlacementCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/BracePlacement/CSharpBracePlacementCodeFixProvider.cs
@@ -46,14 +46,13 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers.BracePlacement
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var tokenToToken = PooledDictionary<SyntaxToken, SyntaxToken>.GetInstance();
+            using var tokenToToken = PooledDictionary<SyntaxToken, SyntaxToken>.GetInstance();
 
             foreach (var diagnostic in diagnostics)
                 FixOne(root, text, tokenToToken, diagnostic, cancellationToken);
 
             var newRoot = root.ReplaceTokens(tokenToToken.Keys, (t1, _) => tokenToToken[t1]);
 
-            tokenToToken.Free();
             return newRoot;
         }
 

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/BracePlacement/CSharpBracePlacementDiagnosticAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/BracePlacement/CSharpBracePlacementDiagnosticAnalyzer.cs
@@ -42,15 +42,8 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers.BracePlacement
 
         private static void AnalyzeTree(SyntaxTreeAnalysisContext context)
         {
-            var stack = ArrayBuilder<SyntaxNode>.GetInstance();
-            try
-            {
-                Recurse(context, stack);
-            }
-            finally
-            {
-                stack.Free();
-            }
+            using var stack = ArrayBuilder<SyntaxNode>.GetInstance();
+            Recurse(context, stack);
         }
 
         private static void Recurse(SyntaxTreeAnalysisContext context, ArrayBuilder<SyntaxNode> stack)

--- a/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
@@ -9,7 +9,7 @@ namespace System.Collections.Immutable
     {
         public static ImmutableHashSet<T> AddRange<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)
         {
-            var builder = PooledHashSet<T>.GetInstance();
+            using var builder = PooledHashSet<T>.GetInstance();
 
             foreach (var item in set1)
             {
@@ -23,17 +23,15 @@ namespace System.Collections.Immutable
 
             if (builder.Count == set1.Count)
             {
-                builder.Free();
                 return set1;
             }
 
             if (builder.Count == set2.Count)
             {
-                builder.Free();
                 return set2;
             }
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutable();
         }
 
         public static ImmutableHashSet<T> IntersectSet<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)
@@ -51,7 +49,7 @@ namespace System.Collections.Immutable
                 return set1.Contains(set2.First()) ? set2 : ImmutableHashSet<T>.Empty;
             }
 
-            var builder = PooledHashSet<T>.GetInstance();
+            using var builder = PooledHashSet<T>.GetInstance();
             foreach (var item in set1)
             {
                 if (set2.Contains(item))
@@ -62,16 +60,14 @@ namespace System.Collections.Immutable
 
             if (builder.Count == set1.Count)
             {
-                builder.Free();
                 return set1;
             }
             else if (builder.Count == set2.Count)
             {
-                builder.Free();
                 return set2;
             }
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutable();
         }
 
         public static bool IsSubsetOfSet<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)

--- a/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
+++ b/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
@@ -185,8 +185,15 @@ namespace Analyzer.Utilities.PooledObjects
         /// Note that Free will try to store recycled objects close to the start thus statistically 
         /// reducing how far we will typically search in Allocate.
         /// </remarks>
-        internal void Free(T obj)
+        internal void Free(T obj, CancellationToken cancellationToken)
         {
+            // Workaround for https://github.com/dotnet/roslyn/issues/46859
+            // Do not free in presence of cancellation.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             Validate(obj);
             ForgetTrackedObject(obj);
 

--- a/src/Utilities/Compiler/PooledObjects/PooledConcurrentDictionary.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledConcurrentDictionary.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -28,12 +29,12 @@ namespace Analyzer.Utilities.PooledObjects
             _pool = pool;
         }
 
-        public void Dispose() => Free();
+        public void Dispose() => Free(CancellationToken.None);
 
-        public void Free()
+        public void Free(CancellationToken cancellationToken)
         {
             this.Clear();
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
         }
 
         // global pool

--- a/src/Utilities/Compiler/PooledObjects/PooledConcurrentSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledConcurrentSet.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -24,8 +25,8 @@ namespace Analyzer.Utilities.PooledObjects
             _dictionary = dictionary;
         }
 
-        public void Dispose() => Free();
-        public void Free() => _dictionary.Free();
+        public void Dispose() => Free(CancellationToken.None);
+        public void Free(CancellationToken cancellationToken) => _dictionary.Free(cancellationToken);
 
         public static PooledConcurrentSet<T> GetInstance(IEqualityComparer<T>? comparer = null)
         {

--- a/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -23,9 +24,9 @@ namespace Analyzer.Utilities.PooledObjects
             _pool = pool;
         }
 
-        public void Dispose() => Free();
+        public void Dispose() => Free(CancellationToken.None);
 
-        public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree()
+        public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree(CancellationToken cancellationToken = default)
         {
             ImmutableDictionary<K, V> result;
             if (Count == 0)
@@ -38,12 +39,14 @@ namespace Analyzer.Utilities.PooledObjects
                 this.Clear();
             }
 
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
             return result;
         }
 
         public ImmutableDictionary<TKey, TValue> ToImmutableDictionaryAndFree<TKey, TValue>(
-           Func<KeyValuePair<K, V>, TKey> keySelector, Func<KeyValuePair<K, V>, TValue> elementSelector, IEqualityComparer<TKey> comparer)
+           Func<KeyValuePair<K, V>, TKey> keySelector, Func<KeyValuePair<K, V>, TValue> elementSelector,
+           IEqualityComparer<TKey> comparer,
+           CancellationToken cancellationToken = default)
         {
             ImmutableDictionary<TKey, TValue> result;
             if (Count == 0)
@@ -56,14 +59,14 @@ namespace Analyzer.Utilities.PooledObjects
                 this.Clear();
             }
 
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
             return result;
         }
 
-        public void Free()
+        public void Free(CancellationToken cancellationToken)
         {
             this.Clear();
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
         }
 
         // global pool

--- a/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledHashSet.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1710 // Rename Microsoft.CodeAnalysis.PooledHashSet<T> to end in 'Collection'.
 #pragma warning disable CA1000 // Do not declare static members on generic types
@@ -23,15 +24,15 @@ namespace Analyzer.Utilities.PooledObjects
             _pool = pool;
         }
 
-        public void Dispose() => Free();
+        public void Dispose() => Free(CancellationToken.None);
 
-        public void Free()
+        public void Free(CancellationToken cancellationToken)
         {
             this.Clear();
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
         }
 
-        public ImmutableHashSet<T> ToImmutableAndFree()
+        public ImmutableHashSet<T> ToImmutableAndFree(CancellationToken cancellationToken = default)
         {
             ImmutableHashSet<T> result;
             if (Count == 0)
@@ -44,7 +45,7 @@ namespace Analyzer.Utilities.PooledObjects
                 this.Clear();
             }
 
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
             return result;
         }
 

--- a/src/Utilities/Compiler/PooledObjects/PooledSortedSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledSortedSet.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -23,12 +24,12 @@ namespace Analyzer.Utilities.PooledObjects
             _pool = pool;
         }
 
-        public void Dispose() => Free();
+        public void Dispose() => Free(CancellationToken.None);
 
-        public void Free()
+        public void Free(CancellationToken cancellationToken)
         {
             this.Clear();
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
         }
 
         // global pool

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -385,51 +385,43 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             protected override void UpdateValuesForAnalysisData(CopyAnalysisData targetAnalysisData)
             {
                 // We need to trim the copy values to only include the entities that are existing keys in targetAnalysisData.
-                var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-                var builder = ArrayBuilder<AnalysisEntity>.GetInstance(targetAnalysisData.CoreAnalysisData.Count);
-                try
+                using var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                using var builder = ArrayBuilder<AnalysisEntity>.GetInstance(targetAnalysisData.CoreAnalysisData.Count);
+                builder.AddRange(targetAnalysisData.CoreAnalysisData.Keys);
+                for (int i = 0; i < builder.Count; i++)
                 {
-                    builder.AddRange(targetAnalysisData.CoreAnalysisData.Keys);
-                    for (int i = 0; i < builder.Count; i++)
+                    var key = builder[i];
+                    if (!processedEntities.Add(key))
                     {
-                        var key = builder[i];
-                        if (!processedEntities.Add(key))
-                        {
-                            continue;
-                        }
-
-                        if (CurrentAnalysisData.TryGetValue(key, out var newValue))
-                        {
-                            var existingValue = targetAnalysisData[key];
-                            if (newValue.AnalysisEntities.Count == 1)
-                            {
-                                if (existingValue.AnalysisEntities.Count == 1)
-                                {
-                                    continue;
-                                }
-                            }
-                            else if (newValue.AnalysisEntities.Count > 1)
-                            {
-                                var entitiesToExclude = newValue.AnalysisEntities.Where(e => !targetAnalysisData.HasAbstractValue(e));
-                                if (entitiesToExclude.Any())
-                                {
-                                    newValue = newValue.WithEntitiesRemoved(entitiesToExclude);
-                                }
-                            }
-
-                            if (newValue != existingValue)
-                            {
-                                targetAnalysisData.SetAbstactValueForEntities(newValue, entityBeingAssigned: null);
-                            }
-
-                            processedEntities.AddRange(newValue.AnalysisEntities);
-                        }
+                        continue;
                     }
-                }
-                finally
-                {
-                    processedEntities.Free();
-                    builder.Free();
+
+                    if (CurrentAnalysisData.TryGetValue(key, out var newValue))
+                    {
+                        var existingValue = targetAnalysisData[key];
+                        if (newValue.AnalysisEntities.Count == 1)
+                        {
+                            if (existingValue.AnalysisEntities.Count == 1)
+                            {
+                                continue;
+                            }
+                        }
+                        else if (newValue.AnalysisEntities.Count > 1)
+                        {
+                            var entitiesToExclude = newValue.AnalysisEntities.Where(e => !targetAnalysisData.HasAbstractValue(e));
+                            if (entitiesToExclude.Any())
+                            {
+                                newValue = newValue.WithEntitiesRemoved(entitiesToExclude);
+                            }
+                        }
+
+                        if (newValue != existingValue)
+                        {
+                            targetAnalysisData.SetAbstactValueForEntities(newValue, entityBeingAssigned: null);
+                        }
+
+                        processedEntities.AddRange(newValue.AnalysisEntities);
+                    }
                 }
             }
 
@@ -465,41 +457,34 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                     returnValueAndPredicateKind.Value.Value.Kind.IsKnown() &&
                     DataFlowAnalysisContext.InterproceduralAnalysisData != null)
                 {
-                    var entitiesToFilterBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+                    using var entitiesToFilterBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
                     var copyValue = returnValueAndPredicateKind.Value.Value;
                     var copyValueEntities = copyValue.AnalysisEntities;
 
-                    try
+                    foreach (var entity in copyValueEntities)
                     {
-                        foreach (var entity in copyValueEntities)
+                        if (ShouldStopTrackingEntityAtExit(entity))
                         {
-                            if (ShouldStopTrackingEntityAtExit(entity))
-                            {
-                                // Stop tracking entity that is now out of scope.
-                                entitiesToFilterBuilder.Add(entity);
+                            // Stop tracking entity that is now out of scope.
+                            entitiesToFilterBuilder.Add(entity);
 
-                                // Additionally, stop tracking all the child entities if the entity type has value copy semantics.
-                                if (entity.Type.HasValueCopySemantics())
-                                {
-                                    var childEntities = copyValueEntities.Where(e => IsChildAnalysisEntity(e, ancestorEntity: entity));
-                                    entitiesToFilterBuilder.AddRange(childEntities);
-                                }
+                            // Additionally, stop tracking all the child entities if the entity type has value copy semantics.
+                            if (entity.Type.HasValueCopySemantics())
+                            {
+                                var childEntities = copyValueEntities.Where(e => IsChildAnalysisEntity(e, ancestorEntity: entity));
+                                entitiesToFilterBuilder.AddRange(childEntities);
                             }
                         }
-
-                        if (entitiesToFilterBuilder.Count > 0)
-                        {
-                            copyValue = entitiesToFilterBuilder.Count == copyValueEntities.Count ?
-                                CopyAbstractValue.Unknown :
-                                copyValue.WithEntitiesRemoved(entitiesToFilterBuilder);
-                        }
-
-                        return (copyValue, returnValueAndPredicateKind.Value.PredicateValueKind);
                     }
-                    finally
+
+                    if (entitiesToFilterBuilder.Count > 0)
                     {
-                        entitiesToFilterBuilder.Free();
+                        copyValue = entitiesToFilterBuilder.Count == copyValueEntities.Count ?
+                            CopyAbstractValue.Unknown :
+                            copyValue.WithEntitiesRemoved(entitiesToFilterBuilder);
                     }
+
+                    return (copyValue, returnValueAndPredicateKind.Value.PredicateValueKind);
                 }
 
                 return returnValueAndPredicateKind;
@@ -517,66 +502,52 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 
             private void ApplyMissingCurrentAnalysisDataCore(CopyAnalysisData mergedData, Func<AnalysisEntity, bool>? predicate)
             {
-                var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-                try
+                using var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                foreach (var kvp in CurrentAnalysisData.CoreAnalysisData)
                 {
-                    foreach (var kvp in CurrentAnalysisData.CoreAnalysisData)
+                    var key = kvp.Key;
+                    var copyValue = kvp.Value;
+                    if (mergedData.CoreAnalysisData.ContainsKey(key) ||
+                        (predicate != null && !predicate(key)) ||
+                        !processedEntities.Add(key))
                     {
-                        var key = kvp.Key;
-                        var copyValue = kvp.Value;
-                        if (mergedData.CoreAnalysisData.ContainsKey(key) ||
-                            (predicate != null && !predicate(key)) ||
-                            !processedEntities.Add(key))
-                        {
-                            continue;
-                        }
-
-                        if (predicate != null && copyValue.AnalysisEntities.Count > 1)
-                        {
-                            var entitiesToRemove = copyValue.AnalysisEntities.Where(entity => key != entity && !predicate(entity));
-                            if (entitiesToRemove.Any())
-                            {
-                                copyValue = copyValue.WithEntitiesRemoved(entitiesToRemove);
-                            }
-                        }
-
-                        Debug.Assert(copyValue.AnalysisEntities.Contains(key));
-                        Debug.Assert(predicate == null || copyValue.AnalysisEntities.All(predicate));
-                        mergedData.SetAbstactValueForEntities(copyValue, entityBeingAssigned: null);
-                        processedEntities.AddRange(copyValue.AnalysisEntities);
+                        continue;
                     }
 
-                    AssertValidCopyAnalysisData(mergedData);
+                    if (predicate != null && copyValue.AnalysisEntities.Count > 1)
+                    {
+                        var entitiesToRemove = copyValue.AnalysisEntities.Where(entity => key != entity && !predicate(entity));
+                        if (entitiesToRemove.Any())
+                        {
+                            copyValue = copyValue.WithEntitiesRemoved(entitiesToRemove);
+                        }
+                    }
+
+                    Debug.Assert(copyValue.AnalysisEntities.Contains(key));
+                    Debug.Assert(predicate == null || copyValue.AnalysisEntities.All(predicate));
+                    mergedData.SetAbstactValueForEntities(copyValue, entityBeingAssigned: null);
+                    processedEntities.AddRange(copyValue.AnalysisEntities);
                 }
-                finally
-                {
-                    processedEntities.Free();
-                }
+
+                AssertValidCopyAnalysisData(mergedData);
             }
 
             protected override CopyAnalysisData GetTrimmedCurrentAnalysisData(IEnumerable<AnalysisEntity> withEntities)
             {
-                var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-                try
+                using var processedEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                var analysisData = new CopyAnalysisData();
+                foreach (var entity in withEntities)
                 {
-                    var analysisData = new CopyAnalysisData();
-                    foreach (var entity in withEntities)
+                    if (processedEntities.Add(entity))
                     {
-                        if (processedEntities.Add(entity))
-                        {
-                            var copyValue = GetAbstractValue(entity);
-                            analysisData.SetAbstactValueForEntities(copyValue, entityBeingAssigned: null);
-                            processedEntities.AddRange(copyValue.AnalysisEntities);
-                        }
+                        var copyValue = GetAbstractValue(entity);
+                        analysisData.SetAbstactValueForEntities(copyValue, entityBeingAssigned: null);
+                        processedEntities.AddRange(copyValue.AnalysisEntities);
                     }
+                }
 
-                    AssertValidCopyAnalysisData(analysisData);
-                    return analysisData;
-                }
-                finally
-                {
-                    processedEntities.Free();
-                }
+                AssertValidCopyAnalysisData(analysisData);
+                return analysisData;
             }
 
             protected override CopyAnalysisData GetInitialInterproceduralAnalysisData(

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis;
@@ -75,7 +76,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 }
                 finally
                 {
-                    escapedLocationsBuilder.Free();
+                    escapedLocationsBuilder.Dispose();
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public void Dispose()
         {
-            AllEntities.Free();
-            PointsToValues.Free();
+            AllEntities.Dispose();
+            PointsToValues.Dispose();
         }
 
         public void AddEntityAndPointsToValue(AnalysisEntity analysisEntity, PointsToAbstractValue value)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
@@ -101,30 +101,22 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 
         internal ImmutableDictionary<(INamedTypeSymbol, bool), string> GetTypeToNameMapping(WellKnownTypeProvider wellKnownTypeProvider)
         {
-            PooledDictionary<(INamedTypeSymbol, bool), string> pooledDictionary = PooledDictionary<(INamedTypeSymbol, bool), string>.GetInstance();
-            try
-            {
-                foreach (KeyValuePair<(HazardousUsageEvaluatorKind Kind, string? InstanceTypeName, string? MethodName, string? ParameterName, bool derivedClasses), HazardousUsageEvaluator> kvp
+            using PooledDictionary<(INamedTypeSymbol, bool), string> pooledDictionary = PooledDictionary<(INamedTypeSymbol, bool), string>.GetInstance();
+            foreach (KeyValuePair<(HazardousUsageEvaluatorKind Kind, string? InstanceTypeName, string? MethodName, string? ParameterName, bool derivedClasses), HazardousUsageEvaluator> kvp
                     in this.HazardousUsageEvaluators)
+            {
+                if (kvp.Key.InstanceTypeName == null || kvp.Key.Kind != HazardousUsageEvaluatorKind.Invocation)
                 {
-                    if (kvp.Key.InstanceTypeName == null || kvp.Key.Kind != HazardousUsageEvaluatorKind.Invocation)
-                    {
-                        continue;
-                    }
-
-                    if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(kvp.Key.InstanceTypeName, out INamedTypeSymbol? namedTypeSymbol))
-                    {
-                        pooledDictionary[(namedTypeSymbol, kvp.Key.derivedClasses)] = kvp.Key.InstanceTypeName;
-                    }
+                    continue;
                 }
 
-                return pooledDictionary.ToImmutableDictionaryAndFree();
+                if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(kvp.Key.InstanceTypeName, out INamedTypeSymbol? namedTypeSymbol))
+                {
+                    pooledDictionary[(namedTypeSymbol, kvp.Key.derivedClasses)] = kvp.Key.InstanceTypeName;
+                }
             }
-            catch (Exception)
-            {
-                pooledDictionary.Free();
-                throw;
-            }
+
+            return pooledDictionary.ToImmutableDictionary();
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
@@ -161,23 +161,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 newLength = this.KnownPropertyAbstractValues.Length;
             }
 
-            ArrayBuilder<PropertySetAbstractValueKind> kinds = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(newLength);
-            try
-            {
-                kinds.AddRange(this.KnownPropertyAbstractValues);
+            using ArrayBuilder<PropertySetAbstractValueKind> kinds = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(newLength);
+            kinds.AddRange(this.KnownPropertyAbstractValues);
 
-                while (kinds.Count < newLength)
-                {
-                    kinds.Add(PropertySetAbstractValueKind.Unknown);
-                }
-
-                kinds[index] = kind;
-                return GetInstance(kinds);
-            }
-            finally
+            while (kinds.Count < newLength)
             {
-                kinds.Free();
+                kinds.Add(PropertySetAbstractValueKind.Unknown);
             }
+
+            kinds[index] = kind;
+            return GetInstance(kinds);
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
@@ -57,20 +57,13 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 // The PropertySetAbstractValue indexer allows accessing beyond KnownValuesCount (returns Unknown),
                 // so looping through the max of the two KnownValuesCount.
                 int maxKnownCount = Math.Max(value1.KnownValuesCount, value2.KnownValuesCount);
-                ArrayBuilder<PropertySetAbstractValueKind> builder = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(maxKnownCount);
-                try
+                using ArrayBuilder<PropertySetAbstractValueKind> builder = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(maxKnownCount);
+                for (int i = 0; i < maxKnownCount; i++)
                 {
-                    for (int i = 0; i < maxKnownCount; i++)
-                    {
-                        builder.Add(MergeKind(value1[i], value2[i]));
-                    }
+                    builder.Add(MergeKind(value1[i], value2[i]));
+                }
 
-                    return PropertySetAbstractValue.GetInstance(builder);
-                }
-                finally
-                {
-                    builder.Free();
-                }
+                return PropertySetAbstractValue.GetInstance(builder);
             }
 
             private static PropertySetAbstractValueKind MergeKind(PropertySetAbstractValueKind kind1, PropertySetAbstractValueKind kind2)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.TrackedAssignmentData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.TrackedAssignmentData.cs
@@ -30,17 +30,17 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 
                 public void Free()
                 {
-                    this.AssignmentsWithUnknownLocation?.Free();
+                    this.AssignmentsWithUnknownLocation?.Dispose();
                     this.AssignmentsWithUnknownLocation = null;
 
                     if (this.AbstractLocationsToAssignments != null)
                     {
                         foreach (PooledHashSet<IAssignmentOperation> hashSet in this.AbstractLocationsToAssignments.Values)
                         {
-                            hashSet?.Free();
+                            hashSet?.Dispose();
                         }
 
-                        this.AbstractLocationsToAssignments.Free();
+                        this.AbstractLocationsToAssignments.Dispose();
                         this.AbstractLocationsToAssignments = null;
                     }
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -170,41 +170,26 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                     }
                     else if (constructorMapper.MapFromPointsToAbstractValue != null)
                     {
-                        ArrayBuilder<PointsToAbstractValue> builder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
-                        try
+                        using ArrayBuilder<PointsToAbstractValue> builder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
+                        foreach (IArgumentOperation argumentOperation in operation.Arguments)
                         {
-                            foreach (IArgumentOperation argumentOperation in operation.Arguments)
-                            {
-                                builder.Add(this.GetPointsToAbstractValue(argumentOperation));
-                            }
+                            builder.Add(this.GetPointsToAbstractValue(argumentOperation));
+                        }
 
-                            abstractValue = constructorMapper.MapFromPointsToAbstractValue(operation.Constructor, builder);
-                        }
-                        finally
-                        {
-                            builder.Free();
-                        }
+                        abstractValue = constructorMapper.MapFromPointsToAbstractValue(operation.Constructor, builder);
                     }
                     else if (constructorMapper.MapFromValueContentAbstractValue != null)
                     {
                         Debug.Assert(this.DataFlowAnalysisContext.ValueContentAnalysisResult != null);
-                        ArrayBuilder<PointsToAbstractValue> pointsToBuilder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
-                        ArrayBuilder<ValueContentAbstractValue> valueContentBuilder = ArrayBuilder<ValueContentAbstractValue>.GetInstance();
-                        try
+                        using ArrayBuilder<PointsToAbstractValue> pointsToBuilder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
+                        using ArrayBuilder<ValueContentAbstractValue> valueContentBuilder = ArrayBuilder<ValueContentAbstractValue>.GetInstance();
+                        foreach (IArgumentOperation argumentOperation in operation.Arguments)
                         {
-                            foreach (IArgumentOperation argumentOperation in operation.Arguments)
-                            {
-                                pointsToBuilder.Add(this.GetPointsToAbstractValue(argumentOperation));
-                                valueContentBuilder.Add(this.GetValueContentAbstractValue(argumentOperation.Value));
-                            }
+                            pointsToBuilder.Add(this.GetPointsToAbstractValue(argumentOperation));
+                            valueContentBuilder.Add(this.GetValueContentAbstractValue(argumentOperation.Value));
+                        }
 
-                            abstractValue = constructorMapper.MapFromValueContentAbstractValue(operation.Constructor, valueContentBuilder, pointsToBuilder);
-                        }
-                        finally
-                        {
-                            pointsToBuilder.Free();
-                            valueContentBuilder.Free();
-                        }
+                        abstractValue = constructorMapper.MapFromValueContentAbstractValue(operation.Constructor, valueContentBuilder, pointsToBuilder);
                     }
                     else
                     {
@@ -470,7 +455,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                         trackedAssignmentData.Free();
                     }
 
-                    this.TrackedFieldPropertyAssignments.Free();
+                    this.TrackedFieldPropertyAssignments.Dispose();
                     this.TrackedFieldPropertyAssignments = null;
                 }
             }
@@ -570,7 +555,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 }
                 finally
                 {
-                    hazardousUsageTypeNames?.Free();
+                    hazardousUsageTypeNames?.Dispose();
                 }
 
                 return false;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -384,10 +384,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 }
                 finally
                 {
-                    taintedTargets?.Free();
-                    taintedParameterPairs?.Free();
-                    sanitizedParameterPairs?.Free();
-                    taintedParameterNamesCached?.Free();
+                    taintedTargets?.Dispose();
+                    taintedParameterPairs?.Dispose();
+                    sanitizedParameterPairs?.Dispose();
+                    taintedParameterNamesCached?.Dispose();
                 }
 
                 return result;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -102,35 +102,28 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             base.ProcessOutOfScopeLocalsAndFlowCaptures(locals, flowCaptures);
 
-            var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-            try
+            using var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            AddTrackedEntities(allEntities);
+
+            // Stop tracking entities for locals and capture Ids that are now out of scope.
+            foreach (var local in locals)
             {
-                AddTrackedEntities(allEntities);
-
-                // Stop tracking entities for locals and capture Ids that are now out of scope.
-                foreach (var local in locals)
+                if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(local, out var analysisEntity))
                 {
-                    if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(local, out var analysisEntity))
-                    {
-                        StopTrackingDataForEntity(analysisEntity, allEntities);
-                    }
-                    else
-                    {
-                        Debug.Fail("TryCreateForSymbolDeclaration failed");
-                    }
+                    StopTrackingDataForEntity(analysisEntity, allEntities);
                 }
-
-                foreach (var captureId in flowCaptures)
+                else
                 {
-                    if (AnalysisEntityFactory.TryGetForFlowCapture(captureId, out var analysisEntity))
-                    {
-                        StopTrackingDataForEntity(analysisEntity, allEntities);
-                    }
+                    Debug.Fail("TryCreateForSymbolDeclaration failed");
                 }
             }
-            finally
+
+            foreach (var captureId in flowCaptures)
             {
-                allEntities.Free();
+                if (AnalysisEntityFactory.TryGetForFlowCapture(captureId, out var analysisEntity))
+                {
+                    StopTrackingDataForEntity(analysisEntity, allEntities);
+                }
             }
         }
 
@@ -178,52 +171,38 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         {
             if (!parameterEntities.IsEmpty)
             {
-                var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                using var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                AddTrackedEntities(allEntities);
 
-                try
+                foreach (var (parameter, parameterEntity) in parameterEntities)
                 {
-                    AddTrackedEntities(allEntities);
+                    StopTrackingDataForEntity(parameterEntity, CurrentAnalysisData, allEntities);
 
-                    foreach (var (parameter, parameterEntity) in parameterEntities)
+                    if (parameter.IsParams)
                     {
-                        StopTrackingDataForEntity(parameterEntity, CurrentAnalysisData, allEntities);
-
-                        if (parameter.IsParams)
-                        {
-                            StopTrackingDataForParamArrayParameterIndices(parameterEntity, CurrentAnalysisData, allEntities);
-                        }
+                        StopTrackingDataForParamArrayParameterIndices(parameterEntity, CurrentAnalysisData, allEntities);
                     }
-                }
-                finally
-                {
-                    allEntities.Free();
                 }
             }
         }
 
         protected override TAnalysisData GetMergedAnalysisDataForPossibleThrowingOperation(TAnalysisData? existingData, IOperation operation)
         {
-            var entitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            try
-            {
-                // Get tracked entities.
-                AddTrackedEntities(entitiesBuilder);
+            using var entitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
 
-                // Only non-child entities are tracked for now.
-                var resultAnalysisData = GetTrimmedCurrentAnalysisData(entitiesBuilder.Where(e => !e.IsChildOrInstanceMember && HasAbstractValue(e)));
-                if (existingData != null)
-                {
-                    var mergedAnalysisData = MergeAnalysisData(resultAnalysisData, existingData);
-                    resultAnalysisData.Dispose();
-                    resultAnalysisData = mergedAnalysisData;
-                }
+            // Get tracked entities.
+            AddTrackedEntities(entitiesBuilder);
 
-                return resultAnalysisData;
-            }
-            finally
+            // Only non-child entities are tracked for now.
+            var resultAnalysisData = GetTrimmedCurrentAnalysisData(entitiesBuilder.Where(e => !e.IsChildOrInstanceMember && HasAbstractValue(e)));
+            if (existingData != null)
             {
-                entitiesBuilder.Free();
+                var mergedAnalysisData = MergeAnalysisData(resultAnalysisData, existingData);
+                resultAnalysisData.Dispose();
+                resultAnalysisData = mergedAnalysisData;
             }
+
+            return resultAnalysisData;
         }
 
         #region Helper methods to handle initialization/assignment operations
@@ -511,129 +490,117 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     isLambdaOrLocalFunction, hasParameterWithDelegateType);
             }
 
-            var candidateEntitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            var interproceduralEntitiesToRetainBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            var worklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-            var worklistPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
-            var processedPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
-            var childWorklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var candidateEntitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var interproceduralEntitiesToRetainBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var worklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var worklistPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
+            using var processedPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
+            using var childWorklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
 
-            try
+            // All tracked entities are candidates to be retained for initial interprocedural
+            // analysis data.
+            AddTrackedEntities(candidateEntitiesBuilder, forInterproceduralAnalysis: true);
+            var candidateEntitiesCount = candidateEntitiesBuilder.Count;
+
+            // Add entities and PointsTo values for invocation instance, this or me instance
+            // and argument values to the initial worklist
+
+            if (invocationInstance.HasValue)
             {
-                // All tracked entities are candidates to be retained for initial interprocedural
-                // analysis data.
-                AddTrackedEntities(candidateEntitiesBuilder, forInterproceduralAnalysis: true);
-                var candidateEntitiesCount = candidateEntitiesBuilder.Count;
+                AddWorklistEntityAndPointsToValue(invocationInstance.Value.Instance);
+                AddWorklistPointsToValue(invocationInstance.Value.PointsToValue);
+            }
 
-                // Add entities and PointsTo values for invocation instance, this or me instance
-                // and argument values to the initial worklist
+            if (thisOrMeInstanceForCaller.HasValue)
+            {
+                AddWorklistEntityAndPointsToValue(thisOrMeInstanceForCaller.Value.Instance);
+                AddWorklistPointsToValue(thisOrMeInstanceForCaller.Value.PointsToValue);
+            }
 
-                if (invocationInstance.HasValue)
+            foreach (var argument in argumentValuesMap.Values)
+            {
+                if (!AddWorklistEntityAndPointsToValue(argument.AnalysisEntity))
                 {
-                    AddWorklistEntityAndPointsToValue(invocationInstance.Value.Instance);
-                    AddWorklistPointsToValue(invocationInstance.Value.PointsToValue);
+                    // For allocations passed as arguments.
+                    AddWorklistPointsToValue(argument.InstanceLocation);
                 }
+            }
 
-                if (thisOrMeInstanceForCaller.HasValue)
+            // Worklist based algorithm to compute the transitive closure of analysis entities
+            // that are accessible in the callee via the PointsTo value chain.
+            while (worklistEntities.Count > 0 || worklistPointsToValues.Count > 0)
+            {
+                if (worklistEntities.Count > 0)
                 {
-                    AddWorklistEntityAndPointsToValue(thisOrMeInstanceForCaller.Value.Instance);
-                    AddWorklistPointsToValue(thisOrMeInstanceForCaller.Value.PointsToValue);
-                }
+                    // Add all the worklistEntities to interproceduralEntitiesBuilder
+                    // to ensure these entities are retained.
+                    interproceduralEntitiesToRetainBuilder.AddRange(worklistEntities);
 
-                foreach (var argument in argumentValuesMap.Values)
-                {
-                    if (!AddWorklistEntityAndPointsToValue(argument.AnalysisEntity))
+                    // Remove the worklistEntities from tracked candidate entities.
+                    candidateEntitiesBuilder.ExceptWith(worklistEntities);
+
+                    // Add child entities of worklistEntities to childWorklistEntities.
+                    // PERF: We cannot have any child entities for PointsToAnalysis if we
+                    // not computing complete PointsToAnalysis data.
+                    if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
                     {
-                        // For allocations passed as arguments.
-                        AddWorklistPointsToValue(argument.InstanceLocation);
-                    }
-                }
-
-                // Worklist based algorithm to compute the transitive closure of analysis entities
-                // that are accessible in the callee via the PointsTo value chain.
-                while (worklistEntities.Count > 0 || worklistPointsToValues.Count > 0)
-                {
-                    if (worklistEntities.Count > 0)
-                    {
-                        // Add all the worklistEntities to interproceduralEntitiesBuilder
-                        // to ensure these entities are retained.
-                        interproceduralEntitiesToRetainBuilder.AddRange(worklistEntities);
-
-                        // Remove the worklistEntities from tracked candidate entities.
-                        candidateEntitiesBuilder.ExceptWith(worklistEntities);
-
-                        // Add child entities of worklistEntities to childWorklistEntities.
-                        // PERF: We cannot have any child entities for PointsToAnalysis if we
-                        // not computing complete PointsToAnalysis data.
-                        if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
+                        foreach (var candidateEntity in candidateEntitiesBuilder)
                         {
-                            foreach (var candidateEntity in candidateEntitiesBuilder)
+                            foreach (var ancestorEntity in worklistEntities)
                             {
-                                foreach (var ancestorEntity in worklistEntities)
+                                if (IsChildAnalysisEntity(candidateEntity, ancestorEntity))
                                 {
-                                    if (IsChildAnalysisEntity(candidateEntity, ancestorEntity))
-                                    {
-                                        childWorklistEntities.Add(candidateEntity);
-                                        break;
-                                    }
+                                    childWorklistEntities.Add(candidateEntity);
+                                    break;
                                 }
                             }
                         }
-
-                        worklistEntities.Clear();
                     }
 
-                    if (worklistPointsToValues.Count > 0)
+                    worklistEntities.Clear();
+                }
+
+                if (worklistPointsToValues.Count > 0)
+                {
+                    // Add child entities which are accessible from PointsTo chain to childWorklistEntities.
+                    // PERF: We cannot have any child entities for PointsToAnalysis if we
+                    // not computing complete PointsToAnalysis data.
+                    if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
                     {
-                        // Add child entities which are accessible from PointsTo chain to childWorklistEntities.
-                        // PERF: We cannot have any child entities for PointsToAnalysis if we
-                        // not computing complete PointsToAnalysis data.
-                        if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
+                        foreach (var candidateEntity in candidateEntitiesBuilder)
                         {
-                            foreach (var candidateEntity in candidateEntitiesBuilder)
+                            foreach (var pointsToValue in worklistPointsToValues)
                             {
-                                foreach (var pointsToValue in worklistPointsToValues)
+                                Debug.Assert(ShouldProcessPointsToValue(pointsToValue));
+                                if (IsChildAnalysisEntity(candidateEntity, pointsToValue))
                                 {
-                                    Debug.Assert(ShouldProcessPointsToValue(pointsToValue));
-                                    if (IsChildAnalysisEntity(candidateEntity, pointsToValue))
-                                    {
-                                        childWorklistEntities.Add(candidateEntity);
-                                        break;
-                                    }
+                                    childWorklistEntities.Add(candidateEntity);
+                                    break;
                                 }
                             }
                         }
-
-                        worklistPointsToValues.Clear();
                     }
 
-                    // Move all the child work list entities and their PointsTo values to the worklist.
-                    foreach (var childEntity in childWorklistEntities)
-                    {
-                        AddWorklistEntityAndPointsToValue(childEntity);
-                    }
-
-                    childWorklistEntities.Clear();
+                    worklistPointsToValues.Clear();
                 }
 
-                // If all candidates being retained, just retain the cloned current analysis data.
-                if (interproceduralEntitiesToRetainBuilder.Count == candidateEntitiesCount)
+                // Move all the child work list entities and their PointsTo values to the worklist.
+                foreach (var childEntity in childWorklistEntities)
                 {
-                    return GetClonedCurrentAnalysisData();
+                    AddWorklistEntityAndPointsToValue(childEntity);
                 }
 
-                // Otherwise, return cloned current analysis data with trimmed keys.
-                return GetTrimmedCurrentAnalysisData(interproceduralEntitiesToRetainBuilder);
+                childWorklistEntities.Clear();
             }
-            finally
+
+            // If all candidates being retained, just retain the cloned current analysis data.
+            if (interproceduralEntitiesToRetainBuilder.Count == candidateEntitiesCount)
             {
-                candidateEntitiesBuilder.Free();
-                interproceduralEntitiesToRetainBuilder.Free();
-                worklistEntities.Free();
-                worklistPointsToValues.Free();
-                processedPointsToValues.Free();
-                childWorklistEntities.Free();
+                return GetClonedCurrentAnalysisData();
             }
+
+            // Otherwise, return cloned current analysis data with trimmed keys.
+            return GetTrimmedCurrentAnalysisData(interproceduralEntitiesToRetainBuilder);
 
             // Local functions.
             bool AddWorklistEntityAndPointsToValue(AnalysisEntity? analysisEntity)
@@ -739,29 +706,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 AnalysisDataForUnhandledThrowOperations != null &&
                 AnalysisDataForUnhandledThrowOperations.Values.Any(HasAnyAbstractValue))
             {
-                var allAnalysisEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                using var allAnalysisEntities = PooledHashSet<AnalysisEntity>.GetInstance();
 
-                try
+                foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
                 {
-                    foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
-                    {
-                        AddTrackedEntities(dataAtException, allAnalysisEntities, forInterproceduralAnalysis: true);
-                    }
+                    AddTrackedEntities(dataAtException, allAnalysisEntities, forInterproceduralAnalysis: true);
+                }
 
-                    foreach (var entity in allAnalysisEntities)
+                foreach (var entity in allAnalysisEntities)
+                {
+                    if (ShouldStopTrackingEntityAtExit(entity))
                     {
-                        if (ShouldStopTrackingEntityAtExit(entity))
+                        foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
                         {
-                            foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
-                            {
-                                StopTrackingDataForEntity(entity, dataAtException, allAnalysisEntities);
-                            }
+                            StopTrackingDataForEntity(entity, dataAtException, allAnalysisEntities);
                         }
                     }
-                }
-                finally
-                {
-                    allAnalysisEntities.Free();
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -342,14 +342,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 Debug.Assert(parentEntity.InstanceLocation == instanceLocation);
 
-                var builder = ArrayBuilder<AnalysisEntity>.GetInstance(tupleType.TupleElements.Length);
+                using var builder = ArrayBuilder<AnalysisEntity>.GetInstance(tupleType.TupleElements.Length);
                 foreach (var field in tupleType.TupleElements)
                 {
                     var tupleFieldName = field.CorrespondingTupleField.Name;
                     var mappedValueTupleField = underlyingValueTupleType.GetMembers(tupleFieldName).OfType<IFieldSymbol>().FirstOrDefault();
                     if (mappedValueTupleField == null)
                     {
-                        builder.Free();
                         return false;
                     }
 
@@ -357,7 +356,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         type: mappedValueTupleField.Type, instanceLocation, parentEntity));
                 }
 
-                elementEntities = builder.ToImmutableAndFree();
+                elementEntities = builder.ToImmutable();
                 return true;
             }
             finally

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -57,12 +57,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 return default;
             }
 
-            var resultBuilder = new DataFlowAnalysisResultBuilder<TAnalysisData>();
-            var uniqueSuccessors = PooledHashSet<BasicBlock>.GetInstance();
-            var finallyBlockSuccessorsMap = PooledDictionary<int, List<BranchWithInfo>>.GetInstance();
+            using var resultBuilder = new DataFlowAnalysisResultBuilder<TAnalysisData>();
+            using var uniqueSuccessors = PooledHashSet<BasicBlock>.GetInstance();
+            using var finallyBlockSuccessorsMap = PooledDictionary<int, List<BranchWithInfo>>.GetInstance();
             var catchBlockInputDataMap = PooledDictionary<ControlFlowRegion, TAnalysisData>.GetInstance();
             var inputDataFromInfeasibleBranchesMap = PooledDictionary<int, TAnalysisData>.GetInstance();
-            var unreachableBlocks = PooledHashSet<int>.GetInstance();
+            using var unreachableBlocks = PooledHashSet<int>.GetInstance();
             var worklist = new SortedSet<int>();
             var pendingBlocksNeedingAtLeastOnePass = new SortedSet<int>(cfg.Blocks.Select(b => b.Ordinal));
 
@@ -80,12 +80,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             //  This map allows us to optimize the number of merge operations. We can avoid merge and directly
             //  overwrite analysis data into a successor if successor block has no entry or entry with non-null tuple value
             //  with the matching input branch.
-            var blockToUniqueInputFlowMap = PooledDictionary<int, (int Ordinal, ControlFlowConditionKind BranchKind)?>.GetInstance();
+            using var blockToUniqueInputFlowMap = PooledDictionary<int, (int Ordinal, ControlFlowConditionKind BranchKind)?>.GetInstance();
 
             // Map from basic block ordinals that are destination of back edge(s) to the minimum block ordinal that dominates it,
             // i.e. for every '{key, value}' pair in the dictionary, 'key' is the destination of at least one back edge
             // and 'value' is the minimum ordinal such that there is no back edge to 'key' from any basic block with ordinal > 'value'.
-            var loopRangeMap = PooledDictionary<int, int>.GetInstance();
+            using var loopRangeMap = PooledDictionary<int, int>.GetInstance();
             ComputeLoopRangeMap(cfg, loopRangeMap);
 
             TAnalysisData? normalPathsExitBlockData = null, exceptionPathsExitBlockData = null;
@@ -161,16 +161,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
             finally
             {
-                resultBuilder.Dispose();
-                uniqueSuccessors.Free();
-                finallyBlockSuccessorsMap.Free();
                 catchBlockInputDataMap.Values.Dispose();
-                catchBlockInputDataMap.Free();
+                catchBlockInputDataMap.Dispose();
                 inputDataFromInfeasibleBranchesMap.Values.Dispose();
-                inputDataFromInfeasibleBranchesMap.Free();
-                unreachableBlocks.Free();
-                blockToUniqueInputFlowMap.Free();
-                loopRangeMap.Free();
+                inputDataFromInfeasibleBranchesMap.Dispose();
             }
         }
 
@@ -188,293 +182,280 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             PooledDictionary<int, int> loopRangeMap,
             bool exceptionPathsAnalysisPostPass)
         {
-            var unreachableBlocks = PooledHashSet<int>.GetInstance();
-            try
+            using var unreachableBlocks = PooledHashSet<int>.GetInstance();
+
+            // Add each basic block to the result.
+            foreach (var block in cfg.Blocks)
             {
-                // Add each basic block to the result.
-                foreach (var block in cfg.Blocks)
+                if (!block.IsReachable)
                 {
-                    if (!block.IsReachable)
+                    unreachableBlocks.Add(block.Ordinal);
+                }
+            }
+
+            while (worklist.Count > 0 || pendingBlocksNeedingAtLeastOnePass.Count > 0)
+            {
+                UpdateUnreachableBlocks();
+
+                // Get the next block to process from the worklist.
+                // If worklist is empty, get any one of the pendingBlocksNeedingAtLeastOnePass, which must be unreachable from Entry block.
+                int blockOrdinal;
+                if (worklist.Count > 0)
+                {
+                    blockOrdinal = worklist.Min;
+                    worklist.Remove(blockOrdinal);
+                }
+                else
+                {
+                    blockOrdinal = pendingBlocksNeedingAtLeastOnePass.Min;
+                }
+
+                var block = cfg.Blocks[blockOrdinal];
+
+                // Ensure that we execute potential nested catch blocks before the finally region.
+                if (pendingBlocksNeedingAtLeastOnePass.Any())
+                {
+                    var finallyRegion = block.GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Finally);
+                    if (finallyRegion?.EnclosingRegion.Kind == ControlFlowRegionKind.TryAndFinally)
                     {
-                        unreachableBlocks.Add(block.Ordinal);
+                        // Add all catch blocks in the try region corresponding to the finally.
+                        var tryRegion = finallyRegion.EnclosingRegion.NestedRegions[0];
+                        Debug.Assert(tryRegion.Kind == ControlFlowRegionKind.Try);
+
+                        var nestedCatchBlockOrdinals = pendingBlocksNeedingAtLeastOnePass.Where(
+                            p => p >= tryRegion.FirstBlockOrdinal &&
+                                 p <= tryRegion.LastBlockOrdinal &&
+                                 cfg.Blocks[p].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null);
+                        if (nestedCatchBlockOrdinals.Any())
+                        {
+                            foreach (var catchBlockOrdinal in nestedCatchBlockOrdinals)
+                            {
+                                worklist.Add(catchBlockOrdinal);
+                            }
+
+                            // Also add back the finally start block to be processed after catch blocks.
+                            worklist.Add(blockOrdinal);
+                            continue;
+                        }
                     }
                 }
 
-                while (worklist.Count > 0 || pendingBlocksNeedingAtLeastOnePass.Count > 0)
-                {
-                    UpdateUnreachableBlocks();
+                var needsAtLeastOnePass = pendingBlocksNeedingAtLeastOnePass.Remove(blockOrdinal);
+                var isUnreachableBlock = unreachableBlocks.Contains(block.Ordinal);
 
-                    // Get the next block to process from the worklist.
-                    // If worklist is empty, get any one of the pendingBlocksNeedingAtLeastOnePass, which must be unreachable from Entry block.
-                    int blockOrdinal;
-                    if (worklist.Count > 0)
+                // Get the input data for the block.
+                var input = resultBuilder[block];
+                if (input == null)
+                {
+                    Debug.Assert(needsAtLeastOnePass);
+
+                    if (isUnreachableBlock &&
+                        inputDataFromInfeasibleBranchesMap.TryGetValue(block.Ordinal, out var currentInfeasibleData))
                     {
-                        blockOrdinal = worklist.Min;
-                        worklist.Remove(blockOrdinal);
+                        // Block is unreachable due to predicate analysis.
+                        // Initialize the input from predecessors to avoid false reports in unreachable code.
+                        Debug.Assert(!currentInfeasibleData.IsDisposed);
+                        input = currentInfeasibleData;
+                        inputDataFromInfeasibleBranchesMap.Remove(block.Ordinal);
                     }
                     else
                     {
-                        blockOrdinal = pendingBlocksNeedingAtLeastOnePass.Min;
+                        // For catch and filter regions, we track the initial input data in the catchBlockInputDataMap.
+                        ControlFlowRegion? enclosingTryAndCatchRegion = GetEnclosingTryAndCatchRegionIfStartsHandler(block);
+                        if (enclosingTryAndCatchRegion != null &&
+                            catchBlockInputDataMap.TryGetValue(enclosingTryAndCatchRegion, out var catchBlockInput))
+                        {
+                            Debug.Assert(enclosingTryAndCatchRegion.Kind == ControlFlowRegionKind.TryAndCatch);
+                            Debug.Assert(block.EnclosingRegion.Kind == ControlFlowRegionKind.Catch || block.EnclosingRegion.Kind == ControlFlowRegionKind.Filter);
+                            Debug.Assert(block.EnclosingRegion.FirstBlockOrdinal == block.Ordinal);
+                            Debug.Assert(!catchBlockInput.IsDisposed);
+                            input = catchBlockInput;
+
+                            // Mark that all input into successorBlockOpt requires a merge.
+                            blockToUniqueInputFlowMap[block.Ordinal] = null;
+                        }
                     }
 
-                    var block = cfg.Blocks[blockOrdinal];
+                    input = input != null ?
+                        AnalysisDomain.Clone(input) :
+                        GetClonedAnalysisDataOrEmptyData(initialAnalysisData);
 
-                    // Ensure that we execute potential nested catch blocks before the finally region.
-                    if (pendingBlocksNeedingAtLeastOnePass.Any())
+                    UpdateInput(resultBuilder, block, input);
+                }
+
+                // Check if we are starting a try region which has one or more associated catch/filter regions.
+                // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
+                if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
+                    block.EnclosingRegion?.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
+                    block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
+                {
+                    MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
+                }
+
+                // Flow the new input through the block to get a new output.
+                using var output = Flow(OperationVisitor, block, AnalysisDomain.Clone(input));
+
+                // Update the current block result's
+                // output values with the new ones.
+                CloneAndUpdateOutputIfEntryOrExitBlock(resultBuilder, block, output);
+
+                // Propagate the output data to all the successor blocks of the current block.
+                uniqueSuccessors.Clear();
+
+                // Get the successors with corresponding flow branches.
+                // CONSIDER: Currently we need to do a bunch of branch adjusments for branches to/from finally, catch and filter regions.
+                //           We should revisit the overall CFG API and the walker to avoid such adjustments.
+                var successorsWithAdjustedBranches = GetSuccessorsWithAdjustedBranches(block).ToArray();
+                foreach ((BranchWithInfo successorWithBranch, BranchWithInfo preadjustSuccessorWithBranch) in successorsWithAdjustedBranches)
+                {
+                    // successorWithAdjustedBranch returns a pair of branches:
+                    //  1. successorWithBranch - This is the adjusted branch for a branch from inside a try region to outside the try region, where we don't flow into finally region.
+                    //                           The adjusted branch is targeted into the finally.
+                    //  2. preadjustSuccessorWithBranch - This is the original branch, which is primarily used to update the input data and successors of finally and catch region regions.
+                    //                                    Currently, these blocks have no branch coming out from it.
+
+                    // Flow the current analysis data through the branch.
+                    (TAnalysisData newSuccessorInput, bool isFeasibleBranch) = OperationVisitor.FlowBranch(block, successorWithBranch, AnalysisDomain.Clone(output));
+
+                    if (preadjustSuccessorWithBranch != null)
                     {
-                        var finallyRegion = block.GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Finally);
-                        if (finallyRegion?.EnclosingRegion.Kind == ControlFlowRegionKind.TryAndFinally)
+                        UpdateFinallySuccessorsAndCatchInput(preadjustSuccessorWithBranch, newSuccessorInput, block);
+                    }
+
+                    // Certain branches have no destination (e.g. BranchKind.Throw), so we don't need to update the input data for the branch destination block.
+                    var successorBlock = successorWithBranch.Destination;
+                    if (successorBlock == null)
+                    {
+                        newSuccessorInput.Dispose();
+                        continue;
+                    }
+
+                    if (exceptionPathsAnalysisPostPass)
+                    {
+                        // For exception paths analysis, we need to force re-analysis of entire finally region
+                        // whenever we start try region analysis so analysis data for unhandled exceptions at end of the finally region is correctly updated.
+                        if (successorBlock.IsFirstBlockOfRegionKind(ControlFlowRegionKind.TryAndFinally, out var tryAndFinally))
                         {
-                            // Add all catch blocks in the try region corresponding to the finally.
-                            var tryRegion = finallyRegion.EnclosingRegion.NestedRegions[0];
-                            Debug.Assert(tryRegion.Kind == ControlFlowRegionKind.Try);
+                            var finallyRegion = tryAndFinally.NestedRegions[1];
+                            Debug.Assert(finallyRegion.Kind == ControlFlowRegionKind.Finally);
 
-                            var nestedCatchBlockOrdinals = pendingBlocksNeedingAtLeastOnePass.Where(
-                                p => p >= tryRegion.FirstBlockOrdinal &&
-                                     p <= tryRegion.LastBlockOrdinal &&
-                                     cfg.Blocks[p].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null);
-                            if (nestedCatchBlockOrdinals.Any())
+                            for (int i = finallyRegion.FirstBlockOrdinal; i <= finallyRegion.LastBlockOrdinal; i++)
                             {
-                                foreach (var catchBlockOrdinal in nestedCatchBlockOrdinals)
-                                {
-                                    worklist.Add(catchBlockOrdinal);
-                                }
-
-                                // Also add back the finally start block to be processed after catch blocks.
-                                worklist.Add(blockOrdinal);
-                                continue;
+                                worklist.Add(i);
                             }
                         }
                     }
 
-                    var needsAtLeastOnePass = pendingBlocksNeedingAtLeastOnePass.Remove(blockOrdinal);
-                    var isUnreachableBlock = unreachableBlocks.Contains(block.Ordinal);
+                    // Perf: We can stop tracking data for entities whose lifetime is limited by the leaving regions.
+                    //       Below invocation explicitly drops such data from destination input.
+                    newSuccessorInput = OperationVisitor.OnLeavingRegions(successorWithBranch.LeavingRegionLocals,
+                        successorWithBranch.LeavingRegionFlowCaptures, block, newSuccessorInput);
 
-                    // Get the input data for the block.
-                    var input = resultBuilder[block];
-                    if (input == null)
+                    var isBackEdge = block.Ordinal >= successorBlock.Ordinal;
+                    if (isUnreachableBlock && !unreachableBlocks.Contains(successorBlock.Ordinal))
                     {
-                        Debug.Assert(needsAtLeastOnePass);
-
-                        if (isUnreachableBlock &&
-                            inputDataFromInfeasibleBranchesMap.TryGetValue(block.Ordinal, out var currentInfeasibleData))
+                        // Skip processing successor input for branch from an unreachable block to a reachable block.
+                        newSuccessorInput.Dispose();
+                        continue;
+                    }
+                    else if (!isFeasibleBranch)
+                    {
+                        // Skip processing the successor input for conditional branch that can never be taken.
+                        if (inputDataFromInfeasibleBranchesMap.TryGetValue(successorBlock.Ordinal, out TAnalysisData currentInfeasibleData))
                         {
-                            // Block is unreachable due to predicate analysis.
-                            // Initialize the input from predecessors to avoid false reports in unreachable code.
-                            Debug.Assert(!currentInfeasibleData.IsDisposed);
-                            input = currentInfeasibleData;
-                            inputDataFromInfeasibleBranchesMap.Remove(block.Ordinal);
-                        }
-                        else
-                        {
-                            // For catch and filter regions, we track the initial input data in the catchBlockInputDataMap.
-                            ControlFlowRegion? enclosingTryAndCatchRegion = GetEnclosingTryAndCatchRegionIfStartsHandler(block);
-                            if (enclosingTryAndCatchRegion != null &&
-                                catchBlockInputDataMap.TryGetValue(enclosingTryAndCatchRegion, out var catchBlockInput))
-                            {
-                                Debug.Assert(enclosingTryAndCatchRegion.Kind == ControlFlowRegionKind.TryAndCatch);
-                                Debug.Assert(block.EnclosingRegion.Kind == ControlFlowRegionKind.Catch || block.EnclosingRegion.Kind == ControlFlowRegionKind.Filter);
-                                Debug.Assert(block.EnclosingRegion.FirstBlockOrdinal == block.Ordinal);
-                                Debug.Assert(!catchBlockInput.IsDisposed);
-                                input = catchBlockInput;
-
-                                // Mark that all input into successorBlockOpt requires a merge.
-                                blockToUniqueInputFlowMap[block.Ordinal] = null;
-                            }
+                            var dataToDispose = newSuccessorInput;
+                            newSuccessorInput = OperationVisitor.MergeAnalysisData(currentInfeasibleData, newSuccessorInput, successorBlock, isBackEdge);
+                            Debug.Assert(!ReferenceEquals(dataToDispose, newSuccessorInput));
+                            dataToDispose.Dispose();
                         }
 
-                        input = input != null ?
-                            AnalysisDomain.Clone(input) :
-                            GetClonedAnalysisDataOrEmptyData(initialAnalysisData);
-
-                        UpdateInput(resultBuilder, block, input);
+                        inputDataFromInfeasibleBranchesMap[successorBlock.Ordinal] = newSuccessorInput;
+                        continue;
                     }
 
-                    // Check if we are starting a try region which has one or more associated catch/filter regions.
-                    // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
-                    if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
-                        block.EnclosingRegion?.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
-                        block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
+                    var blockToSuccessorBranchKind = successorWithBranch.ControlFlowConditionKind;
+                    var currentSuccessorInput = resultBuilder[successorBlock];
+
+                    // We need to merge the incoming analysis data if both the following conditions are satisfied:
+                    //  1. Successor already has a non-null input from prior analysis iteration.
+                    //  2. 'blockToPreviousInputBlockMap' has an entry for successor block such that one of the following conditions are satisfied:
+                    //      a. Value is null, indicating it already had analysis data flow in from multiple branches OR
+                    //      b. Value is non-null, indicating it has unique input from prior analysis, but the prior input
+                    //         analysis data was from a different branch, i.e. either different source block or different condition kind.
+                    var needsMerge = currentSuccessorInput != null &&
+                        blockToUniqueInputFlowMap.TryGetValue(successorBlock.Ordinal, out var uniqueInputBranchOpt) &&
+                        (uniqueInputBranchOpt == null ||
+                         uniqueInputBranchOpt.Value.Ordinal != block.Ordinal ||
+                         uniqueInputBranchOpt.Value.BranchKind != blockToSuccessorBranchKind);
+
+                    TAnalysisData mergedSuccessorInput;
+                    if (needsMerge)
                     {
-                        MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
-                    }
+                        RoslynDebug.Assert(currentSuccessorInput != null);
 
-                    // Flow the new input through the block to get a new output.
-                    var output = Flow(OperationVisitor, block, AnalysisDomain.Clone(input));
+                        // Mark that all input into successorBlockOpt requires a merge as we have non-unique input flow branches into successor block.
+                        blockToUniqueInputFlowMap[successorBlock.Ordinal] = null;
 
-                    try
-                    {
-                        // Update the current block result's
-                        // output values with the new ones.
-                        CloneAndUpdateOutputIfEntryOrExitBlock(resultBuilder, block, output);
-
-                        // Propagate the output data to all the successor blocks of the current block.
-                        uniqueSuccessors.Clear();
-
-                        // Get the successors with corresponding flow branches.
-                        // CONSIDER: Currently we need to do a bunch of branch adjusments for branches to/from finally, catch and filter regions.
-                        //           We should revisit the overall CFG API and the walker to avoid such adjustments.
-                        var successorsWithAdjustedBranches = GetSuccessorsWithAdjustedBranches(block).ToArray();
-                        foreach ((BranchWithInfo successorWithBranch, BranchWithInfo preadjustSuccessorWithBranch) in successorsWithAdjustedBranches)
+                        // Check if the current input data for the successor block is equal to the new input data from this branch.
+                        // If so, we don't need to propagate new input data from this branch.
+                        if (AnalysisDomain.Equals(currentSuccessorInput, newSuccessorInput))
                         {
-                            // successorWithAdjustedBranch returns a pair of branches:
-                            //  1. successorWithBranch - This is the adjusted branch for a branch from inside a try region to outside the try region, where we don't flow into finally region.
-                            //                           The adjusted branch is targeted into the finally.
-                            //  2. preadjustSuccessorWithBranch - This is the original branch, which is primarily used to update the input data and successors of finally and catch region regions.
-                            //                                    Currently, these blocks have no branch coming out from it.
-
-                            // Flow the current analysis data through the branch.
-                            (TAnalysisData newSuccessorInput, bool isFeasibleBranch) = OperationVisitor.FlowBranch(block, successorWithBranch, AnalysisDomain.Clone(output));
-
-                            if (preadjustSuccessorWithBranch != null)
-                            {
-                                UpdateFinallySuccessorsAndCatchInput(preadjustSuccessorWithBranch, newSuccessorInput, block);
-                            }
-
-                            // Certain branches have no destination (e.g. BranchKind.Throw), so we don't need to update the input data for the branch destination block.
-                            var successorBlock = successorWithBranch.Destination;
-                            if (successorBlock == null)
-                            {
-                                newSuccessorInput.Dispose();
-                                continue;
-                            }
-
-                            if (exceptionPathsAnalysisPostPass)
-                            {
-                                // For exception paths analysis, we need to force re-analysis of entire finally region
-                                // whenever we start try region analysis so analysis data for unhandled exceptions at end of the finally region is correctly updated.
-                                if (successorBlock.IsFirstBlockOfRegionKind(ControlFlowRegionKind.TryAndFinally, out var tryAndFinally))
-                                {
-                                    var finallyRegion = tryAndFinally.NestedRegions[1];
-                                    Debug.Assert(finallyRegion.Kind == ControlFlowRegionKind.Finally);
-
-                                    for (int i = finallyRegion.FirstBlockOrdinal; i <= finallyRegion.LastBlockOrdinal; i++)
-                                    {
-                                        worklist.Add(i);
-                                    }
-                                }
-                            }
-
-                            // Perf: We can stop tracking data for entities whose lifetime is limited by the leaving regions.
-                            //       Below invocation explicitly drops such data from destination input.
-                            newSuccessorInput = OperationVisitor.OnLeavingRegions(successorWithBranch.LeavingRegionLocals,
-                                successorWithBranch.LeavingRegionFlowCaptures, block, newSuccessorInput);
-
-                            var isBackEdge = block.Ordinal >= successorBlock.Ordinal;
-                            if (isUnreachableBlock && !unreachableBlocks.Contains(successorBlock.Ordinal))
-                            {
-                                // Skip processing successor input for branch from an unreachable block to a reachable block.
-                                newSuccessorInput.Dispose();
-                                continue;
-                            }
-                            else if (!isFeasibleBranch)
-                            {
-                                // Skip processing the successor input for conditional branch that can never be taken.
-                                if (inputDataFromInfeasibleBranchesMap.TryGetValue(successorBlock.Ordinal, out TAnalysisData currentInfeasibleData))
-                                {
-                                    var dataToDispose = newSuccessorInput;
-                                    newSuccessorInput = OperationVisitor.MergeAnalysisData(currentInfeasibleData, newSuccessorInput, successorBlock, isBackEdge);
-                                    Debug.Assert(!ReferenceEquals(dataToDispose, newSuccessorInput));
-                                    dataToDispose.Dispose();
-                                }
-
-                                inputDataFromInfeasibleBranchesMap[successorBlock.Ordinal] = newSuccessorInput;
-                                continue;
-                            }
-
-                            var blockToSuccessorBranchKind = successorWithBranch.ControlFlowConditionKind;
-                            var currentSuccessorInput = resultBuilder[successorBlock];
-
-                            // We need to merge the incoming analysis data if both the following conditions are satisfied:
-                            //  1. Successor already has a non-null input from prior analysis iteration.
-                            //  2. 'blockToPreviousInputBlockMap' has an entry for successor block such that one of the following conditions are satisfied:
-                            //      a. Value is null, indicating it already had analysis data flow in from multiple branches OR
-                            //      b. Value is non-null, indicating it has unique input from prior analysis, but the prior input
-                            //         analysis data was from a different branch, i.e. either different source block or different condition kind.
-                            var needsMerge = currentSuccessorInput != null &&
-                                blockToUniqueInputFlowMap.TryGetValue(successorBlock.Ordinal, out var uniqueInputBranchOpt) &&
-                                (uniqueInputBranchOpt == null ||
-                                 uniqueInputBranchOpt.Value.Ordinal != block.Ordinal ||
-                                 uniqueInputBranchOpt.Value.BranchKind != blockToSuccessorBranchKind);
-
-                            TAnalysisData mergedSuccessorInput;
-                            if (needsMerge)
-                            {
-                                RoslynDebug.Assert(currentSuccessorInput != null);
-
-                                // Mark that all input into successorBlockOpt requires a merge as we have non-unique input flow branches into successor block.
-                                blockToUniqueInputFlowMap[successorBlock.Ordinal] = null;
-
-                                // Check if the current input data for the successor block is equal to the new input data from this branch.
-                                // If so, we don't need to propagate new input data from this branch.
-                                if (AnalysisDomain.Equals(currentSuccessorInput, newSuccessorInput))
-                                {
-                                    newSuccessorInput.Dispose();
-                                    continue;
-                                }
-
-                                // Otherwise, check if the input data for the successor block changes after merging with the new input data.
-                                mergedSuccessorInput = OperationVisitor.MergeAnalysisData(currentSuccessorInput, newSuccessorInput, successorBlock, isBackEdge);
-                                newSuccessorInput.Dispose();
-
-                                int compare = AnalysisDomain.Compare(currentSuccessorInput, mergedSuccessorInput);
-
-                                // The newly computed abstract values for each basic block
-                                // must be always greater or equal than the previous value
-                                // to ensure termination.
-                                Debug.Assert(compare <= 0, "The newly computed abstract value must be greater or equal than the previous one.");
-
-                                // Is old input value >= new input value
-                                if (compare >= 0)
-                                {
-                                    mergedSuccessorInput.Dispose();
-                                    continue;
-                                }
-                            }
-                            else
-                            {
-                                Debug.Assert(currentSuccessorInput == null || AnalysisDomain.Compare(currentSuccessorInput, newSuccessorInput) <= 0);
-                                mergedSuccessorInput = newSuccessorInput;
-
-                                // Mark that all input into successorBlockOpt can skip merge as long as it from the current input flow branch.
-                                blockToUniqueInputFlowMap[successorBlock.Ordinal] = (block.Ordinal, blockToSuccessorBranchKind);
-                            }
-
-                            // Input to successor has changed, so we need to update its new input and
-                            // reprocess the successor by adding it to the worklist.
-                            UpdateInput(resultBuilder, successorBlock, mergedSuccessorInput);
-
-                            if (isBackEdge)
-                            {
-                                // For back edges, analysis data in subsequent iterations needs
-                                // to be merged with analysis data from previous iterations.
-                                var dominatorBlockOrdinal = loopRangeMap[successorBlock.Ordinal];
-                                Debug.Assert(dominatorBlockOrdinal >= block.Ordinal);
-                                Debug.Assert(dominatorBlockOrdinal >= successorBlock.Ordinal);
-
-                                for (int i = successorBlock.Ordinal; i <= dominatorBlockOrdinal + 1; i++)
-                                {
-                                    blockToUniqueInputFlowMap[i] = null;
-                                }
-                            }
-
-                            if (uniqueSuccessors.Add(successorBlock))
-                            {
-                                worklist.Add(successorBlock.Ordinal);
-                            }
+                            newSuccessorInput.Dispose();
+                            continue;
                         }
 
-                        Debug.Assert(IsValidWorklistState());
+                        // Otherwise, check if the input data for the successor block changes after merging with the new input data.
+                        mergedSuccessorInput = OperationVisitor.MergeAnalysisData(currentSuccessorInput, newSuccessorInput, successorBlock, isBackEdge);
+                        newSuccessorInput.Dispose();
+
+                        int compare = AnalysisDomain.Compare(currentSuccessorInput, mergedSuccessorInput);
+
+                        // The newly computed abstract values for each basic block
+                        // must be always greater or equal than the previous value
+                        // to ensure termination.
+                        Debug.Assert(compare <= 0, "The newly computed abstract value must be greater or equal than the previous one.");
+
+                        // Is old input value >= new input value
+                        if (compare >= 0)
+                        {
+                            mergedSuccessorInput.Dispose();
+                            continue;
+                        }
                     }
-                    finally
+                    else
                     {
-                        output.Dispose();
+                        Debug.Assert(currentSuccessorInput == null || AnalysisDomain.Compare(currentSuccessorInput, newSuccessorInput) <= 0);
+                        mergedSuccessorInput = newSuccessorInput;
+
+                        // Mark that all input into successorBlockOpt can skip merge as long as it from the current input flow branch.
+                        blockToUniqueInputFlowMap[successorBlock.Ordinal] = (block.Ordinal, blockToSuccessorBranchKind);
+                    }
+
+                    // Input to successor has changed, so we need to update its new input and
+                    // reprocess the successor by adding it to the worklist.
+                    UpdateInput(resultBuilder, successorBlock, mergedSuccessorInput);
+
+                    if (isBackEdge)
+                    {
+                        // For back edges, analysis data in subsequent iterations needs
+                        // to be merged with analysis data from previous iterations.
+                        var dominatorBlockOrdinal = loopRangeMap[successorBlock.Ordinal];
+                        Debug.Assert(dominatorBlockOrdinal >= block.Ordinal);
+                        Debug.Assert(dominatorBlockOrdinal >= successorBlock.Ordinal);
+
+                        for (int i = successorBlock.Ordinal; i <= dominatorBlockOrdinal + 1; i++)
+                        {
+                            blockToUniqueInputFlowMap[i] = null;
+                        }
+                    }
+
+                    if (uniqueSuccessors.Add(successorBlock))
+                    {
+                        worklist.Add(successorBlock.Ordinal);
                     }
                 }
-            }
-            finally
-            {
-                unreachableBlocks.Free();
+
+                Debug.Assert(IsValidWorklistState());
             }
 
             // Local functions.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public void Dispose()
         {
             _info.Values.Dispose();
-            _info.Free();
+            _info.Dispose();
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -473,22 +473,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             DictionaryAnalysisData<TKey, TAbstractAnalysisValue> newAnalysisData)
             where TKey : notnull
         {
-            var builder = ArrayBuilder<TKey>.GetInstance(targetAnalysisData.Count);
-            try
+            using var builder = ArrayBuilder<TKey>.GetInstance(targetAnalysisData.Count);
+            builder.AddRange(targetAnalysisData.Keys);
+            for (int i = 0; i < builder.Count; i++)
             {
-                builder.AddRange(targetAnalysisData.Keys);
-                for (int i = 0; i < builder.Count; i++)
+                var key = builder[i];
+                if (newAnalysisData.TryGetValue(key, out var newValue))
                 {
-                    var key = builder[i];
-                    if (newAnalysisData.TryGetValue(key, out var newValue))
-                    {
-                        targetAnalysisData[key] = newValue;
-                    }
+                    targetAnalysisData[key] = newValue;
                 }
-            }
-            finally
-            {
-                builder.Free();
             }
         }
 
@@ -2345,37 +2338,30 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         return ImmutableDictionary<ISymbol, PointsToAbstractValue>.Empty;
                     }
 
-                    var capturedVariables = cfg.OriginalOperation.GetCaptures(invokedMethod);
-                    try
+                    using var capturedVariables = cfg.OriginalOperation.GetCaptures(invokedMethod);
+                    if (capturedVariables.Count == 0)
                     {
-                        if (capturedVariables.Count == 0)
+                        return ImmutableDictionary<ISymbol, PointsToAbstractValue>.Empty;
+                    }
+                    else
+                    {
+                        var builder = ImmutableDictionary.CreateBuilder<ISymbol, PointsToAbstractValue>();
+                        foreach (var capturedVariable in capturedVariables)
                         {
-                            return ImmutableDictionary<ISymbol, PointsToAbstractValue>.Empty;
-                        }
-                        else
-                        {
-                            var builder = ImmutableDictionary.CreateBuilder<ISymbol, PointsToAbstractValue>();
-                            foreach (var capturedVariable in capturedVariables)
+                            if (capturedVariable.Kind == SymbolKind.NamedType)
                             {
-                                if (capturedVariable.Kind == SymbolKind.NamedType)
-                                {
-                                    // ThisOrMeInstance capture can be skipped here
-                                    // as we already pass down the invocation instance through "GetInvocationInstance".
-                                    continue;
-                                }
-
-                                var success = AnalysisEntityFactory.TryCreateForSymbolDeclaration(capturedVariable, out var capturedEntity);
-                                Debug.Assert(success);
-                                RoslynDebug.Assert(capturedEntity != null);
-                                builder.Add(capturedVariable, capturedEntity.InstanceLocation);
+                                // ThisOrMeInstance capture can be skipped here
+                                // as we already pass down the invocation instance through "GetInvocationInstance".
+                                continue;
                             }
 
-                            return builder.ToImmutable();
+                            var success = AnalysisEntityFactory.TryCreateForSymbolDeclaration(capturedVariable, out var capturedEntity);
+                            Debug.Assert(success);
+                            RoslynDebug.Assert(capturedEntity != null);
+                            builder.Add(capturedVariable, capturedEntity.InstanceLocation);
                         }
-                    }
-                    finally
-                    {
-                        capturedVariables.Free();
+
+                        return builder.ToImmutable();
                     }
                 }
 
@@ -3201,49 +3187,41 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public override TAbstractAnalysisValue VisitTuple(ITupleOperation operation, object? argument)
         {
-            var elementValueBuilder = ArrayBuilder<TAbstractAnalysisValue>.GetInstance(operation.Elements.Length);
-
-            try
+            using var elementValueBuilder = ArrayBuilder<TAbstractAnalysisValue>.GetInstance(operation.Elements.Length);
+            foreach (var element in operation.Elements)
             {
-                foreach (var element in operation.Elements)
-                {
-                    elementValueBuilder.Add(Visit(element, argument));
-                }
+                elementValueBuilder.Add(Visit(element, argument));
+            }
 
-                // Set abstract value for tuple element/field assignment if the tuple is not target of a deconstruction assignment.
-                // For deconstruction assignment, the value would be assigned from the computed value for the right side of the assignment.
-                var deconstructionAncestor = operation.GetAncestor<IDeconstructionAssignmentOperation>(OperationKind.DeconstructionAssignment);
-                if (deconstructionAncestor == null ||
-                    !deconstructionAncestor.Target.Descendants().Contains(operation))
+            // Set abstract value for tuple element/field assignment if the tuple is not target of a deconstruction assignment.
+            // For deconstruction assignment, the value would be assigned from the computed value for the right side of the assignment.
+            var deconstructionAncestor = operation.GetAncestor<IDeconstructionAssignmentOperation>(OperationKind.DeconstructionAssignment);
+            if (deconstructionAncestor == null ||
+                !deconstructionAncestor.Target.Descendants().Contains(operation))
+            {
+                if (AnalysisEntityFactory.TryCreateForTupleElements(operation, out var elementEntities))
                 {
-                    if (AnalysisEntityFactory.TryCreateForTupleElements(operation, out var elementEntities))
+                    Debug.Assert(elementEntities.Length == elementValueBuilder.Count);
+                    Debug.Assert(elementEntities.Length == operation.Elements.Length);
+                    for (int i = 0; i < elementEntities.Length; i++)
                     {
-                        Debug.Assert(elementEntities.Length == elementValueBuilder.Count);
-                        Debug.Assert(elementEntities.Length == operation.Elements.Length);
-                        for (int i = 0; i < elementEntities.Length; i++)
-                        {
-                            var tupleElementEntity = elementEntities[i];
-                            var assignedValueOperation = operation.Elements[i];
-                            var assignedValue = elementValueBuilder[i];
-                            SetAbstractValueForTupleElementAssignment(tupleElementEntity, assignedValueOperation, assignedValue);
-                        }
-                    }
-                    else
-                    {
-                        // Reset data for elements.
-                        foreach (var element in operation.Elements)
-                        {
-                            SetAbstractValueForAssignment(element, operation, ValueDomain.UnknownOrMayBeValue);
-                        }
+                        var tupleElementEntity = elementEntities[i];
+                        var assignedValueOperation = operation.Elements[i];
+                        var assignedValue = elementValueBuilder[i];
+                        SetAbstractValueForTupleElementAssignment(tupleElementEntity, assignedValueOperation, assignedValue);
                     }
                 }
+                else
+                {
+                    // Reset data for elements.
+                    foreach (var element in operation.Elements)
+                    {
+                        SetAbstractValueForAssignment(element, operation, ValueDomain.UnknownOrMayBeValue);
+                    }
+                }
+            }
 
-                return GetAbstractDefaultValue(operation.Type);
-            }
-            finally
-            {
-                elementValueBuilder.Free();
-            }
+            return GetAbstractDefaultValue(operation.Type);
         }
 
         public virtual TAbstractAnalysisValue VisitUnaryOperatorCore(IUnaryOperation operation, object? argument)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             if (disposing)
             {
-                _coreAnalysisData.Free();
+                _coreAnalysisData.Dispose();
                 _coreAnalysisData = null!;
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             if (_lazyPredicateDataMap != null)
             {
                 Debug.Assert(!_lazyPredicateDataMap.IsDisposed);
-                var builder = PooledHashSet<DictionaryAnalysisData<TKey, TValue>>.GetInstance();
+                using var builder = PooledHashSet<DictionaryAnalysisData<TKey, TValue>>.GetInstance();
                 foreach (var value in _lazyPredicateDataMap.Values)
                 {
                     if (value.TruePredicatedData != null)
@@ -77,8 +77,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         Debug.Assert(builder.Add(value.FalsePredicatedData));
                     }
                 }
-
-                builder.Free();
             }
         }
 


### PR DESCRIPTION
**Strongly recommended to review ignoring white space diffs: https://github.com/dotnet/roslyn-analyzers/pull/4026/files?diff=unified&w=1**

See https://github.com/dotnet/roslyn/issues/46859 and https://github.com/dotnet/roslyn-analyzers/pull/3917#issuecomment-674477914 for details. We might end up with corrup pooled data structures in presence of cancellation, so work around the Roslyn bug by not returning pooled object back to the pool in presence of cancellation.