### PR TITLE
[RC1] CA1835 fix - Automatically add using/imports System if not yet included

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -37,6 +38,18 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                            argNode.NameColon?.Name?.Identifier.ValueText == name;
                 });
             }
+        }
+
+        protected override bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> importList)
+        {
+            foreach (SyntaxNode import in importList)
+            {
+                if (import is UsingDirectiveSyntax { Name: IdentifierNameSyntax { Identifier: { Text: nameof(System) } } })
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,6 +33,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     {
         // Checks if the argument in the specified index has a name. If it doesn't, returns that arguments. If it does, then looks for the argument using the specified name, and returns it, or null if not found.
         protected abstract IArgumentOperation? GetArgumentByPositionOrName(ImmutableArray<IArgumentOperation> args, int index, string name, out bool isNamed);
+
+        // Verifies if a namespace has already been added to the usings/imports list.
+        protected abstract bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> importList);
 
         public sealed override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(PreferStreamAsyncMemoryOverloads.RuleId);
@@ -100,7 +104,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 context.Diagnostics);
         }
 
-        private static Task<Document> FixInvocation(Document doc, SyntaxNode root, IInvocationOperation invocation, string methodName,
+        private Task<Document> FixInvocation(Document doc, SyntaxNode root, IInvocationOperation invocation, string methodName,
             SyntaxNode bufferValueNode, bool isBufferNamed,
             SyntaxNode offsetValueNode, bool isOffsetNamed,
             SyntaxNode countValueNode, bool isCountNamed,
@@ -145,11 +149,16 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             }
             SyntaxNode newInvocationExpression = generator.InvocationExpression(asyncMethodNode, nodeArguments).WithTriviaFrom(streamInstanceNode);
 
+            bool containsSystemImport = IsSystemNamespaceImported(generator.GetNamespaceImports(root));
+
+            // The invocation needs to be replaced before adding the import/using, it won't work the other way around
             SyntaxNode newRoot = generator.ReplaceNode(root, invocation.Syntax, newInvocationExpression.WithTriviaFrom(invocation.Syntax));
-            return Task.FromResult(doc.WithSyntaxRoot(newRoot));
+            SyntaxNode newRootWithImports = containsSystemImport ? newRoot : generator.AddNamespaceImports(newRoot, generator.NamespaceImportDeclaration(nameof(System)));
+
+            return Task.FromResult(doc.WithSyntaxRoot(newRootWithImports));
         }
 
-        // Needed for Telemetry (https://github.com/dotnet/roslyn-analyzers/issues/192) 
+        // Needed for Telemetry (https://github.com/dotnet/roslyn-analyzers/issues/192)
         private class MyCodeAction : DocumentChangeAction
         {
             public MyCodeAction(string title, Func<CancellationToken, Task<Document>> createChangedDocument, string equivalenceKey)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 
@@ -578,6 +576,42 @@ class C
                                         "(new byte[s.Length]).AsMemory(0, (int)s.Length), new CancellationToken()" };
         }
 
+        [Fact]
+        public Task CS_Fixer_Diagnostic_EnsureSystemNamespaceAutoAdded()
+        {
+            string originalCode = @"
+using System.IO;
+using System.Threading;
+class C
+{
+    public async void M()
+    {
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {
+            byte[] buffer = new byte[s.Length];
+            await s.ReadAsync(new byte[s.Length], 0, (int)s.Length);
+        }
+    }
+}";
+            string fixedCode = @"
+using System.IO;
+using System.Threading;
+using System;
+
+class C
+{
+    public async void M()
+    {
+        using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
+        {
+            byte[] buffer = new byte[s.Length];
+            await s.ReadAsync((new byte[s.Length]).AsMemory(0, (int)s.Length));
+        }
+    }
+}";
+            return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetCSharpResult(11, 19, 11, 68));
+        }
+
         [Theory]
         [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
         [MemberData(nameof(CSharpNamedArgumentsTestData))]
@@ -758,6 +792,38 @@ End Module
                                         @"(New Byte(s.Length - 1) {}).AsMemory(0, s.Length)" };
             yield return new object[] { @"New Byte(s.Length - 1) {}, 0, s.Length, New CancellationToken()",
                                         @"(New Byte(s.Length - 1) {}).AsMemory(0, s.Length), New CancellationToken()" };
+        }
+
+        [Fact]
+        public Task VB_Fixer_Diagnostic_EnsureSystemNamespaceAutoAdded()
+        {
+            string originalCode = @"
+Imports System.IO
+Imports System.Threading
+Class C
+    Public Async Sub M()
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Dim buffer As Byte() = New Byte(s.Length - 1) {}
+            Await s.ReadAsync(New Byte(s.Length - 1) {}, 0, s.Length)
+        End Using
+    End Sub
+End Class
+";
+            string fixedCode = @"
+Imports System.IO
+Imports System.Threading
+Imports System
+
+Class C
+    Public Async Sub M()
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Dim buffer As Byte() = New Byte(s.Length - 1) {}
+            Await s.ReadAsync((New Byte(s.Length - 1) {}).AsMemory(0, s.Length))
+        End Using
+    End Sub
+End Class
+";
+            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(8, 19, 8, 70));
         }
 
         [Theory]

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -32,5 +32,32 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                 End If
             End If
         End Function
+
+        Protected Overrides Function IsSystemNamespaceImported(importList As IReadOnlyList(Of SyntaxNode)) As Boolean
+
+            For Each import As SyntaxNode In importList
+
+                Dim importsStatement As ImportsStatementSyntax = TryCast(import, ImportsStatementSyntax)
+                If importsStatement IsNot Nothing Then
+
+                    For Each clause As ImportsClauseSyntax In importsStatement.ImportsClauses
+
+                        Dim simpleClause As SimpleImportsClauseSyntax = TryCast(clause, SimpleImportsClauseSyntax)
+                        If simpleClause IsNot Nothing Then
+
+                            Dim identifier As IdentifierNameSyntax = TryCast(simpleClause.Name, IdentifierNameSyntax)
+                            If identifier IsNot Nothing AndAlso identifier.Identifier.Text = "System" Then
+                                Return True
+                            End If
+
+                        End If
+                    Next
+                End If
+            Next
+
+            Return False
+
+        End Function
+
     End Class
 End Namespace

--- a/src/Utilities/Workspaces/SyntaxNodeExtensions.cs
+++ b/src/Utilities/Workspaces/SyntaxNodeExtensions.cs
@@ -24,6 +24,11 @@ namespace Analyzer.Utilities
             }
         }
 
+        /// <summary>
+        /// Annotates a syntax node representing a type so that any missing imports get automatically added. Does not work in any other kinds of nodes.
+        /// </summary>
+        /// <param name="syntaxNode">The type node to annotate.</param>
+        /// <returns>The annotated type node.</returns>
         public static SyntaxNode WithAddImportsAnnotation(this SyntaxNode syntaxNode)
         {
             if (AddImportsAnnotation is null)


### PR DESCRIPTION
This is a backport of https://github.com/dotnet/roslyn-analyzers/pull/3931

If rule CA1835 finds a diagnostic and applies a fix, but the System namespace has not yet been added (which contains the `AsMemory()` method for byte arrays), then the compilation can fail.
With this change, the `System` namespace should be automatically added when the user applies the fix, if the namespace has not been added it yet.