### PR TITLE
Ensure that we handle cancellation in returning pooled objects to the pool

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldDifferByMoreThanCase.cs
@@ -177,7 +177,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     addDiagnostic(symbol.CreateDiagnostic(Rule, Member, GetSymbolDisplayString(membersWithName)));
                 }
 
-                membersWithName.Free();
+                membersWithName.Dispose();
             }
         }
 
@@ -256,7 +256,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     context.ReportNoLocationDiagnostic(Rule, Type, GetSymbolDisplayString(typesWithName));
                 }
 
-                typesWithName.Free();
+                typesWithName.Dispose();
             }
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     context.ReportNoLocationDiagnostic(Rule, Namespace, GetSymbolDisplayString(namespacesWithName));
                 }
 
-                namespacesWithName.Free();
+                namespacesWithName.Dispose();
             }
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpClientCRLCheck.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpClientCRLCheck.cs
@@ -235,8 +235,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotInstallRootCert.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotInstallRootCert.cs
@@ -223,8 +223,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseCreateEncryptorWithNonDefaultIV.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseCreateEncryptorWithNonDefaultIV.cs
@@ -198,8 +198,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolver.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJavascriptSerializerWithSimpleTypeResolver.cs
@@ -259,8 +259,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinder.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerJsonNetWithoutBinder.cs
@@ -238,8 +238,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureDeserializerWithoutBinderBase.cs
@@ -230,8 +230,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureSettingsForJsonNet.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureSettingsForJsonNet.cs
@@ -263,8 +263,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFInsufficientIterationCount.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFInsufficientIterationCount.cs
@@ -216,8 +216,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
@@ -188,8 +188,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
                 });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SourceTriggeredTaintedDataAnalyzerBase.cs
@@ -254,7 +254,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                     }
                                     finally
                                     {
-                                        rootOperationsNeedingAnalysis.Free();
+                                        rootOperationsNeedingAnalysis.Free(compilationContext.CancellationToken);
                                     }
                                 });
                         });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSecureCookiesASPNetCore.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSecureCookiesASPNetCore.cs
@@ -218,8 +218,8 @@ namespace Microsoft.NetCore.Analyzers.Security
                             }
                             finally
                             {
-                                rootOperationsNeedingAnalysis.Free();
-                                allResults?.Free();
+                                rootOperationsNeedingAnalysis.Free(compilationAnalysisContext.CancellationToken);
+                                allResults?.Free(compilationAnalysisContext.CancellationToken);
                             }
                         });
 

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -477,43 +477,36 @@ namespace Analyzer.Utilities.Extensions
             lambdaOrLocalFunction = lambdaOrLocalFunction.OriginalDefinition;
 
             var builder = PooledHashSet<ISymbol>.GetInstance();
-            var nestedLambdasAndLocalFunctions = PooledHashSet<IMethodSymbol>.GetInstance();
+            using var nestedLambdasAndLocalFunctions = PooledHashSet<IMethodSymbol>.GetInstance();
             nestedLambdasAndLocalFunctions.Add(lambdaOrLocalFunction);
 
-            try
+            foreach (var child in operation.Descendants())
             {
-                foreach (var child in operation.Descendants())
+                switch (child.Kind)
                 {
-                    switch (child.Kind)
-                    {
-                        case OperationKind.LocalReference:
-                            ProcessLocalOrParameter(((ILocalReferenceOperation)child).Local);
-                            break;
+                    case OperationKind.LocalReference:
+                        ProcessLocalOrParameter(((ILocalReferenceOperation)child).Local);
+                        break;
 
-                        case OperationKind.ParameterReference:
-                            ProcessLocalOrParameter(((IParameterReferenceOperation)child).Parameter);
-                            break;
+                    case OperationKind.ParameterReference:
+                        ProcessLocalOrParameter(((IParameterReferenceOperation)child).Parameter);
+                        break;
 
-                        case OperationKind.InstanceReference:
-                            builder.Add(lambdaOrLocalFunction.ContainingType);
-                            break;
+                    case OperationKind.InstanceReference:
+                        builder.Add(lambdaOrLocalFunction.ContainingType);
+                        break;
 
-                        case OperationKind.AnonymousFunction:
-                            nestedLambdasAndLocalFunctions.Add(((IAnonymousFunctionOperation)child).Symbol);
-                            break;
+                    case OperationKind.AnonymousFunction:
+                        nestedLambdasAndLocalFunctions.Add(((IAnonymousFunctionOperation)child).Symbol);
+                        break;
 
-                        case OperationKind.LocalFunction:
-                            nestedLambdasAndLocalFunctions.Add(((ILocalFunctionOperation)child).Symbol);
-                            break;
-                    }
+                    case OperationKind.LocalFunction:
+                        nestedLambdasAndLocalFunctions.Add(((ILocalFunctionOperation)child).Symbol);
+                        break;
                 }
+            }
 
-                return builder;
-            }
-            finally
-            {
-                nestedLambdasAndLocalFunctions.Free();
-            }
+            return builder;
 
             // Local functions.
             void ProcessLocalOrParameter(ISymbol symbol)

--- a/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ImmutableHashSetExtensions.cs
@@ -9,7 +9,7 @@ namespace System.Collections.Immutable
     {
         public static ImmutableHashSet<T> AddRange<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)
         {
-            var builder = PooledHashSet<T>.GetInstance();
+            using var builder = PooledHashSet<T>.GetInstance();
 
             foreach (var item in set1)
             {
@@ -23,17 +23,15 @@ namespace System.Collections.Immutable
 
             if (builder.Count == set1.Count)
             {
-                builder.Free();
                 return set1;
             }
 
             if (builder.Count == set2.Count)
             {
-                builder.Free();
                 return set2;
             }
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutable();
         }
 
         public static ImmutableHashSet<T> IntersectSet<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)
@@ -51,7 +49,7 @@ namespace System.Collections.Immutable
                 return set1.Contains(set2.First()) ? set2 : ImmutableHashSet<T>.Empty;
             }
 
-            var builder = PooledHashSet<T>.GetInstance();
+            using var builder = PooledHashSet<T>.GetInstance();
             foreach (var item in set1)
             {
                 if (set2.Contains(item))
@@ -62,16 +60,14 @@ namespace System.Collections.Immutable
 
             if (builder.Count == set1.Count)
             {
-                builder.Free();
                 return set1;
             }
             else if (builder.Count == set2.Count)
             {
-                builder.Free();
                 return set2;
             }
 
-            return builder.ToImmutableAndFree();
+            return builder.ToImmutable();
         }
 
         public static bool IsSubsetOfSet<T>(this ImmutableHashSet<T> set1, ImmutableHashSet<T> set2)

--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1710 // Rename Microsoft.CodeAnalysis.ArrayBuilder<T> to end in 'Collection'.
 #pragma warning disable CA1000 // Do not declare static members on generic types
@@ -304,7 +305,7 @@ namespace Analyzer.Utilities.PooledObjects
 
         // To implement Poolable, you need two things:
         // 1) Expose Freeing primitive. 
-        public void Free()
+        private void Free()
         {
             var pool = _pool;
             if (pool != null)
@@ -325,7 +326,7 @@ namespace Analyzer.Utilities.PooledObjects
                         this.Clear();
                     }
 
-                    pool.Free(this);
+                    pool.Free(this, CancellationToken.None);
                     return;
                 }
                 else
@@ -506,7 +507,7 @@ namespace Analyzer.Utilities.PooledObjects
 
         public void RemoveDuplicates()
         {
-            var set = PooledHashSet<T>.GetInstance();
+            using var set = PooledHashSet<T>.GetInstance();
 
             int j = 0;
             for (int i = 0; i < Count; i++)
@@ -519,13 +520,12 @@ namespace Analyzer.Utilities.PooledObjects
             }
 
             Clip(j);
-            set.Free();
         }
 
         public ImmutableArray<S> SelectDistinct<S>(Func<T, S> selector)
         {
-            var result = ArrayBuilder<S>.GetInstance(Count);
-            var set = PooledHashSet<S>.GetInstance();
+            using var result = ArrayBuilder<S>.GetInstance(Count);
+            using var set = PooledHashSet<S>.GetInstance();
 
             foreach (var item in _builder)
             {
@@ -536,8 +536,7 @@ namespace Analyzer.Utilities.PooledObjects
                 }
             }
 
-            set.Free();
-            return result.ToImmutableAndFree();
+            return result.ToImmutable();
         }
     }
 }

--- a/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
+++ b/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
@@ -185,8 +185,15 @@ namespace Analyzer.Utilities.PooledObjects
         /// Note that Free will try to store recycled objects close to the start thus statistically 
         /// reducing how far we will typically search in Allocate.
         /// </remarks>
-        internal void Free(T obj)
+        internal void Free(T obj, CancellationToken cancellationToken)
         {
+            // Do not free in presence of cancellation.
+            // See https://github.com/dotnet/roslyn/issues/46859 for details.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             Validate(obj);
             ForgetTrackedObject(obj);
 

--- a/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledDictionary.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
 
@@ -22,7 +23,7 @@ namespace Analyzer.Utilities.PooledObjects
             _pool = pool;
         }
 
-        public void Dispose() => Free();
+        public void Dispose() => Free(CancellationToken.None);
 
         public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree()
         {
@@ -37,14 +38,21 @@ namespace Analyzer.Utilities.PooledObjects
                 this.Clear();
             }
 
-            _pool?.Free(this);
+            _pool?.Free(this, CancellationToken.None);
             return result;
         }
 
-        public void Free()
+        public void Free(CancellationToken cancellationToken)
         {
+            // Do not free in presence of cancellation.
+            // See https://github.com/dotnet/roslyn/issues/46859 for details.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             this.Clear();
-            _pool?.Free(this);
+            _pool?.Free(this, cancellationToken);
         }
 
         // global pool

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 }
                 finally
                 {
-                    escapedLocationsBuilder.Free();
+                    escapedLocationsBuilder.Dispose();
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/TrackedEntitiesBuilder.cs
@@ -39,8 +39,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public void Dispose()
         {
-            AllEntities.Free();
-            PointsToValues.Free();
+            AllEntities.Dispose();
+            PointsToValues.Dispose();
         }
 
         public void AddEntityAndPointsToValue(AnalysisEntity analysisEntity, PointsToAbstractValue value)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluatorCollection.cs
@@ -101,30 +101,22 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 
         internal ImmutableDictionary<(INamedTypeSymbol, bool), string> GetTypeToNameMapping(WellKnownTypeProvider wellKnownTypeProvider)
         {
-            PooledDictionary<(INamedTypeSymbol, bool), string> pooledDictionary = PooledDictionary<(INamedTypeSymbol, bool), string>.GetInstance();
-            try
-            {
-                foreach (KeyValuePair<(HazardousUsageEvaluatorKind Kind, string? InstanceTypeName, string? MethodName, string? ParameterName, bool derivedClasses), HazardousUsageEvaluator> kvp
+            using PooledDictionary<(INamedTypeSymbol, bool), string> pooledDictionary = PooledDictionary<(INamedTypeSymbol, bool), string>.GetInstance();
+            foreach (KeyValuePair<(HazardousUsageEvaluatorKind Kind, string? InstanceTypeName, string? MethodName, string? ParameterName, bool derivedClasses), HazardousUsageEvaluator> kvp
                     in this.HazardousUsageEvaluators)
+            {
+                if (kvp.Key.InstanceTypeName == null || kvp.Key.Kind != HazardousUsageEvaluatorKind.Invocation)
                 {
-                    if (kvp.Key.InstanceTypeName == null || kvp.Key.Kind != HazardousUsageEvaluatorKind.Invocation)
-                    {
-                        continue;
-                    }
-
-                    if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(kvp.Key.InstanceTypeName, out INamedTypeSymbol? namedTypeSymbol))
-                    {
-                        pooledDictionary[(namedTypeSymbol, kvp.Key.derivedClasses)] = kvp.Key.InstanceTypeName;
-                    }
+                    continue;
                 }
 
-                return pooledDictionary.ToImmutableDictionaryAndFree();
+                if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(kvp.Key.InstanceTypeName, out INamedTypeSymbol? namedTypeSymbol))
+                {
+                    pooledDictionary[(namedTypeSymbol, kvp.Key.derivedClasses)] = kvp.Key.InstanceTypeName;
+                }
             }
-            catch (Exception)
-            {
-                pooledDictionary.Free();
-                throw;
-            }
+
+            return pooledDictionary.ToImmutableDictionary();
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
@@ -161,23 +161,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 newLength = this.KnownPropertyAbstractValues.Length;
             }
 
-            ArrayBuilder<PropertySetAbstractValueKind> kinds = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(newLength);
-            try
-            {
-                kinds.AddRange(this.KnownPropertyAbstractValues);
+            using ArrayBuilder<PropertySetAbstractValueKind> kinds = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(newLength);
+            kinds.AddRange(this.KnownPropertyAbstractValues);
 
-                while (kinds.Count < newLength)
-                {
-                    kinds.Add(PropertySetAbstractValueKind.Unknown);
-                }
-
-                kinds[index] = kind;
-                return GetInstance(kinds);
-            }
-            finally
+            while (kinds.Count < newLength)
             {
-                kinds.Free();
+                kinds.Add(PropertySetAbstractValueKind.Unknown);
             }
+
+            kinds[index] = kind;
+            return GetInstance(kinds);
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetAbstractValueDomain.cs
@@ -57,20 +57,14 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 // The PropertySetAbstractValue indexer allows accessing beyond KnownValuesCount (returns Unknown),
                 // so looping through the max of the two KnownValuesCount.
                 int maxKnownCount = Math.Max(value1.KnownValuesCount, value2.KnownValuesCount);
-                ArrayBuilder<PropertySetAbstractValueKind> builder = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(maxKnownCount);
-                try
-                {
-                    for (int i = 0; i < maxKnownCount; i++)
-                    {
-                        builder.Add(MergeKind(value1[i], value2[i]));
-                    }
+                using ArrayBuilder<PropertySetAbstractValueKind> builder = ArrayBuilder<PropertySetAbstractValueKind>.GetInstance(maxKnownCount);
 
-                    return PropertySetAbstractValue.GetInstance(builder);
-                }
-                finally
+                for (int i = 0; i < maxKnownCount; i++)
                 {
-                    builder.Free();
+                    builder.Add(MergeKind(value1[i], value2[i]));
                 }
+
+                return PropertySetAbstractValue.GetInstance(builder);
             }
 
             private static PropertySetAbstractValueKind MergeKind(PropertySetAbstractValueKind kind1, PropertySetAbstractValueKind kind2)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.TrackedAssignmentData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.TrackedAssignmentData.cs
@@ -30,17 +30,17 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
 
                 public void Free()
                 {
-                    this.AssignmentsWithUnknownLocation?.Free();
+                    this.AssignmentsWithUnknownLocation?.Dispose();
                     this.AssignmentsWithUnknownLocation = null;
 
                     if (this.AbstractLocationsToAssignments != null)
                     {
                         foreach (PooledHashSet<IAssignmentOperation> hashSet in this.AbstractLocationsToAssignments.Values)
                         {
-                            hashSet?.Free();
+                            hashSet?.Dispose();
                         }
 
-                        this.AbstractLocationsToAssignments.Free();
+                        this.AbstractLocationsToAssignments.Dispose();
                         this.AbstractLocationsToAssignments = null;
                     }
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -170,41 +170,28 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                     }
                     else if (constructorMapper.MapFromPointsToAbstractValue != null)
                     {
-                        ArrayBuilder<PointsToAbstractValue> builder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
-                        try
-                        {
-                            foreach (IArgumentOperation argumentOperation in operation.Arguments)
-                            {
-                                builder.Add(this.GetPointsToAbstractValue(argumentOperation));
-                            }
+                        using ArrayBuilder<PointsToAbstractValue> builder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
 
-                            abstractValue = constructorMapper.MapFromPointsToAbstractValue(operation.Constructor, builder);
-                        }
-                        finally
+                        foreach (IArgumentOperation argumentOperation in operation.Arguments)
                         {
-                            builder.Free();
+                            builder.Add(this.GetPointsToAbstractValue(argumentOperation));
                         }
+
+                        abstractValue = constructorMapper.MapFromPointsToAbstractValue(operation.Constructor, builder);
                     }
                     else if (constructorMapper.MapFromValueContentAbstractValue != null)
                     {
                         Debug.Assert(this.DataFlowAnalysisContext.ValueContentAnalysisResultOpt != null);
-                        ArrayBuilder<PointsToAbstractValue> pointsToBuilder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
-                        ArrayBuilder<ValueContentAbstractValue> valueContentBuilder = ArrayBuilder<ValueContentAbstractValue>.GetInstance();
-                        try
-                        {
-                            foreach (IArgumentOperation argumentOperation in operation.Arguments)
-                            {
-                                pointsToBuilder.Add(this.GetPointsToAbstractValue(argumentOperation));
-                                valueContentBuilder.Add(this.GetValueContentAbstractValue(argumentOperation.Value));
-                            }
+                        using ArrayBuilder<PointsToAbstractValue> pointsToBuilder = ArrayBuilder<PointsToAbstractValue>.GetInstance();
+                        using ArrayBuilder<ValueContentAbstractValue> valueContentBuilder = ArrayBuilder<ValueContentAbstractValue>.GetInstance();
 
-                            abstractValue = constructorMapper.MapFromValueContentAbstractValue(operation.Constructor, valueContentBuilder, pointsToBuilder);
-                        }
-                        finally
+                        foreach (IArgumentOperation argumentOperation in operation.Arguments)
                         {
-                            pointsToBuilder.Free();
-                            valueContentBuilder.Free();
+                            pointsToBuilder.Add(this.GetPointsToAbstractValue(argumentOperation));
+                            valueContentBuilder.Add(this.GetValueContentAbstractValue(argumentOperation.Value));
                         }
+
+                        abstractValue = constructorMapper.MapFromValueContentAbstractValue(operation.Constructor, valueContentBuilder, pointsToBuilder);
                     }
                     else
                     {
@@ -470,7 +457,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                         trackedAssignmentData.Free();
                     }
 
-                    this.TrackedFieldPropertyAssignmentsOpt.Free();
+                    this.TrackedFieldPropertyAssignmentsOpt.Dispose();
                     this.TrackedFieldPropertyAssignmentsOpt = null;
                 }
             }
@@ -570,7 +557,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 }
                 finally
                 {
-                    hazardousUsageTypeNames?.Free();
+                    hazardousUsageTypeNames?.Dispose();
                 }
 
                 return false;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -384,10 +384,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 }
                 finally
                 {
-                    taintedTargets?.Free();
-                    taintedParameterPairs?.Free();
-                    sanitizedParameterPairs?.Free();
-                    taintedParameterNamesCached?.Free();
+                    taintedTargets?.Dispose();
+                    taintedParameterPairs?.Dispose();
+                    sanitizedParameterPairs?.Dispose();
+                    taintedParameterNamesCached?.Dispose();
                 }
 
                 return result;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -102,35 +102,28 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             base.ProcessOutOfScopeLocalsAndFlowCaptures(locals, flowCaptures);
 
-            var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-            try
+            using var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            AddTrackedEntities(allEntities);
+
+            // Stop tracking entities for locals and capture Ids that are now out of scope.
+            foreach (var local in locals)
             {
-                AddTrackedEntities(allEntities);
-
-                // Stop tracking entities for locals and capture Ids that are now out of scope.
-                foreach (var local in locals)
+                if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(local, out var analysisEntity))
                 {
-                    if (AnalysisEntityFactory.TryCreateForSymbolDeclaration(local, out var analysisEntity))
-                    {
-                        StopTrackingDataForEntity(analysisEntity, allEntities);
-                    }
-                    else
-                    {
-                        Debug.Fail("TryCreateForSymbolDeclaration failed");
-                    }
+                    StopTrackingDataForEntity(analysisEntity, allEntities);
                 }
-
-                foreach (var captureId in flowCaptures)
+                else
                 {
-                    if (AnalysisEntityFactory.TryGetForFlowCapture(captureId, out var analysisEntity))
-                    {
-                        StopTrackingDataForEntity(analysisEntity, allEntities);
-                    }
+                    Debug.Fail("TryCreateForSymbolDeclaration failed");
                 }
             }
-            finally
+
+            foreach (var captureId in flowCaptures)
             {
-                allEntities.Free();
+                if (AnalysisEntityFactory.TryGetForFlowCapture(captureId, out var analysisEntity))
+                {
+                    StopTrackingDataForEntity(analysisEntity, allEntities);
+                }
             }
         }
 
@@ -178,52 +171,37 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         {
             if (!parameterEntities.IsEmpty)
             {
-                var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                using var allEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                AddTrackedEntities(allEntities);
 
-                try
+                foreach (var (parameter, parameterEntity) in parameterEntities)
                 {
-                    AddTrackedEntities(allEntities);
+                    StopTrackingDataForEntity(parameterEntity, CurrentAnalysisData, allEntities);
 
-                    foreach (var (parameter, parameterEntity) in parameterEntities)
+                    if (parameter.IsParams)
                     {
-                        StopTrackingDataForEntity(parameterEntity, CurrentAnalysisData, allEntities);
-
-                        if (parameter.IsParams)
-                        {
-                            StopTrackingDataForParamArrayParameterIndices(parameterEntity, CurrentAnalysisData, allEntities);
-                        }
+                        StopTrackingDataForParamArrayParameterIndices(parameterEntity, CurrentAnalysisData, allEntities);
                     }
-                }
-                finally
-                {
-                    allEntities.Free();
                 }
             }
         }
 
         protected override TAnalysisData GetMergedAnalysisDataForPossibleThrowingOperation(TAnalysisData? existingDataOpt, IOperation operation)
         {
-            var entitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            try
-            {
-                // Get tracked entities.
-                AddTrackedEntities(entitiesBuilder);
+            // Get tracked entities.
+            using var entitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+            AddTrackedEntities(entitiesBuilder);
 
-                // Only non-child entities are tracked for now.
-                var resultAnalysisData = GetTrimmedCurrentAnalysisData(entitiesBuilder.Where(e => !e.IsChildOrInstanceMember && HasAbstractValue(e)));
-                if (existingDataOpt != null)
-                {
-                    var mergedAnalysisData = MergeAnalysisData(resultAnalysisData, existingDataOpt);
-                    resultAnalysisData.Dispose();
-                    resultAnalysisData = mergedAnalysisData;
-                }
-
-                return resultAnalysisData;
-            }
-            finally
+            // Only non-child entities are tracked for now.
+            var resultAnalysisData = GetTrimmedCurrentAnalysisData(entitiesBuilder.Where(e => !e.IsChildOrInstanceMember && HasAbstractValue(e)));
+            if (existingDataOpt != null)
             {
-                entitiesBuilder.Free();
+                var mergedAnalysisData = MergeAnalysisData(resultAnalysisData, existingDataOpt);
+                resultAnalysisData.Dispose();
+                resultAnalysisData = mergedAnalysisData;
             }
+
+            return resultAnalysisData;
         }
 
         #region Helper methods to handle initialization/assignment operations
@@ -511,129 +489,117 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     isLambdaOrLocalFunction, hasParameterWithDelegateType);
             }
 
-            var candidateEntitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            var interproceduralEntitiesToRetainBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
-            var worklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
-            var worklistPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
-            var processedPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
-            var childWorklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var candidateEntitiesBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var interproceduralEntitiesToRetainBuilder = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var worklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+            using var worklistPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
+            using var processedPointsToValues = PooledHashSet<PointsToAbstractValue>.GetInstance();
+            using var childWorklistEntities = PooledHashSet<AnalysisEntity>.GetInstance();
 
-            try
+            // All tracked entities are candidates to be retained for initial interprocedural
+            // analysis data.
+            AddTrackedEntities(candidateEntitiesBuilder, forInterproceduralAnalysis: true);
+            var candidateEntitiesCount = candidateEntitiesBuilder.Count;
+
+            // Add entities and PointsTo values for invocation instance, this or me instance
+            // and argument values to the initial worklist
+
+            if (invocationInstanceOpt.HasValue)
             {
-                // All tracked entities are candidates to be retained for initial interprocedural
-                // analysis data.
-                AddTrackedEntities(candidateEntitiesBuilder, forInterproceduralAnalysis: true);
-                var candidateEntitiesCount = candidateEntitiesBuilder.Count;
+                AddWorklistEntityAndPointsToValue(invocationInstanceOpt.Value.InstanceOpt);
+                AddWorklistPointsToValue(invocationInstanceOpt.Value.PointsToValue);
+            }
 
-                // Add entities and PointsTo values for invocation instance, this or me instance
-                // and argument values to the initial worklist
+            if (thisOrMeInstanceForCallerOpt.HasValue)
+            {
+                AddWorklistEntityAndPointsToValue(thisOrMeInstanceForCallerOpt.Value.Instance);
+                AddWorklistPointsToValue(thisOrMeInstanceForCallerOpt.Value.PointsToValue);
+            }
 
-                if (invocationInstanceOpt.HasValue)
+            foreach (var argument in argumentValuesMap.Values)
+            {
+                if (!AddWorklistEntityAndPointsToValue(argument.AnalysisEntityOpt))
                 {
-                    AddWorklistEntityAndPointsToValue(invocationInstanceOpt.Value.InstanceOpt);
-                    AddWorklistPointsToValue(invocationInstanceOpt.Value.PointsToValue);
+                    // For allocations passed as arguments.
+                    AddWorklistPointsToValue(argument.InstanceLocation);
                 }
+            }
 
-                if (thisOrMeInstanceForCallerOpt.HasValue)
+            // Worklist based algorithm to compute the transitive closure of analysis entities
+            // that are accessible in the callee via the PointsTo value chain.
+            while (worklistEntities.Count > 0 || worklistPointsToValues.Count > 0)
+            {
+                if (worklistEntities.Count > 0)
                 {
-                    AddWorklistEntityAndPointsToValue(thisOrMeInstanceForCallerOpt.Value.Instance);
-                    AddWorklistPointsToValue(thisOrMeInstanceForCallerOpt.Value.PointsToValue);
-                }
+                    // Add all the worklistEntities to interproceduralEntitiesBuilder
+                    // to ensure these entities are retained.
+                    interproceduralEntitiesToRetainBuilder.AddRange(worklistEntities);
 
-                foreach (var argument in argumentValuesMap.Values)
-                {
-                    if (!AddWorklistEntityAndPointsToValue(argument.AnalysisEntityOpt))
+                    // Remove the worklistEntities from tracked candidate entities.
+                    candidateEntitiesBuilder.ExceptWith(worklistEntities);
+
+                    // Add child entities of worklistEntities to childWorklistEntities.
+                    // PERF: We cannot have any child entities for PointsToAnalysis if we
+                    // not computing complete PointsToAnalysis data.
+                    if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
                     {
-                        // For allocations passed as arguments.
-                        AddWorklistPointsToValue(argument.InstanceLocation);
-                    }
-                }
-
-                // Worklist based algorithm to compute the transitive closure of analysis entities
-                // that are accessible in the callee via the PointsTo value chain.
-                while (worklistEntities.Count > 0 || worklistPointsToValues.Count > 0)
-                {
-                    if (worklistEntities.Count > 0)
-                    {
-                        // Add all the worklistEntities to interproceduralEntitiesBuilder
-                        // to ensure these entities are retained.
-                        interproceduralEntitiesToRetainBuilder.AddRange(worklistEntities);
-
-                        // Remove the worklistEntities from tracked candidate entities.
-                        candidateEntitiesBuilder.ExceptWith(worklistEntities);
-
-                        // Add child entities of worklistEntities to childWorklistEntities.
-                        // PERF: We cannot have any child entities for PointsToAnalysis if we
-                        // not computing complete PointsToAnalysis data.
-                        if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
+                        foreach (var candidateEntity in candidateEntitiesBuilder)
                         {
-                            foreach (var candidateEntity in candidateEntitiesBuilder)
+                            foreach (var ancestorEntity in worklistEntities)
                             {
-                                foreach (var ancestorEntity in worklistEntities)
+                                if (IsChildAnalysisEntity(candidateEntity, ancestorEntity))
                                 {
-                                    if (IsChildAnalysisEntity(candidateEntity, ancestorEntity))
-                                    {
-                                        childWorklistEntities.Add(candidateEntity);
-                                        break;
-                                    }
+                                    childWorklistEntities.Add(candidateEntity);
+                                    break;
                                 }
                             }
                         }
-
-                        worklistEntities.Clear();
                     }
 
-                    if (worklistPointsToValues.Count > 0)
+                    worklistEntities.Clear();
+                }
+
+                if (worklistPointsToValues.Count > 0)
+                {
+                    // Add child entities which are accessible from PointsTo chain to childWorklistEntities.
+                    // PERF: We cannot have any child entities for PointsToAnalysis if we
+                    // not computing complete PointsToAnalysis data.
+                    if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
                     {
-                        // Add child entities which are accessible from PointsTo chain to childWorklistEntities.
-                        // PERF: We cannot have any child entities for PointsToAnalysis if we
-                        // not computing complete PointsToAnalysis data.
-                        if (HasCompletePointsToAnalysisResult || !IsPointsToAnalysis)
+                        foreach (var candidateEntity in candidateEntitiesBuilder)
                         {
-                            foreach (var candidateEntity in candidateEntitiesBuilder)
+                            foreach (var pointsToValue in worklistPointsToValues)
                             {
-                                foreach (var pointsToValue in worklistPointsToValues)
+                                Debug.Assert(ShouldProcessPointsToValue(pointsToValue));
+                                if (IsChildAnalysisEntity(candidateEntity, pointsToValue))
                                 {
-                                    Debug.Assert(ShouldProcessPointsToValue(pointsToValue));
-                                    if (IsChildAnalysisEntity(candidateEntity, pointsToValue))
-                                    {
-                                        childWorklistEntities.Add(candidateEntity);
-                                        break;
-                                    }
+                                    childWorklistEntities.Add(candidateEntity);
+                                    break;
                                 }
                             }
                         }
-
-                        worklistPointsToValues.Clear();
                     }
 
-                    // Move all the child work list entities and their PointsTo values to the worklist.
-                    foreach (var childEntity in childWorklistEntities)
-                    {
-                        AddWorklistEntityAndPointsToValue(childEntity);
-                    }
-
-                    childWorklistEntities.Clear();
+                    worklistPointsToValues.Clear();
                 }
 
-                // If all candidates being retained, just retain the cloned current analysis data.
-                if (interproceduralEntitiesToRetainBuilder.Count == candidateEntitiesCount)
+                // Move all the child work list entities and their PointsTo values to the worklist.
+                foreach (var childEntity in childWorklistEntities)
                 {
-                    return GetClonedCurrentAnalysisData();
+                    AddWorklistEntityAndPointsToValue(childEntity);
                 }
 
-                // Otherwise, return cloned current analysis data with trimmed keys.
-                return GetTrimmedCurrentAnalysisData(interproceduralEntitiesToRetainBuilder);
+                childWorklistEntities.Clear();
             }
-            finally
+
+            // If all candidates being retained, just retain the cloned current analysis data.
+            if (interproceduralEntitiesToRetainBuilder.Count == candidateEntitiesCount)
             {
-                candidateEntitiesBuilder.Free();
-                interproceduralEntitiesToRetainBuilder.Free();
-                worklistEntities.Free();
-                worklistPointsToValues.Free();
-                processedPointsToValues.Free();
-                childWorklistEntities.Free();
+                return GetClonedCurrentAnalysisData();
             }
+
+            // Otherwise, return cloned current analysis data with trimmed keys.
+            return GetTrimmedCurrentAnalysisData(interproceduralEntitiesToRetainBuilder);
 
             // Local functions.
             bool AddWorklistEntityAndPointsToValue(AnalysisEntity? analysisEntityOpt)
@@ -739,29 +705,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 AnalysisDataForUnhandledThrowOperations != null &&
                 AnalysisDataForUnhandledThrowOperations.Values.Any(HasAnyAbstractValue))
             {
-                var allAnalysisEntities = PooledHashSet<AnalysisEntity>.GetInstance();
+                using var allAnalysisEntities = PooledHashSet<AnalysisEntity>.GetInstance();
 
-                try
+                foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
                 {
-                    foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
-                    {
-                        AddTrackedEntities(dataAtException, allAnalysisEntities, forInterproceduralAnalysis: true);
-                    }
+                    AddTrackedEntities(dataAtException, allAnalysisEntities, forInterproceduralAnalysis: true);
+                }
 
-                    foreach (var entity in allAnalysisEntities)
+                foreach (var entity in allAnalysisEntities)
+                {
+                    if (ShouldStopTrackingEntityAtExit(entity))
                     {
-                        if (ShouldStopTrackingEntityAtExit(entity))
+                        foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
                         {
-                            foreach (var dataAtException in AnalysisDataForUnhandledThrowOperations.Values)
-                            {
-                                StopTrackingDataForEntity(entity, dataAtException, allAnalysisEntities);
-                            }
+                            StopTrackingDataForEntity(entity, dataAtException, allAnalysisEntities);
                         }
                     }
-                }
-                finally
-                {
-                    allAnalysisEntities.Free();
                 }
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityFactory.cs
@@ -342,14 +342,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 Debug.Assert(parentEntity.InstanceLocation == instanceLocation);
 
-                var builder = ArrayBuilder<AnalysisEntity>.GetInstance(tupleType.TupleElements.Length);
+                using var builder = ArrayBuilder<AnalysisEntity>.GetInstance(tupleType.TupleElements.Length);
                 foreach (var field in tupleType.TupleElements)
                 {
                     var tupleFieldName = field.CorrespondingTupleField.Name;
                     var mappedValueTupleField = underlyingValueTupleType.GetMembers(tupleFieldName).OfType<IFieldSymbol>().FirstOrDefault();
                     if (mappedValueTupleField == null)
                     {
-                        builder.Free();
                         return false;
                     }
 
@@ -357,7 +356,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         type: mappedValueTupleField.Type, instanceLocation, parentEntity));
                 }
 
-                elementEntities = builder.ToImmutableAndFree();
+                elementEntities = builder.ToImmutable();
                 return true;
             }
             finally

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -57,14 +57,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 return default;
             }
 
-            var resultBuilder = new DataFlowAnalysisResultBuilder<TAnalysisData>();
-            var uniqueSuccessors = PooledHashSet<BasicBlock>.GetInstance();
-            var finallyBlockSuccessorsMap = PooledDictionary<int, List<BranchWithInfo>>.GetInstance();
+            using var resultBuilder = new DataFlowAnalysisResultBuilder<TAnalysisData>();
+            using var uniqueSuccessors = PooledHashSet<BasicBlock>.GetInstance();
+            using var finallyBlockSuccessorsMap = PooledDictionary<int, List<BranchWithInfo>>.GetInstance();
             var catchBlockInputDataMap = PooledDictionary<ControlFlowRegion, TAnalysisData>.GetInstance();
             var inputDataFromInfeasibleBranchesMap = PooledDictionary<int, TAnalysisData>.GetInstance();
-            var unreachableBlocks = PooledHashSet<int>.GetInstance();
-            var worklist = new SortedSet<int>();
-            var pendingBlocksNeedingAtLeastOnePass = new SortedSet<int>(cfg.Blocks.Select(b => b.Ordinal));
+            using var unreachableBlocks = PooledHashSet<int>.GetInstance();
+            using var worklist = PooledSortedSet<int>.GetInstance();
+            using var pendingBlocksNeedingAtLeastOnePass = PooledSortedSet<int>.GetInstance(cfg.Blocks.Select(b => b.Ordinal));
 
             // Map from Ordinal -> (Ordinal, ControlFlowConditionKind)? with following semantics:
             //  1. Key is a valid basic block ordinal.
@@ -80,12 +80,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             //  This map allows us to optimize the number of merge operations. We can avoid merge and directly
             //  overwrite analysis data into a successor if successor block has no entry or entry with non-null tuple value
             //  with the matching input branch.
-            var blockToUniqueInputFlowMap = PooledDictionary<int, (int Ordinal, ControlFlowConditionKind BranchKind)?>.GetInstance();
+            using var blockToUniqueInputFlowMap = PooledDictionary<int, (int Ordinal, ControlFlowConditionKind BranchKind)?>.GetInstance();
 
             // Map from basic block ordinals that are destination of back edge(s) to the minimum block ordinal that dominates it,
             // i.e. for every '{key, value}' pair in the dictionary, 'key' is the destination of at least one back edge
             // and 'value' is the minimum ordinal such that there is no back edge to 'key' from any basic block with ordinal > 'value'.
-            var loopRangeMap = PooledDictionary<int, int>.GetInstance();
+            using var loopRangeMap = PooledDictionary<int, int>.GetInstance();
             ComputeLoopRangeMap(cfg, loopRangeMap);
 
             TAnalysisData? normalPathsExitBlockData = null, exceptionPathsExitBlockDataOpt = null;
@@ -161,23 +161,17 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
             finally
             {
-                resultBuilder.Dispose();
-                uniqueSuccessors.Free();
-                finallyBlockSuccessorsMap.Free();
                 catchBlockInputDataMap.Values.Dispose();
-                catchBlockInputDataMap.Free();
+                catchBlockInputDataMap.Dispose();
                 inputDataFromInfeasibleBranchesMap.Values.Dispose();
-                inputDataFromInfeasibleBranchesMap.Free();
-                unreachableBlocks.Free();
-                blockToUniqueInputFlowMap.Free();
-                loopRangeMap.Free();
+                inputDataFromInfeasibleBranchesMap.Dispose();
             }
         }
 
         private void RunCore(
             ControlFlowGraph cfg,
-            SortedSet<int> worklist,
-            SortedSet<int> pendingBlocksNeedingAtLeastOnePass,
+            PooledSortedSet<int> worklist,
+            PooledSortedSet<int> pendingBlocksNeedingAtLeastOnePass,
             TAnalysisData? initialAnalysisDataOpt,
             DataFlowAnalysisResultBuilder<TAnalysisData> resultBuilder,
             PooledHashSet<BasicBlock> uniqueSuccessors,
@@ -188,293 +182,286 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             PooledDictionary<int, int> loopRangeMap,
             bool exceptionPathsAnalysisPostPass)
         {
-            var unreachableBlocks = PooledHashSet<int>.GetInstance();
-            try
+            using var unreachableBlocks = PooledHashSet<int>.GetInstance();
+            // Add each basic block to the result.
+            foreach (var block in cfg.Blocks)
             {
-                // Add each basic block to the result.
-                foreach (var block in cfg.Blocks)
+                if (!block.IsReachable)
                 {
-                    if (!block.IsReachable)
+                    unreachableBlocks.Add(block.Ordinal);
+                }
+            }
+
+            while (worklist.Count > 0 || pendingBlocksNeedingAtLeastOnePass.Count > 0)
+            {
+                UpdateUnreachableBlocks();
+
+                // Get the next block to process from the worklist.
+                // If worklist is empty, get any one of the pendingBlocksNeedingAtLeastOnePass, which must be unreachable from Entry block.
+                int blockOrdinal;
+                if (worklist.Count > 0)
+                {
+                    blockOrdinal = worklist.Min;
+                    worklist.Remove(blockOrdinal);
+                }
+                else
+                {
+                    blockOrdinal = pendingBlocksNeedingAtLeastOnePass.Min;
+                }
+
+                var block = cfg.Blocks[blockOrdinal];
+
+                // Ensure that we execute potential nested catch blocks before the finally region.
+                if (pendingBlocksNeedingAtLeastOnePass.Any())
+                {
+                    var finallyRegionOpt = block.GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Finally);
+                    if (finallyRegionOpt?.EnclosingRegion.Kind == ControlFlowRegionKind.TryAndFinally)
                     {
-                        unreachableBlocks.Add(block.Ordinal);
+                        // Add all catch blocks in the try region corresponding to the finally.
+                        var tryRegion = finallyRegionOpt.EnclosingRegion.NestedRegions[0];
+                        Debug.Assert(tryRegion.Kind == ControlFlowRegionKind.Try);
+
+                        var nestedCatchBlockOrdinals = pendingBlocksNeedingAtLeastOnePass.Where(
+                            p => p >= tryRegion.FirstBlockOrdinal &&
+                                 p <= tryRegion.LastBlockOrdinal &&
+                                 cfg.Blocks[p].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null);
+                        if (nestedCatchBlockOrdinals.Any())
+                        {
+                            foreach (var catchBlockOrdinal in nestedCatchBlockOrdinals)
+                            {
+                                worklist.Add(catchBlockOrdinal);
+                            }
+
+                            // Also add back the finally start block to be processed after catch blocks.
+                            worklist.Add(blockOrdinal);
+                            continue;
+                        }
                     }
                 }
 
-                while (worklist.Count > 0 || pendingBlocksNeedingAtLeastOnePass.Count > 0)
-                {
-                    UpdateUnreachableBlocks();
+                var needsAtLeastOnePass = pendingBlocksNeedingAtLeastOnePass.Remove(blockOrdinal);
+                var isUnreachableBlock = unreachableBlocks.Contains(block.Ordinal);
 
-                    // Get the next block to process from the worklist.
-                    // If worklist is empty, get any one of the pendingBlocksNeedingAtLeastOnePass, which must be unreachable from Entry block.
-                    int blockOrdinal;
-                    if (worklist.Count > 0)
+                // Get the input data for the block.
+                var input = resultBuilder[block];
+                if (input == null)
+                {
+                    Debug.Assert(needsAtLeastOnePass);
+
+                    if (isUnreachableBlock &&
+                        inputDataFromInfeasibleBranchesMap.TryGetValue(block.Ordinal, out var currentInfeasibleData))
                     {
-                        blockOrdinal = worklist.Min;
-                        worklist.Remove(blockOrdinal);
+                        // Block is unreachable due to predicate analysis.
+                        // Initialize the input from predecessors to avoid false reports in unreachable code.
+                        Debug.Assert(!currentInfeasibleData.IsDisposed);
+                        input = currentInfeasibleData;
+                        inputDataFromInfeasibleBranchesMap.Remove(block.Ordinal);
                     }
                     else
                     {
-                        blockOrdinal = pendingBlocksNeedingAtLeastOnePass.Min;
-                    }
-
-                    var block = cfg.Blocks[blockOrdinal];
-
-                    // Ensure that we execute potential nested catch blocks before the finally region.
-                    if (pendingBlocksNeedingAtLeastOnePass.Any())
-                    {
-                        var finallyRegionOpt = block.GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Finally);
-                        if (finallyRegionOpt?.EnclosingRegion.Kind == ControlFlowRegionKind.TryAndFinally)
+                        // For catch and filter regions, we track the initial input data in the catchBlockInputDataMap.
+                        ControlFlowRegion? enclosingTryAndCatchRegion = GetEnclosingTryAndCatchRegionIfStartsHandler(block);
+                        if (enclosingTryAndCatchRegion != null &&
+                            catchBlockInputDataMap.TryGetValue(enclosingTryAndCatchRegion, out var catchBlockInput))
                         {
-                            // Add all catch blocks in the try region corresponding to the finally.
-                            var tryRegion = finallyRegionOpt.EnclosingRegion.NestedRegions[0];
-                            Debug.Assert(tryRegion.Kind == ControlFlowRegionKind.Try);
+                            Debug.Assert(enclosingTryAndCatchRegion.Kind == ControlFlowRegionKind.TryAndCatch);
+                            Debug.Assert(block.EnclosingRegion.Kind == ControlFlowRegionKind.Catch || block.EnclosingRegion.Kind == ControlFlowRegionKind.Filter);
+                            Debug.Assert(block.EnclosingRegion.FirstBlockOrdinal == block.Ordinal);
+                            Debug.Assert(!catchBlockInput.IsDisposed);
+                            input = catchBlockInput;
 
-                            var nestedCatchBlockOrdinals = pendingBlocksNeedingAtLeastOnePass.Where(
-                                p => p >= tryRegion.FirstBlockOrdinal &&
-                                     p <= tryRegion.LastBlockOrdinal &&
-                                     cfg.Blocks[p].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null);
-                            if (nestedCatchBlockOrdinals.Any())
-                            {
-                                foreach (var catchBlockOrdinal in nestedCatchBlockOrdinals)
-                                {
-                                    worklist.Add(catchBlockOrdinal);
-                                }
-
-                                // Also add back the finally start block to be processed after catch blocks.
-                                worklist.Add(blockOrdinal);
-                                continue;
-                            }
+                            // Mark that all input into successorBlockOpt requires a merge.
+                            blockToUniqueInputFlowMap[block.Ordinal] = null;
                         }
                     }
 
-                    var needsAtLeastOnePass = pendingBlocksNeedingAtLeastOnePass.Remove(blockOrdinal);
-                    var isUnreachableBlock = unreachableBlocks.Contains(block.Ordinal);
+                    input = input != null ?
+                        AnalysisDomain.Clone(input) :
+                        GetClonedAnalysisDataOrEmptyData(initialAnalysisDataOpt);
 
-                    // Get the input data for the block.
-                    var input = resultBuilder[block];
-                    if (input == null)
+                    UpdateInput(resultBuilder, block, input);
+                }
+
+                // Check if we are starting a try region which has one or more associated catch/filter regions.
+                // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
+                if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
+                    block.EnclosingRegion?.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
+                    block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
+                {
+                    MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
+                }
+
+                // Flow the new input through the block to get a new output.
+                var output = Flow(OperationVisitor, block, AnalysisDomain.Clone(input));
+
+                try
+                {
+                    // Update the current block result's
+                    // output values with the new ones.
+                    CloneAndUpdateOutputIfEntryOrExitBlock(resultBuilder, block, output);
+
+                    // Propagate the output data to all the successor blocks of the current block.
+                    uniqueSuccessors.Clear();
+
+                    // Get the successors with corresponding flow branches.
+                    // CONSIDER: Currently we need to do a bunch of branch adjusments for branches to/from finally, catch and filter regions.
+                    //           We should revisit the overall CFG API and the walker to avoid such adjustments.
+                    var successorsWithAdjustedBranches = GetSuccessorsWithAdjustedBranches(block).ToArray();
+                    foreach ((BranchWithInfo successorWithBranch, BranchWithInfo preadjustSuccessorWithBranch) in successorsWithAdjustedBranches)
                     {
-                        Debug.Assert(needsAtLeastOnePass);
+                        // successorWithAdjustedBranch returns a pair of branches:
+                        //  1. successorWithBranch - This is the adjusted branch for a branch from inside a try region to outside the try region, where we don't flow into finally region.
+                        //                           The adjusted branch is targeted into the finally.
+                        //  2. preadjustSuccessorWithBranch - This is the original branch, which is primarily used to update the input data and successors of finally and catch region regions.
+                        //                                    Currently, these blocks have no branch coming out from it.
 
-                        if (isUnreachableBlock &&
-                            inputDataFromInfeasibleBranchesMap.TryGetValue(block.Ordinal, out var currentInfeasibleData))
+                        // Flow the current analysis data through the branch.
+                        (TAnalysisData newSuccessorInput, bool isFeasibleBranch) = OperationVisitor.FlowBranch(block, successorWithBranch, AnalysisDomain.Clone(output));
+
+                        if (preadjustSuccessorWithBranch != null)
                         {
-                            // Block is unreachable due to predicate analysis.
-                            // Initialize the input from predecessors to avoid false reports in unreachable code.
-                            Debug.Assert(!currentInfeasibleData.IsDisposed);
-                            input = currentInfeasibleData;
-                            inputDataFromInfeasibleBranchesMap.Remove(block.Ordinal);
+                            UpdateFinallySuccessorsAndCatchInput(preadjustSuccessorWithBranch, newSuccessorInput, block);
+                        }
+
+                        // Certain branches have no destination (e.g. BranchKind.Throw), so we don't need to update the input data for the branch destination block.
+                        var successorBlockOpt = successorWithBranch.Destination;
+                        if (successorBlockOpt == null)
+                        {
+                            newSuccessorInput.Dispose();
+                            continue;
+                        }
+
+                        if (exceptionPathsAnalysisPostPass)
+                        {
+                            // For exception paths analysis, we need to force re-analysis of entire finally region
+                            // whenever we start try region analysis so analysis data for unhandled exceptions at end of the finally region is correctly updated.
+                            if (successorBlockOpt.IsFirstBlockOfRegionKind(ControlFlowRegionKind.TryAndFinally, out var tryAndFinally))
+                            {
+                                var finallyRegion = tryAndFinally.NestedRegions[1];
+                                Debug.Assert(finallyRegion.Kind == ControlFlowRegionKind.Finally);
+
+                                for (int i = finallyRegion.FirstBlockOrdinal; i <= finallyRegion.LastBlockOrdinal; i++)
+                                {
+                                    worklist.Add(i);
+                                }
+                            }
+                        }
+
+                        // Perf: We can stop tracking data for entities whose lifetime is limited by the leaving regions.
+                        //       Below invocation explicitly drops such data from destination input.
+                        newSuccessorInput = OperationVisitor.OnLeavingRegions(successorWithBranch.LeavingRegionLocals,
+                            successorWithBranch.LeavingRegionFlowCaptures, block, newSuccessorInput);
+
+                        var isBackEdge = block.Ordinal >= successorBlockOpt.Ordinal;
+                        if (isUnreachableBlock && !unreachableBlocks.Contains(successorBlockOpt.Ordinal))
+                        {
+                            // Skip processing successor input for branch from an unreachable block to a reachable block.
+                            newSuccessorInput.Dispose();
+                            continue;
+                        }
+                        else if (!isFeasibleBranch)
+                        {
+                            // Skip processing the successor input for conditional branch that can never be taken.
+                            if (inputDataFromInfeasibleBranchesMap.TryGetValue(successorBlockOpt.Ordinal, out TAnalysisData currentInfeasibleData))
+                            {
+                                var dataToDispose = newSuccessorInput;
+                                newSuccessorInput = OperationVisitor.MergeAnalysisData(currentInfeasibleData, newSuccessorInput, isBackEdge);
+                                Debug.Assert(!ReferenceEquals(dataToDispose, newSuccessorInput));
+                                dataToDispose.Dispose();
+                            }
+
+                            inputDataFromInfeasibleBranchesMap[successorBlockOpt.Ordinal] = newSuccessorInput;
+                            continue;
+                        }
+
+                        var blockToSuccessorBranchKind = successorWithBranch.ControlFlowConditionKind;
+                        var currentSuccessorInput = resultBuilder[successorBlockOpt];
+
+                        // We need to merge the incoming analysis data if both the following conditions are satisfied:
+                        //  1. Successor already has a non-null input from prior analysis iteration.
+                        //  2. 'blockToPreviousInputBlockMap' has an entry for successor block such that one of the following conditions are satisfied:
+                        //      a. Value is null, indicating it already had analysis data flow in from multiple branches OR
+                        //      b. Value is non-null, indicating it has unique input from prior analysis, but the prior input
+                        //         analysis data was from a different branch, i.e. either different source block or different condition kind.
+                        var needsMerge = currentSuccessorInput != null &&
+                            blockToUniqueInputFlowMap.TryGetValue(successorBlockOpt.Ordinal, out var uniqueInputBranchOpt) &&
+                            (uniqueInputBranchOpt == null ||
+                             uniqueInputBranchOpt.Value.Ordinal != block.Ordinal ||
+                             uniqueInputBranchOpt.Value.BranchKind != blockToSuccessorBranchKind);
+
+                        TAnalysisData mergedSuccessorInput;
+                        if (needsMerge)
+                        {
+                            RoslynDebug.Assert(currentSuccessorInput != null);
+
+                            // Mark that all input into successorBlockOpt requires a merge as we have non-unique input flow branches into successor block.
+                            blockToUniqueInputFlowMap[successorBlockOpt.Ordinal] = null;
+
+                            // Check if the current input data for the successor block is equal to the new input data from this branch.
+                            // If so, we don't need to propagate new input data from this branch.
+                            if (AnalysisDomain.Equals(currentSuccessorInput, newSuccessorInput))
+                            {
+                                newSuccessorInput.Dispose();
+                                continue;
+                            }
+
+                            // Otherwise, check if the input data for the successor block changes after merging with the new input data.
+                            mergedSuccessorInput = OperationVisitor.MergeAnalysisData(currentSuccessorInput, newSuccessorInput, isBackEdge);
+                            newSuccessorInput.Dispose();
+
+                            int compare = AnalysisDomain.Compare(currentSuccessorInput, mergedSuccessorInput);
+
+                            // The newly computed abstract values for each basic block
+                            // must be always greater or equal than the previous value
+                            // to ensure termination.
+                            Debug.Assert(compare <= 0, "The newly computed abstract value must be greater or equal than the previous one.");
+
+                            // Is old input value >= new input value
+                            if (compare >= 0)
+                            {
+                                mergedSuccessorInput.Dispose();
+                                continue;
+                            }
                         }
                         else
                         {
-                            // For catch and filter regions, we track the initial input data in the catchBlockInputDataMap.
-                            ControlFlowRegion? enclosingTryAndCatchRegion = GetEnclosingTryAndCatchRegionIfStartsHandler(block);
-                            if (enclosingTryAndCatchRegion != null &&
-                                catchBlockInputDataMap.TryGetValue(enclosingTryAndCatchRegion, out var catchBlockInput))
-                            {
-                                Debug.Assert(enclosingTryAndCatchRegion.Kind == ControlFlowRegionKind.TryAndCatch);
-                                Debug.Assert(block.EnclosingRegion.Kind == ControlFlowRegionKind.Catch || block.EnclosingRegion.Kind == ControlFlowRegionKind.Filter);
-                                Debug.Assert(block.EnclosingRegion.FirstBlockOrdinal == block.Ordinal);
-                                Debug.Assert(!catchBlockInput.IsDisposed);
-                                input = catchBlockInput;
+                            Debug.Assert(currentSuccessorInput == null || AnalysisDomain.Compare(currentSuccessorInput, newSuccessorInput) <= 0);
+                            mergedSuccessorInput = newSuccessorInput;
 
-                                // Mark that all input into successorBlockOpt requires a merge.
-                                blockToUniqueInputFlowMap[block.Ordinal] = null;
-                            }
+                            // Mark that all input into successorBlockOpt can skip merge as long as it from the current input flow branch.
+                            blockToUniqueInputFlowMap[successorBlockOpt.Ordinal] = (block.Ordinal, blockToSuccessorBranchKind);
                         }
 
-                        input = input != null ?
-                            AnalysisDomain.Clone(input) :
-                            GetClonedAnalysisDataOrEmptyData(initialAnalysisDataOpt);
+                        // Input to successor has changed, so we need to update its new input and
+                        // reprocess the successor by adding it to the worklist.
+                        UpdateInput(resultBuilder, successorBlockOpt, mergedSuccessorInput);
 
-                        UpdateInput(resultBuilder, block, input);
-                    }
-
-                    // Check if we are starting a try region which has one or more associated catch/filter regions.
-                    // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
-                    if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
-                        block.EnclosingRegion?.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
-                        block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
-                    {
-                        MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
-                    }
-
-                    // Flow the new input through the block to get a new output.
-                    var output = Flow(OperationVisitor, block, AnalysisDomain.Clone(input));
-
-                    try
-                    {
-                        // Update the current block result's
-                        // output values with the new ones.
-                        CloneAndUpdateOutputIfEntryOrExitBlock(resultBuilder, block, output);
-
-                        // Propagate the output data to all the successor blocks of the current block.
-                        uniqueSuccessors.Clear();
-
-                        // Get the successors with corresponding flow branches.
-                        // CONSIDER: Currently we need to do a bunch of branch adjusments for branches to/from finally, catch and filter regions.
-                        //           We should revisit the overall CFG API and the walker to avoid such adjustments.
-                        var successorsWithAdjustedBranches = GetSuccessorsWithAdjustedBranches(block).ToArray();
-                        foreach ((BranchWithInfo successorWithBranch, BranchWithInfo preadjustSuccessorWithBranch) in successorsWithAdjustedBranches)
+                        if (isBackEdge)
                         {
-                            // successorWithAdjustedBranch returns a pair of branches:
-                            //  1. successorWithBranch - This is the adjusted branch for a branch from inside a try region to outside the try region, where we don't flow into finally region.
-                            //                           The adjusted branch is targeted into the finally.
-                            //  2. preadjustSuccessorWithBranch - This is the original branch, which is primarily used to update the input data and successors of finally and catch region regions.
-                            //                                    Currently, these blocks have no branch coming out from it.
+                            // For back edges, analysis data in subsequent iterations needs
+                            // to be merged with analysis data from previous iterations.
+                            var dominatorBlockOrdinal = loopRangeMap[successorBlockOpt.Ordinal];
+                            Debug.Assert(dominatorBlockOrdinal >= block.Ordinal);
+                            Debug.Assert(dominatorBlockOrdinal >= successorBlockOpt.Ordinal);
 
-                            // Flow the current analysis data through the branch.
-                            (TAnalysisData newSuccessorInput, bool isFeasibleBranch) = OperationVisitor.FlowBranch(block, successorWithBranch, AnalysisDomain.Clone(output));
-
-                            if (preadjustSuccessorWithBranch != null)
+                            for (int i = successorBlockOpt.Ordinal; i <= dominatorBlockOrdinal + 1; i++)
                             {
-                                UpdateFinallySuccessorsAndCatchInput(preadjustSuccessorWithBranch, newSuccessorInput, block);
-                            }
-
-                            // Certain branches have no destination (e.g. BranchKind.Throw), so we don't need to update the input data for the branch destination block.
-                            var successorBlockOpt = successorWithBranch.Destination;
-                            if (successorBlockOpt == null)
-                            {
-                                newSuccessorInput.Dispose();
-                                continue;
-                            }
-
-                            if (exceptionPathsAnalysisPostPass)
-                            {
-                                // For exception paths analysis, we need to force re-analysis of entire finally region
-                                // whenever we start try region analysis so analysis data for unhandled exceptions at end of the finally region is correctly updated.
-                                if (successorBlockOpt.IsFirstBlockOfRegionKind(ControlFlowRegionKind.TryAndFinally, out var tryAndFinally))
-                                {
-                                    var finallyRegion = tryAndFinally.NestedRegions[1];
-                                    Debug.Assert(finallyRegion.Kind == ControlFlowRegionKind.Finally);
-
-                                    for (int i = finallyRegion.FirstBlockOrdinal; i <= finallyRegion.LastBlockOrdinal; i++)
-                                    {
-                                        worklist.Add(i);
-                                    }
-                                }
-                            }
-
-                            // Perf: We can stop tracking data for entities whose lifetime is limited by the leaving regions.
-                            //       Below invocation explicitly drops such data from destination input.
-                            newSuccessorInput = OperationVisitor.OnLeavingRegions(successorWithBranch.LeavingRegionLocals,
-                                successorWithBranch.LeavingRegionFlowCaptures, block, newSuccessorInput);
-
-                            var isBackEdge = block.Ordinal >= successorBlockOpt.Ordinal;
-                            if (isUnreachableBlock && !unreachableBlocks.Contains(successorBlockOpt.Ordinal))
-                            {
-                                // Skip processing successor input for branch from an unreachable block to a reachable block.
-                                newSuccessorInput.Dispose();
-                                continue;
-                            }
-                            else if (!isFeasibleBranch)
-                            {
-                                // Skip processing the successor input for conditional branch that can never be taken.
-                                if (inputDataFromInfeasibleBranchesMap.TryGetValue(successorBlockOpt.Ordinal, out TAnalysisData currentInfeasibleData))
-                                {
-                                    var dataToDispose = newSuccessorInput;
-                                    newSuccessorInput = OperationVisitor.MergeAnalysisData(currentInfeasibleData, newSuccessorInput, isBackEdge);
-                                    Debug.Assert(!ReferenceEquals(dataToDispose, newSuccessorInput));
-                                    dataToDispose.Dispose();
-                                }
-
-                                inputDataFromInfeasibleBranchesMap[successorBlockOpt.Ordinal] = newSuccessorInput;
-                                continue;
-                            }
-
-                            var blockToSuccessorBranchKind = successorWithBranch.ControlFlowConditionKind;
-                            var currentSuccessorInput = resultBuilder[successorBlockOpt];
-
-                            // We need to merge the incoming analysis data if both the following conditions are satisfied:
-                            //  1. Successor already has a non-null input from prior analysis iteration.
-                            //  2. 'blockToPreviousInputBlockMap' has an entry for successor block such that one of the following conditions are satisfied:
-                            //      a. Value is null, indicating it already had analysis data flow in from multiple branches OR
-                            //      b. Value is non-null, indicating it has unique input from prior analysis, but the prior input
-                            //         analysis data was from a different branch, i.e. either different source block or different condition kind.
-                            var needsMerge = currentSuccessorInput != null &&
-                                blockToUniqueInputFlowMap.TryGetValue(successorBlockOpt.Ordinal, out var uniqueInputBranchOpt) &&
-                                (uniqueInputBranchOpt == null ||
-                                 uniqueInputBranchOpt.Value.Ordinal != block.Ordinal ||
-                                 uniqueInputBranchOpt.Value.BranchKind != blockToSuccessorBranchKind);
-
-                            TAnalysisData mergedSuccessorInput;
-                            if (needsMerge)
-                            {
-                                RoslynDebug.Assert(currentSuccessorInput != null);
-
-                                // Mark that all input into successorBlockOpt requires a merge as we have non-unique input flow branches into successor block.
-                                blockToUniqueInputFlowMap[successorBlockOpt.Ordinal] = null;
-
-                                // Check if the current input data for the successor block is equal to the new input data from this branch.
-                                // If so, we don't need to propagate new input data from this branch.
-                                if (AnalysisDomain.Equals(currentSuccessorInput, newSuccessorInput))
-                                {
-                                    newSuccessorInput.Dispose();
-                                    continue;
-                                }
-
-                                // Otherwise, check if the input data for the successor block changes after merging with the new input data.
-                                mergedSuccessorInput = OperationVisitor.MergeAnalysisData(currentSuccessorInput, newSuccessorInput, isBackEdge);
-                                newSuccessorInput.Dispose();
-
-                                int compare = AnalysisDomain.Compare(currentSuccessorInput, mergedSuccessorInput);
-
-                                // The newly computed abstract values for each basic block
-                                // must be always greater or equal than the previous value
-                                // to ensure termination.
-                                Debug.Assert(compare <= 0, "The newly computed abstract value must be greater or equal than the previous one.");
-
-                                // Is old input value >= new input value
-                                if (compare >= 0)
-                                {
-                                    mergedSuccessorInput.Dispose();
-                                    continue;
-                                }
-                            }
-                            else
-                            {
-                                Debug.Assert(currentSuccessorInput == null || AnalysisDomain.Compare(currentSuccessorInput, newSuccessorInput) <= 0);
-                                mergedSuccessorInput = newSuccessorInput;
-
-                                // Mark that all input into successorBlockOpt can skip merge as long as it from the current input flow branch.
-                                blockToUniqueInputFlowMap[successorBlockOpt.Ordinal] = (block.Ordinal, blockToSuccessorBranchKind);
-                            }
-
-                            // Input to successor has changed, so we need to update its new input and
-                            // reprocess the successor by adding it to the worklist.
-                            UpdateInput(resultBuilder, successorBlockOpt, mergedSuccessorInput);
-
-                            if (isBackEdge)
-                            {
-                                // For back edges, analysis data in subsequent iterations needs
-                                // to be merged with analysis data from previous iterations.
-                                var dominatorBlockOrdinal = loopRangeMap[successorBlockOpt.Ordinal];
-                                Debug.Assert(dominatorBlockOrdinal >= block.Ordinal);
-                                Debug.Assert(dominatorBlockOrdinal >= successorBlockOpt.Ordinal);
-
-                                for (int i = successorBlockOpt.Ordinal; i <= dominatorBlockOrdinal + 1; i++)
-                                {
-                                    blockToUniqueInputFlowMap[i] = null;
-                                }
-                            }
-
-                            if (uniqueSuccessors.Add(successorBlockOpt))
-                            {
-                                worklist.Add(successorBlockOpt.Ordinal);
+                                blockToUniqueInputFlowMap[i] = null;
                             }
                         }
 
-                        Debug.Assert(IsValidWorklistState());
+                        if (uniqueSuccessors.Add(successorBlockOpt))
+                        {
+                            worklist.Add(successorBlockOpt.Ordinal);
+                        }
                     }
-                    finally
-                    {
-                        output.Dispose();
-                    }
+
+                    Debug.Assert(IsValidWorklistState());
                 }
-            }
-            finally
-            {
-                unreachableBlocks.Free();
+                finally
+                {
+                    output.Dispose();
+                }
             }
 
             // Local functions.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResultBuilder.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public void Dispose()
         {
             _info.Values.Dispose();
-            _info.Free();
+            _info.Dispose();
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DictionaryAnalysisData.cs
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
             if (disposing)
             {
-                _coreAnalysisData.Free();
+                _coreAnalysisData.Dispose();
                 _coreAnalysisData = null!;
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/PredicatedAnalysisData.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             if (_lazyPredicateDataMap != null)
             {
                 Debug.Assert(!_lazyPredicateDataMap.IsDisposed);
-                var builder = PooledHashSet<DictionaryAnalysisData<TKey, TValue>>.GetInstance();
+                using var builder = PooledHashSet<DictionaryAnalysisData<TKey, TValue>>.GetInstance();
                 foreach (var value in _lazyPredicateDataMap.Values)
                 {
                     if (value.TruePredicatedData != null)
@@ -77,8 +77,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         Debug.Assert(builder.Add(value.FalsePredicatedData));
                     }
                 }
-
-                builder.Free();
             }
         }
 


### PR DESCRIPTION
**Strongly recommended to review ignoring white space diffs: https://github.com/dotnet/roslyn-analyzers/pull/4037/files?diff=unified&w=1**

If an analyzer callback throws operation cancelled exception ,it is known to have cancelled its work without side effects. An action which throws OperationCancelledException after cancellation is requested is considered to have not been invoked, i.e. if work resumes for analyzing the same compilation, then another call needs to be made for this callback. Analyzers are responsible for ensuring cancelled callbacks do not have side effects. Once a side effect has been applied by the analyzer callback, the callback should ensure that the remainder of the operation is not cancelled, otherwise state corruption could occur.