### PR TITLE
Fix IndexOutOfRangeException

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             var identifier = symbol.Name;
-            if (s_typeNames.Contains(identifier))
+            if (s_typeNames.Contains(identifier) && symbol.Locations.Length > 0)
             {
                 Diagnostic diagnostic = Diagnostic.Create(Rule, symbol.Locations[0], identifier);
                 context.ReportDiagnostic(diagnostic);


### PR DESCRIPTION
Fixes #4052
Not very sure this is the correct fix. I just prevented accessing `Locations[0]` if `Locations` doesn't have any items.