### PR TITLE
Fix documentation comments

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CSharpDefineAccessorsForAttributeArguments.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CSharpDefineAccessorsForAttributeArguments.cs
@@ -9,10 +9,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.CodeQuality.CSharp.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// CA1019: Define accessors for attribute arguments
-    /// 
+    /// <para>CA1019: Define accessors for attribute arguments</para>
+    /// <para>
     /// Cause:
     /// In its constructor, an attribute defines arguments that do not have corresponding properties.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpDefineAccessorsForAttributeArgumentsAnalyzer : DefineAccessorsForAttributeArgumentsAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -11,22 +11,25 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// CA2227: Collection properties should be read only
-    ///
+    /// <para>CA2227: Collection properties should be read only</para>
+    /// <para>
     /// Cause:
     /// An externally visible writable property is a type that implements System.Collections.ICollection.
     /// Arrays, indexers(properties with the name 'Item'), and permission sets are ignored by the rule.
-    ///
+    /// </para>
+    /// <para>
     /// Description:
     /// A writable collection property allows a user to replace the collection with a completely different collection.
     /// A read-only property stops the collection from being replaced but still allows the individual members to be set.
     /// If replacing the collection is a goal, the preferred design pattern is to include a method to remove all the elements
     /// from the collection and a method to re-populate the collection.See the Clear and AddRange methods of the System.Collections.ArrayList class
     /// for an example of this pattern.
-    ///
+    /// </para>
+    /// <para>
     /// Both binary and XML serialization support read-only properties that are collections.
     /// The System.Xml.Serialization.XmlSerializer class has specific requirements for types that implement ICollection and
     /// System.Collections.IEnumerable in order to be serializable.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class CollectionPropertiesShouldBeReadOnlyAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.cs
@@ -13,10 +13,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// CA1019: Define accessors for attribute arguments
-    ///
+    /// <para>CA1019: Define accessors for attribute arguments</para>
+    /// <para>
     /// Cause:
     /// In its constructor, an attribute defines arguments that do not have corresponding properties.
+    /// </para>
     /// </summary>
     public abstract class DefineAccessorsForAttributeArgumentsAnalyzer : DiagnosticAnalyzer
     {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotRaiseExceptionsInUnexpectedLocations.cs
@@ -273,7 +273,6 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         /// </summary>
         /// <param name="method"></param>
         /// <param name="compilation"></param>
-        /// <returns></returns>
         private static bool IsGetHashCodeInterfaceImplementation(IMethodSymbol method, Compilation compilation)
         {
             if (method.Name != WellKnownMemberNames.ObjectGetHashCode)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumWithFlagsAttribute.cs
@@ -14,20 +14,20 @@ using Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.Helpers;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// Implements CA1027 and CA2217
-    ///
-    /// 1) CA1027: Mark enums with FlagsAttribute
-    ///
+    /// <para>Implements CA1027 and CA2217</para>
+    /// <para>1) CA1027: Mark enums with FlagsAttribute</para>
+    /// <para>
     /// Cause:
     /// The values of a public enumeration are powers of two or are combinations of other values that are defined in the enumeration,
     /// and the System.FlagsAttribute attribute is not present.
     /// To reduce false positives, this rule does not report a violation for enumerations that have contiguous values.
-    ///
-    /// 2) CA2217: Do not mark enums with FlagsAttribute
-    ///
+    /// </para>
+    /// <para>2) CA2217: Do not mark enums with FlagsAttribute</para>
+    /// <para>
     /// Cause:
     /// An externally visible enumeration is marked with FlagsAttribute and it has one or more values that are not powers of two or
     /// a combination of the other defined values on the enumeration.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class EnumWithFlagsAttributeAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValue.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValue.cs
@@ -13,12 +13,13 @@ using System.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// CA1008: Enums should have zero value
-    ///
+    /// <para>CA1008: Enums should have zero value</para>
+    /// <para>
     /// Cause:
     /// An enumeration without an applied System.FlagsAttribute does not define a member that has a value of zero;
     /// or an enumeration that has an applied FlagsAttribute defines a member that has a value of zero but its name is not 'None',
     /// or the enumeration defines multiple zero-valued members.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class EnumsShouldHaveZeroValueAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNames.cs
@@ -10,14 +10,17 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
+    /// <para>
     /// CA1720-redefined: Identifiers should not contain type names
     /// Cause:
     /// The name of a parameter or a member contains a language-specific data type name.
-    ///
+    /// </para>
+    /// <para>
     /// Description:
     /// Names of parameters and members are better used to communicate their meaning than
     /// to describe their type, which is expected to be provided by development tools. For names of members,
     /// if a data type name must be used, use a language-independent name instead of a language-specific one.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class IdentifiersShouldNotContainTypeNames : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UseGenericEventHandlerInstances.cs
@@ -10,10 +10,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
+    /// <para>
     /// CA1003: Use generic event handler instances
     /// CA1009: A delegate that handles a public or protected event does not have the correct signature, return type, or parameter names.
-    ///
-    /// Recommends that event handlers use <see cref="System.EventHandler{TEventArgs}"/>
+    /// </para>
+    /// <para>Recommends that event handlers use <see cref="System.EventHandler{TEventArgs}"/></para>
     /// </summary>
     /// <remarks>
     /// NOTE: Legacy FxCop reports CA1009 for delegate type that handles a public or protected event and does not have the correct signature, return type, or parameter names.

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
@@ -10,10 +10,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
     /// <summary>
-    /// CA1024: Use properties where appropriate
-    ///
+    /// <para>CA1024: Use properties where appropriate</para>
+    /// <para>
     /// Cause:
     /// A public or protected method has a name that starts with Get, takes no parameters, and returns a value that is not an array.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class UsePropertiesWhereAppropriateAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/CodeMetricsAnalyzer.cs
@@ -32,14 +32,18 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.CodeMetrics
         internal const string CA1506RuleId = "CA1506";
 
         /// <summary>
+        /// <para>
         /// Configuration file to configure custom threshold values for supported code metrics.
         /// For example, the below entry changes the maximum allowed inheritance depth from the default value of 5 to 10:
-        ///
+        /// </para>
+        /// <para>
         ///     # FORMAT:
         ///     # 'RuleId'(Optional 'SymbolKind'): 'Threshold'
-        ///
+        /// </para>
+        /// <para>
         ///     CA1501: 10
         /// See CA1509 unit tests for more examples.
+        /// </para>
         /// </summary>
         private const string CodeMetricsConfigurationFile = "CodeMetricsConfig.txt";
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/DoNotCallOverridableMethodsInConstructors.cs
@@ -10,13 +10,13 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 {
     /// <summary>
-    /// CA2214: Do not call overridable methods in constructors
-    ///
-    /// Cause: The constructor of an unsealed type calls a virtual method defined in its class.
-    ///
+    /// <para>CA2214: Do not call overridable methods in constructors</para>
+    /// <para>Cause: The constructor of an unsealed type calls a virtual method defined in its class.</para>
+    /// <para>
     /// Description: When a virtual method is called, the actual type that executes the method is not selected
     /// until run time. When a constructor calls a virtual method, it is possible that the constructor for the
     /// instance that invokes the method has not executed.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotCallOverridableMethodsInConstructorsAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeMethodsShouldCallBaseClassDispose.cs
@@ -11,11 +11,12 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA2215: Dispose methods should call base class dispose
-    ///
+    /// <para>CA2215: Dispose methods should call base class dispose</para>
+    /// <para>
     /// A type that implements System.IDisposable inherits from a type that also implements IDisposable.
     /// The Dispose method of the inheriting type does not call the Dispose method of the parent type.
     /// To fix a violation of this rule, call base.Dispose in your Dispose method.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DisposeMethodsShouldCallBaseClassDispose : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotLockOnObjectsWithWeakIdentity.cs
@@ -10,15 +10,17 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA2002: Do not lock on objects with weak identities
-    ///
+    /// <para>CA2002: Do not lock on objects with weak identities</para>
+    /// <para>
     /// Cause:
     /// A thread that attempts to acquire a lock on an object that has a weak identity could cause hangs.
-    ///
+    /// </para>
+    /// <para>
     /// Description:
     /// An object is said to have a weak identity when it can be directly accessed across application domain boundaries.
     /// A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in
     /// a different application domain that has a lock on the same object.
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotLockOnObjectsWithWeakIdentityAnalyzer : DiagnosticAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotRaiseReservedExceptionTypes.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotRaiseReservedExceptionTypes.cs
@@ -11,13 +11,14 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA2201: Do not raise reserved exception types
-    ///
+    /// <para>CA2201: Do not raise reserved exception types</para>
+    /// <para>
     /// Too generic:
     ///     System.Exception
     ///     System.ApplicationException
     ///     System.SystemException
-    ///
+    /// </para>
+    /// <para>
     /// Reserved:
     ///     System.OutOfMemoryException
     ///     System.IndexOutOfRangeException
@@ -28,6 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     ///     System.Runtime.InteropServices.COMException
     ///     System.Runtime.InteropServices.SEHException
     ///     System.AccessViolationException
+    /// </para>
     ///
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseEnumerableMethodsOnIndexableCollectionsInsteadUseTheCollectionDirectly.cs
@@ -91,12 +91,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         }
 
         /// <summary>
+        /// <para>
         /// The Enumerable.Last method will only special case indexable types that implement <see cref="IList{T}" />.  Types 
         /// which implement only <see cref="IReadOnlyList{T}"/> will be treated the same as IEnumerable{T} and go through a 
         /// full enumeration.  This method identifies such types.
-        /// 
+        /// </para>
+        /// <para>
         /// At this point it only identifies <see cref="IReadOnlyList{T}"/> directly but could easily be extended to support
         /// any type which has an index and count property.  
+        /// </para>
         /// </summary>
         private static bool IsTypeWithInefficientLinqMethods(ITypeSymbol targetType, ITypeSymbol readonlyListType, ITypeSymbol listType)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
@@ -13,20 +13,22 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA2016: Forward CancellationToken to invocations.
-    /// 
+    /// <para>CA2016: Forward CancellationToken to invocations.</para>
+    /// <para>
     /// Conditions for positive cases:
     ///     - The containing method signature receives a ct parameter. It can be a method, a nested method, an action or a func.
     ///     - The invocation method is not receiving a ct argument, and...
     ///     - The invocation method either:
     ///         - Has no overloads but its current signature receives an optional ct=default, currently implicit, or...
     ///         - Has a method overload with the exact same arguments in the same order, plus one ct parameter at the end.
-    ///         
+    /// </para>
+    /// <para>
     /// Conditions for negative cases:
     ///     - The containing method signature does not receive a ct parameter.
     ///     - The invocation method signature receives a ct and one is already being explicitly passed, or...
     ///     - The invocation method does not have an overload with the exact same arguments that also receives a ct, or...
     ///     - The invocation method only has overloads that receive more than one ct.
+    /// </para>
     /// </summary>
     public abstract class ForwardCancellationTokenToInvocationsAnalyzer : DiagnosticAnalyzer
     {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -14,19 +14,19 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA1835: Prefer Memory/ReadOnlyMemory overloads for Stream ReadAsync/WriteAsync methods.
-    ///
-    /// Undesired methods (available since .NET Framework 4.5):
-    ///
+    /// <para>CA1835: Prefer Memory/ReadOnlyMemory overloads for Stream ReadAsync/WriteAsync methods.</para>
+    /// <para>Undesired methods (available since .NET Framework 4.5):</para>
+    /// <para>
     /// - Stream.WriteAsync(Byte[], Int32, Int32)
     /// - Stream.WriteAsync(Byte[], Int32, Int32, CancellationToken)
     /// - Stream.ReadAsync(Byte[], Int32, Int32)
     /// - Stream.ReadAsync(Byte[], Int32, Int32, CancellationToken)
-    ///
-    /// Preferred methods (available since .NET Standard 2.1 and .NET Core 2.1):
-    ///
+    /// </para>
+    /// <para>Preferred methods (available since .NET Standard 2.1 and .NET Core 2.1):</para>
+    /// <para>
     /// - Stream.WriteAsync(ReadOnlyMemory{Byte}, CancellationToken)
     /// - Stream.ReadAsync(Memory{Byte}, CancellationToken)
+    /// </para>
     ///
     /// </summary>
     public abstract class PreferStreamAsyncMemoryOverloadsFixer : CodeFixProvider

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.cs
@@ -12,19 +12,19 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
     /// <summary>
-    /// CA1835: Prefer Memory/ReadOnlyMemory overloads for Stream ReadAsync/WriteAsync methods.
-    ///
-    /// Undesired methods (available since .NET Framework 4.5):
-    ///
+    /// <para>CA1835: Prefer Memory/ReadOnlyMemory overloads for Stream ReadAsync/WriteAsync methods.</para>
+    /// <para>Undesired methods (available since .NET Framework 4.5):</para>
+    /// <para>
     /// - Stream.WriteAsync(Byte[], Int32, Int32)
     /// - Stream.WriteAsync(Byte[], Int32, Int32, CancellationToken)
     /// - Stream.ReadAsync(Byte[], Int32, Int32)
     /// - Stream.ReadAsync(Byte[], Int32, Int32, CancellationToken)
-    ///
-    /// Preferred methods (available since .NET Standard 2.1 and .NET Core 2.1):
-    ///
+    /// </para>
+    /// <para>Preferred methods (available since .NET Standard 2.1 and .NET Core 2.1):</para>
+    /// <para>
     /// - Stream.WriteAsync(ReadOnlyMemory{Byte}, CancellationToken)
     /// - Stream.ReadAsync(Memory{Byte}, CancellationToken)
+    /// </para>
     ///
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/SecurityHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/SecurityHelpers.cs
@@ -24,9 +24,9 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
         /// <param name="titleResourceStringName">Name of the resource string inside <see cref="MicrosoftNetCoreAnalyzersResources"/> for the diagnostic's title.</param>
         /// <param name="messageResourceStringName">Name of the resource string inside <see cref="MicrosoftNetCoreAnalyzersResources"/> for the diagnostic's message.</param>
         /// <param name="ruleLevel">Indicates the <see cref="RuleLevel"/> for this rule.</param>
-        /// <param name="descriptionResourceStringName">Name of the resource string inside <see cref="MicrosoftNetCoreAnalyzersResources"/> for the diagnostic's descrption.</param>
         /// <param name="isPortedFxCopRule">Flag indicating if this is a rule ported from legacy FxCop.</param>
         /// <param name="isDataflowRule">Flag indicating if this is a dataflow analysis based rule.</param>
+        /// <param name="descriptionResourceStringName">Name of the resource string inside <see cref="MicrosoftNetCoreAnalyzersResources"/> for the diagnostic's descrption.</param>
         /// <returns>new DiagnosticDescriptor</returns>
         public static DiagnosticDescriptor CreateDiagnosticDescriptor(
             string id,
@@ -56,9 +56,9 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
         /// <param name="titleResourceStringName">Name of the resource string inside <paramref name="resourceSource"/> for the diagnostic's title.</param>
         /// <param name="messageResourceStringName">Name of the resource string inside <paramref name="resourceSource"/> for the diagnostic's message.</param>
         /// <param name="ruleLevel">Indicates the <see cref="RuleLevel"/> for this rule.</param>
-        /// <param name="descriptionResourceStringName">Name of the resource string inside <paramref name="resourceSource"/> for the diagnostic's descrption.</param>
         /// <param name="isPortedFxCopRule">Flag indicating if this is a rule ported from legacy FxCop.</param>
         /// <param name="isDataflowRule">Flag indicating if this is a dataflow analysis based rule.</param>
+        /// <param name="descriptionResourceStringName">Name of the resource string inside <paramref name="resourceSource"/> for the diagnostic's descrption.</param>
         /// <returns>new DiagnosticDescriptor</returns>
         public static DiagnosticDescriptor CreateDiagnosticDescriptor(
             string id,

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/Helpers/SecurityDiagnosticHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/Helpers/SecurityDiagnosticHelpers.cs
@@ -241,7 +241,6 @@ namespace Microsoft.NetFramework.Analyzers.Helpers
         /// <param name="current">Current syntax not to examine</param>
         /// <param name="model">The semantic model</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns></returns>
         public static string GetNonEmptyParentName(SyntaxNode current, SemanticModel model, CancellationToken cancellationToken)
         {
             while (current.Parent != null)

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -694,7 +694,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             /// <summary>
             /// Calculated the set of APIs which have been deleted but not yet documented.
             /// </summary>
-            /// <returns></returns>
             internal List<ApiLine> GetDeletedApiList()
             {
                 var list = new List<ApiLine>();

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentslRefactoring.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentslRefactoring.cs
@@ -20,11 +20,14 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Roslyn.Diagnostics.Analyzers
 {
     /// <summary>
+    /// <para>
     /// This refactoring looks for numbered comments `// N` or `// N, N+1, ...` on non-empty lines within string literals
     /// and checks that the numbers are sequential. If they are not, the refactoring is offered.
-    ///
+    /// </para>
+    /// <para>
     /// This pattern is commonly used by compiler tests.
     /// Comments that don't look like numbered comments are left alone. For instance, any comment that contains alpha characters.
+    /// </para>
     /// </summary>
     [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(NumberCommentslRefactoring)), Shared]
     internal sealed class NumberCommentslRefactoring : CodeRefactoringProvider

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -11,11 +11,12 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Roslyn.Diagnostics.Analyzers
 {
     /// <summary>
-    /// The importing constructor for a MEF-exported type should be marked obsolete.
-    ///
+    /// <para>The importing constructor for a MEF-exported type should be marked obsolete.</para>
+    /// <para>
     /// <code>
     /// [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     /// </code>
+    /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class ImportingConstructorShouldBeObsolete : DiagnosticAnalyzer

--- a/src/Tools/GenerateDocumentationAndConfigFiles/JsonWriter.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/JsonWriter.cs
@@ -11,14 +11,16 @@ using System.Text;
 namespace Roslyn.Utilities
 {
     /// <summary>
+    /// <para>
     /// A simple, forward-only JSON writer to avoid adding dependencies to the compiler.
     /// Used to generate /errorlogger output.
-    /// 
+    /// </para>
+    /// <para>
     /// Does not guarantee well-formed JSON if misused. It is the caller's responsibility 
     /// to balance array/object start/end, to only write key-value pairs to objects and
     /// elements to arrays, etc.
-    /// 
-    /// Takes ownership of the given <see cref="TextWriter" /> at construction and handles its disposal.
+    /// </para>
+    /// <para>Takes ownership of the given <see cref="TextWriter" /> at construction and handles its disposal.</para>
     /// </summary>
     internal sealed class JsonWriter : IDisposable
     {

--- a/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -106,7 +106,6 @@ namespace Analyzer.Utilities.Extensions
         /// </summary>
         /// <param name="members"></param>
         /// <param name="expectedParameterTypesInOrder"></param>
-        /// <returns></returns>
         public static IMethodSymbol? GetFirstOrDefaultMemberWithParameterInfos(this IEnumerable<IMethodSymbol>? members, params ParameterInfo[] expectedParameterTypesInOrder)
         {
             var expectedParameterCount = expectedParameterTypesInOrder.Length;

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -357,7 +357,6 @@ namespace Analyzer.Utilities.Extensions
         /// Indicates if the given <paramref name="binaryOperation"/> is a predicate operation used in a condition.
         /// </summary>
         /// <param name="binaryOperation"></param>
-        /// <returns></returns>
         public static bool IsComparisonOperator(this IBinaryOperation binaryOperation)
         {
             switch (binaryOperation.OperatorKind)

--- a/src/Utilities/Compiler/Lightup/NullableContext.cs
+++ b/src/Utilities/Compiler/Lightup/NullableContext.cs
@@ -40,7 +40,7 @@ namespace Analyzer.Utilities.Lightup
         /// </summary>
         /// <remarks>
         /// The project default can change depending on the file type. Generated
-        /// files have nullable off by default, regardless of of the project-level
+        /// files have nullable off by default, regardless of the project-level
         /// default setting.
         /// </remarks>
         WarningsContextInherited = 1 << 2,
@@ -50,7 +50,7 @@ namespace Analyzer.Utilities.Lightup
         /// </summary>
         /// <remarks>
         /// The project default can change depending on the file type. Generated
-        /// files have nullable off by default, regardless of of the project-level
+        /// files have nullable off by default, regardless of the project-level
         /// default setting.
         /// </remarks>
         AnnotationsContextInherited = 1 << 3,
@@ -63,7 +63,7 @@ namespace Analyzer.Utilities.Lightup
         /// <para>This flag is set by default at the start of all files.</para>
         /// <para>
         /// The project default can change depending on the file type. Generated
-        /// files have nullable off by default, regardless of of the project-level
+        /// files have nullable off by default, regardless of the project-level
         /// default setting.
         /// </para>
         /// </remarks>

--- a/src/Utilities/Compiler/Lightup/NullableContext.cs
+++ b/src/Utilities/Compiler/Lightup/NullableContext.cs
@@ -60,11 +60,12 @@ namespace Analyzer.Utilities.Lightup
         /// the project default.
         /// </summary>
         /// <remarks>
-        /// This flag is set by default at the start of all files.
-        ///
+        /// <para>This flag is set by default at the start of all files.</para>
+        /// <para>
         /// The project default can change depending on the file type. Generated
         /// files have nullable off by default, regardless of of the project-level
         /// default setting.
+        /// </para>
         /// </remarks>
         ContextInherited = WarningsContextInherited | AnnotationsContextInherited
     }

--- a/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
@@ -15,14 +15,14 @@ namespace Analyzer.Utilities
     using static CategorizedAnalyzerConfigOptionsExtensions;
 
     /// <summary>
-    /// Aggregate analyzer configuration options:
-    ///
+    /// <para>Aggregate analyzer configuration options:</para>
+    /// <para>
     /// <list type="number">
     /// <item><description>Per syntax tree options from <see cref="AnalyzerConfigOptionsProvider"/>.</description></item>
     /// <item><description>Options from an <strong>.editorconfig</strong> file passed in as an additional file (back compat).</description></item>
     /// </list>
-    ///
-    /// <inheritdoc cref="ICategorizedAnalyzerConfigOptions"/>
+    /// </para>
+    /// <para><inheritdoc cref="ICategorizedAnalyzerConfigOptions"/></para>
     /// </summary>
     internal sealed class AggregateCategorizedAnalyzerConfigOptions : ICategorizedAnalyzerConfigOptions
     {

--- a/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
+++ b/src/Utilities/Compiler/PooledObjects/ObjectPool.cs
@@ -21,21 +21,26 @@ using System.Runtime.CompilerServices;
 namespace Analyzer.Utilities.PooledObjects
 {
     /// <summary>
+    /// <para>
     /// Generic implementation of object pooling pattern with predefined pool size limit. The main
     /// purpose is that limited number of frequently used objects can be kept in the pool for
     /// further recycling.
-    /// 
+    /// </para>
+    /// <para>
     /// Notes: 
     /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
     ///    is no space in the pool, extra returned objects will be dropped.
-    /// 
+    /// </para>
+    /// <para>
     /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
     ///    a relatively short time. Keeping checked out objects for long durations is ok, but 
     ///    reduces usefulness of pooling. Just new up your own.
-    /// 
+    /// </para>
+    /// <para>
     /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
     /// Rationale: 
     ///    If there is no intent for reusing the object, do not use pool - just use "new". 
+    /// </para>
     /// </summary>
     internal class ObjectPool<T> where T : class
     {
@@ -227,12 +232,13 @@ namespace Analyzer.Utilities.PooledObjects
         }
 
         /// <summary>
-        /// Removes an object from leak tracking.  
-        /// 
+        /// <para>Removes an object from leak tracking.  </para>
+        /// <para>
         /// This is called when an object is returned to the pool.  It may also be explicitly 
         /// called if an object allocated from the pool is intentionally not being returned
         /// to the pool.  This can be of use with pooled arrays if the consumer wants to 
         /// return a larger array to the pool than was originally allocated.
+        /// </para>
         /// </summary>
         [Conditional("DEBUG")]
         internal static void ForgetTrackedObject(T old, T? replacement = null)

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -69,11 +69,12 @@ namespace Analyzer.Utilities
         /// so we can query <see cref="IAssemblySymbol.NamespaceNames"/>.
         /// </summary>
         /// <remarks>
-        /// Example: "System.Collections.Generic.List`1" => [ "System", "Collections", "Generic" ]
-        /// 
+        /// <para>Example: "System.Collections.Generic.List`1" => [ "System", "Collections", "Generic" ]</para>
+        /// <para>
         /// https://github.com/dotnet/roslyn/blob/9e786147b8cb884af454db081bb747a5bd36a086/src/Compilers/CSharp/Portable/Symbols/AssemblySymbol.cs#L455
         /// suggests the TypeNames collection can be checked to avoid expensive operations. But realizing TypeNames seems to be
         /// as memory intensive as unnecessary calls GetTypeByMetadataName() in some cases. So we'll go with namespace names.
+        /// </para>
         /// </remarks>
         private static readonly ConcurrentDictionary<string, ImmutableArray<string>> _fullTypeNameToNamespaceNames =
             new ConcurrentDictionary<string, ImmutableArray<string>>(StringComparer.Ordinal);

--- a/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
+++ b/src/Utilities/FlowAnalysis/Extensions/BasicBlockExtensions.cs
@@ -161,7 +161,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis
         /// for example, if the block only has a structured exception handling branch for throw operation.
         /// </summary>
         /// <param name="basicBlock"></param>
-        /// <returns></returns>
         internal static int GetMaxSuccessorOrdinal(this BasicBlock basicBlock)
             => Math.Max(basicBlock.FallThroughSuccessor?.Destination?.Ordinal ?? -1,
                         basicBlock.ConditionalSuccessor?.Destination?.Ordinal ?? -1);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
         }
 
         /// <summary>
-        /// Updates the the copy values for all entities that are part of the given <paramref name="copyValue"/> set,
+        /// Updates the copy values for all entities that are part of the given <paramref name="copyValue"/> set,
         /// i.e. <see cref="CopyAbstractValue.AnalysisEntities"/>.
         /// We do not support the <see cref="SetAbstractValue(AnalysisEntity, CopyAbstractValue)"/> overload
         /// that updates copy value for each individual entity.

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/IAbstractAnalysisValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/IAbstractAnalysisValue.cs
@@ -13,13 +13,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         /// Return negated value if the analysis value is a predicated value.
         /// Otherwise, return the current instance itself.
         /// </summary>
-        /// <returns></returns>
         IAbstractAnalysisValue GetNegatedValue();
 
         /// <summary>
         /// String representation of the abstract value.
         /// </summary>
-        /// <returns></returns>
         string ToString();
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAbstractValue.cs
@@ -15,13 +15,16 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
     /// cref="PropertySetAbstractValueKind"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Note that <see cref="KnownPropertyAbstractValues"/> may be
     /// "incomplete", i.e. it doesn't cover all properties.  In such cases,
     /// missing elements are implicitly <see 
     /// cref="PropertySetAbstractValueKind.Unknown"/>.
-    /// 
+    /// </para>
+    /// <para>
     /// The reason for the "sparse" array is so that the Unknown value doesn't
     /// have to be aware of how many properties are being tracked.
+    /// </para>
     /// </remarks>
     internal partial class PropertySetAbstractValue
     {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SanitizerInfo.cs
@@ -45,9 +45,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Methods that untaint tainted data.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// MethodMatcher determines if the outermost tuple applies, based on the method names and arguments.
         /// (IfTaintedParameter, ThenUnTaintedTarget) determines if the ThenUnTaintedTarget is untainted, based on if the IfTaintedParameter is tainted.
-        ///
+        /// </para>
+        /// <para>
         /// Example:
         /// (
         ///   (methodName, argumentOperations) => methodName == "Bar",  // MethodMatcher
@@ -55,8 +57,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         ///      ("a", "b")
         ///   }
         /// )
-        ///
-        /// will treat the parameter "b" as untainted when parameter "a" is tainted of the "Bar" method.
+        /// </para>
+        /// <para>will treat the parameter "b" as untainted when parameter "a" is tainted of the "Bar" method.</para>
         /// </remarks>
         public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(string IfTaintedParameter, string ThenUnTaintedTarget)>)> SanitizingMethods { get; }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/SourceInfo.cs
@@ -98,10 +98,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Methods that generate tainted data and whose arguments don't need extra value content analysis.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// MethodMatcher determines if the outermost tuple applies, based on the method names and arguments.
         /// PointsToCheck determines if the inner tuple applies, based on the method invocation's arguments PointsToAbstractValues.
         /// TaintedTarget is the tainted target (arguments / return value).
-        ///
+        /// </para>
+        /// <para>
         /// Example:
         /// (
         ///   (methodName, argumentOperations) => methodName == "Bar",  // MethodMatcher
@@ -112,8 +114,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         ///      )
         ///   }
         /// )
-        ///
-        /// will treat any invocation of the "Bar" method's return value as tainted.
+        /// </para>
+        /// <para>will treat any invocation of the "Bar" method's return value as tainted.</para>
         /// </remarks>
         public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(PointsToCheck PointsToCheck, string TaintedTarget)>)> TaintedMethodsNeedsPointsToAnalysis { get; }
 
@@ -121,10 +123,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Methods that generate tainted data and whose arguments need extra value content analysis and points to analysis.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// MethodMatcher determines if the outermost tuple applies, based on the method names and arguments.
         /// ValueContentCheck determines if the inner tuple applies, based on the method invocation's arguments PointsToAbstractValues and ValueContentAbstractValues.
         /// TaintedTarget is the tainted target (arguments / return value).
-        ///
+        /// </para>
+        /// <para>
         /// Example:
         /// (
         ///   (methodName, argumentOperations) => methodName == "Bar",  // MethodMatcher
@@ -135,8 +139,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         ///      )
         ///   }
         /// )
-        ///
-        /// will treat any invocation of the "Bar" method's return value as tainted.
+        /// </para>
+        /// <para>will treat any invocation of the "Bar" method's return value as tainted.</para>
         /// </remarks>
         public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(ValueContentCheck ValueContentCheck, string TaintedTarget)>)> TaintedMethodsNeedsValueContentAnalysis { get; }
 
@@ -144,9 +148,11 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// Methods that could taint another argument when one of its argument is tainted.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// MethodMatcher determines if the outermost tuple applies, based on the method names and arguments.
         /// (IfTaintedParameter, ThenTaintedTarget) determines if the ThenTaintedTarget is tainted, based on if the IfTaintedParameter is tainted.
-        ///
+        /// </para>
+        /// <para>
         /// Example:
         /// (
         ///   (methodName, argumentOperations) => methodName == "Bar",  // MethodMatcher
@@ -154,8 +160,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         ///      ("a", "b")
         ///   }
         /// )
-        ///
-        /// will treat the parameter "b" as tainted when parameter "a" is tainted of the "Bar" method.
+        /// </para>
+        /// <para>will treat the parameter "b" as tainted when parameter "a" is tainted of the "Bar" method.</para>
         /// </remarks>
         public ImmutableHashSet<(MethodMatcher MethodMatcher, ImmutableHashSet<(string IfTaintedParameter, string ThenTaintedTarget)>)> TransferMethods { get; }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAbstractValue.cs
@@ -43,8 +43,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <summary>
         /// Creates a TaintedDataAbstractValue that's marked as tainted.
         /// </summary>
-        /// <param name="accessingSyntax">Where the tainted data is originally coming from.</param>
         /// <param name="taintedSymbol">Symbol that's tainted.</param>
+        /// <param name="accessingSyntax">Where the tainted data is originally coming from.</param>
         /// <param name="accessingMethod">Method that's accessing the tainted data.</param>
         /// <returns>New TaintedDataAbstractValue that's marked as tainted.</returns>
         internal static TaintedDataAbstractValue CreateTainted(ISymbol taintedSymbol, SyntaxNode accessingSyntax, ISymbol accessingMethod)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMapExtensions.cs
@@ -28,7 +28,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <param name="pointsToFactory">If the method needs to do PointsToAnalysis, the PointsToAnalysis result will be produced by the passed value factory.</param>
         /// <param name="valueContentFactory">If the method needs to do ValueContentAnalysis, the ValueContentAnalysis result will be produced by the passed value factory.</param>
         /// <param name="allTaintedTargets"></param>
-        /// <returns></returns>
         public static bool IsSourceMethod(
             this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap,
             IMethodSymbol method,
@@ -117,7 +116,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         /// <param name="sourceSymbolMap"></param>
         /// <param name="propertySymbol"></param>
-        /// <returns></returns>
         public static bool IsSourceProperty(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IPropertySymbol propertySymbol)
         {
             foreach (SourceInfo sourceInfo in sourceSymbolMap.GetInfosForType(propertySymbol.ContainingType))
@@ -136,7 +134,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         /// <param name="sourceSymbolMap"></param>
         /// <param name="parameterSymbol"></param>
-        /// <returns></returns>
         public static bool IsSourceParameter(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IParameterSymbol parameterSymbol, WellKnownTypeProvider wellKnownTypeProvider)
         {
             ISymbol containingSymbol = parameterSymbol.ContainingSymbol;
@@ -156,7 +153,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// </summary>
         /// <param name="sourceSymbolMap"></param>
         /// <param name="arrayTypeSymbol"></param>
-        /// <returns></returns>
         public static bool IsSourceConstantArrayOfType(this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap, IArrayTypeSymbol arrayTypeSymbol)
         {
             if (arrayTypeSymbol.ElementType is INamedTypeSymbol elementType)
@@ -180,7 +176,6 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <param name="method"></param>
         /// <param name="taintedParameterNames"></param>
         /// <param name="taintedParameterPairs">The set of parameter pairs (tainted source parameter name, tainted end parameter name).</param>
-        /// <returns></returns>
         public static bool IsSourceTransferMethod(
             this TaintedDataSymbolMap<SourceInfo> sourceSymbolMap,
             IMethodSymbol method,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractAnalysisDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractAnalysisDomain.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// Creates a clone of the analysis data.
         /// </summary>
         /// <param name="value"></param>
-        /// <returns></returns>
         public abstract TAnalysisData Clone(TAnalysisData value);
 
         /// <summary>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -3087,7 +3087,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// Visits an invocation, either as a direct method call, or intermediately through a delegate.
         /// </summary>
         /// <param name="method">Method that is invoked.</param>
-        /// <param name="visitedInstance">Instance that that the method is invoked on, if any.</param>
+        /// <param name="visitedInstance">Instance that the method is invoked on, if any.</param>
         /// <param name="visitedArguments">Arguments to the invoked method.</param>
         /// <param name="invokedAsDelegate">Indicates that invocation is a delegate invocation.</param>
         /// <param name="originalOperation">Original invocation operation, which may be a delegate invocation.</param>


### PR DESCRIPTION
This PR uses Roslynator analyzers to apply following code fixes:

* Add paragraphs to documentation comments ([RCS1226](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1226.md))
* Remove unused elements in documentation comments (RCS1228)
* Order elements in documentation comments (RCS1232)
* Remove duplicate word in documentation comments (RCS1243)