### PR TITLE
Few analyzer bug fixes in presence of top level programs

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -244,6 +244,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return true;
             }
 
+            // Ignore type generated for holding top level statements
+            if (type.IsTopLevelStatementsEntryPointType())
+            {
+                return true;
+            }
+
             // The type containing the assembly's entry point is OK.
             if (ContainsEntryPoint(type, compilation))
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParameters.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParameters.cs
@@ -233,6 +233,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return false;
             }
 
+            // Ignore generated method for top level statements
+            if (method.IsTopLevelStatementsEntryPointMethod())
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainTypeNamesTests.cs
@@ -459,6 +459,25 @@ public class C
 }");
         }
 
+        [Fact, WorkItem(4052, "https://github.com/dotnet/roslyn-analyzers/issues/4052")]
+        public async Task CA1720_TopLevelStatements_NoDiagnostic()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"int x = 0;",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                    {
+                        var project = solution.GetProject(projectId);
+                        project = project.WithCompilationOptions(project.CompilationOptions.WithOutputKind(CodeAnalysis.OutputKind.ConsoleApplication));
+                        return project.Solution;
+                    },
+                }
+            }.RunAsync();
+        }
+
         #region Helpers
 
         private static DiagnosticResult GetCA1720CSharpResultAt(int line, int column, string identifierName)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -1592,6 +1592,25 @@ Friend NotInheritable Class [|C1|]
 End Class");
         }
 
+        [Fact, WorkItem(4052, "https://github.com/dotnet/roslyn-analyzers/issues/4052")]
+        public async Task CA1812_CSharp_TopLevelStatements_NoDiagnostic()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"int x = 0;",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                    {
+                        var project = solution.GetProject(projectId);
+                        project = project.WithCompilationOptions(project.CompilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                        return project.Solution;
+                    },
+                }
+            }.RunAsync();
+        }
+
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string className)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
@@ -1178,6 +1178,25 @@ public class Class1
 ");
         }
 
+        [Fact, WorkItem(4052, "https://github.com/dotnet/roslyn-analyzers/issues/4052")]
+        public async Task CA1801_TopLevelStatements_NoDiagnostic()
+        {
+            await new VerifyCS.Test()
+            {
+                TestCode = @"int x = 0;",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                    {
+                        var project = solution.GetProject(projectId);
+                        project = project.WithCompilationOptions(project.CompilationOptions.WithOutputKind(OutputKind.ConsoleApplication));
+                        return project.Solution;
+                    },
+                }
+            }.RunAsync();
+        }
+
         #endregion
 
         #region Unit tests for analyzer diagnostic(s)

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -680,5 +680,18 @@ namespace Analyzer.Utilities.Extensions
             => methodSymbol.IsPropertyAccessor()
             && methodSymbol.AssociatedSymbol is IPropertySymbol propertySymbol
             && propertySymbol.IsAutoProperty();
+
+        /// <summary>
+        /// Check if the given <paramref name="methodSymbol"/> is an implicitly generated method for top level statements.
+        /// </summary>
+        public static bool IsTopLevelStatementsEntryPointMethod([NotNullWhen(true)] this IMethodSymbol? methodSymbol)
+            => methodSymbol?.ContainingType.IsTopLevelStatementsEntryPointType() == true &&
+               methodSymbol.IsStatic &&
+               methodSymbol.Name switch
+               {
+                   "$Main" => true,
+                   "<$Main>$" => true,
+                   _ => false
+               };
     }
 }

--- a/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -269,5 +270,16 @@ namespace Analyzer.Utilities.Extensions
 
             return knownTestAttributes.GetOrAdd(attributeClass, attributeClass.DerivesFrom(xunitFactAttribute));
         }
+
+        /// <summary>
+        /// Check if the given <paramref name="typeSymbol"/> is an implicitly generated type for top level statements.
+        /// </summary>
+        public static bool IsTopLevelStatementsEntryPointType([NotNullWhen(true)] this INamedTypeSymbol? typeSymbol)
+            => typeSymbol?.IsStatic == true && typeSymbol.Name switch
+            {
+                "$Program" => true,
+                "<Program>$" => true,
+                _ => false
+            };
     }
 }

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -30,6 +30,8 @@ namespace Analyzer.Utilities
                 case SymbolKind.Namespace when ((INamespaceSymbol)symbol).IsGlobalNamespace:
                     tree = null;
                     return false;
+                case SymbolKind.Parameter:
+                    return TryGetSyntaxTreeForOption(symbol.ContainingSymbol, out tree);
                 default:
                     tree = symbol.Locations[0].SourceTree;
                     return tree != null;


### PR DESCRIPTION
Fixes #4052
Fixes #4068

C# 9 language feature: https://devblogs.microsoft.com/dotnet/welcome-to-c-9-0/#top-level-programs
This change fixes an AD0001 and couple of false positives from CA analyzers for top level programs