### PR TITLE
Report a warning when user has a package reference to an older versio…

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/CommonPropertyNames.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/CommonPropertyNames.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace GenerateDocumentationAndConfigFiles
+{
+    public static class CommonPropertyNames
+    {
+        public const string NetAnalyzersPackageName = "Microsoft.CodeAnalysis.NetAnalyzers";
+        public const string NetAnalyzersNugetAssemblyVersionPropertyName = "_NETAnalyzersNuGetAssemblyVersion";
+        public const string NetAnalyzersSDKAssemblyVersionPropertyName = "_NETAnalyzersSDKAssemblyVersion";
+
+        public const string FxCopAnalyzersPackageName = "Microsoft.CodeAnalysis.FxCopAnalyzers";
+        public const string NetCoreAnalyzersPackageName = "Microsoft.NetCore.Analyzers";
+        public const string NetFrameworkAnalyzersPackageName = "Microsoft.NetFramework.Analyzers";
+        public const string CodeQualityAnalyzersPackageName = "Microsoft.CodeQuality.Analyzers";
+
+        public const string CodeAnalysisAnalyzersPackageName = "Microsoft.CodeAnalysis.Analyzers";
+        public const string PublicApiAnalyzersPackageName = "Microsoft.CodeAnalysis.PublicApiAnalyzers";
+        public const string PerformanceSensitiveAnalyzersPackageName = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers";
+    }
+}

--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -13,6 +13,7 @@ using System.Text;
 using Analyzer.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using static GenerateDocumentationAndConfigFiles.CommonPropertyNames;
 
 namespace GenerateDocumentationAndConfigFiles
 {
@@ -201,6 +202,8 @@ $@"<Project>
 
                 if (!string.IsNullOrEmpty(disableNetAnalyzersImport))
                 {
+                    Debug.Assert(Version.TryParse(analyzerVersion, out _));
+
                     fileWithPath = Path.Combine(directory.FullName, propsFileToDisableNetAnalyzersInNuGetPackageName);
                     fileContents =
 $@"<Project>
@@ -210,6 +213,7 @@ $@"<Project>
   -->
   <PropertyGroup>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <{NetAnalyzersNugetAssemblyVersionPropertyName}>{analyzerVersion}</{NetAnalyzersNugetAssemblyVersionPropertyName}>
   </PropertyGroup>
 </Project>";
                     File.WriteAllText(fileWithPath, fileContents);
@@ -221,11 +225,11 @@ $@"<Project>
                 {
                     if (!string.IsNullOrEmpty(propsFileToDisableNetAnalyzersInNuGetPackageName))
                     {
-                        Debug.Assert(analyzerPackageName is "Microsoft.CodeAnalysis.NetAnalyzers" or
-                            "Microsoft.CodeAnalysis.FxCopAnalyzers" or
-                            "Microsoft.NetCore.Analyzers" or
-                            "Microsoft.NetFramework.Analyzers" or
-                            "Microsoft.CodeQuality.Analyzers");
+                        Debug.Assert(analyzerPackageName is NetAnalyzersPackageName or
+                            FxCopAnalyzersPackageName or
+                            NetCoreAnalyzersPackageName or
+                            NetFrameworkAnalyzersPackageName or
+                            CodeQualityAnalyzersPackageName);
 
                         return $@"
   <!-- 
@@ -233,6 +237,14 @@ $@"<Project>
     This additional props file should only be present in the analyzer NuGet package, it should **not** be inserted into the .NET SDK.
   -->
   <Import Project=""{propsFileToDisableNetAnalyzersInNuGetPackageName}"" Condition=""Exists('{propsFileToDisableNetAnalyzersInNuGetPackageName}')"" />
+
+  <!--
+    PropertyGroup to set the NetAnalyzers version installed in the SDK.
+    We rely on the additional props file '{propsFileToDisableNetAnalyzersInNuGetPackageName}' not being present in the SDK.
+  -->
+  <PropertyGroup Condition=""!Exists('{propsFileToDisableNetAnalyzersInNuGetPackageName}')"">
+    <{NetAnalyzersSDKAssemblyVersionPropertyName}>{analyzerVersion}</{NetAnalyzersSDKAssemblyVersionPropertyName}>
+  </PropertyGroup>
 ";
                     }
 

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -16,6 +16,7 @@
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ArrayBuilder.Enumerator.cs" Link="ArrayBuilder.Enumerator.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\ObjectPool.cs" Link="ObjectPool.cs" />
     <Compile Include="..\..\Utilities\Compiler\PooledObjects\PooledHashSet.cs" Link="PooledHashSet.cs" />
+    <Compile Include="..\GenerateDocumentationAndConfigFiles\CommonPropertyNames.cs" Link="CommonPropertyNames.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />


### PR DESCRIPTION
…n of .NET SDK analyzers then built-in ones in the .NET SDK

Fixes #3977

Verified the change locally by applying the targets and props file changes even in the SDK version of these files. There needs to be an additional change in the SDK to unconditionally import the SDK props, instead of conditioning it on EnableNETAnalyzers. This is required to ensure the `_NETAnalyzersSDKAssemblyVersion` is correctly set in the SDK to compare against the version in the NuGet package. I will submit a separate PR to the SDK repo for this change.

![image](https://user-images.githubusercontent.com/10605811/91620594-39cd6a00-e945-11ea-9c03-282b0b27536f.png)
