### PR TITLE
CA2014: Don't warn if a local function containing stackalloc is inside a loop

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
@@ -39,6 +39,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // We found a stackalloc.  Walk up from it to see if it's in a loop at any level.
                 for (SyntaxNode node = ctx.Node; node != null; node = node.Parent)
                 {
+                    // Don't warn of the stackalloc is in anonymous function.
+                    if (ctx.SemanticModel.GetOperation(node, ctx.CancellationToken)?.Kind == OperationKind.AnonymousFunction)
+                    {
+                        return;
+                    }
+
                     switch (node.Kind())
                     {
                         // Don't warn if a local function containing stackalloc is inside a loop.

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
@@ -41,6 +41,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     switch (node.Kind())
                     {
+                        // Don't warn if a local function containing stackalloc is inside a loop.
+                        case SyntaxKind.LocalFunctionStatement:
+                            return;
+
                         // Look for loops.  We don't bother with ad-hoc loops via gotos as we're
                         // too likely to incur false positives.
                         case SyntaxKind.ForStatement:

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoops.cs
@@ -39,16 +39,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // We found a stackalloc.  Walk up from it to see if it's in a loop at any level.
                 for (SyntaxNode node = ctx.Node; node != null; node = node.Parent)
                 {
-                    // Don't warn of the stackalloc is in anonymous function.
-                    if (ctx.SemanticModel.GetOperation(node, ctx.CancellationToken)?.Kind == OperationKind.AnonymousFunction)
-                    {
-                        return;
-                    }
-
                     switch (node.Kind())
                     {
-                        // Don't warn if a local function containing stackalloc is inside a loop.
+                        // Don't warn if a local function or lambda containing stackalloc is inside a loop.
                         case SyntaxKind.LocalFunctionStatement:
+                        case SyntaxKind.ParenthesizedLambdaExpression:
+                        case SyntaxKind.SimpleLambdaExpression:
+                        case SyntaxKind.AnonymousMethodExpression:
                             return;
 
                         // Look for loops.  We don't bother with ad-hoc loops via gotos as we're

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DoNotUseStackallocInLoopsAnalyzer,
@@ -61,6 +62,30 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                         while (true);
                     }
                 }");
+        }
+
+        [Fact]
+        public async Task NoDiagnostics_StackallocInLoopButInsideALocalFunction()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+using System;
+class TestClass {
+    private static void StackAllocInLoopButInsideLocalFunction() {
+        while (true) {
+            XX();
+
+            static void XX()
+            {
+                Span<int> tmp = stackalloc int[10];
+                Console.WriteLine(tmp[0]);
+            }
+        }
+    }
+}"
+            }.RunAsync();
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -89,6 +89,28 @@ class TestClass {
         }
 
         [Fact]
+        public async Task NoDiagnostics_StackallocInLoopButInsideALambda()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+using System;
+class TestClass {
+    private static void StackallocInLoopButInsideALambda() {
+        while (true) {
+            Action a = () => {
+                Span<int> tmp = stackalloc int[10];
+                Console.WriteLine(tmp[0]);
+            };
+            a();
+        }
+    }
+}"
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task Diagnostics_LoopsWithStackallocPtr()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -111,6 +111,24 @@ class TestClass {
         }
 
         [Fact]
+        public async Task NoDiagnostics_StackallocInLoopButInsideALambda2()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+using System;
+class TestClass {
+    private static void StackallocInLoopButInsideALambda2() {
+        while (true) {
+            Action<int> a = _ => Console.Write((stackalloc int[10]).Length);
+        }
+    }
+}"
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task NoDiagnostics_StackallocInLoopButInsideFunc()
         {
             await new VerifyCS.Test

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -111,6 +111,29 @@ class TestClass {
         }
 
         [Fact]
+        public async Task NoDiagnostics_StackallocInLoopButInsideFunc()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+using System;
+class TestClass {
+    private static void StackallocInLoopButInsideAction() {
+        while (true) {
+            Func<int> a = delegate()
+            {
+                Span<int> tmp = stackalloc int[10];
+                return 0;
+            };
+            a();
+        }
+    }
+}"
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task Diagnostics_LoopsWithStackallocPtr()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
Fixes #4135