### PR TITLE
By default platform compat analyzer should be disabled for TFM < 5.0

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -744,12 +744,12 @@ Example: `dotnet_code_quality.CA1711.allowed_suffixes = Flag|Flags`
 
 ### Enable platform compatibility analyzer for TFMs <= net5.0
 
-Option Name: `enable_platform_analyzer`
+Option Name: `enable_platform_analyzer_on_pre_net5_target`
 
-Configurable Rules: [CA14016](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1416)
+Configurable Rules: [CA14016](https://docs.microsoft.com/visualstudio/code-quality/ca1416)
 
 Option Values: Boolean values
 
 Default Value: `false`
 
-Example: `dotnet_code_quality.enable_platform_analyzer = true` or `dotnet_code_quality.CA1416.enable_platform_analyzer = true`
+Example: `dotnet_code_quality.enable_platform_analyzer_on_pre_net5_target = true` or `dotnet_code_quality.CA1416.enable_platform_analyzer_on_pre_net5_target = true`

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -741,3 +741,15 @@ Configurable Rules: [CA1711](https://docs.microsoft.com/visualstudio/code-qualit
 Option Values: List (separated by '|') of allowed suffixes
 
 Example: `dotnet_code_quality.CA1711.allowed_suffixes = Flag|Flags`
+
+### Enable platform compatibility analyzer for TFMs <= net5.0
+
+Option Name: `enable_platform_analyzer`
+
+Configurable Rules: [CA14016](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca1416)
+
+Option Values: Boolean values
+
+Default Value: `false`
+
+Example: `dotnet_code_quality.enable_platform_analyzer = true` or `dotnet_code_quality.CA1416.enable_platform_analyzer = true`

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -173,8 +173,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             var tfmString = options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.TargetFramework, compilation, token);
 
-            if (tfmString != null &&
-                tfmString.Length >= 4 &&
+            if (tfmString?.Length >= 4 &&
                 tfmString.StartsWith(Net, StringComparison.OrdinalIgnoreCase) &&
                 int.TryParse(tfmString[3].ToString(), out var major) &&
                 major >= 5)
@@ -189,7 +188,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool LowerTargetsEnabled(AnalyzerOptions options, Compilation compilation, CancellationToken cancellationToken) =>
             compilation.SyntaxTrees.FirstOrDefault() is { } tree &&
-            options.GetBoolOptionValue(EditorConfigOptionNames.EnablePlatformAnalyzer, SupportedOsRule, tree, compilation, false, cancellationToken);
+            options.GetBoolOptionValue(EditorConfigOptionNames.EnablePlatformAnalyzerOnPreNet5Target, SupportedOsRule, tree, compilation, false, cancellationToken);
 
         private void AnalyzeOperationBlock(
             OperationBlockStartAnalysisContext context,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -49,6 +49,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private const string IsOSPlatform = nameof(IsOSPlatform);
         private const string IsPrefix = "Is";
         private const string OptionalSuffix = "VersionAtLeast";
+        private const char SeparatorSemicolon = ';';
+        private const string Net = "net";
 
         internal static DiagnosticDescriptor SupportedOsVersionRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
@@ -96,6 +98,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             context.RegisterCompilationStartAction(context =>
             {
+                if (!PlatformAnalysisAllowed(context.Options, context.Compilation, context.CancellationToken))
+                {
+                    return;
+                }
+
                 var typeName = WellKnownTypeNames.SystemOperatingSystem;
 
                 // TODO: remove 'typeName + "Helper"' after tests able to consume the real new APIs
@@ -160,6 +167,60 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             static bool NameAndParametersValid(IMethodSymbol method) => method.Name.StartsWith(IsPrefix, StringComparison.Ordinal) &&
                     (method.Parameters.Length == 0 || method.Name.EndsWith(OptionalSuffix, StringComparison.Ordinal));
+        }
+
+        private static bool PlatformAnalysisAllowed(AnalyzerOptions options, Compilation compilation, CancellationToken token)
+        {
+            var tfmString = options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.TargetFramework, compilation, token);
+            if (tfmString != null)
+            {
+                foreach (var tfm in tfmString.Split(SeparatorSemicolon))
+                {
+                    if (TryParseTfm(tfm, out var platform, out var version))
+                    {
+                        if (platform.Equals(Net, StringComparison.OrdinalIgnoreCase) &&
+                            version != null &&
+                            int.TryParse(version[0].ToString(), out var value)
+                            && value >= 5)
+                        {
+                            return true;
+                        }
+                        else
+                        {
+                            return LowerTargetsEnabled(options, compilation, token);
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool LowerTargetsEnabled(AnalyzerOptions options, Compilation compilation, CancellationToken cancellationToken) =>
+            compilation.SyntaxTrees.FirstOrDefault() is { } tree &&
+            options.GetBoolOptionValue(EditorConfigOptionNames.EnablePlatformAnalyzer, SupportedOsRule, tree, compilation, false, cancellationToken);
+
+        private static bool TryParseTfm(string tfm, [NotNullWhen(true)] out string? platform, out string? version)
+        {
+            version = null;
+            for (int i = 0; i < tfm.Length; i++)
+            {
+                if (char.IsDigit(tfm[i]))
+                {
+                    if (i > 0)
+                    {
+                        platform = tfm.Substring(0, i);
+                        version = tfm[i..];
+                        return true;
+                    }
+                    platform = null;
+                    return false;
+                }
+            }
+            platform = tfm;
+            return true;
         }
 
         private void AnalyzeOperationBlock(

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3419,7 +3419,7 @@ class Test
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive");
+            await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive\nbuild_property.TargetFramework = net5");
         }
 
         [Fact(Skip = "TODO: Analysis value not returned, needs to be fixed")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -49,6 +49,7 @@ public class Test
             yield return new object[] { "build_property.TargetFramework = uap10.0", false };
             yield return new object[] { "build_property.TargetFramework = netstandard2.1", false };
             yield return new object[] { "build_property.TargetFramework = net5", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0", true };
             yield return new object[] { "build_property.TargetFramework = net5.0-windows", true };
             yield return new object[] { "build_property.TargetFramework = net5.0-ios14.0", true };
             yield return new object[] { "build_property.TargetFramework = Net99", true };
@@ -85,17 +86,20 @@ namespace CallerTargetsBelow5_0
 
         public static IEnumerable<object[]> Create_DifferentTfmsWithOption()
         {
-            yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer=true", true };
-            yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer=false", false };
-            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.enable_platform_analyzer=true", true };
-            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.CA1416.enable_platform_analyzer=false", false };
-            yield return new object[] { "build_property.TargetFramework = dotnet\ndotnet_code_quality.enable_platform_analyzer=true", true };
-            yield return new object[] { "build_property.TargetFramework = uap10.0\ndotnet_code_quality.enable_platform_analyzer=false", false };
-            yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer=true", true };
-            yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer=false", false };
-            yield return new object[] { "build_property.TargetFramework = net5\ndotnet_code_quality.enable_platform_analyzer=false", true };
-            yield return new object[] { "build_property.TargetFramework = net6.0\ndotnet_code_quality.enable_platform_analyzer=false", true };
-            yield return new object[] { "build_property.TargetFramework = netcoreapp5\ndotnet_code_quality.enable_platform_analyzer=false", false };
+            yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=true", true };
+            yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", false };
+            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=true", true };
+            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.CA1416.enable_platform_analyzer_on_pre_net5_target=false", false };
+            yield return new object[] { "build_property.TargetFramework = dotnet\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=true", true };
+            yield return new object[] { "build_property.TargetFramework = uap10.0\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", false };
+            yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=true", true };
+            yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", false };
+            yield return new object[] { "build_property.TargetFramework = net5\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0-windows\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0-ios14.0\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", true };
+            yield return new object[] { "build_property.TargetFramework = net6.0\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", true };
+            yield return new object[] { "build_property.TargetFramework = netcoreapp5\ndotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=false", false };
         }
 
         [Theory]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -49,7 +49,9 @@ public class Test
             yield return new object[] { "build_property.TargetFramework = uap10.0", false };
             yield return new object[] { "build_property.TargetFramework = netstandard2.1", false };
             yield return new object[] { "build_property.TargetFramework = net5", true };
-            yield return new object[] { "build_property.TargetFramework = net99", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0-windows", true };
+            yield return new object[] { "build_property.TargetFramework = net5.0-ios14.0", true };
+            yield return new object[] { "build_property.TargetFramework = Net99", true };
             yield return new object[] { "build_property.TargetFramework = netcoreapp5", false };
         }
 
@@ -86,7 +88,7 @@ namespace CallerTargetsBelow5_0
             yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer=true", true };
             yield return new object[] { "build_property.TargetFramework = net472\ndotnet_code_quality.enable_platform_analyzer=false", false };
             yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.enable_platform_analyzer=true", true };
-            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.enable_platform_analyzer=false", false };
+            yield return new object[] { "build_property.TargetFramework = netcoreapp1.0\ndotnet_code_quality.CA1416.enable_platform_analyzer=false", false };
             yield return new object[] { "build_property.TargetFramework = dotnet\ndotnet_code_quality.enable_platform_analyzer=true", true };
             yield return new object[] { "build_property.TargetFramework = uap10.0\ndotnet_code_quality.enable_platform_analyzer=false", false };
             yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer=true", true };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 {
     public partial class PlatformCompatabilityAnalyzerTests
     {
-        private const string s_msBuildPlatforms = "build_property._SupportedPlatformList=windows,browser, ios";//\nbuild_property.TargetFramework=net5.0";
+        private const string s_msBuildPlatforms = "build_property._SupportedPlatformList=windows,browser, ios;\nbuild_property.TargetFramework=net5.0";
 
         [Fact(Skip = "TODO need to be fixed: Test for for wrong arguments, not sure how to report the Compiler error diagnostic")]
         public async Task TestOsPlatformAttributesWithNonStringArgument()
@@ -92,7 +92,7 @@ namespace CallerTargetsBelow5_0
             yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer=true", true };
             yield return new object[] { "build_property.TargetFramework = netstandard2.1\ndotnet_code_quality.enable_platform_analyzer=false", false };
             yield return new object[] { "build_property.TargetFramework = net5\ndotnet_code_quality.enable_platform_analyzer=false", true };
-            yield return new object[] { "build_property.TargetFramework = net99\ndotnet_code_quality.enable_platform_analyzer=false", true };
+            yield return new object[] { "build_property.TargetFramework = net6.0\ndotnet_code_quality.enable_platform_analyzer=false", true };
             yield return new object[] { "build_property.TargetFramework = netcoreapp5\ndotnet_code_quality.enable_platform_analyzer=false", false };
         }
 
@@ -1793,7 +1793,7 @@ namespace PlatformCompatDemo.SupportedUnupported
         }
 
         private static async Task VerifyAnalyzerAsyncCs(string sourceCode, params DiagnosticResult[] expectedDiagnostics)
-            => await PopulateTestCs(sourceCode, expectedDiagnostics).RunAsync();
+            => await VerifyAnalyzerAsyncCs(sourceCode, "build_property.TargetFramework = net5", expectedDiagnostics);
 
         private static async Task VerifyAnalyzerAsyncCs(string sourceCode, string editorconfigText, params DiagnosticResult[] expectedDiagnostics)
         {
@@ -1810,7 +1810,7 @@ namespace PlatformCompatDemo.SupportedUnupported
         }
 
         private static async Task VerifyAnalyzerAsyncVb(string sourceCode, params DiagnosticResult[] expectedDiagnostics)
-            => await PopulateTestVb(sourceCode, expectedDiagnostics).RunAsync();
+            => await VerifyAnalyzerAsyncVb(sourceCode, "build_property.TargetFramework = net5", expectedDiagnostics);
 
         private static async Task VerifyAnalyzerAsyncVb(string sourceCode, string editorconfigText, params DiagnosticResult[] expectedDiagnostics)
         {

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -29,6 +29,11 @@ namespace Analyzer.Utilities
         public const string ExcludeAsyncVoidMethods = "exclude_async_void_methods";
 
         /// <summary>
+        /// Boolean option to enable platform commpatibility analyzer for lower version than 5.0.
+        /// </summary>
+        public const string EnablePlatformAnalyzer = "enable_platform_analyzer";
+
+        /// <summary>
         /// Option to configure analyzed output kinds, i.e. <see cref="Microsoft.CodeAnalysis.CompilationOptions.OutputKind"/> of the compilation.
         /// Allowed option values: One or more fields of <see cref="Microsoft.CodeAnalysis.CompilationOptions.OutputKind"/> as a comma separated list.
         /// </summary>

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -29,7 +29,7 @@ namespace Analyzer.Utilities
         public const string ExcludeAsyncVoidMethods = "exclude_async_void_methods";
 
         /// <summary>
-        /// Boolean option to enable platform commpatibility analyzer for lower version than 5.0.
+        /// Boolean option to enable platform commpatibility analyzer for TFMs with lower version than net5.0 (https://docs.microsoft.com/visualstudio/code-quality/ca1416).
         /// </summary>
         public const string EnablePlatformAnalyzer = "enable_platform_analyzer";
 

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -31,7 +31,7 @@ namespace Analyzer.Utilities
         /// <summary>
         /// Boolean option to enable platform commpatibility analyzer for TFMs with lower version than net5.0 (https://docs.microsoft.com/visualstudio/code-quality/ca1416).
         /// </summary>
-        public const string EnablePlatformAnalyzer = "enable_platform_analyzer";
+        public const string EnablePlatformAnalyzerOnPreNet5Target = "enable_platform_analyzer_on_pre_net5_target";
 
         /// <summary>
         /// Option to configure analyzed output kinds, i.e. <see cref="Microsoft.CodeAnalysis.CompilationOptions.OutputKind"/> of the compilation.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4091