### PR TITLE
CA5377 shouldn't warn when unable to get control flow graph

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicy.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicy.cs
@@ -139,34 +139,36 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 if (argumentOperation != null)
                                 {
                                     var cfg = invocationOperation.GetTopmostParentBlock()?.GetEnclosingControlFlowGraph();
-                                    if (cfg != null)
+                                    if (cfg == null)
                                     {
-                                        var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
-                                                                                operationBlockStartContext.Options,
-                                                                                SupportedDiagnostics,
-                                                                                defaultInterproceduralAnalysisKind: InterproceduralAnalysisKind.None,
-                                                                                cancellationToken: operationBlockStartContext.CancellationToken,
-                                                                                defaultMaxInterproceduralMethodCallChain: 1);
-                                        var pointsToAnalysisResult = PointsToAnalysis.TryGetOrComputeResult(
-                                                                        cfg,
-                                                                        owningSymbol,
-                                                                        operationBlockStartContext.Options,
-                                                                        wellKnownTypeProvider,
-                                                                        PointsToAnalysisKind.Complete,
-                                                                        interproceduralAnalysisConfig,
-                                                                        interproceduralAnalysisPredicateOpt: null,
-                                                                        false);
-                                        if (pointsToAnalysisResult == null)
-                                        {
-                                            return;
-                                        }
+                                        return;
+                                    }
 
-                                        var pointsToAbstractValue = pointsToAnalysisResult[argumentOperation.Kind, argumentOperation.Syntax];
+                                    var interproceduralAnalysisConfig = InterproceduralAnalysisConfiguration.Create(
+                                                                            operationBlockStartContext.Options,
+                                                                            SupportedDiagnostics,
+                                                                            defaultInterproceduralAnalysisKind: InterproceduralAnalysisKind.None,
+                                                                            cancellationToken: operationBlockStartContext.CancellationToken,
+                                                                            defaultMaxInterproceduralMethodCallChain: 1);
+                                    var pointsToAnalysisResult = PointsToAnalysis.TryGetOrComputeResult(
+                                                                    cfg,
+                                                                    owningSymbol,
+                                                                    operationBlockStartContext.Options,
+                                                                    wellKnownTypeProvider,
+                                                                    PointsToAnalysisKind.Complete,
+                                                                    interproceduralAnalysisConfig,
+                                                                    interproceduralAnalysisPredicateOpt: null,
+                                                                    false);
+                                    if (pointsToAnalysisResult == null)
+                                    {
+                                        return;
+                                    }
 
-                                        if (pointsToAbstractValue.NullState != NullAbstractValue.Null)
-                                        {
-                                            return;
-                                        }
+                                    var pointsToAbstractValue = pointsToAnalysisResult[argumentOperation.Kind, argumentOperation.Syntax];
+
+                                    if (pointsToAbstractValue.NullState != NullAbstractValue.Null)
+                                    {
+                                        return;
                                     }
                                 }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -97,6 +97,35 @@ class TestClass
         }
 
         [Fact]
+        public async Task TestPropertyInitializerGroupPolicyIdentifierOfBlobNamespaceNoDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+class TestClass
+{
+    public string SAS { get; } = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, ""foo"", null, null);
+}");
+        }
+
+        [Fact]
+        public async Task TestFieldInitializerGroupPolicyIdentifierOfBlobNamespaceNoDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+class TestClass
+{
+    public string GroupPolicyIdentifier;
+    public string SAS = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, ""foo"", null, null);
+}");
+        }
+
+        [Fact]
         public async Task TestAccessPolicyIdentifierOfTableNamespaceIsNullDiagnostic()
         {
             await VerifyCSharpWithDependenciesAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -67,6 +67,36 @@ class TestClass
         }
 
         [Fact]
+        public async Task TestPropertyInitializerGroupPolicyIdentifierOfBlobNamespaceIsNullDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+class TestClass
+{
+    public string SAS { get; } = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, null, null, null);
+}",
+            GetCSharpResultAt(8, 34));
+        }
+
+        [Fact]
+        public async Task TestFieldInitializerGroupPolicyIdentifierOfBlobNamespaceIsNullDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+class TestClass
+{
+    public string SAS = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, null, null, null);
+}",
+            GetCSharpResultAt(8, 25));
+        }
+
+        [Fact]
         public async Task TestAccessPolicyIdentifierOfTableNamespaceIsNullDiagnostic()
         {
             await VerifyCSharpWithDependenciesAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -120,7 +120,6 @@ using Microsoft.WindowsAzure.Storage.Blob;
 
 class TestClass
 {
-    public string GroupPolicyIdentifier;
     public string SAS = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, ""foo"", null, null);
 }");
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -77,8 +77,9 @@ using Microsoft.WindowsAzure.Storage.Blob;
 class TestClass
 {
     public string SAS { get; } = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, null, null, null);
-}",
-            GetCSharpResultAt(8, 34));
+}"
+            /* ,  GetCSharpResultAt(8, 34)    // Can't find a CFG in 2.9.x => don't report */
+            );
         }
 
         [Fact]
@@ -92,8 +93,9 @@ using Microsoft.WindowsAzure.Storage.Blob;
 class TestClass
 {
     public string SAS = new CloudAppendBlob(null).GetSharedAccessSignature(null, null, null, null, null);
-}",
-            GetCSharpResultAt(8, 25));
+}"
+            /*, GetCSharpResultAt(8, 25)    // Can't find a CFG in 2.9.x => don't report */
+            );
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
@@ -77,8 +77,9 @@ using Microsoft.WindowsAzure.Storage.File;
 class TestClass
 {
     public string SAS { get; } = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOrHttp, null);
-}",
-            GetCSharpResultAt(8, 34));
+}"
+            /* , GetCSharpResultAt(8, 34)    // Can't get CFG in 2.9.x => don't warn */
+            );
         }
 
         [Fact]
@@ -92,8 +93,9 @@ using Microsoft.WindowsAzure.Storage.File;
 class TestClass
 {
     public string SAS = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOrHttp, null);
-}",
-            GetCSharpResultAt(8, 25));
+}"
+            /* , GetCSharpResultAt(8, 25)    // Can't get CFG in 2.9.x => don't warn */
+            );
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
@@ -67,6 +67,37 @@ class TestClass
         }
 
         [Fact]
+        public async Task TestPropertyInitializerGetSharedAccessSignatureNotFromCloudStorageAccountWithProtocolsParameterDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.File;
+
+class TestClass
+{
+    public string SAS { get; } = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOrHttp, null);
+}",
+            GetCSharpResultAt(8, 34));
+        }
+
+        [Fact]
+        public async Task TestFieldInitializerGetSharedAccessSignatureNotFromCloudStorageAccountWithProtocolsParameterDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.File;
+
+class TestClass
+{
+    public string SAS = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOrHttp, null);
+}",
+            GetCSharpResultAt(8, 25));
+        }
+
+
+        [Fact]
         public async Task TestGetSharedAccessSignatureNotFromCloudStorageAccountWithoutProtocolsParameterNoDiagnostic()
         {
             await VerifyCSharpWithDependenciesAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
@@ -96,6 +96,33 @@ class TestClass
             GetCSharpResultAt(8, 25));
         }
 
+        [Fact]
+        public async Task TestPropertyInitializerGetSharedAccessSignatureNotFromCloudStorageAccountWithProtocolsParameterNoDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.File;
+
+class TestClass
+{
+    public string SAS { get; } = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOnly, null);
+}");
+        }
+
+        [Fact]
+        public async Task TestFieldInitializerGetSharedAccessSignatureNotFromCloudStorageAccountWithProtocolsParameterNoDiagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.File;
+
+class TestClass
+{
+    public string SAS = new CloudFile(null).GetSharedAccessSignature(null, null, null, SharedAccessProtocol.HttpsOnly, null);
+}");
+        }
 
         [Fact]
         public async Task TestGetSharedAccessSignatureNotFromCloudStorageAccountWithoutProtocolsParameterNoDiagnostic()


### PR DESCRIPTION
As per https://github.com/dotnet/roslyn-analyzers/pull/4109#discussion_r481397796