### PR TITLE
Store the global flow values per operation as a post-step

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -52,31 +52,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     return GlobalFlowStateAnalysisValueSet.Unknown;
                 }
 
-                return GetValueOrDefault(value);
-            }
-
-            public override GlobalFlowStateAnalysisValueSet VisitPropertyReference(IPropertyReferenceOperation operation, object? argument)
-            {
-                return GetValueOrDefault(base.VisitPropertyReference(operation, argument));
-            }
-
-            public override GlobalFlowStateAnalysisValueSet VisitFieldReference(IFieldReferenceOperation operation, object? argument)
-            {
-                return GetValueOrDefault(base.VisitFieldReference(operation, argument));
-            }
-
-            public override GlobalFlowStateAnalysisValueSet VisitObjectCreation(IObjectCreationOperation operation, object? argument)
-            {
-                return GetValueOrDefault(base.VisitObjectCreation(operation, argument));
-            }
-
-            public override GlobalFlowStateAnalysisValueSet VisitEventReference(IEventReferenceOperation operation, object? argument)
-            {
-                return GetValueOrDefault(base.VisitEventReference(operation, argument));
-            }
-            public override GlobalFlowStateAnalysisValueSet VisitMethodReference(IMethodReferenceOperation operation, object? argument)
-            {
-                return GetValueOrDefault(base.VisitMethodReference(operation, argument));
+                return value;
             }
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.cs
@@ -102,7 +102,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         }
 
         protected override GlobalFlowStateAnalysisResult ToResult(GlobalFlowStateAnalysisContext analysisContext, GlobalFlowStateAnalysisResult dataFlowAnalysisResult)
-            => dataFlowAnalysisResult;
+        {
+            // Update the operation state map with global values map
+            // These are the values that analyzers care about.
+            var operationVisitor = (GlobalFlowStateDataFlowOperationVisitor)OperationVisitor;
+            return dataFlowAnalysisResult.With(operationVisitor.GetGlobalValuesMap());
+        }
 
         protected override GlobalFlowStateBlockAnalysisResult ToBlockResult(BasicBlock basicBlock, GlobalFlowStateAnalysisData data)
             => new GlobalFlowStateBlockAnalysisResult(basicBlock, data);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateDataFlowOperationVisitor.cs
@@ -26,12 +26,18 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         private readonly AnalysisEntity _globalEntity;
         private readonly bool _hasPredicatedGlobalState;
 
+        private readonly ImmutableDictionary<IOperation, GlobalFlowStateAnalysisValueSet>.Builder _globalValuesMapBuilder;
+
         protected GlobalFlowStateDataFlowOperationVisitor(GlobalFlowStateAnalysisContext analysisContext, bool hasPredicatedGlobalState)
             : base(analysisContext)
         {
             _globalEntity = GetGlobalEntity(analysisContext);
             _hasPredicatedGlobalState = hasPredicatedGlobalState;
+            _globalValuesMapBuilder = ImmutableDictionary.CreateBuilder<IOperation, GlobalFlowStateAnalysisValueSet>();
         }
+
+        internal ImmutableDictionary<IOperation, GlobalFlowStateAnalysisValueSet> GetGlobalValuesMap()
+            => _globalValuesMapBuilder.ToImmutable();
 
         private static AnalysisEntity GetGlobalEntity(GlobalFlowStateAnalysisContext analysisContext)
         {
@@ -188,15 +194,21 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
             bool hasParameterWithDelegateType)
             => GetClonedCurrentAnalysisData();
 
-        protected GlobalFlowStateAnalysisValueSet GetValueOrDefault(GlobalFlowStateAnalysisValueSet value)
-            => value.Kind == GlobalFlowStateAnalysisValueSetKind.Known ? value : GlobalState;
-
         #region Visitor methods
 
         public override GlobalFlowStateAnalysisValueSet Visit(IOperation operation, object? argument)
         {
             var value = base.Visit(operation, argument);
-            return GetValueOrDefault(value);
+
+            if (operation != null)
+            {
+                // Store the current global value in a separate global values builder.
+                // These values need to be saved into the base operation value builder in the final analysis result.
+                // This will be done as a post-step after the analysis is complete.
+                _globalValuesMapBuilder.Add(operation, GlobalState);
+            }
+
+            return value;
         }
 
         public override GlobalFlowStateAnalysisValueSet VisitInvocation_NonLambdaOrDelegateOrLocalFunction(
@@ -216,7 +228,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 MergeAndSetGlobalState(argumentValue);
             }
 
-            return GetValueOrDefault(value);
+            return value;
         }
 
         public override GlobalFlowStateAnalysisValueSet VisitUnaryOperatorCore(IUnaryOperation operation, object? argument)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysisResult.cs
@@ -81,6 +81,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 analysisDataForUnhandledThrowOperations, TaskWrappedValuesMap, ControlFlowGraph, _defaultUnknownValue);
         }
 
+        internal DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue> With(ImmutableDictionary<IOperation, TAbstractAnalysisValue> operationStateMap)
+        {
+            return new DataFlowAnalysisResult<TBlockAnalysisResult, TAbstractAnalysisValue>(
+                _basicBlockStateMap, operationStateMap, _predicateValueKindMap, ReturnValueAndPredicateKind,
+                _interproceduralResultsMap, _standaloneLocalFunctionAnalysisResultsMap, LambdaAndLocalFunctionAnalysisInfo,
+                EntryBlockOutput, ExitBlockOutput, ExceptionPathsExitBlockOutput, MergedStateForUnhandledThrowOperations,
+                _analysisDataForUnhandledThrowOperations, TaskWrappedValuesMap, ControlFlowGraph, _defaultUnknownValue);
+        }
+
 #pragma warning disable CA1043 // Use Integral Or String Argument For Indexers
         public TBlockAnalysisResult this[BasicBlock block] => _basicBlockStateMap[block];
         public TAbstractAnalysisValue this[IOperation operation]


### PR DESCRIPTION
Fixes #4182
Verified that the added unit test causes an infinite loop in flow analysis prior to this fix.

Analyzers executing global flow analysis need the global flow state values at each operation in the flow graph. Currently, we store these global values into the operation state map while performing analysis, but this seems to lead to incorrect analysis results. As these global analysis values per operation are not required by the flow analysis itself, we now store these values in separate global value map during analysis. These values will be stored onto the final result after analysis, so the analyzers will see only global flow state values in the result.