### PR TITLE
[2.9.x] Move to latest CodeStyle package and fix violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -181,7 +181,11 @@ visual_basic_style_unused_value_assignment_preference = unused_local_variable:wa
 ### Configuration for IDE code style by diagnostic IDs ###
 [*.{cs,vb}]
 
+# Default severity for all IDE code style rules with category 'Style'
 dotnet_analyzer_diagnostic.category-Style.severity = warning
+
+# Default severity for all IDE code quality rules with category 'CodeQuality'
+dotnet_analyzer_diagnostic.category-CodeQuality.severity = warning
 
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,15 +22,15 @@
     <!-- Use the correct compiler version -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNETCoreCompilersPackageVersion>3.7.0-3.20269.11</MicrosoftNETCoreCompilersPackageVersion>
+    <MicrosoftNETCoreCompilersPackageVersion>3.8.0-3.20460.2</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftNetCompilersToolsetVersion>
+    <CodeStyleAnalyersVersion>$(MicrosoftNETCoreCompilersPackageVersion)</CodeStyleAnalyersVersion>
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
     <DogfoodAnalyzersVersion>3.3.0-beta1.20351.1</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyersVersion>
     <MicrosoftCodeAnalysisAnalyersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisAnalyersVersion>
-    <CodeStyleAnalyersVersion>3.8.0-1.20330.5</CodeStyleAnalyersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
 
     <!-- Roslyn Testing -->

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Analyzer.Utilities;
@@ -62,7 +61,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             public DisposableFieldAnalyzer(Compilation compilation)
             {
                 DisposeAnalysisHelper.TryGetOrCreate(compilation, out _disposeAnalysisHelper!);
-                Debug.Assert(_disposeAnalysisHelper != null);
+                RoslynDebug.Assert(_disposeAnalysisHelper != null);
             }
 
             public void AnalyzeSymbol(SymbolAnalysisContext symbolContext)

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotUseCountWhenAnyCanBeUsedFixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotUseCountWhenAnyCanBeUsedFixer.vb
@@ -32,11 +32,11 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                     Dim invocation = TryCast(node, InvocationExpressionSyntax)
 
-                    If Not invocation Is Nothing Then
+                    If invocation IsNot Nothing Then
 
                         Dim member = TryCast(invocation.Expression, MemberAccessExpressionSyntax)
 
-                        If Not member Is Nothing Then
+                        If member IsNot Nothing Then
 
                             GetExpressionAndInvocationArguments(
                                 sourceExpression:=member.Expression,
@@ -54,7 +54,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                     Dim invocation = TryCast(node, InvocationExpressionSyntax)
 
-                    If Not invocation Is Nothing AndAlso invocation.ArgumentList.Arguments.Count = 1 Then
+                    If invocation IsNot Nothing AndAlso invocation.ArgumentList.Arguments.Count = 1 Then
 
                         GetExpressionAndInvocationArguments(
                             sourceExpression:=invocation.ArgumentList.Arguments(0).GetExpression(),
@@ -70,7 +70,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                     Dim binary = TryCast(node, BinaryExpressionSyntax)
 
-                    If Not binary Is Nothing Then
+                    If binary IsNot Nothing Then
 
                         GetExpressionAndInvocationArguments(
                             sourceExpression:=binary.Left,
@@ -86,7 +86,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                     Dim binary = TryCast(node, BinaryExpressionSyntax)
 
-                    If Not binary Is Nothing Then
+                    If binary IsNot Nothing Then
 
                         GetExpressionAndInvocationArguments(
                             sourceExpression:=binary.Right,
@@ -109,7 +109,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
             Dim parenthesizedExpression = TryCast(sourceExpression, ParenthesizedExpressionSyntax)
 
-            While Not parenthesizedExpression Is Nothing
+            While parenthesizedExpression IsNot Nothing
 
                 sourceExpression = parenthesizedExpression.Expression
                 parenthesizedExpression = TryCast(sourceExpression, ParenthesizedExpressionSyntax)
@@ -122,7 +122,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                 Dim awaitExpressionSyntax = TryCast(sourceExpression, AwaitExpressionSyntax)
 
-                If Not awaitExpressionSyntax Is Nothing Then
+                If awaitExpressionSyntax IsNot Nothing Then
 
                     invocationExpression = TryCast(awaitExpressionSyntax.Expression, InvocationExpressionSyntax)
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUsePropertyInsteadOfCountMethodWhenAvailable.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUsePropertyInsteadOfCountMethodWhenAvailable.Fixer.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
             Dim memberAccessExpression = TryCast(invocationExpression.Expression, MemberAccessExpressionSyntax)
 
-            If Not memberAccessExpression Is Nothing Then
+            If memberAccessExpression IsNot Nothing Then
 
                 memberAccessNode = memberAccessExpression
                 nameNode = memberAccessExpression.Name

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUsePropertyInsteadOfCountMethodWhenAvailable.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUsePropertyInsteadOfCountMethodWhenAvailable.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                     Dim convertionOperation = TryCast(invocationOperation.Instance, IConversionOperation)
 
-                    Return If(Not convertionOperation Is Nothing,
+                    Return If(convertionOperation IsNot Nothing,
                         convertionOperation.Operand.Type,
                         invocationOperation.Instance.Type)
 

--- a/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ReportDiagnosticExtensions.cs
@@ -39,14 +39,11 @@ namespace Microsoft.CodeAnalysis
                     return false;
 
                 case ReportDiagnostic.Warn:
-                    switch (other)
+                    return other switch
                     {
-                        case ReportDiagnostic.Error:
-                            return true;
-
-                        default:
-                            return false;
-                    }
+                        ReportDiagnostic.Error => true,
+                        _ => false,
+                    };
 
                 case ReportDiagnostic.Info:
                     switch (other)

--- a/src/Utilities/Compiler/WordParser.cs
+++ b/src/Utilities/Compiler/WordParser.cs
@@ -98,7 +98,7 @@ namespace Analyzer.Utilities
         {
             if (options < WordParserOptions.None || options > (WordParserOptions.IgnoreMnemonicsIndicators | WordParserOptions.SplitCompoundWords))
             {
-                throw new ArgumentException($"'{nameof(options)}' ({(int)options}) is invalid for Enum type'{typeof(WordParserOptions).Name}'");
+                throw new ArgumentException($"'{nameof(options)}' ({(int)options}) is invalid for Enum type'{nameof(WordParserOptions)}'");
             }
 
             _text = text ?? throw new ArgumentNullException(nameof(text));


### PR DESCRIPTION
NOTE: Developers will require to be on VS2019 16.8 Preview3 or later after this change