### PR TITLE
Fix inconsistency bug, child cannot widen as support, can narrow

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -763,8 +763,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             out SmallDictionary<string, PlatformAttributes> notSuppressedAttributes)
         {
             notSuppressedAttributes = new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
-            bool? supportedOnlyList = null;
-            bool mandatoryMatchFound = false;
+            bool? mandatorySupportFound = null;
             using var supportedOnlyPlatforms = PooledHashSet<string>.GetInstance(StringComparer.OrdinalIgnoreCase);
             foreach (var (platformName, attribute) in operationAttributes)
             {
@@ -775,20 +774,15 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     if (attribute.UnsupportedFirst == null || attribute.UnsupportedFirst > attribute.SupportedFirst)
                     {
                         // If only supported for current platform
-                        if (supportedOnlyList.HasValue && !supportedOnlyList.Value)
-                        {
-                            return true; // invalid state, do not need to add this API to the list
-                        }
-
                         supportedOnlyPlatforms.Add(platformName);
-                        supportedOnlyList = true;
+                        mandatorySupportFound ??= false;
 
                         if (callSiteAttributes.TryGetValue(platformName, out var callSiteAttribute))
                         {
                             var attributeToCheck = attribute.SupportedSecond ?? attribute.SupportedFirst;
                             if (MandatoryOsVersionsSuppressed(callSiteAttribute, attributeToCheck))
                             {
-                                mandatoryMatchFound = true;
+                                mandatorySupportFound = true;
                             }
                             else
                             {
@@ -803,15 +797,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             }
                         }
                     }
-                    else if (attribute.UnsupportedFirst != null) // also means Unsupported <= Supported, optional list
+                    else if (attribute.UnsupportedFirst != null) // also means Unsupported < Supported, allow list
                     {
-                        if (supportedOnlyList.HasValue && supportedOnlyList.Value)
-                        {
-                            return true; // do not need to add this API to the list
-                        }
-
-                        supportedOnlyList = false;
-
                         if (callSiteAttributes.TryGetValue(platformName, out var callSiteAttribute))
                         {
                             if (callSiteAttribute.SupportedFirst != null)
@@ -847,13 +834,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
                 else
                 {
-                    if (supportedOnlyList.HasValue && supportedOnlyList.Value)
-                    {
-                        return true; // do not need to add this API to the list
-                    }
-
-                    supportedOnlyList = false;
-
                     if (attribute.UnsupportedFirst != null) // Unsupported for this but supported all other
                     {
                         if (callSiteAttributes.TryGetValue(platformName, out var callSiteAttribute))
@@ -887,9 +867,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            if (supportedOnlyList.HasValue && supportedOnlyList.Value)
+            if (mandatorySupportFound.HasValue)
             {
-                if (!mandatoryMatchFound)
+                if (!mandatorySupportFound.Value)
                 {
                     foreach (var (name, attributes) in operationAttributes)
                     {
@@ -989,6 +969,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 var container = symbol.ContainingSymbol;
 
+                if (symbol is IMethodSymbol method && method.IsAccessorMethod())
+                {
+                    // Add attributes for the associated Property
+                    container = method.AssociatedSymbol;
+                }
+
                 // Namespaces do not have attributes
                 while (container is INamespaceSymbol)
                 {
@@ -1001,30 +987,87 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     attributes = CopyAttributes(containerAttributes);
                 }
 
-                AddPlatformAttributes(symbol.GetAttributes(), ref attributes);
-
-                if (symbol is IMethodSymbol method && method.IsAccessorMethod())
-                {
-                    // Add attributes for the associated Property
-                    AddPlatformAttributes(method.AssociatedSymbol.GetAttributes(), ref attributes);
-                }
+                MergePlatformAttributes(symbol.GetAttributes(), ref attributes);
 
                 attributes = platformSpecificMembers.GetOrAdd(symbol, attributes);
             }
 
             return attributes != null;
 
-            static bool AddPlatformAttributes(ImmutableArray<AttributeData> immediateAttributes, [NotNullWhen(true)] ref SmallDictionary<string, PlatformAttributes>? attributes)
+            static void MergePlatformAttributes(ImmutableArray<AttributeData> immediateAttributes, [NotNullWhen(true)] ref SmallDictionary<string, PlatformAttributes>? parentAttributes)
             {
-                bool added = false;
+                SmallDictionary<string, PlatformAttributes>? childAttributes = null;
                 foreach (AttributeData attribute in immediateAttributes)
                 {
                     if (s_osPlatformAttributes.Contains(attribute.AttributeClass.Name))
                     {
-                        added |= TryAddValidAttribute(ref attributes, attribute);
+                        TryAddValidAttribute(ref childAttributes, attribute);
                     }
                 }
-                return added;
+
+                if (childAttributes != null)
+                {
+                    if (parentAttributes != null && parentAttributes.Any())
+                    {
+                        foreach (var (platform, attributes) in parentAttributes)
+                        {
+                            if (DenyList(attributes) &&
+                                !parentAttributes.Any(ca => AllowList(ca.Value)))
+                            {
+                                // if all are deny list then we can add the child attributes
+                                foreach (var (name, childAttribute) in childAttributes)
+                                {
+                                    if (parentAttributes.TryGetValue(name, out var existing))
+                                    {
+                                        // but don't override existing unless narrowing the support
+                                        if (childAttribute.UnsupportedFirst != null &&
+                                            childAttribute.UnsupportedFirst < attributes.UnsupportedFirst)
+                                        {
+                                            attributes.UnsupportedFirst = childAttribute.UnsupportedFirst;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        parentAttributes[name] = childAttribute;
+                                    }
+                                }
+                                return;
+                            }
+                            else if (AllowList(attributes))
+                            {
+                                // only attributes with same platform matter, could narrow the list
+                                if (childAttributes.TryGetValue(platform, out var childAttribute))
+                                {
+                                    // Only later versions could narrow, other versions ignored 
+                                    if (childAttribute.SupportedFirst > attributes.SupportedFirst)
+                                    {
+                                        attributes.SupportedSecond = childAttribute.SupportedFirst;
+                                    }
+
+                                    if (childAttribute.UnsupportedFirst != null)
+                                    {
+                                        if (childAttribute.UnsupportedFirst <= attributes.SupportedFirst)
+                                        {
+                                            attributes.SupportedFirst = null;
+                                            attributes.SupportedSecond = null;
+                                        }
+                                        else if (childAttribute.UnsupportedFirst <= attributes.SupportedSecond)
+                                        {
+                                            attributes.SupportedSecond = null;
+                                        }
+
+                                        attributes.UnsupportedFirst = childAttribute.UnsupportedFirst;
+                                    }
+                                }
+                                // other platform attributes are ignored as the list couldn't be extended
+                            }
+                        }
+                    }
+                    else
+                    {
+                        parentAttributes = childAttributes;
+                    }
+                }
             }
         }
 
@@ -1039,13 +1082,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 TryParsePlatformNameAndVersion(argument.Value.ToString(), out string platformName, out Version? version))
             {
                 attributes ??= new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
-
                 if (!attributes.TryGetValue(platformName, out var _))
                 {
                     attributes[platformName] = new PlatformAttributes();
                 }
 
-                AddAttribute(attribute.AttributeClass.Name, version, attributes, platformName);
+                AddAttribute(attribute.AttributeClass.Name, version, attributes[platformName]);
                 return true;
             }
 
@@ -1076,20 +1118,19 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return true;
         }
 
-        private static void AddAttribute(string name, Version version, SmallDictionary<string, PlatformAttributes> existingAttributes, string platformName)
+        private static void AddAttribute(string name, Version version, PlatformAttributes attributes)
         {
             if (name == SupportedOSPlatformAttribute)
             {
-                AddOrUpdateSupportedAttribute(existingAttributes[platformName], version);
+                AddOrUpdateSupportedAttribute(attributes, version);
             }
             else
             {
                 Debug.Assert(name == UnsupportedOSPlatformAttribute);
-                AddOrUpdateUnsupportedAttribute(platformName, existingAttributes[platformName], version, existingAttributes);
+                AddOrUpdateUnsupportedAttribute(attributes, version);
             }
 
-            static void AddOrUpdateUnsupportedAttribute(string name, PlatformAttributes attributes,
-                Version version, SmallDictionary<string, PlatformAttributes> existingAttributes)
+            static void AddOrUpdateUnsupportedAttribute(PlatformAttributes attributes, Version version)
             {
                 if (attributes.UnsupportedFirst != null)
                 {
@@ -1131,32 +1172,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
                 else
                 {
-                    if (attributes.SupportedFirst != null && attributes.SupportedFirst >= version)
-                    {
-                        // Override needed
-                        if (attributes.SupportedSecond != null)
-                        {
-                            attributes.SupportedFirst = attributes.SupportedSecond;
-                            attributes.SupportedSecond = null;
-                        }
-                        else
-                        {
-                            attributes.SupportedFirst = null;
-                        }
-                        if (!HasAnySupportedOnlyAttribute(name, existingAttributes))
-                        {
-                            attributes.UnsupportedFirst = version;
-                        }
-                    }
-                    else
-                    {
-                        attributes.UnsupportedFirst = version;
-                    }
+                    attributes.UnsupportedFirst = version;
                 }
-
-                static bool HasAnySupportedOnlyAttribute(string name, SmallDictionary<string, PlatformAttributes> existingAttributes) =>
-                    existingAttributes.Any(a => !a.Key.Equals(name, StringComparison.OrdinalIgnoreCase) &&
-                    AllowList(a.Value));
             }
 
             static void AddOrUpdateSupportedAttribute(PlatformAttributes attributes, Version version)
@@ -1165,34 +1182,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     if (attributes.SupportedFirst > version)
                     {
-                        if (attributes.SupportedSecond != null)
-                        {
-                            if (attributes.SupportedSecond < attributes.SupportedFirst)
-                            {
-                                attributes.SupportedSecond = attributes.SupportedFirst;
-                            }
-                        }
-                        else
-                        {
-                            attributes.SupportedSecond = attributes.SupportedFirst;
-                        }
-
                         attributes.SupportedFirst = version;
                     }
-                    else
-                    {
-                        if (attributes.SupportedSecond != null)
-                        {
-                            if (attributes.SupportedSecond < version)
-                            {
-                                attributes.SupportedSecond = version;
-                            }
-                        }
-                        else
-                        {
-                            attributes.SupportedSecond = version;
-                        }
-                    }
+                    // only keep lowest version, ignore other versions
                 }
                 else
                 {
@@ -1208,7 +1200,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// <returns>true if it is allow list</returns>
         private static bool AllowList(PlatformAttributes attributes) =>
             attributes.SupportedFirst != null &&
-            (attributes.UnsupportedFirst == null || attributes.SupportedFirst < attributes.UnsupportedFirst);
+            (attributes.UnsupportedFirst == null || attributes.SupportedFirst <= attributes.UnsupportedFirst);
 
         /// <summary>
         /// Determines if the attributes unsupported only for the platform (deny list)
@@ -1217,6 +1209,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// <returns>true if it is deny list</returns>
         private static bool DenyList(PlatformAttributes attributes) =>
             attributes.UnsupportedFirst != null &&
-            (attributes.SupportedFirst == null || attributes.UnsupportedFirst <= attributes.SupportedFirst);
+            (attributes.SupportedFirst == null || attributes.UnsupportedFirst < attributes.SupportedFirst);
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -242,7 +242,7 @@ namespace PlatformCompatDemo.SupportedUnupported
                 unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser(); 
+                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11(); 
                 unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
@@ -260,7 +260,7 @@ namespace PlatformCompatDemo.SupportedUnupported
                 [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|];
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11()|];
+                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
                 unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
@@ -278,7 +278,6 @@ namespace PlatformCompatDemo.SupportedUnupported
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(37, 17).WithMessage("'TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11()' is unsupported on 'windows'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(38, 17).WithMessage("'TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()' is unsupported on 'windows'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(39, 17).WithMessage("'TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()' is unsupported on 'windows'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(42, 17).WithMessage("'TypeUnsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11()' is unsupported on 'windows'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(47, 64).WithMessage("'TypeUnsupportedOnWindowsSupportedOnWindows11' is unsupported on 'windows'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(48, 17).WithMessage("'TypeUnsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13()' is unsupported on 'windows'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(50, 86).WithMessage("'TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12' is unsupported on 'windows'"));
@@ -905,8 +904,7 @@ class Test
 using System.Runtime.Versioning;
 using System;
 
-[assembly:SupportedOSPlatform(""windows7.0"")]
-
+[SupportedOSPlatform(""windows7.0"")]
 static class Program
 {
     public static void Main()
@@ -938,7 +936,7 @@ public class WindowsSpecificApis
 using System;
 using System.Runtime.Versioning;
 
-[assembly:SupportedOSPlatform(""windows"")]
+[SupportedOSPlatform(""windows"")]
 static class Program
 {
     public static void Main()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -198,8 +198,9 @@ public class Test
         UnsupportedOSPlatformWithNullString();
         UnsupportedWithEmptyString();
         [|NotForWindows()|];
+        UnattributedFunction();
     }
-
+    public void UnattributedFunction() { }
     [UnsupportedOSPlatform(""Windows"")]
     public void NotForWindows()
     {
@@ -346,7 +347,7 @@ Public Class Test
         Get
             Return True
         End Get
-        < SupportedOSPlatform(""windows"") >
+        <SupportedOSPlatform(""windows"")>
         Set(ByVal value As Boolean)
         End Set
     End Property
@@ -1080,6 +1081,164 @@ public class Test
             await VerifyAnalyzerAsyncCs(source);
         }
 
+        [Fact, WorkItem(4168, "https://github.com/dotnet/roslyn-analyzers/issues/4168")]
+        public async Task UnsupportedShouldNotSuppressSupportedWithSameVersion()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+static class Program
+{
+    public static void Main()
+    {
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 3 diagnostics expected
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        UnsupportedOnBrowserType.SupportedOnBrowser();
+    }
+}
+[UnsupportedOSPlatform(""browser"")]
+class UnsupportedOnBrowserType
+{
+    [SupportedOSPlatform(""windows"")]
+    [SupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""tvos"")] 
+    public static void SupportedOnWindowsIosTvos() {}
+    [SupportedOSPlatform(""browser2.0"")] 
+    public static void SupportedOnBrowser() {}
+    [SupportedOSPlatform(""tvos4.0"")]    
+    public static void SupportedOnTvos4() {}
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(7, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'ios'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(7, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'tvos'"));
+        }
+
+        [Fact, WorkItem(4168, "https://github.com/dotnet/roslyn-analyzers/issues/4168")]
+        public async Task CallSitesUnsupportedShouldNotSuppressSupportedWithSameVersion()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[UnsupportedOSPlatform(""browser"")]
+static class Program
+{
+    public static void Main()
+    {
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 3 diagnostics expected
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        UnsupportedOnBrowserType.SupportedOnBrowser(); // child support ignored (should not extend)
+        UnsupportedOnBrowserType.UnsupportedOnBrowser();
+    }
+}
+
+[SupportedOSPlatform(""browser"")]
+static class Program2
+{
+    public static void Main()
+    {
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 4 diagnostics expected
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        [|UnsupportedOnBrowserType.SupportedOnBrowser()|];    // only warns for parent attribute
+        [|UnsupportedOnBrowserType.UnsupportedOnBrowser()|];
+    }
+}
+
+[UnsupportedOSPlatform(""browser"")]
+[SupportedOSPlatform(""windows"")]
+static class Program3
+{
+    public static void Main()
+    {
+        UnsupportedOnBrowserType.SupportedOnWindowsIosTvos(); // No diagnostics expected
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        UnsupportedOnBrowserType.SupportedOnBrowser();
+        UnsupportedOnBrowserType.UnsupportedOnBrowser();
+    }
+}
+
+[UnsupportedOSPlatform(""browser"")]
+class UnsupportedOnBrowserType
+{
+    [SupportedOSPlatform(""windows"")]
+    [SupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""tvos"")] 
+    public static void SupportedOnWindowsIosTvos() {}
+    [SupportedOSPlatform(""browser2.0"")] 
+    public static void SupportedOnBrowser() {}
+    [UnsupportedOSPlatform(""browser1.0"")] 
+    public static void UnsupportedOnBrowser() {}
+    [SupportedOSPlatform(""tvos4.0"")]    
+    public static void SupportedOnTvos4() {}
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(9, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'ios'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(9, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'tvos'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(21, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is unsupported on 'browser'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(21, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'ios'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(21, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is supported on 'tvos'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(22, 9)
+                    .WithMessage("'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on 'browser'"));
+        }
+
+        [Fact, WorkItem(4168, "https://github.com/dotnet/roslyn-analyzers/issues/4168")]
+        public async Task CallSiteUnsupportedShouldNotSuppressSupportedWithSameVersionAndSameLevel()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[UnsupportedOSPlatform(""browser"")]
+static class Program
+{
+    public static void Main()
+    {
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // One diagnostics expected only for parent
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|];   // Same here
+    }
+}
+
+[SupportedOSPlatform(""browser"")]
+static class Program2
+{
+    public static void Main()
+    {
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // 2 diagnostics expected only for parent
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|]; // Same here 
+    }
+}
+
+[SupportedOSPlatform(""windows"")]
+static class Program3
+{
+    public static void Main()
+    {
+        UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos(); // No diagnostics expected
+        UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4();
+    }
+}
+
+[UnsupportedOSPlatform(""browser"")]
+[SupportedOSPlatform(""windows"")]
+class UnsupportedOnBrowserSupportedOnWindowType
+{
+    [SupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""tvos"")]  // these attributes will be ignored
+    public static void SupportedOnIosTvos() {}
+    [SupportedOSPlatform(""tvos4.0"")]    // same here
+    public static void SupportedOnTvos4() {}
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(19, 9)
+                    .WithMessage("'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()' is unsupported on 'browser'"),
+                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(20, 9)
+                    .WithMessage("'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()' is unsupported on 'browser'"));
+        }
+
         [Fact]
         public async Task CallerSupportsSubsetOfTarget()
         {
@@ -1222,6 +1381,7 @@ namespace CallerSupportsSubsetOfTarget
             [|Target.SupportedOnWindows()|];
             [|Target.SupportedOnBrowser()|];
             [|Target.SupportedOnWindowsAndBrowser()|]; // two diagnostics expected
+            [|Target.SupportedOnWindowsAndUnsupportedOnBrowser()|];
 
             [|Target.UnsupportedOnWindows()|];
             [|Target.UnsupportedOnWindows11()|];
@@ -1253,6 +1413,9 @@ namespace CallerSupportsSubsetOfTarget
 
         [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
         public static void UnsupportedOnWindowsAndBrowser() { }
+
+        [SupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
+        public static void SupportedOnWindowsAndUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
         public static void UnsupportedOnWindowsUntilWindows11() { }
@@ -1326,7 +1489,7 @@ namespace CallerSupportsSubsetOfTarget
         }
 
         [Fact]
-        public async Task UnsupportedMustSuppressSupported()
+        public async Task UnsupportedSamePlatformMustSuppressSupported()
         {
             var source = @"
 using System.Runtime.Versioning;
@@ -1335,8 +1498,8 @@ static class Program
 {
     public static void Main()
     {
-        [|Some.Api1()|];
-        [|Some.Api2()|]; // TvOs is suppressed
+        [|Some.Api1()|]; // 2 diagnostics
+        [|Some.Api2()|]; // One suppressed by unsupport
     }
 }
 
@@ -1346,12 +1509,12 @@ class Some
 {
     public static void Api1() {}
 
-    [UnsupportedOSPlatform(""tvos"")]
+    [UnsupportedOSPlatform(""tvos"")] // Not ignored
     public static void Api2() {}
 }
 " + MockAttributesCsSource;
             await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(8, 9)
-                    .WithMessage("'Some.Api1()' is supported on 'tvos' 4.0 and later").WithArguments("UnsupportedOnWindowsAndBrowser", "windows"));
+                    .WithMessage("'Some.Api1()' is supported on 'tvos' 4.0 and later"));
         }
 
         [Fact]
@@ -1368,37 +1531,37 @@ namespace PlatformCompatDemo.Bugs
         public void TestSupportedOnWindows()
         {
             [|TargetSupportedOnWindows.FunctionUnsupportedOnWindows()|]; // should warn for unsupported windows
-            TargetSupportedOnWindows.FunctionUnsupportedOnBrowser();
+            TargetSupportedOnWindows.FunctionUnsupportedOnBrowser();     // browser unsupport not related so ignored
 
-            TargetUnsupportedOnWindows.FunctionSupportedOnWindows();
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|]; // should warn for unsupported windows                                    
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnWindows()|]; // Should warn only for unsupported type
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|]; // should warn for unsupported windows and browser support                                   
         }
 
         [UnsupportedOSPlatform(""windows"")]
         public void TestUnsupportedOnWindows()
         {
             TargetSupportedOnWindows.FunctionUnsupportedOnWindows();
-            [|TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()|]; // should warn supported on windows ignore unsupported on browser as this is allow list
+            [|TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()|];  // should warn supported on windows ignore unsupported on browser as this is allow list
 
-            TargetUnsupportedOnWindows.FunctionSupportedOnBrowser();   //  should warn supported on browser, but is this valid scenario? => Invalid scenario, so not warn 
-            TargetUnsupportedOnWindows.FunctionSupportedOnWindows();   // It's unsupporting Windows at the call site, which means the call site supports all other platforms.
-        }                                                               // It's calling into code that was NOT supported only on Windows but eventually added support, so it shouldn't raise diagnostic
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|];  // should warn supported on browser 
+            TargetUnsupportedOnWindows.FunctionSupportedOnWindows();      // it's unsupporting Windows at the call site, so it should warn for windows support on the API
+        }                                                                 
     }
 
     [SupportedOSPlatform(""windows"")]
     class TargetSupportedOnWindows
     {
-        [UnsupportedOSPlatform(""windows"")]
+        [UnsupportedOSPlatform(""windows"")]  // Not  Ignored
         public static void FunctionUnsupportedOnWindows() { }
 
-        [UnsupportedOSPlatform(""browser"")]
+        [UnsupportedOSPlatform(""browser"")]  // Will be ignored ignored
         public static void FunctionUnsupportedOnBrowser() { }
     }
 
     [UnsupportedOSPlatform(""windows"")]
     class TargetUnsupportedOnWindows
     {
-        [SupportedOSPlatform(""windows"")]
+        [SupportedOSPlatform(""windows"")] // will be ignored
         public static void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""browser"")]
@@ -1406,16 +1569,16 @@ namespace PlatformCompatDemo.Bugs
     }
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source);
+            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(15, 13)
+                    .WithMessage("'TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()' is supported on 'browser'"));
         }
 
         [Fact]
-        public async Task UnsupportedMustSuppressSupportedAssemblyAttribute()
+        public async Task ChildUnsupportedMustParentSupportedPlatformMustNotIgnored()
         {
             var source = @"
 using System.Runtime.Versioning;
 [assembly:SupportedOSPlatform(""browser"")]
-
 namespace PlatformCompatDemo
 {
     static class Program
@@ -1423,7 +1586,8 @@ namespace PlatformCompatDemo
         public static void Main()
         {
             [|CrossPlatformApis.DoesNotWorkOnBrowser()|];
-            var nonBrowser = [|new NonBrowserApis()|];
+            CrossPlatformApis.NormalFunction();
+            var nonBrowser = new NonLinuxApis();
         }
     }
 
@@ -1431,10 +1595,42 @@ namespace PlatformCompatDemo
     {
         [UnsupportedOSPlatform(""browser"")]
         public static void DoesNotWorkOnBrowser() { }
+        public static void NormalFunction() { }
     }
 
-    [UnsupportedOSPlatform(""browser"")]
-    public class NonBrowserApis
+    [UnsupportedOSPlatform(""linux"")] // must be ignored
+    public class NonLinuxApis { }
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
+        [Fact]
+        public async Task SupportedMustSuppressUnsupportedAssemblyAttribute()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+[assembly:UnsupportedOSPlatform(""browser"")]
+
+namespace PlatformCompatDemo
+{
+    static class Program
+    {
+        public static void Main()
+        {
+            [|CrossPlatformApis.WindowsApi()|];
+            var nonBrowser = new BrowserApis();
+        }
+    }
+
+    public class CrossPlatformApis
+    {
+        [SupportedOSPlatform(""windows"")]
+        public static void WindowsApi() { }
+    }
+
+    [SupportedOSPlatform(""browser"")]
+    public class BrowserApis
     {
     }
 }
@@ -1443,7 +1639,7 @@ namespace PlatformCompatDemo
         }
 
         [Fact]
-        public async Task UsingUnsupportedApiShouldWarn()
+        public async Task UsingUnsupportedApiWithinAllowListShouldWarn()
         {
             var source = @"
 using System.Runtime.Versioning;
@@ -1453,21 +1649,22 @@ static class Program
 {
     public static void Main()
     {
-        [|SomeWindowsSpecific.Api()|];
+        new SomeWindowsSpecific();
+        [|SomeWindowsSpecific.NotForWindows()|];
     }
 }
 
 class SomeWindowsSpecific
 {
-    [UnsupportedOSPlatform(""windows"")]
-    public static void Api() { }
+    [UnsupportedOSPlatform(""windows"")] // This will not be ignored
+    public static void NotForWindows() { }
 }
 " + MockAttributesCsSource;
             await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
-        public async Task UsingVersionedApiFromUnversionedAssembly()
+        public async Task UsingVersionedApiFromAllowListAssemblyNotIgnored()
         {
             var source = @"
 using System.Runtime.Versioning;
@@ -1477,14 +1674,18 @@ static class Program
 {
     public static void Main()
     {
-        [|Some.WindowsSpecificApi()|];
+        [|Some.Windows10SpecificApi()|];
+        WindowsSpecificApi();
+    }
+    public static void WindowsSpecificApi()
+    {
     }
 }
 
-[SupportedOSPlatform(""windows10.0"")]
+[SupportedOSPlatform(""windows10.0"")] // This attribute will not be ignored
 static class Some
 {
-    public static void WindowsSpecificApi()
+    public static void Windows10SpecificApi()
     {
     }
 }
@@ -1493,7 +1694,7 @@ static class Some
         }
 
         [Fact]
-        public async Task ReintroducingApiSupport_NotWarn()
+        public async Task ReintroducingHigherApiSupport_Warn()
         {
             var source = @"
 using System.Runtime.Versioning;
@@ -1503,16 +1704,20 @@ static class Program
 {
     public static void Main()
     {
-        Some.WindowsSpecificApi();
+        [|Some.WindowsSpecificApi11()|];
+        Some.WindowsSpecificApi1();
     }
 }
 
 static class Some
 {
-    [SupportedOSPlatform(""windows"")]
-    [UnsupportedOSPlatform(""windows8.1"")]
-    [SupportedOSPlatform(""windows10.0"")]
-    public static void WindowsSpecificApi()
+    [SupportedOSPlatform(""windows11.0"")]
+    public static void WindowsSpecificApi11()
+    {
+    }
+
+    [SupportedOSPlatform(""windows1.0"")]
+    public static void WindowsSpecificApi1()
     {
     }
 }
@@ -1629,9 +1834,9 @@ public class OsDependentClass
  using System.Runtime.Versioning;
  
 [SupportedOSPlatform(""Windows"")]
+[UnsupportedOSPlatform(""" + suppressingVersion + @""")]
 public class Test
 {
-    [UnsupportedOSPlatform(""" + suppressingVersion + @""")]
     public void M1()
     {
         OsDependentClass odc = new OsDependentClass();
@@ -1854,14 +2059,14 @@ namespace PlatformCompatDemo.SupportedUnupported
             [|supported.TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser()|];
 
             var supportedOnWindows = [|new TypeSupportedOnWindows()|];
-            [|supportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnBrowser()|];
+            [|supportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnBrowser()|]; // browser support ignored
             [|supportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnWindows11AndBrowser()|];
 
             var supportedOnBrowser = [|new TypeSupportedOnBrowser()|];
             [|supportedOnBrowser.TypeSupportedOnBrowser_FunctionSupportedOnWindows()|];
 
             var supportedOnWindows10 = [|new TypeSupportedOnWindows10()|];
-            [|supportedOnWindows10.TypeSupportedOnWindows10_FunctionSupportedOnBrowser()|];
+            [|supportedOnWindows10.TypeSupportedOnWindows10_FunctionSupportedOnBrowser()|]; // child function support will be ignored
 
             var supportedOnWindowsAndBrowser = [|new TypeSupportedOnWindowsAndBrowser()|];
             [|supportedOnWindowsAndBrowser.TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11()|];
@@ -1925,10 +2130,6 @@ namespace PlatformCompatDemo.SupportedUnupported
 
             await VerifyAnalyzerAsyncCs(source,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(13, 13).WithMessage("'TypeWithoutAttributes.TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser()' is supported on 'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(16, 13).WithMessage("'TypeSupportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnBrowser()' is supported on 'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(17, 13).WithMessage("'TypeSupportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnWindows11AndBrowser()' is supported on 'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(20, 13).WithMessage("'TypeSupportedOnBrowser.TypeSupportedOnBrowser_FunctionSupportedOnWindows()' is supported on 'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(23, 13).WithMessage("'TypeSupportedOnWindows10.TypeSupportedOnWindows10_FunctionSupportedOnBrowser()' is supported on 'browser'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(25, 48).WithMessage("'TypeSupportedOnWindowsAndBrowser' is supported on 'browser'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(26, 13).WithMessage("'TypeSupportedOnWindowsAndBrowser.TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11()' is supported on 'browser'"));
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4168

Besides fixing the inconsistency issue this PR is updating out attributes handling logic:

**Before**: We were collecting all attributes for the invoked member and its containing types, after that were determining attributes inconsistency along with suppression from call site attributes when incosistency occurs bailout to avoid false positives. Also in case lowest version of supported and unsupported attributes are equal that counted as Deny list
 
**Now**: We are checking attributes consistency for each level, starting from the Parent, for merging each child member's attributes follow the rule suggested by @terrajobst: `child annotations can narrow support, but they cannot widen it`, attributes not respecting the rule are ignored. Also in case, the lowest version of supported and unsupported attributes are equal that counted as Allow list.
 