### PR TITLE
Switch platform compat analyzer to do an optimistic flow analysis

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -235,6 +235,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     var analysisResult = GlobalFlowStateAnalysis.TryGetOrComputeResult(
                         cfg, context.OwningSymbol, CreateOperationVisitor, wellKnownTypeProvider,
                         context.Options, SupportedOsRule, performValueContentAnalysis,
+                        pessimisticAnalysis: false,
                         context.CancellationToken, out var valueContentAnalysisResult,
                         additionalSupportedValueTypes: osPlatformTypeArray,
                         getValueContentValueForAdditionalSupportedValueTypeOperation: GetValueContentValue);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -2705,6 +2705,40 @@ public class Test
             await VerifyAnalyzerAsyncCs(source);
         }
 
+        [Fact, WorkItem(4209, "https://github.com/dotnet/roslyn-analyzers/issues/4209")]
+        public async Task LambdaInvocationWithUnknownTarget_BeforeGuardedCall()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+class Test
+{
+    Func<string> Greetings = () => ""Hi!"";
+    
+    void M1()
+    {
+        Greetings();
+        if (OperatingSystemHelper.IsBrowser())
+        {
+            SupportedOnBrowser();
+        }
+        else
+        {
+            UnsupportedOnBrowser();
+        }
+    }
+
+    [SupportedOSPlatform(""browser"")]
+    void SupportedOnBrowser() { }
+
+    [UnsupportedOSPlatform(""browser"")]
+    void UnsupportedOnBrowser() { }
+}
+" + MockAttributesCsSource + MockOperatingSystemApiSource;
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
         [Fact]
         public async Task OsDependentEventAccessed_GuardedCall_SimpleIfElse()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.cs
@@ -27,6 +27,32 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         {
         }
 
+        /// <summary>
+        /// Performs global flow state analysis and returns the analysis result.
+        /// </summary>
+        /// <param name="cfg">Control flow graph to analyze.</param>
+        /// <param name="owningSymbol">Owning symbol for the analyzed <paramref name="cfg"/>.</param>
+        /// <param name="createOperationVisitor">Delegate to create a <see cref="GlobalFlowStateDataFlowOperationVisitor"/> that performs the core analysis.</param>
+        /// <param name="wellKnownTypeProvider">Well-known type provider for the compilation.</param>
+        /// <param name="analyzerOptions">Analyzer options for analysis</param>
+        /// <param name="rule"><see cref="DiagnosticDescriptor"/> for fetching any rule specific analyzer option values from <paramref name="analyzerOptions"/>.</param>
+        /// <param name="performValueContentAnalysis">Flag to indicate if <see cref="ValueContentAnalysis.ValueContentAnalysis"/> should be performed.</param>
+        /// <param name="pessimisticAnalysis">
+        /// This boolean field determines if we should perform an optimistic OR a pessimistic analysis.
+        /// For example, invoking a lambda method for which we do not know the target method being invoked can change/invalidate the current global flow state.
+        /// An optimistic points to analysis assumes that the global flow state doesn't change for such scenarios.
+        /// A pessimistic points to analysis resets the the global flow state to an unknown state for such scenarios.
+        /// </param>
+        /// <param name="cancellationToken">Token to cancel analysis.</param>
+        /// <param name="valueContentAnalysisResult">Optional value content analysis result, if <paramref name="performValueContentAnalysis"/> is true</param>
+        /// <param name="interproceduralAnalysisKind"><see cref="InterproceduralAnalysisKind"/> for the analysis.</param>
+        /// <param name="interproceduralAnalysisPredicate">Optional predicate for interprocedural analysis.</param>
+        /// <param name="additionalSupportedValueTypes">Additional value types for which the caller wants to track stored values during value content analysis.</param>
+        /// <param name="getValueContentValueForAdditionalSupportedValueTypeOperation">
+        /// Optional delegate to compute values for <paramref name="additionalSupportedValueTypes"/>.
+        /// Must be non-null if <paramref name="additionalSupportedValueTypes"/> is non-empty.
+        /// </param>
+        /// <returns>Global flow state analysis result, or null if analysis did not succeed.</returns>
         public static GlobalFlowStateAnalysisResult? TryGetOrComputeResult(
             ControlFlowGraph cfg,
             ISymbol owningSymbol,
@@ -35,10 +61,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
             AnalyzerOptions analyzerOptions,
             DiagnosticDescriptor rule,
             bool performValueContentAnalysis,
+            bool pessimisticAnalysis,
             CancellationToken cancellationToken,
             out ValueContentAnalysisResult? valueContentAnalysisResult,
             InterproceduralAnalysisKind interproceduralAnalysisKind = InterproceduralAnalysisKind.None,
-            bool pessimisticAnalysis = true,
             InterproceduralAnalysisPredicate? interproceduralAnalysisPredicate = null,
             ImmutableArray<INamedTypeSymbol> additionalSupportedValueTypes = default,
             Func<IOperation, ValueContentAbstractValue>? getValueContentValueForAdditionalSupportedValueTypeOperation = null)


### PR DESCRIPTION
Fixes #4209
Our flow analyses take a boolean parameter `pessimisticAnalysis` that determines the state change to be done when we encounter invocation to an unknown lambda target. Currently, the analysis was pessimistically reseting the state to unknown, but now we optimistically assume such a call does not change current flow analysis state.