### PR TITLE
RethrowToPreserveStackDetailsAnalyzer: bail early on records

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
@@ -62,6 +62,7 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                     case SyntaxKind.AnonymousMethodExpression:
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.StructDeclaration:
+                    case SyntaxKind.RecordDeclaration:
                         return;
                 }
             }

--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/QualityGuidelines/CSharpRethrowToPreserveStackDetails.cs
@@ -62,7 +62,9 @@ namespace Microsoft.CodeQuality.CSharp.Analyzers.QualityGuidelines
                     case SyntaxKind.AnonymousMethodExpression:
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.StructDeclaration:
+#if CODEANALYSIS_V3_OR_BETTER
                     case SyntaxKind.RecordDeclaration:
+#endif
                         return;
                 }
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -495,6 +495,23 @@ End Class
 ");
         }
 
+        [Fact]
+        public async Task CA2200_NoDiagnosticsForFieldInClassOrRecord()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+public class C
+{
+    private string s = default(string) ?? throw new Exception();
+}
+
+public record R
+{
+    private string s = default(string) ?? throw new Exception();
+}");
+        }
+
         private static DiagnosticResult GetCA2200BasicResultAt(int line, int column)
             => VerifyVB.Diagnostic()
                 .WithLocation(line, column);


### PR DESCRIPTION
While walking up the tree, we can't find catch clauses if we arrived to a record declaration (just the same as class declaration).

The change here shouldn't change any behavior (i.e. it's un-testable), and only to avoid walking up the tree unnecessarily.