### PR TITLE
Add test for records in static holder analyzer

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -827,12 +827,16 @@ public abstract class C1
         [Fact]
         public async Task CA1052NoDiagnosticRecords()
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp9,
+                TestCode = @"
 public record C
 {
     public static void M() { }
 }
-");
+"
+            }.RunAsync();
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -823,5 +823,16 @@ public abstract class C1
 }
 ");
         }
+
+        [Fact]
+        public async Task CA1052NoDiagnosticRecords()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+public record C
+{
+    public static void M() { }
+}
+");
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/StaticHolderTypeTests.cs
@@ -829,7 +829,7 @@ public abstract class C1
         {
             await new VerifyCS.Test
             {
-                LanguageVersion = LanguageVersion.CSharp9,
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp9,
                 TestCode = @"
 public record C
 {


### PR DESCRIPTION
The behavior is currently correct as records can't be marked static. This is just to prevent any later refactoring from introducing a bug.