### PR TITLE
Remove MyGet feeds now that dependencies are published to AzDO

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,8 +7,6 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
These were the only occurances of 'myget' in this repo.