### PR TITLE
Fix to improve code fixer heuristic employed by CA1835

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -58,14 +58,14 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 // First argument should be an identifier name node
                 bufferValueNode is IdentifierNameSyntax firstArgumentIdentifierName &&
                 // Second argument should be a literal expression node with a constant value of zero
-                model.GetConstantValue(offsetValueNode) is Optional<object> optionalValue && optionalValue.HasValue && optionalValue.Value is int value && value == 0 &&
+                model.GetConstantValue(offsetValueNode) is Optional<object> optionalValue && optionalValue.HasValue && optionalValue.Value is 0 &&
                 // Third argument should be a member access node...
                 countValueNode is MemberAccessExpressionSyntax thirdArgumentMemberAccessExpression &&
                 thirdArgumentMemberAccessExpression.Expression is IdentifierNameSyntax thirdArgumentIdentifierName &&
                 // whose identifier is that of the first argument...
                 firstArgumentIdentifierName.Identifier.ValueText == thirdArgumentIdentifierName.Identifier.ValueText &&
                 // and the member name is `Length`
-                thirdArgumentMemberAccessExpression.Name.Identifier.ValueText == "Length";
+                thirdArgumentMemberAccessExpression.Name.Identifier.ValueText == WellKnownMemberNames.LengthPropertyName;
         }
     }
 }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -52,15 +52,13 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             return false;
         }
 
-        protected override bool IsPassingZeroAndBufferLength(SyntaxNode bufferValueNode, SyntaxNode offsetValueNode, SyntaxNode countValueNode)
+        protected override bool IsPassingZeroAndBufferLength(SemanticModel model, SyntaxNode bufferValueNode, SyntaxNode offsetValueNode, SyntaxNode countValueNode)
         {
             return
                 // First argument should be an identifier name node
                 bufferValueNode is IdentifierNameSyntax firstArgumentIdentifierName &&
-                // Second argument should be a literal expression node...
-                offsetValueNode is LiteralExpressionSyntax secondArgumentLiteralExpression &&
-                // and its value should be zero
-                secondArgumentLiteralExpression.Token.ValueText == "0" &&
+                // Second argument should be a literal expression node with a constant value of zero
+                model.GetConstantValue(offsetValueNode) is Optional<object> optionalValue && optionalValue.HasValue && optionalValue.Value is int value && value == 0 &&
                 // Third argument should be a member access node...
                 countValueNode is MemberAccessExpressionSyntax thirdArgumentMemberAccessExpression &&
                 thirdArgumentMemberAccessExpression.Expression is IdentifierNameSyntax thirdArgumentIdentifierName &&

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -51,5 +51,23 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             }
             return false;
         }
+
+        protected override bool IsPassingZeroAndBufferLength(SyntaxNode bufferValueNode, SyntaxNode offsetValueNode, SyntaxNode countValueNode)
+        {
+            return
+                // First argument should be an identifier name node
+                bufferValueNode is IdentifierNameSyntax firstArgumentIdentifierName &&
+                // Second argument should be a literal expression node...
+                offsetValueNode is LiteralExpressionSyntax secondArgumentLiteralExpression &&
+                // and its value should be zero
+                secondArgumentLiteralExpression.Token.ValueText == "0" &&
+                // Third argument should be a member access node...
+                countValueNode is MemberAccessExpressionSyntax thirdArgumentMemberAccessExpression &&
+                thirdArgumentMemberAccessExpression.Expression is IdentifierNameSyntax thirdArgumentIdentifierName &&
+                // whose identifier is that of the first argument...
+                firstArgumentIdentifierName.Identifier.ValueText == thirdArgumentIdentifierName.Identifier.ValueText &&
+                // and the member name is `Length`
+                thirdArgumentMemberAccessExpression.Name.Identifier.ValueText == "Length";
+        }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -122,11 +122,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Depending on the arguments being passed to Read/WriteAsync, it's the substitution we will make
             SyntaxNode replacedInvocationNode;
 
-            if(IsPassingZeroAndBufferLength(bufferValueNode, offsetValueNode, countValueNode))
+            if (IsPassingZeroAndBufferLength(bufferValueNode, offsetValueNode, countValueNode))
             {
                 // Remove 0 and buffer.length
                 replacedInvocationNode =
-                        (isBufferNamed ? generator.Argument(name: "buffer", RefKind.None, bufferValueNode) : bufferValueNode)
+                    (isBufferNamed ? generator.Argument(name: "buffer", RefKind.None, bufferValueNode) : bufferValueNode)
                     .WithTriviaFrom(bufferValueNode);
             }
             else
@@ -146,7 +146,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 // Generate the new buffer argument, ensuring we include the buffer argument name if the user originally indicated one
                 replacedInvocationNode =
-                        (isBufferNamed ? generator.Argument(name: "buffer", RefKind.None, asMemoryInvocationNode) : asMemoryInvocationNode)
+                    (isBufferNamed ? generator.Argument(name: "buffer", RefKind.None, asMemoryInvocationNode) : asMemoryInvocationNode)
                     .WithTriviaFrom(bufferValueNode);
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -103,193 +103,385 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         protected string GetConfigureAwaitVisualBasic(bool isEmpty) => isEmpty ? "" : @".ConfigureAwait(False)";
 
-        public static IEnumerable<object[]> CSharpUnnamedArgumentsTestData()
+        public static IEnumerable<object[]> CSharpUnnamedArgumentsFullBufferTestData()
         {
             yield return new object[] { "buffer, 0, buffer.Length",
-                                        "buffer.AsMemory(0, buffer.Length)" };
-            yield return new object[] { "buffer, 0, buffer.Length, new CancellationToken()",
-                                        "buffer.AsMemory(0, buffer.Length), new CancellationToken()" };
+                                        "buffer" };
+            yield return new object[] { "buffer, 0, buffer.Length, CancellationToken.None",
+                                        "buffer, CancellationToken.None" };
+        }
+        public static IEnumerable<object[]> CSharpUnnamedArgumentsPartialBufferTestData()
+        {
+            yield return new object[] { "buffer, 1, buffer.Length",
+                                        "buffer.AsMemory(1, buffer.Length)" };
+            yield return new object[] { "buffer, 1, buffer.Length, new CancellationToken()",
+                                        "buffer.AsMemory(1, buffer.Length), new CancellationToken()" };
+            yield return new object[] { "buffer, 1, 2",
+                                        "buffer.AsMemory(1, 2)" };
+            yield return new object[] { "buffer, 1, 2, default(CancellationToken)",
+                                        "buffer.AsMemory(1, 2), default(CancellationToken)" };
         }
 
-        public static IEnumerable<object[]> CSharpNamedArgumentsTestData()
+        public static IEnumerable<object[]> CSharpNamedArgumentsFullBufferTestData()
         {
             // Normal argument order is: (byte[] buffer, int offset, int count)
             yield return new object[] { "buffer, offset: 0, count: buffer.Length",
-                                        "buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer" };
             yield return new object[] { "buffer: buffer, offset: 0, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "count: buffer.Length, offset: 0, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "offset: 0, buffer: buffer, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length)" };
+                                        "buffer: buffer" };
             // Skipping naming
             yield return new object[] { "buffer: buffer, 0, buffer.Length",
-                                        "buffer: buffer.AsMemory(0, buffer.Length)" };
+                                        "buffer: buffer" };
             yield return new object[] { "buffer, offset: 0, buffer.Length",
-                                        "buffer.AsMemory(start: 0, buffer.Length)" };
+                                        "buffer" };
             yield return new object[] { "buffer, 0, count: buffer.Length",
-                                        "buffer.AsMemory(0, length: buffer.Length)" };
+                                        "buffer" };
             yield return new object[] { "buffer: buffer, 0, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(0, length: buffer.Length)" };
+                                        "buffer: buffer" };
         }
 
-        public static IEnumerable<object[]> CSharpNamedArgumentsWithCancellationTokenTestData()
+        public static IEnumerable<object[]> CSharpNamedArgumentsPartialBufferTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count)
+            yield return new object[] { "buffer, offset: 1, count: buffer.Length",
+                                        "buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, offset: 1, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "count: buffer.Length, offset: 1, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "offset: 1, buffer: buffer, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            yield return new object[] { "offset: 1, count: buffer.Length, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length)" };
+            // Skipping naming
+            yield return new object[] { "buffer: buffer, 1, buffer.Length",
+                                        "buffer: buffer.AsMemory(1, buffer.Length)" };
+            yield return new object[] { "buffer, offset: 1, buffer.Length",
+                                        "buffer.AsMemory(start: 1, buffer.Length)" };
+            yield return new object[] { "buffer, 1, count: buffer.Length",
+                                        "buffer.AsMemory(1, length: buffer.Length)" };
+            yield return new object[] { "buffer: buffer, 1, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(1, length: buffer.Length)" };
+        }
+
+        public static IEnumerable<object[]> CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData()
         {
             // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             // Cancellation token as fourth argument
-            yield return new object[] { "buffer, offset: 0, count: buffer.Length, cancellationToken: new CancellationToken()",
-                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, offset: 0, count: buffer.Length, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 0, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, offset: 0, buffer: buffer, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 0, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken()",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer, offset: 1, count: buffer.Length, cancellationToken: new CancellationToken()",
+                                        "buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, offset: 1, count: buffer.Length, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 1, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, offset: 1, buffer: buffer, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 1, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken()",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
             // Cancellation token as third argument
-            yield return new object[] { "buffer, offset: 0, cancellationToken: new CancellationToken(), count: buffer.Length",
-                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, offset: 0, cancellationToken: new CancellationToken(), count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken(), offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, offset: 0, cancellationToken: new CancellationToken(), buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken(), offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer, offset: 1, cancellationToken: new CancellationToken(), count: buffer.Length",
+                                        "buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, offset: 1, cancellationToken: new CancellationToken(), count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, cancellationToken: new CancellationToken(), offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, offset: 1, cancellationToken: new CancellationToken(), buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, cancellationToken: new CancellationToken(), offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
             // Cancellation token as second argument
-            yield return new object[] { "buffer, cancellationToken: new CancellationToken(), offset: 0, count: buffer.Length",
-                                        "buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), offset: 0, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), offset: 0, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "offset: 0, cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer, cancellationToken: new CancellationToken(), offset: 1, count: buffer.Length",
+                                        "buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), offset: 1, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "buffer: buffer, cancellationToken: new CancellationToken(), count: buffer.Length, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), offset: 1, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: new CancellationToken(), buffer: buffer, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "offset: 1, cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
             // Cancellation token as first argument
-            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, offset: 0, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, offset: 0, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer, offset: 0",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 0, buffer: buffer, count: buffer.Length",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
-            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 0, count: buffer.Length, buffer: buffer",
-                                        "buffer: buffer.AsMemory(start: 0, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, offset: 1, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), buffer: buffer, count: buffer.Length, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, offset: 1, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), count: buffer.Length, buffer: buffer, offset: 1",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 1, buffer: buffer, count: buffer.Length",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
+            yield return new object[] { "cancellationToken: new CancellationToken(), offset: 1, count: buffer.Length, buffer: buffer",
+                                        "buffer: buffer.AsMemory(start: 1, length: buffer.Length), cancellationToken: new CancellationToken()" };
         }
 
-        public static IEnumerable<object[]> VisualBasicUnnamedArgumentsTestData()
+        public static IEnumerable<object[]> CSharpNamedArgumentsWithCancellationTokenFullBufferTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            // Cancellation token as fourth argument
+            yield return new object[] { "buffer, offset: 0, count: buffer.Length, cancellationToken: CancellationToken.None",
+                                        "buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "buffer: buffer, offset: 0, count: buffer.Length, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, offset: 0, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "count: buffer.Length, offset: 0, buffer: buffer, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, offset: 0, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "offset: 0, buffer: buffer, count: buffer.Length, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            yield return new object[] { "offset: 0, count: buffer.Length, buffer: buffer, cancellationToken: CancellationToken.None",
+                                        "buffer: buffer, cancellationToken: CancellationToken.None" };
+            // Cancellation token as third argument
+            yield return new object[] { "buffer, offset: 0, cancellationToken: default(CancellationToken), count: buffer.Length",
+                                        "buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "buffer: buffer, offset: 0, cancellationToken: default(CancellationToken), count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "buffer: buffer, count: buffer.Length, cancellationToken: default(CancellationToken), offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "count: buffer.Length, offset: 0, cancellationToken: default(CancellationToken), buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "count: buffer.Length, buffer: buffer, cancellationToken: default(CancellationToken), offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "offset: 0, buffer: buffer, cancellationToken: default(CancellationToken), count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "offset: 0, count: buffer.Length, cancellationToken: default(CancellationToken), buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            // Cancellation token as second argument
+            yield return new object[] { "buffer, cancellationToken: default(CancellationToken), offset: 0, count: buffer.Length",
+                                        "buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "buffer: buffer, cancellationToken: default(CancellationToken), offset: 0, count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "buffer: buffer, cancellationToken: default(CancellationToken), count: buffer.Length, offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: default(CancellationToken), offset: 0, buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "count: buffer.Length, cancellationToken: default(CancellationToken), buffer: buffer, offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "offset: 0, cancellationToken: default(CancellationToken), buffer: buffer, count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "offset: 0, cancellationToken: default(CancellationToken), count: buffer.Length, buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            // Cancellation token as first argument
+            yield return new object[] { "cancellationToken: default(CancellationToken), buffer: buffer, offset: 0, count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "cancellationToken: default(CancellationToken), buffer: buffer, count: buffer.Length, offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "cancellationToken: default(CancellationToken), count: buffer.Length, offset: 0, buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "cancellationToken: default(CancellationToken), count: buffer.Length, buffer: buffer, offset: 0",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "cancellationToken: default(CancellationToken), offset: 0, buffer: buffer, count: buffer.Length",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+            yield return new object[] { "cancellationToken: default(CancellationToken), offset: 0, count: buffer.Length, buffer: buffer",
+                                        "buffer: buffer, cancellationToken: default(CancellationToken)" };
+        }
+
+        public static IEnumerable<object[]> VisualBasicUnnamedArgumentsPartialBufferTestData()
+        {
+            yield return new object[] { "buffer, 1, buffer.Length",
+                                        "buffer.AsMemory(1, buffer.Length)" };
+            yield return new object[] { "buffer, 1, buffer.Length, New CancellationToken()",
+                                        "buffer.AsMemory(1, buffer.Length), New CancellationToken()" };
+        }
+
+        public static IEnumerable<object[]> VisualBasicUnnamedArgumentsFullBufferTestData()
         {
             yield return new object[] { "buffer, 0, buffer.Length",
-                                        "buffer.AsMemory(0, buffer.Length)" };
-            yield return new object[] { "buffer, 0, buffer.Length, New CancellationToken()",
-                                        "buffer.AsMemory(0, buffer.Length), New CancellationToken()" };
+                                        "buffer" };
+            yield return new object[] { "buffer, 0, buffer.Length, CancellationToken.None",
+                                        "buffer, CancellationToken.None" };
         }
 
-        public static IEnumerable<object[]> VisualBasicNamedArgumentsTestData()
+        public static IEnumerable<object[]> VisualBasicNamedArgumentsPartialBufferTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count)
+            yield return new object[] { "buffer, offset:=1, count:=buffer.Length",
+                                        "buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "buffer:=buffer, offset:=1, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "count:=buffer.Length, offset:=1, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "offset:=1, buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "offset:=1, count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+        }
+
+        public static IEnumerable<object[]> VisualBasicNamedArgumentsFullBufferTestData()
         {
             // Normal argument order is: (byte[] buffer, int offset, int count)
             yield return new object[] { "buffer, offset:=0, count:=buffer.Length",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer" };
             yield return new object[] { "buffer:=buffer, offset:=0, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
             yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
             yield return new object[] { "count:=buffer.Length, offset:=0, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
             yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
             yield return new object[] { "offset:=0, buffer:=buffer, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
             yield return new object[] { "offset:=0, count:=buffer.Length, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length)" };
+                                        "buffer:=buffer" };
         }
 
-        public static IEnumerable<object[]> VisualBasicNamedArgumentsWithCancellationTokenTestData()
+        public static IEnumerable<object[]> VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData()
         {
             // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             // Cancellation token as fourth argument
-            yield return new object[] { "buffer, offset:=0, count:=buffer.Length, cancellationToken:=New CancellationToken()",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, offset:=0, count:=buffer.Length, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=0, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, offset:=0, buffer:=buffer, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=0, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, buffer:=buffer, count:=buffer.Length, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, count:=buffer.Length, buffer:=buffer, cancellationToken:=New CancellationToken()",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer, offset:=1, count:=buffer.Length, cancellationToken:=New CancellationToken()",
+                                        "buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, offset:=1, count:=buffer.Length, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=1, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, offset:=1, buffer:=buffer, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=1, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, buffer:=buffer, count:=buffer.Length, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, count:=buffer.Length, buffer:=buffer, cancellationToken:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
             // Cancellation token as third argument
-            yield return new object[] { "buffer, offset:=0, cancellationToken:=New CancellationToken(), count:=buffer.Length",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, offset:=0, cancellationToken:=New CancellationToken(), count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, count:=buffer.Length, cancellationToken:=New CancellationToken(), offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, offset:=0, cancellationToken:=New CancellationToken(), buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, buffer:=buffer, cancellationToken:=New CancellationToken(), offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, buffer:=buffer, cancellationToken:=New CancellationToken(), count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, count:=buffer.Length, cancellationToken:=New CancellationToken(), buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer, offset:=1, cancellationToken:=New CancellationToken(), count:=buffer.Length",
+                                        "buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, offset:=1, cancellationToken:=New CancellationToken(), count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, cancellationToken:=New CancellationToken(), offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, offset:=1, cancellationToken:=New CancellationToken(), buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, cancellationToken:=New CancellationToken(), offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, buffer:=buffer, cancellationToken:=New CancellationToken(), count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, count:=buffer.Length, cancellationToken:=New CancellationToken(), buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
             // Cancellation token as second argument
-            yield return new object[] { "buffer, cancellationToken:=New CancellationToken(), offset:=0, count:=buffer.Length",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, cancellationToken:=New CancellationToken(), offset:=0, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "buffer:=buffer, cancellationToken:=New CancellationToken(), count:=buffer.Length, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, cancellationToken:=New CancellationToken(), offset:=0, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "count:=buffer.Length, cancellationToken:=New CancellationToken(), buffer:=buffer, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, cancellationToken:=New CancellationToken(), buffer:=buffer, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "offset:=0, cancellationToken:=New CancellationToken(), count:=buffer.Length, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer, cancellationToken:=New CancellationToken(), offset:=1, count:=buffer.Length",
+                                        "buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, cancellationToken:=New CancellationToken(), offset:=1, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "buffer:=buffer, cancellationToken:=New CancellationToken(), count:=buffer.Length, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, cancellationToken:=New CancellationToken(), offset:=1, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "count:=buffer.Length, cancellationToken:=New CancellationToken(), buffer:=buffer, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, cancellationToken:=New CancellationToken(), buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "offset:=1, cancellationToken:=New CancellationToken(), count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
             // Cancellation token as first argument
-            yield return new object[] { "cancellationToken:=New CancellationToken(), buffer:=buffer, offset:=0, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "cancellationToken:=New CancellationToken(), buffer:=buffer, count:=buffer.Length, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "cancellationToken:=New CancellationToken(), count:=buffer.Length, offset:=0, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "cancellationToken:=New CancellationToken(), count:=buffer.Length, buffer:=buffer, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "cancellationToken:=New CancellationToken(), offset:=0, buffer:=buffer, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
-            yield return new object[] { "cancellationToken:=New CancellationToken(), offset:=0, count:=buffer.Length, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), buffer:=buffer, offset:=1, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), buffer:=buffer, count:=buffer.Length, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), count:=buffer.Length, offset:=1, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), count:=buffer.Length, buffer:=buffer, offset:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), offset:=1, buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "cancellationToken:=New CancellationToken(), offset:=1, count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+        }
+
+        public static IEnumerable<object[]> VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData()
+        {
+            // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            // Cancellation token as fourth argument
+            yield return new object[] { "buffer, offset:=0, count:=buffer.Length, cancellationToken:=CancellationToken.None",
+                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, offset:=0, count:=buffer.Length, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=0, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, offset:=0, buffer:=buffer, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=0, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, buffer:=buffer, count:=buffer.Length, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, count:=buffer.Length, buffer:=buffer, cancellationToken:=CancellationToken.None",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            // Cancellation token as third argument
+            yield return new object[] { "buffer, offset:=0, cancellationToken:=default(CancellationToken), count:=buffer.Length",
+                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "buffer:=buffer, offset:=0, cancellationToken:=default(CancellationToken), count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, cancellationToken:=default(CancellationToken), offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "count:=buffer.Length, offset:=0, cancellationToken:=default(CancellationToken), buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, cancellationToken:=default(CancellationToken), offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "offset:=0, buffer:=buffer, cancellationToken:=default(CancellationToken), count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "offset:=0, count:=buffer.Length, cancellationToken:=default(CancellationToken), buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            // Cancellation token as second argument
+            yield return new object[] { "buffer, cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length",
+                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, cancellationToken:=CancellationToken.None, count:=buffer.Length, offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, cancellationToken:=CancellationToken.None, offset:=0, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, cancellationToken:=CancellationToken.None, buffer:=buffer, offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, cancellationToken:=CancellationToken.None, buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, cancellationToken:=CancellationToken.None, count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+            // Cancellation token as first argument
+            yield return new object[] { "cancellationToken:=default(CancellationToken), buffer:=buffer, offset:=0, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=default(CancellationToken), buffer:=buffer, count:=buffer.Length, offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=default(CancellationToken), count:=buffer.Length, offset:=0, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=default(CancellationToken), count:=buffer.Length, buffer:=buffer, offset:=0",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=default(CancellationToken), offset:=0, buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=default(CancellationToken), offset:=0, count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -426,62 +426,62 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             // Normal argument order is: (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             // Cancellation token as fourth argument
             yield return new object[] { "buffer, offset:=0, count:=buffer.Length, cancellationToken:=CancellationToken.None",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "buffer:=buffer, offset:=0, count:=buffer.Length, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "buffer:=buffer, count:=buffer.Length, offset:=0, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "count:=buffer.Length, offset:=0, buffer:=buffer, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "count:=buffer.Length, buffer:=buffer, offset:=0, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "offset:=0, buffer:=buffer, count:=buffer.Length, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "offset:=0, count:=buffer.Length, buffer:=buffer, cancellationToken:=CancellationToken.None",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             // Cancellation token as third argument
-            yield return new object[] { "buffer, offset:=0, cancellationToken:=default(CancellationToken), count:=buffer.Length",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "buffer:=buffer, offset:=0, cancellationToken:=default(CancellationToken), count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "buffer:=buffer, count:=buffer.Length, cancellationToken:=default(CancellationToken), offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "count:=buffer.Length, offset:=0, cancellationToken:=default(CancellationToken), buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "count:=buffer.Length, buffer:=buffer, cancellationToken:=default(CancellationToken), offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "offset:=0, buffer:=buffer, cancellationToken:=default(CancellationToken), count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "offset:=0, count:=buffer.Length, cancellationToken:=default(CancellationToken), buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "buffer, offset:=0, cancellationToken:=CancellationToken.None, count:=buffer.Length",
+                                        "buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, offset:=0, cancellationToken:=CancellationToken.None, count:=buffer.Length",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "buffer:=buffer, count:=buffer.Length, cancellationToken:=CancellationToken.None, offset:=0",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, offset:=0, cancellationToken:=CancellationToken.None, buffer:=buffer",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "count:=buffer.Length, buffer:=buffer, cancellationToken:=CancellationToken.None, offset:=0",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, buffer:=buffer, cancellationToken:=CancellationToken.None, count:=buffer.Length",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "offset:=0, count:=buffer.Length, cancellationToken:=CancellationToken.None, buffer:=buffer",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             // Cancellation token as second argument
             yield return new object[] { "buffer, cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length",
-                                        "buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "buffer:=buffer, cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "buffer:=buffer, cancellationToken:=CancellationToken.None, count:=buffer.Length, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "count:=buffer.Length, cancellationToken:=CancellationToken.None, offset:=0, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "count:=buffer.Length, cancellationToken:=CancellationToken.None, buffer:=buffer, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "offset:=0, cancellationToken:=CancellationToken.None, buffer:=buffer, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             yield return new object[] { "offset:=0, cancellationToken:=CancellationToken.None, count:=buffer.Length, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=CancellationToken.None" };
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
             // Cancellation token as first argument
-            yield return new object[] { "cancellationToken:=default(CancellationToken), buffer:=buffer, offset:=0, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "cancellationToken:=default(CancellationToken), buffer:=buffer, count:=buffer.Length, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "cancellationToken:=default(CancellationToken), count:=buffer.Length, offset:=0, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "cancellationToken:=default(CancellationToken), count:=buffer.Length, buffer:=buffer, offset:=0",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "cancellationToken:=default(CancellationToken), offset:=0, buffer:=buffer, count:=buffer.Length",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
-            yield return new object[] { "cancellationToken:=default(CancellationToken), offset:=0, count:=buffer.Length, buffer:=buffer",
-                                        "buffer:=buffer.AsMemory(start:=0, length:=buffer.Length), cancellationToken:=default(CancellationToken)" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, buffer:=buffer, offset:=0, count:=buffer.Length",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, buffer:=buffer, count:=buffer.Length, offset:=0",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, count:=buffer.Length, offset:=0, buffer:=buffer",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, count:=buffer.Length, buffer:=buffer, offset:=0",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, offset:=0, buffer:=buffer, count:=buffer.Length",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+            yield return new object[] { "cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length, buffer:=buffer",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -613,16 +613,22 @@ class C
         }
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
@@ -637,16 +643,22 @@ class C
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: true, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_AwaitInvocationPassedAsArgument(string originalArgs, string fixedArgs) =>
             CS_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             CS_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: false);
 
@@ -698,7 +710,7 @@ class C
         using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer /* BufferTrailingTrivia */, 0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer /* BufferTrailingTrivia */, 1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -715,7 +727,7 @@ class C
         using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer.AsMemory(0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer.AsMemory(1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -742,7 +754,7 @@ class C
         using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer /* BufferTrailingTrivia */, 0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer /* BufferTrailingTrivia */, 1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -759,7 +771,7 @@ class C
         using (FileStream s = new FileStream(""path.txt"", FileMode.Create))
         {
             byte[] buffer = new byte[s.Length];
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer.AsMemory(0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.ReadAsync(buffer.AsMemory(1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -827,16 +839,22 @@ End Class
         }
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
@@ -851,16 +869,22 @@ End Class
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: true, isEmptyConfigureAwait: false);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument(string originalArgs, string fixedArgs) =>
             VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: false);
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -579,7 +579,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            await s.WriteAsync(buffer, 0, buffer.Length);
+            await s.WriteAsync(buffer, 1, buffer.Length);
         }
     }
 }";
@@ -595,7 +595,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            await s.WriteAsync(buffer.AsMemory(0, buffer.Length));
+            await s.WriteAsync(buffer.AsMemory(1, buffer.Length));
         }
     }
 }";
@@ -603,30 +603,42 @@ class C
         }
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_AsStream(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(CSharpUnnamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsTestData))]
-        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(CSharpUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(CSharpNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task CS_Fixer_Diagnostic_AsStream_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             CSharpVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
@@ -658,7 +670,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer /* BufferTrailingTrivia */, 0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer /* BufferTrailingTrivia */, 1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -675,7 +687,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer.AsMemory(0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer.AsMemory(1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -702,7 +714,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer /* BufferTrailingTrivia */, 0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer /* BufferTrailingTrivia */, 1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -719,7 +731,7 @@ class C
         using (FileStream s = File.Open(""path.txt"", FileMode.Open))
         {
             byte[] buffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
-            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer.AsMemory(0 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
+            /* AwaitLeadingTrivia */ await /* InvocationLeadingTrivia */ s.WriteAsync(buffer.AsMemory(1 /* OffsetTrailingTrivia */, buffer.Length /* CountTrailingTrivia */) /* BufferTrailingTrivia */, new CancellationToken() /* CancellationTokenTrailingTrivia */).ConfigureAwait(/* ConfigureAwaitArgLeadingTrivia */ false /* ConfigureAwaitArgTrailngTrivia */) /* InvocationTrailingTrivia */; /* AwaitTrailingTrivia */
         }
     }
 }
@@ -787,30 +799,39 @@ End Class
         }
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
         public Task VB_Fixer_Diagnostic_AsStream(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
         [Theory]
-        [MemberData(nameof(VisualBasicUnnamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsTestData))]
-        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]
+        [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
         public Task VB_Fixer_Diagnostic_AsStream_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -59,5 +59,38 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
         End Function
 
+        Protected Overrides Function IsPassingZeroAndBufferLength(bufferValueNode As SyntaxNode, offsetValueNode As SyntaxNode, countValueNode As SyntaxNode) As Boolean
+
+            ' First argument should be an identifier name node
+            Dim firstArgumentIdentifierName As IdentifierNameSyntax = TryCast(bufferValueNode, IdentifierNameSyntax)
+            If firstArgumentIdentifierName Is Nothing Then
+                Return False
+            End If
+
+            ' Second argument should be a literal expression node and its value should be zero
+            Dim secondArgumentLiteralExpression As LiteralExpressionSyntax = TryCast(offsetValueNode, LiteralExpressionSyntax)
+            If secondArgumentLiteralExpression Is Nothing Or
+                secondArgumentLiteralExpression.Token.ValueText IsNot "0" Then
+                Return False
+            End If
+
+            ' Third argument should be a member access node...
+            Dim thirdArgumentMemberAccessExpression As MemberAccessExpressionSyntax = TryCast(countValueNode, MemberAccessExpressionSyntax)
+            If thirdArgumentMemberAccessExpression Is Nothing Then
+                Return False
+            End If
+
+            ' whose identifier is an identifier name node, and its value is the same as the value of first argument, and the member name is `Length`
+            Dim thirdArgumentIdentifierName As IdentifierNameSyntax = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
+            If thirdArgumentIdentifierName Is Nothing Or
+            thirdArgumentIdentifierName.Identifier.ValueText IsNot firstArgumentIdentifierName.Identifier.ValueText Or
+            thirdArgumentMemberAccessExpression.Name.Identifier.ValueText IsNot "Length" Then
+                Return False
+            End If
+
+            Return True
+
+        End Function
+
     End Class
 End Namespace

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -37,15 +37,15 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
             For Each import As SyntaxNode In importList
 
-                Dim importsStatement As ImportsStatementSyntax = TryCast(import, ImportsStatementSyntax)
+                Dim importsStatement = TryCast(import, ImportsStatementSyntax)
                 If importsStatement IsNot Nothing Then
 
                     For Each clause As ImportsClauseSyntax In importsStatement.ImportsClauses
 
-                        Dim simpleClause As SimpleImportsClauseSyntax = TryCast(clause, SimpleImportsClauseSyntax)
+                        Dim simpleClause = TryCast(clause, SimpleImportsClauseSyntax)
                         If simpleClause IsNot Nothing Then
 
-                            Dim identifier As IdentifierNameSyntax = TryCast(simpleClause.Name, IdentifierNameSyntax)
+                            Dim identifier = TryCast(simpleClause.Name, IdentifierNameSyntax)
                             If identifier IsNot Nothing AndAlso identifier.Identifier.Text = "System" Then
                                 Return True
                             End If
@@ -62,29 +62,29 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Protected Overrides Function IsPassingZeroAndBufferLength(bufferValueNode As SyntaxNode, offsetValueNode As SyntaxNode, countValueNode As SyntaxNode) As Boolean
 
             ' First argument should be an identifier name node
-            Dim firstArgumentIdentifierName As IdentifierNameSyntax = TryCast(bufferValueNode, IdentifierNameSyntax)
+            Dim firstArgumentIdentifierName = TryCast(bufferValueNode, IdentifierNameSyntax)
             If firstArgumentIdentifierName Is Nothing Then
                 Return False
             End If
 
             ' Second argument should be a literal expression node and its value should be zero
-            Dim secondArgumentLiteralExpression As LiteralExpressionSyntax = TryCast(offsetValueNode, LiteralExpressionSyntax)
+            Dim secondArgumentLiteralExpression = TryCast(offsetValueNode, LiteralExpressionSyntax)
             If secondArgumentLiteralExpression Is Nothing Or
                 secondArgumentLiteralExpression.Token.ValueText IsNot "0" Then
                 Return False
             End If
 
             ' Third argument should be a member access node...
-            Dim thirdArgumentMemberAccessExpression As MemberAccessExpressionSyntax = TryCast(countValueNode, MemberAccessExpressionSyntax)
+            Dim thirdArgumentMemberAccessExpression = TryCast(countValueNode, MemberAccessExpressionSyntax)
             If thirdArgumentMemberAccessExpression Is Nothing Then
                 Return False
             End If
 
             ' whose identifier is an identifier name node, and its value is the same as the value of first argument, and the member name is `Length`
-            Dim thirdArgumentIdentifierName As IdentifierNameSyntax = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
+            Dim thirdArgumentIdentifierName = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
             If thirdArgumentIdentifierName Is Nothing Or
-            thirdArgumentIdentifierName.Identifier.ValueText IsNot firstArgumentIdentifierName.Identifier.ValueText Or
-            thirdArgumentMemberAccessExpression.Name.Identifier.ValueText IsNot "Length" Then
+                thirdArgumentIdentifierName.Identifier.ValueText IsNot firstArgumentIdentifierName.Identifier.ValueText Or
+                thirdArgumentMemberAccessExpression.Name.Identifier.ValueText IsNot "Length" Then
                 Return False
             End If
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -91,7 +91,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             Dim thirdArgumentIdentifierName = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
             If thirdArgumentIdentifierName IsNot Nothing And
                 thirdArgumentIdentifierName.Identifier.Text = firstArgumentIdentifierName.Identifier.Text And
-                thirdArgumentMemberAccessExpression.Name.Identifier.Text = "Length" Then
+                thirdArgumentMemberAccessExpression.Name.Identifier.Text = WellKnownMemberNames.LengthPropertyName Then
                 Return True
             End If
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4235

For invocations of ReadAsync/WriteAsync that consider the full buffer (from `0` to `buffer.Length`):
```cs
await stream.ReadAsync(buffer, 0, buffer.Length);
```

Instead of suggesting this:
```cs
await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
```

We now want to suggest this:
```cs
await stream.ReadAsync(buffer);
```