### PR TITLE
Ignore identity conversions in UseValueTasksCorrectly

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -170,6 +170,16 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                                 operationContext.ReportDiagnostic(invocation.CreateDiagnostic(UnconsumedRule));
                                 return;
 
+                            case OperationKind.Conversion:
+                                var conversion = (IConversionOperation)operation.Parent;
+                                if (conversion.Conversion.IsIdentity)
+                                {
+                                    // Ignore identity conversions, which can pop in from time to time.
+                                    operation = operation.Parent;
+                                    continue;
+                                }
+                                goto default;
+
                             // At this point, we're "in the weeds", but there are still some rare-but-used valid patterns to check for.
 
                             case OperationKind.Coalesce:

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Tasks/UseValueTaskCorrectlyTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
             {
                 public static System.Threading.Tasks.ValueTask ReturnsValueTask() => throw null;
                 public static System.Threading.Tasks.ValueTask<T> ReturnsValueTaskOfT<T>() => throw null;
+                public static System.Threading.Tasks.ValueTask<T> ReturnsValueTaskOfT<T>(T value) => throw null;
                 public static System.Threading.Tasks.ValueTask<int> ReturnsValueTaskOfInt() => throw null;
 
                 public static void AcceptsValueTask(System.Threading.Tasks.ValueTask vt) => throw null;
@@ -338,6 +339,13 @@ namespace Microsoft.NetCore.Analyzers.Tasks.UnitTests
                     public ValueTask<T> ReturnValueTaskOfTExpression<T>() => Helpers.ReturnsValueTaskOfT<T>();
 
                     public ValueTask<int> ReturnValueTaskOfIntExpression() => Helpers.ReturnsValueTaskOfInt();
+
+                    public ValueTask<(string, string)> ReturnTupleWithConsts() => Helpers.ReturnsValueTaskOfT<(string, string)>(("""", """"));
+
+                    public ValueTask<(string, string)> ReturnTupleWithCalls() => Helpers.ReturnsValueTaskOfT((SomeMethod(), SomeProp));
+
+                    private string SomeProp => """";
+                    private string SomeMethod() => """";
 
                     public ValueTask ReturnValueTask()
                     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4271
cc: @NickCraver 