### PR TITLE
Continue analysis even RuntimeInformation, OSPlatofrm types not loaded

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -13,11 +13,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private sealed class OperationVisitor : GlobalFlowStateDataFlowOperationVisitor
         {
             private readonly ImmutableArray<IMethodSymbol> _platformCheckMethods;
-            private readonly INamedTypeSymbol _osPlatformType;
+            private readonly INamedTypeSymbol? _osPlatformType;
 
             public OperationVisitor(
                 ImmutableArray<IMethodSymbol> platformCheckMethods,
-                INamedTypeSymbol osPlatformType,
+                INamedTypeSymbol? osPlatformType,
                 GlobalFlowStateAnalysisContext analysisContext)
                 : base(analysisContext, hasPredicatedGlobalState: true)
             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 IMethodSymbol invokedPlatformCheckMethod,
                 ImmutableArray<IArgumentOperation> arguments,
                 ValueContentAnalysisResult? valueContentAnalysisResult,
-                INamedTypeSymbol osPlatformType,
+                INamedTypeSymbol? osPlatformType,
                 ArrayBuilder<PlatformMethodValue> infosBuilder)
             {
                 // Accelerators like OperatingSystem.IsPlatformName()
@@ -129,7 +129,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             private static bool TryDecodeRuntimeInformationIsOSPlatform(
                 IOperation argumentValue,
-                INamedTypeSymbol osPlatformType,
+                INamedTypeSymbol? osPlatformType,
                 ValueContentAnalysisResult? valueContentAnalysisResult,
                 ArrayBuilder<string> decodedOsPlatformNamesBuilder)
             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -133,7 +133,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                 var guardMethods = GetOperatingSystemGuardMethods(runtimeIsOSPlatformMethod, operatingSystemType);
                 var platformSpecificMembers = new ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?>();
-                var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
                 var osPlatformCreateMethod = osPlatformType?.GetMembers("Create").OfType<IMethodSymbol>().FirstOrDefault(m =>
                     m.IsStatic &&
                     m.ReturnType.Equals(osPlatformType) &&
@@ -142,7 +141,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                 context.RegisterOperationBlockStartAction(
                     context => AnalyzeOperationBlock(context, guardMethods, runtimeIsOSPlatformMethod, osPlatformCreateMethod,
-                                    osPlatformTypeArray, stringType, platformSpecificMembers, msBuildPlatforms));
+                                    osPlatformType, stringType, platformSpecificMembers, msBuildPlatforms));
             });
 
             static ImmutableArray<IMethodSymbol> GetOperatingSystemGuardMethods(IMethodSymbol? runtimeIsOSPlatformMethod, INamedTypeSymbol operatingSystemType)
@@ -194,12 +193,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             ImmutableArray<IMethodSymbol> guardMethods,
             IMethodSymbol? runtimeIsOSPlatformMethod,
             IMethodSymbol? osPlatformCreateMethod,
-            ImmutableArray<INamedTypeSymbol> osPlatformTypeArray,
+            INamedTypeSymbol? osPlatformType,
             INamedTypeSymbol stringType,
             ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers,
             ImmutableArray<string> msBuildPlatforms)
         {
-            var osPlatformType = osPlatformTypeArray[0];
+            var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
             var platformSpecificOperations = PooledConcurrentDictionary<IOperation, SmallDictionary<string, PlatformAttributes>>.GetInstance();
 
             context.RegisterOperationAction(context =>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -124,8 +124,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 var msBuildPlatforms = GetSupportedPlatforms(context.Options, context.Compilation, context.CancellationToken);
-                var runtimeIsOSPlatformMethod = runtimeInformationType?.GetMembers().OfType<IMethodSymbol>().
-                    FirstOrDefault((m) =>
+                var runtimeIsOSPlatformMethod = runtimeInformationType?.GetMembers().OfType<IMethodSymbol>().FirstOrDefault(m =>
                         IsOSPlatform == m.Name &&
                         m.IsStatic &&
                         m.ReturnType.SpecialType == SpecialType.System_Boolean &&
@@ -135,11 +134,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 var guardMethods = GetOperatingSystemGuardMethods(runtimeIsOSPlatformMethod, operatingSystemType);
                 var platformSpecificMembers = new ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?>();
                 var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
-                var osPlatformCreateMethod = osPlatformType?.GetMembers("Create").OfType<IMethodSymbol>().Where(m =>
+                var osPlatformCreateMethod = osPlatformType?.GetMembers("Create").OfType<IMethodSymbol>().FirstOrDefault(m =>
                     m.IsStatic &&
                     m.ReturnType.Equals(osPlatformType) &&
                     m.Parameters.Length == 1 &&
-                    m.Parameters[0].Type.SpecialType == SpecialType.System_String).FirstOrDefault();
+                    m.Parameters[0].Type.SpecialType == SpecialType.System_String);
 
                 context.RegisterOperationBlockStartAction(
                     context => AnalyzeOperationBlock(context, guardMethods, runtimeIsOSPlatformMethod, osPlatformCreateMethod,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -235,7 +235,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         pessimisticAnalysis: false,
                         context.CancellationToken, out var valueContentAnalysisResult,
                         additionalSupportedValueTypes: osPlatformTypeArray,
-                        getValueContentValueForAdditionalSupportedValueTypeOperation: !osPlatformTypeArray.IsEmpty ? GetValueContentValue : null);
+                        getValueContentValueForAdditionalSupportedValueTypeOperation: osPlatformTypeArray.IsEmpty ? null : GetValueContentValue);
 
                     if (analysisResult == null)
                     {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3566,6 +3566,130 @@ class Test
             await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive\nbuild_property.TargetFramework = net5");
         }
 
+        [Fact, WorkItem(4282, "https://github.com/dotnet/roslyn-analyzers/issues/4282")]
+        public async Task LambdaPassedAsArgumentOrNotInvokedWithinContextWouldNotAnalyzed_WithoutInterproceduralAnalysis()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    public delegate void VoidCallback();
+ 
+    public void DelegateAsArgument(VoidCallback callback) 
+    {
+        callback(); // even call back invoked here could not guarantee it called from guarded context
+    }
+
+    [SupportedOSPlatform(""windows"")]
+    private void WindowsOnly() { }
+
+    public void GuardedCalls()
+    {
+        if (OperatingSystemHelper.IsWindows())
+        {
+            Action a = () =>
+            {
+                [|WindowsOnly()|]; // Warns, not invoked
+            };
+
+            Func<string> greetings = () =>
+            {
+                WindowsOnly(); // Not warn, invoked below
+                return  ""Hi"";
+            };
+            greetings();
+
+            DelegateAsArgument(() => [|WindowsOnly()|]); // Warns, couldn'd analyze
+        }
+    }
+
+    public void AssertedCalls()
+    {
+        Debug.Assert(OperatingSystemHelper.IsWindows());
+
+        Action a = () =>
+        {
+            WindowsOnly(); // Not warn, invoked below
+        };
+        a();
+            
+        Func<string> greetings = () =>
+        {
+            [|WindowsOnly()|]; // Warns, not invoked
+            return ""Hi"";
+        };
+
+        DelegateAsArgument(() => [|WindowsOnly()|]); // Warns, couldn'd analyze
+    }
+}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
+        [Fact, WorkItem(4282, "https://github.com/dotnet/roslyn-analyzers/issues/4282")]
+        public async Task LambdaPassedAsArgumentOrNotInvokedWithinContextWouldAnalyzed_WithInterproceduralAnalysis()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    public delegate void VoidCallback();
+ 
+    public void DelegateAsArgument(VoidCallback callback) 
+    {
+        callback(); // interprocedural analysis would help keep track of context
+    }
+
+    [SupportedOSPlatform(""windows"")]
+    private void WindowsOnly() { }
+
+    public void GuardedCalls()
+    {
+        if (OperatingSystemHelper.IsWindows())
+        {
+            Action a = () =>
+            {
+                WindowsOnly(); // Not warns, interprocedural analysis  enabled
+            };
+
+            Func<string> greetings = () =>
+            {
+                WindowsOnly(); // Same
+                return  ""Hi"";
+            };
+
+            DelegateAsArgument(() => WindowsOnly()); // Same
+        }
+    }
+
+    public void AssertedCalls()
+    {
+        Debug.Assert(OperatingSystemHelper.IsWindows());
+
+        Action a = () =>
+        {
+            WindowsOnly(); // Not warns, interprocedural analysis  enabled
+        };
+            
+        Func<string> greetings = () =>
+        {
+            WindowsOnly();
+            return ""Hi"";
+        };
+
+        DelegateAsArgument(() => WindowsOnly());
+    }
+}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+
+            await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive");
+        }
+
         [Fact, WorkItem(4182, "https://github.com/dotnet/roslyn-analyzers/issues/4182")]
         public async Task LoopWithinGuardCheck()
         {


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/issues/42335 we need to ensure that each of runtime projects can produce warnings/errors from the platform compat analyzer during a normal build. There are several projects not having access to the System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.OSPlatofrm which are used as one of the guard methods for the analzyer. Normally we bail out when any of the types used for the analysis is not loaded/found, but the types mentioned are not essential for the analysis we want to continue the analysis in that case and get warnings if there is any.