### PR TITLE
(XUnit) SkippableFact and FXCop code analysis rule CA1822: Mark members as static

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -298,6 +298,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
             // XUnit attributes
             Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.XunitFactAttribute));
+            Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.XunitSkippableFactAttribute));
 
             // NUnit Attributes
             Add(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.NUnitFrameworkSetUpAttribute));

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -267,6 +267,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftVisualStudioTestToolsUnitTestingStringAssert = "Microsoft.VisualStudio.TestTools.UnitTesting.StringAssert";
         public const string XunitAssert = "Xunit.Assert";
         public const string XunitFactAttribute = "Xunit.FactAttribute";
+        public const string XunitSkippableFactAttribute = "Xunit.SkippableFactAttribute";
         public const string XunitTheoryAttribute = "Xunit.TheoryAttribute";
         public const string NUnitFrameworkAssert = "NUnit.Framework.Assert";
         public const string NUnitFrameworkOneTimeSetUpAttribute = "NUnit.Framework.OneTimeSetUpAttribute";


### PR DESCRIPTION
### Analyzer

**Diagnostic ID**: [CA1822](https://docs.microsoft.com/visualstudio/code-quality/CA1822)

### Describe the improvement

As (X)unit tests should be non-static, allowing test setup and teardown in class constructors and destructors, I think this check should not apply.
FxCop already recognizes XUnit tests by looking at the `FactAttribute`.

### Describe suggestions on how to achieve the rule

I guess that that that can be assigned to FactAttribute instead of strictly being equals to FactAttribute, it would be fine, as SkippableFactAttribute (from [AArnott/Xunit.SkippableFact ](https://github.com/AArnott/Xunit.SkippableFact) / [NuGet Gallery](https://www.nuget.org/packages/Xunit.SkippableFact)) inherits from FactAttribute.

I think this already attempted at https://github.com/dotnet/roslyn-analyzers/blob/master/src/Utilities/Compiler/Extensions/INamedTypeSymbolExtensions.cs#L266, but maybe I don't understand completely.

See also: https://github.com/AArnott/Xunit.SkippableFact/issues/23