### PR TITLE
Update docs link in release tracking analyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer_ReleaseTracking.cs
@@ -366,7 +366,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     long.TryParse(ruleId[2..], out _))
                 {
 #pragma warning disable CA1308 // Normalize strings to uppercase - use lower case ID in help link
-                    return $"https://docs.microsoft.com/visualstudio/code-quality/{ruleId.ToLowerInvariant()}";
+                    return $"https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/{ruleId.ToLowerInvariant()}";
 #pragma warning restore CA1308 // Normalize strings to uppercase
                 }
 


### PR DESCRIPTION
Follow up to #4291
Contributes to #4317
The issue #4317 will be fully fixed after:

1. This fix is released.
2. The new version is used in the repository.
3. Confirm that release tracking analyzer produce a warning for outdated documentation link.