### PR TITLE
New Analyzer: Warn when calling Enumerable.Cast<T>/OfType<T> with incompatible types 

### DIFF
--- a/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
+++ b/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
@@ -12,6 +12,7 @@ CA1856 | Performance | Error | ConstantExpectedAnalyzer, [Documentation](https:/
 CA1857 | Performance | Warning | ConstantExpectedAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857)
 CA1858 | Performance | Info | UseStartsWithInsteadOfIndexOfComparisonWithZero, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858)
 CA1859 | Performance | Info | UseConcreteTypeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859)
+CA2021 | Reliability | Warning | DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021)
 
 ### Removed Rules
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1008,6 +1008,12 @@
   <data name="DoNotAddArchiveItemPathToTheTargetFileSystemPathMessage" xml:space="preserve">
     <value>When creating path for '{0} in method {1}' from relative archive item path to extract file and the source is an untrusted zip archive, make sure to sanitize relative archive item path '{2} in method {3}'</value>
   </data>
+  <data name="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle" xml:space="preserve">
+    <value>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</value>
+  </data>
+  <data name="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType" xml:space="preserve">
+    <value>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</value>
+  </data>
   <data name="DoNotCreateTasksWithoutPassingATaskSchedulerTitle" xml:space="preserve">
     <value>Do not create tasks without passing a TaskScheduler</value>
   </data>
@@ -1721,6 +1727,15 @@
   </data>
   <data name="ModuleInitializerAttributeShouldNotBeUsedInLibrariesTitle" xml:space="preserve">
     <value>The 'ModuleInitializer' attribute should not be used in libraries</value>
+  </data>
+  <data name="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription" xml:space="preserve">
+    <value>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</value>
+  </data>
+  <data name="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast" xml:space="preserve">
+    <value>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</value>
   </data>
   <data name="UseAsyncMethodInAsyncContextMessage" xml:space="preserve">
     <value>'{0}' synchronously blocks. Await '{1}' instead.</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1730,7 +1730,7 @@
   </data>
   <data name="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription" xml:space="preserve">
     <value>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</value>
   </data>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.NetCore.Analyzers.Runtime
+{
+    /// <summary>
+    /// CA2021: Do not call Enumerable.Cast or Enumerable.OfType with incompatible types.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public sealed class DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string RuleId = "CA2021";
+
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+
+        private static readonly LocalizableString s_localizableCastMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableOfTypeMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+
+        internal static DiagnosticDescriptor CastRule = DiagnosticDescriptorHelper.Create(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableCastMessage,
+                                                                             DiagnosticCategory.Reliability,
+                                                                             RuleLevel.BuildWarning,
+                                                                             s_localizableDescription,
+                                                                             isPortedFxCopRule: false,
+                                                                             isDataflowRule: false);
+
+        internal static DiagnosticDescriptor OfTypeRule = DiagnosticDescriptorHelper.Create(RuleId,
+                                                                             s_localizableTitle,
+                                                                             s_localizableOfTypeMessage,
+                                                                             DiagnosticCategory.Reliability,
+                                                                             RuleLevel.BuildWarning,
+                                                                             s_localizableDescription,
+                                                                             isPortedFxCopRule: false,
+                                                                             isDataflowRule: false);
+
+        private static readonly ImmutableArray<(string MethodName, DiagnosticDescriptor Rule)> s_methodMetadataNames = ImmutableArray.Create(
+            (nameof(Enumerable.Cast), CastRule),
+            (nameof(Enumerable.OfType), OfTypeRule)
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(OfTypeRule, CastRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterCompilationStartAction(context =>
+            {
+                if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqEnumerable, out var enumerableType))
+                {
+                    return;
+                }
+
+                var methodRuleDictionary = s_methodMetadataNames
+                    .SelectMany(m => enumerableType
+                        .GetMembers(m.MethodName)
+                        .OfType<IMethodSymbol>()
+                        .Where(method => method.IsExtensionMethod
+                                      && method.TypeParameters.HasExactly(1)
+                                      && method.Parameters.HasExactly(1)
+                                      && method.Parameters[0].Type.OriginalDefinition.SpecialType
+                                            == SpecialType.System_Collections_IEnumerable
+                              )
+                        .Select(method => (method, m.Rule)))
+                    .ToImmutableDictionary(key => key.method, v => v.Rule, SymbolEqualityComparer.Default);
+
+                if (methodRuleDictionary.IsEmpty)
+                {
+                    return;
+                }
+
+                context.RegisterOperationAction(context =>
+                {
+                    var invocation = (IInvocationOperation)context.Operation;
+
+                    var targetMethod = (invocation.TargetMethod.ReducedFrom ?? invocation.TargetMethod).OriginalDefinition;
+
+                    if (!methodRuleDictionary.TryGetValue(targetMethod, out var rule))
+                    {
+                        return;
+                    }
+
+                    var instanceArg = invocation.GetInstance(); // "this" argument of an extension method
+
+                    static ITypeSymbol? GetIEnumerableTParam(ITypeSymbol type)
+                    {
+                        if (type is not INamedTypeSymbol argIEnumerableType
+                            || !argIEnumerableType.TypeArguments.HasExactly(1))
+                        {
+                            return null;
+                        }
+
+                        return argIEnumerableType.TypeArguments[0];
+                    }
+
+                    static ITypeSymbol? FindElementType(IOperation? operation)
+                    {
+                        if (operation is null)
+                        {
+                            return null;
+                        }
+
+                        if (operation.Kind == OperationKind.ArrayCreation)
+                        {
+                            return (operation.Type as IArrayTypeSymbol)?.ElementType;
+                        }
+
+                        if (operation.Type?.OriginalDefinition?.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+                        {
+                            return GetIEnumerableTParam(operation.Type);
+                        }
+
+                        var r = operation?.Type?.AllInterfaces.FirstOrDefault(t => t.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T);
+                        if (r is not null)
+                        {
+                            return GetIEnumerableTParam(r);
+                        }
+
+                        if (operation is IParenthesizedOperation parenthesizedOperation)
+                        {
+                            return FindElementType(parenthesizedOperation.Operand);
+                        }
+
+                        if (operation is IConversionOperation conversionOperation
+                            && conversionOperation.OperatorMethod is null) // implicit meaning 'not user defined'
+                        {
+                            return FindElementType(conversionOperation.Operand);
+                        }
+
+                        return null;
+                    }
+
+                    // because the type of the parameter is actually the non-generic IEnumerable,
+                    // we have to reach back through conversion operator(s) to get the element type
+                    var castFrom = FindElementType(instanceArg);
+                    if (castFrom is null)
+                    {
+                        return;
+                    }
+
+                    if (!invocation.TargetMethod.TypeArguments.HasExactly(1))
+                    {
+                        return;
+                    }
+
+                    var castTo = invocation.TargetMethod.TypeArguments[0];
+
+                    if (CastWillAlwaysFail(castFrom, castTo))
+                    {
+                        context.ReportDiagnostic(invocation.CreateDiagnostic(rule, castFrom.ToDisplayString(), castTo.ToDisplayString()));
+                    }
+                }, OperationKind.Invocation);
+            });
+
+            // because this is a warning, we want to be very sure
+            // this won't catch all problems, but it should never report something 
+            // as a problem in correctly. We don't want another IDE0004
+            static bool CastWillAlwaysFail(ITypeSymbol castFrom, ITypeSymbol castTo)
+            {
+                if (castFrom.TypeKind == TypeKind.Error
+                   || castTo.TypeKind == TypeKind.Error)
+                {
+                    return false;
+                }
+
+                if (castFrom.SpecialType == SpecialType.System_Object
+                   || castTo.SpecialType == SpecialType.System_Object)
+                {
+                    // some things will actually fail, eg. TypedReference
+                    // but they should be pretty rare
+                    return false;
+                }
+
+                if (castFrom.Equals(castTo, SymbolEqualityComparer.Default))
+                {
+                    return false;
+                }
+
+                static ITypeSymbol UnwrapNullableValueType(ITypeSymbol typeSymbol)
+                {
+                    if (typeSymbol.IsValueType
+                        && typeSymbol.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                        && ((INamedTypeSymbol)typeSymbol).TypeArguments[0] is var nullableTypeArgument)
+                    {
+                        return nullableTypeArgument;
+                    }
+                    return typeSymbol;
+                }
+
+                castFrom = UnwrapNullableValueType(castFrom);
+                castTo = UnwrapNullableValueType(castTo);
+
+                static bool IsUnconstrainedTypeParameter(ITypeParameterSymbol typeParameterSymbol)
+                    => !typeParameterSymbol.HasValueTypeConstraint
+                    && typeParameterSymbol.ConstraintTypes.IsEmpty;
+                // because object is a reference type the 'class' reference type constraint
+                // doesn't actually constrain unless a type is specified too
+                // not implemented:
+                //   NotNullConstraint
+                //   ConstructorConstraint
+                //   UnmanagedTypeConstraint
+                //   Nullability annotations
+
+                switch (castFrom.OriginalDefinition.TypeKind, castTo.OriginalDefinition.TypeKind)
+                {
+                    case (TypeKind.TypeParameter, _):
+                        var castFromTypeParam = (ITypeParameterSymbol)castFrom.OriginalDefinition;
+                        if (IsUnconstrainedTypeParameter(castFromTypeParam))
+                        {
+                            return false;
+                        }
+
+                        if (castFromTypeParam.ConstraintTypes.Any(constraintType => CastWillAlwaysFail(constraintType, castTo)))
+                        {
+                            return true;
+                        }
+
+                        if (castFromTypeParam.HasValueTypeConstraint
+                            && castTo.TypeKind == TypeKind.Class)
+                        {
+                            return true;
+                        }
+                        return false;
+                    case (_, TypeKind.TypeParameter):
+                        var castToTypeParam = (ITypeParameterSymbol)castTo.OriginalDefinition;
+                        if (IsUnconstrainedTypeParameter(castToTypeParam))
+                        {
+                            return false;
+                        }
+
+                        if (castToTypeParam.ConstraintTypes.Any(constraintType => CastWillAlwaysFail(castFrom, constraintType)))
+                        {
+                            return true;
+                        }
+
+                        if (castToTypeParam.HasValueTypeConstraint
+                            && castFrom.TypeKind == TypeKind.Class)
+                        {
+                            return true;
+                        }
+                        return false;
+
+                    case (TypeKind.Class, TypeKind.Class):
+                        return !castFrom.DerivesFrom(castTo)
+                            && !castTo.DerivesFrom(castFrom);
+
+                    case (TypeKind.Interface, TypeKind.Class):
+                        return castTo.IsSealed && !castTo.AllInterfaces.Contains(castFrom);
+                    case (TypeKind.Class, TypeKind.Interface):
+                        return castFrom.IsSealed && !castFrom.AllInterfaces.Contains(castTo);
+
+                    case (TypeKind.Class, TypeKind.Enum):
+                        return castFrom.OriginalDefinition.SpecialType != SpecialType.System_Enum
+                            && castFrom.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+                    case (TypeKind.Enum, TypeKind.Class):
+                        return castTo.OriginalDefinition.SpecialType != SpecialType.System_Enum
+                            && castTo.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+
+                    case (TypeKind.Struct, TypeKind.Enum)
+                    when castTo.OriginalDefinition is INamedTypeSymbol toEnum:
+                        return !castFrom.Equals(toEnum.EnumUnderlyingType);
+                    case (TypeKind.Enum, TypeKind.Struct)
+                    when castFrom.OriginalDefinition is INamedTypeSymbol fromEnum:
+                        return !fromEnum.EnumUnderlyingType.Equals(castTo);
+
+                    case (TypeKind.Enum, TypeKind.Enum)
+                    when castFrom.OriginalDefinition is INamedTypeSymbol fromEnum
+                      && castTo.OriginalDefinition is INamedTypeSymbol toEnum:
+                        return !fromEnum.EnumUnderlyingType.Equals(toEnum.EnumUnderlyingType);
+
+                    // this is too conservative
+                    // array variance is not implemented
+                    // - eg. object[] -> class[]
+                    // boxing shouldn't be allowed
+                    // - eg.  object[] -> ValueType[]
+                    case (TypeKind.Array, TypeKind.Array)
+                    when castFrom is IArrayTypeSymbol fromArray
+                      && castTo is IArrayTypeSymbol toArray:
+                        return fromArray.Rank != toArray.Rank
+                            || CastWillAlwaysFail(fromArray.ElementType, toArray.ElementType);
+
+                    case (TypeKind.Array, TypeKind.Class):
+                        return castTo.OriginalDefinition.SpecialType != SpecialType.System_Array;
+                    case (TypeKind.Class, TypeKind.Array):
+                        return castFrom.OriginalDefinition.SpecialType != SpecialType.System_Array;
+
+                    case (TypeKind.Class, TypeKind.Struct):
+                        return castFrom.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+                    case (TypeKind.Struct, TypeKind.Class):
+                        return castTo.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+
+                    case (_, TypeKind.Enum):
+                    case (TypeKind.Enum, _):
+                    case (_, TypeKind.Struct):
+                    case (TypeKind.Struct, _):
+                        return true;
+
+                    case (TypeKind.Interface, TypeKind.Interface):
+                    default:
+                        return false; // we don't *know* it'll fail...
+                }
+            }
+        }
+    }
+}

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
@@ -10,6 +10,8 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
+    using static MicrosoftNetCoreAnalyzersResources;
+
     /// <summary>
     /// CA2021: Do not call Enumerable.Cast or Enumerable.OfType with incompatible types.
     /// </summary>
@@ -18,11 +20,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     {
         internal const string RuleId = "CA2021";
 
-        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle));
+        private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription));
 
-        private static readonly LocalizableString s_localizableCastMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableOfTypeMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableCastMessage = CreateLocalizableResourceString(nameof(DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast));
+        private static readonly LocalizableString s_localizableOfTypeMessage = CreateLocalizableResourceString(nameof(DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType));
 
         internal static DiagnosticDescriptor CastRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                              s_localizableTitle,
@@ -47,8 +49,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             (nameof(Enumerable.OfType), OfTypeRule)
         );
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-            => ImmutableArray.Create(OfTypeRule, CastRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(OfTypeRule, CastRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -195,6 +197,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         return nullableTypeArgument;
                     }
+
                     return typeSymbol;
                 }
 
@@ -231,6 +234,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         {
                             return true;
                         }
+
                         return false;
                     case (_, TypeKind.TypeParameter):
                         var castToTypeParam = (ITypeParameterSymbol)castTo.OriginalDefinition;
@@ -249,6 +253,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         {
                             return true;
                         }
+
                         return false;
 
                     case (TypeKind.Class, TypeKind.Class):
@@ -261,11 +266,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return castFrom.IsSealed && !castFrom.AllInterfaces.Contains(castTo);
 
                     case (TypeKind.Class, TypeKind.Enum):
-                        return castFrom.OriginalDefinition.SpecialType != SpecialType.System_Enum
-                            && castFrom.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+                        return castFrom.OriginalDefinition.SpecialType is not SpecialType.System_Enum
+                                                                      and not SpecialType.System_ValueType;
                     case (TypeKind.Enum, TypeKind.Class):
-                        return castTo.OriginalDefinition.SpecialType != SpecialType.System_Enum
-                            && castTo.OriginalDefinition.SpecialType != SpecialType.System_ValueType;
+                        return castTo.OriginalDefinition.SpecialType is not SpecialType.System_Enum
+                                                                    and not SpecialType.System_ValueType;
 
                     case (TypeKind.Struct, TypeKind.Enum)
                     when castTo.OriginalDefinition is INamedTypeSymbol toEnum:

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Když konstruktor zavolá virtuální metodu, konstruktor dané instance, která metodu vyvolala, se nemusí spustit.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Nevolejte přepsatelné metody v konstruktorech</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Nevolejte přepsatelné metody v konstruktorech</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Nevolejte {0} pro hodnotu {1}.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -552,6 +552,47 @@
         <target state="translated">Při deserializaci instance třídy {0} může metoda {1} volat nebezpečnou metodu {2}. Možná volání metod: {3}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Když konstruktor zavolá virtuální metodu, konstruktor dané instance, která metodu vyvolala, se nemusí spustit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Nevolejte přepsatelné metody v konstruktorech</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Nevolejte přepsatelné metody v konstruktorech</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Nevolejte {0} pro hodnotu {1}.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -552,6 +552,32 @@
         <target state="translated">Wenn eine Instanz der Klasse "{0}" deserialisiert wird, kann die Methode "{1}" die gefährliche Methode "{2}" aufrufen. Mögliche Methodenaufrufe: {3}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">"{0}" nicht für einen {1}-Wert aufrufen</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -552,6 +552,32 @@
         <target state="translated">Al deserializar una instancia de la clase {0}, el método {1} puede llamar al método peligroso {2}. Invocaciones de métodos posibles: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">No llame a {0} en un valor {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -552,6 +552,32 @@
         <target state="translated">Quand vous désérialisez une instance de la classe {0}, la méthode {1} peut appeler une méthode dangereuse {2}. Les appels de méthode potentiels sont : {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Ne pas appeler {0} sur une valeur {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Quando un costruttore chiama un metodo virtuale, è possibile che il costruttore per l'istanza che richiama il metodo non sia stato eseguito.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Non chiamare metodi sottoponibili a override nei costruttori</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Non chiamare metodi sottoponibili a override nei costruttori</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Non chiamare {0} su un valore {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -552,6 +552,47 @@
         <target state="translated">Durante la deserializzazione di un'istanza della classe {0} il metodo {1} può chiamare il metodo pericoloso {2}. Le potenziali chiamate al metodo sono: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Quando un costruttore chiama un metodo virtuale, è possibile che il costruttore per l'istanza che richiama il metodo non sia stato eseguito.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Non chiamare metodi sottoponibili a override nei costruttori</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Non chiamare metodi sottoponibili a override nei costruttori</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Non chiamare {0} su un valore {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">コンストラクターが仮想メソッドを呼び出すときに、メソッドを呼び出すインスタンスのコンストラクターは実行されていない可能性があります。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">コンストラクターのオーバーライド可能なメソッドを呼び出しません</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">コンストラクターのオーバーライド可能なメソッドを呼び出しません</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">{1} 値で {0} を呼び出さないでください</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -552,6 +552,47 @@
         <target state="translated">クラス {0} のインスタンスを逆シリアル化すると、メソッド {1} によって危険なメソッド {2} を呼び出されるおそれがあります。考えられるメソッド呼び出し: {3}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">コンストラクターが仮想メソッドを呼び出すときに、メソッドを呼び出すインスタンスのコンストラクターは実行されていない可能性があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">コンストラクターのオーバーライド可能なメソッドを呼び出しません</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">コンストラクターのオーバーライド可能なメソッドを呼び出しません</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">{1} 値で {0} を呼び出さないでください</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -552,6 +552,47 @@
         <target state="translated">{0} 클래스의 인스턴스를 역직렬화할 때 {1} 메서드가 위험한 메서드 {2}을(를) 호출할 수 있습니다. 잠재적인 메서드 호출은 {3}입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">생성자에서 가상 메서드를 호출하면 메서드를 호출하는 인스턴스에 대한 생성자가 실행되지 않을 수 있습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">생성자에서 재정의 가능한 메서드를 호출하지 마세요.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">생성자에서 재정의 가능한 메서드를 호출하지 마세요.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">{1} 값의 {0}을(를) 호출하지 마세요.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">생성자에서 가상 메서드를 호출하면 메서드를 호출하는 인스턴스에 대한 생성자가 실행되지 않을 수 있습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">생성자에서 재정의 가능한 메서드를 호출하지 마세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">생성자에서 재정의 가능한 메서드를 호출하지 마세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">{1} 값의 {0}을(를) 호출하지 마세요.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -552,6 +552,47 @@
         <target state="translated">Podczas deserializacji wystąpienia klasy {0} metoda {1} może wywołać niebezpieczną metodę {2}. Potencjalne wywołania metod to: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Gdy konstruktor wywołuje metodę wirtualną, konstruktor wystąpienia wywołującego metodę może nie zostać wykonany.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Nie wywołuj w konstruktorach metod, które można przesłaniać</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Nie wywołuj w konstruktorach metod, które można przesłaniać</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Nie wywołuj elementu {0} dla wartości {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Gdy konstruktor wywołuje metodę wirtualną, konstruktor wystąpienia wywołującego metodę może nie zostać wykonany.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Nie wywołuj w konstruktorach metod, które można przesłaniać</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Nie wywołuj w konstruktorach metod, które można przesłaniać</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Nie wywołuj elementu {0} dla wartości {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -552,6 +552,47 @@
         <target state="translated">Ao desserializar uma instância da classe {0}, o método {1} pode chamar o método perigoso {2}. As possíveis invocações de método são: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Quando um construtor chama um método virtual, o construtor para a instância que invoca o método pode não ter sido executado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Não chamar métodos substituíveis em construtores</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Não chamar métodos substituíveis em construtores</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Não chamar {0} em um valor {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Quando um construtor chama um método virtual, o construtor para a instância que invoca o método pode não ter sido executado.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Não chamar métodos substituíveis em construtores</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Não chamar métodos substituíveis em construtores</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Não chamar {0} em um valor {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Когда конструктор вызывает виртуальный метод, конструктор может не выполняться для экземпляра, вызывающего этот метод.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Не вызывайте переопределяемые методы в конструкторах</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Не вызывайте переопределяемые методы в конструкторах</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Не вызывайте {0} для значения {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -552,6 +552,47 @@
         <target state="translated">При десериализации экземпляра класса {0} метод {1} может вызывать опасный метод {2}. Потенциальные вызовы методов: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Когда конструктор вызывает виртуальный метод, конструктор может не выполняться для экземпляра, вызывающего этот метод.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Не вызывайте переопределяемые методы в конструкторах</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Не вызывайте переопределяемые методы в конструкторах</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Не вызывайте {0} для значения {1}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">Bir oluşturucu tarafından sanal bir yöntem çağrıldığında, yöntemi tetikleyen örneğin oluşturucusu yürütülmemiş olabilir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Oluşturucularda geçersiz kılınabilen yöntemleri çağırmayın</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">Oluşturucularda geçersiz kılınabilen yöntemleri çağırmayın</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Bir {1} değeri üzerinde {0} çağırmayın</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -552,6 +552,47 @@
         <target state="translated">{0} sınıfının bir örneği seri durumdan çıkarılırken, {1} metodu tehlikeli {2} metodunu çağırabilir. Olası metot çağırmaları: {3}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">Bir oluşturucu tarafından sanal bir yöntem çağrıldığında, yöntemi tetikleyen örneğin oluşturucusu yürütülmemiş olabilir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Oluşturucularda geçersiz kılınabilen yöntemleri çağırmayın</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">Oluşturucularda geçersiz kılınabilen yöntemleri çağırmayın</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">Bir {1} değeri üzerinde {0} çağırmayın</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -552,6 +552,47 @@
         <target state="translated">反序列化类 {0} 的实例时，方法 {1} 可调用危险方法 {2}。潜在的方法调用为: {3}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">构造函数调用虚方法时，可能尚未执行调用该方法的实例的构造函数。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">不要在构造函数中调用可重写的方法</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">不要在构造函数中调用可重写的方法</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">请勿对 {1} 值调用 {0}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">构造函数调用虚方法时，可能尚未执行调用该方法的实例的构造函数。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">不要在构造函数中调用可重写的方法</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">不要在构造函数中调用可重写的方法</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">请勿对 {1} 值调用 {0}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -578,21 +578,6 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
-        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
-        <target state="translated">當建構函式呼叫虛擬方法時，可能尚未執行叫用方法之執行個體的建構函式。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">請勿呼叫建構函式中的可覆寫方法</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
-        <source>Do not call overridable methods in constructors</source>
-        <target state="translated">請勿呼叫建構函式中的可覆寫方法</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">請勿對 {1} 值呼叫 {0}</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -554,11 +554,11 @@
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
         <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</source>
         <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
 Widening and user defined conversions are not supported with generic types.</target>
         <note />

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -552,6 +552,47 @@
         <target state="translated">將類別 {0} 的執行個體還原序列化時，方法 {1} 可以呼叫危險的方法 {2}。潛在的方法引動過程為: {3}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">
+        <source>Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</source>
+        <target state="new">Enumerable.Cast&lt;T&gt; and Enumerable.OfType&lt;T&gt; require compatible types to function expectedly.  
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast&lt;T&gt; will throw InvalidCastException at runtime on elements of the types specified.  
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType&lt;T&gt; will never succeed with elements of types specified, resulting in an empty sequence.  
+Widening and user defined conversions are not supported with generic types.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageCast">
+        <source>Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</source>
+        <target state="new">Type '{0}' is incompatible with type '{1}' and cast attempts will throw InvalidCastException at runtime</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesMessageOfType">
+        <source>This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</source>
+        <target state="new">This call will always result in an empty sequence because type '{0}' is incompatible with type '{1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesTitle">
+        <source>Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</source>
+        <target state="new">Do not call Enumerable.Cast&lt;T&gt; or Enumerable.OfType&lt;T&gt; with incompatible types</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsDescription">
+        <source>When a constructor calls a virtual method, the constructor for the instance that invokes the method may not have executed.</source>
+        <target state="translated">當建構函式呼叫虛擬方法時，可能尚未執行叫用方法之執行個體的建構函式。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsMessage">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">請勿呼叫建構函式中的可覆寫方法</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallOverridableMethodsInConstructorsTitle">
+        <source>Do not call overridable methods in constructors</source>
+        <target state="translated">請勿呼叫建構函式中的可覆寫方法</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotCallToImmutableCollectionOnAnImmutableCollectionValueMessage">
         <source>Do not call {0} on an {1} value</source>
         <target state="translated">請勿對 {1} 值呼叫 {0}</target>

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1860,7 +1860,7 @@ Some built-in operators added in .NET 7 behave differently when overflowing than
 |CodeFix|False|
 ---
 
-## [CA2021](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019): Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types
+## [CA2021](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021): Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types
 
 Enumerable.Cast\<T> and Enumerable.OfType\<T> require compatible types to function expectedly.  
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1860,6 +1860,24 @@ Some built-in operators added in .NET 7 behave differently when overflowing than
 |CodeFix|False|
 ---
 
+## [CA2021](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019): Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types
+
+Enumerable.Cast\<T> and Enumerable.OfType\<T> require compatible types to function expectedly.  
+
+The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast\<T> will throw InvalidCastException at runtime on elements of the types specified.  
+
+The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType\<T> will never succeed with elements of types specified, resulting in an empty sequence.  
+
+Widening and user defined conversions are not supported with generic types.
+
+|Item|Value|
+|-|-|
+|Category|Reliability|
+|Enabled|True|
+|Severity|Warning|
+|CodeFix|False|
+---
+
 ## [CA2100](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2100): Review SQL queries for security vulnerabilities
 
 SQL queries that directly use user input can be vulnerable to SQL injection attacks. Review this SQL query for potential vulnerabilities, and consider using a parameterized SQL query.

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1864,7 +1864,7 @@ Some built-in operators added in .NET 7 behave differently when overflowing than
 
 Enumerable.Cast\<T> and Enumerable.OfType\<T> require compatible types to function expectedly.  
 
-The generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast\<T> will throw InvalidCastException at runtime on elements of the types specified.  
+The generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast\<T> will throw InvalidCastException at runtime on elements of the types specified.  
 
 The generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType\<T> will never succeed with elements of types specified, resulting in an empty sequence.  
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3358,6 +3358,26 @@
             ]
           }
         },
+        "CA2021": {
+          "id": "CA2021",
+          "shortDescription": "Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types",
+          "fullDescription": "Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  \u000aThe generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  \u000aThe generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  \u000aWidening and user defined conversions are not supported with generic types.",
+          "defaultLevel": "warning",
+          "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021",
+          "properties": {
+            "category": "Reliability",
+            "isEnabledByDefault": true,
+            "typeName": "DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ],
+            "tags": [
+              "Telemetry",
+              "EnabledRuleInAggressiveMode"
+            ]
+          }
+        },
         "CA2100": {
           "id": "CA2100",
           "shortDescription": "Review SQL queries for security vulnerabilities",

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3361,7 +3361,7 @@
         "CA2021": {
           "id": "CA2021",
           "shortDescription": "Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types",
-          "fullDescription": "Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  \u000aThe generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  \u000aThe generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  \u000aWidening and user defined conversions are not supported with generic types.",
+          "fullDescription": "Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  \u000aThe generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  \u000aThe generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  \u000aWidening and user defined conversions are not supported with generic types.",
           "defaultLevel": "warning",
           "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021",
           "properties": {

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3363,7 +3363,7 @@
           "shortDescription": "Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types",
           "fullDescription": "Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  \u000aThe generic cast (IL 'unbox.any') used by the sequenced returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  \u000aThe generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  \u000aWidening and user defined conversions are not supported with generic types.",
           "defaultLevel": "warning",
-          "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021",
+          "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021",
           "properties": {
             "category": "Reliability",
             "isEnabledByDefault": true,

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -12,3 +12,4 @@ CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
 CA1858 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858> | Use 'StartsWith' instead of 'IndexOf' |
 CA1859 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859> | Use concrete types when possible for improved performance |
+CA2021 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -10,6 +10,5 @@ CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513> | Use ObjectDisposedException throw helper |
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
-CA1858 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858> | Use 'StartsWith' instead of 'IndexOf' |
 CA1859 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859> | Use concrete types when possible for improved performance |
-CA2021 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |
+CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -135,7 +135,6 @@ class C
         _ = {|#41:(new Apple[0]).Cast<Shoe>()|}; // error
         _ = {|#42:(new Shoe[0]).Cast<Fruit>()|}; // error
         _ = {|#43:(new Shoe[0]).Cast<Apple>()|}; // error
-        _ = {|#44:(new Shoe[0]).Cast<Shoe>()|}; // error
 
         // interface to class
         _ = (new ICar[0]).Cast<Plant>(); // subclass of Plant could implement ICar

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -1,0 +1,723 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Runtime.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
+{
+    public class DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests
+    {
+        private readonly DiagnosticDescriptor castRule = DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.CastRule;
+        private readonly DiagnosticDescriptor ofTypeRule = DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.OfTypeRule;
+
+        [Fact]
+        public async Task OnlyWellKnownIEnumerable()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+namespace System.Linq
+{ 
+    interface IEnumerable {}
+    // this 'IEnumerable<T>' isn't 'well known', so the analyzer won't fire
+    interface IEnumerable<T> : IEnumerable {} 
+
+    static class Enumerable
+    {
+        public static IEnumerable<T> OfType<T>(this IEnumerable ienum) => null;
+    }
+
+    class C
+    {
+        void M()
+        {
+            _ = Enumerable.OfType<string>(default(IEnumerable<int>));
+            _ = default(IEnumerable<int>).OfType<string>();
+        }
+    }
+}
+");
+        }
+
+        [Fact()]
+        public async Task UnrelatedMethodsDontTrigger()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System.Linq
+{
+    static class Enumerable
+    {
+        // missing 'this'
+        public static IEnumerable<T> Cast<T>(IEnumerable ienum) => null;
+        // wrong parameter type
+        public static IEnumerable<T> Cast<T>(this IEnumerable<int> ienum) => null;
+        // too many parameters
+        public static IEnumerable<T> Cast<T>(this IEnumerable ienum, object distraction) => null;
+        // too many type parameters
+        public static IEnumerable<T> Cast<T, T2>(this IEnumerable ienum) => null;
+    }
+
+    class C
+    {
+        void M()
+        {
+            IEnumerable<int> e = default;
+            _ = Enumerable.Cast<string>(e);
+            _ = e.Cast<string>();
+            _ = e.Cast<string>(null);
+            _ = e.Cast<string, object>();
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public async Task NonGenericCasesCSharp()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Linq;
+class Fruit {}
+class Apple : Fruit {}
+class Shoe {}
+
+interface ICar {}
+
+interface IPlant {}
+interface ITree : IPlant {}
+interface IGrass : IPlant {}
+
+class Plant : IPlant {}
+class Tree : ITree {}
+sealed class Grass : IGrass {}
+
+class C
+{
+    public void M()
+    {
+        _ = (new int[0]).OfType<object>();
+        _ = {|#10:(new int[0]).OfType<string>()|};
+        _ = (new object[0]).OfType<string>();
+
+        // we don't look through extra casts
+        _ = (new System.Uri[0] as object[]).OfType<string>();
+        _ = ((object[])new System.Uri[0]).OfType<string>();
+
+        // expression syntax
+        _ = from string s in new object[0]
+            select s;
+        _ = {|#11:from int i in new string[0]|}
+            select i;
+        _ = {|#12:Enumerable.Cast<string>(new int[0])|};
+
+        // interfaces
+        _ = (new ICar[0]).Cast<ICar>();
+        _ = (new ICar[0]).Cast<IPlant>();
+        _ = (new IPlant[0]).Cast<IPlant>();
+        _ = (new IPlant[0]).Cast<IPlant>();
+
+        // classes
+        _ = (new Fruit[0]).Cast<Fruit>(); // identity
+        _ = (new Fruit[0]).Cast<Apple>(); // upcast
+        _ = {|#40:(new Fruit[0]).Cast<Shoe>()|}; // error
+        _ = (new Apple[0]).Cast<Fruit>(); // downcast
+        _ = (new Apple[0]).Cast<Apple>(); // identity
+        _ = {|#41:(new Apple[0]).Cast<Shoe>()|}; // error
+        _ = {|#42:(new Shoe[0]).Cast<Fruit>()|}; // error
+        _ = {|#43:(new Shoe[0]).Cast<Apple>()|}; // error
+        _ = {|#44:(new Shoe[0]).Cast<Shoe>()|}; // error
+
+        // interface to class
+        _ = (new ICar[0]).Cast<Plant>(); // subclass of Plant could implement ICar
+        _ = (new ICar[0]).Cast<Tree>(); // subclass of Tree could implement ICar
+        _ = {|#50:(new ICar[0]).Cast<Grass>()|}; // subclass of Grass could not implement ICar, as Grass is sealed
+        _ = (new ICar[0]).Cast<Shoe>(); // subclass of Shoe could implement ICar
+
+        _ = (new IPlant[0]).Cast<Plant>();
+        _ = (new IPlant[0]).Cast<Tree>();
+        _ = (new IPlant[0]).Cast<Grass>();
+        _ = (new IPlant[0]).Cast<Shoe>();
+
+        _ = (new ITree[0]).Cast<Plant>();
+        _ = (new ITree[0]).Cast<Tree>();
+        _ = {|#51:(new ITree[0]).Cast<Grass>()|}; // subclass of Grass could not implement ICar, as Grass is sealed
+        _ = (new ITree[0]).Cast<Shoe>();
+
+        _ = (new IGrass[0]).Cast<Plant>();
+        _ = (new IGrass[0]).Cast<Tree>();
+        _ = (new IGrass[0]).Cast<Grass>();
+        _ = (new IGrass[0]).Cast<Shoe>();
+
+        // class to interface
+        _ = (new Plant[0]).Cast<ICar>();
+        _ = (new Tree[0]).Cast<ICar>();
+        _ = {|#52:(new Grass[0]).Cast<ICar>()|}; // grass doesn't implement ICar, and is sealed so a subclass couldn't either
+        _ = (new Shoe[0]).Cast<ICar>();
+
+        _ = (new Plant[0]).Cast<IPlant>();
+        _ = (new Tree[0]).Cast<IPlant>();
+        _ = (new Grass[0]).Cast<IPlant>();
+        _ = (new Shoe[0]).Cast<IPlant>();
+
+        _ = (new Plant[0]).Cast<ITree>();
+        _ = (new Tree[0]).Cast<ITree>();
+        _ = {|#53:(new Grass[0]).Cast<ITree>()|};
+        _ = (new Shoe[0]).Cast<ITree>();
+
+        _ = (new Plant[0]).Cast<IGrass>();
+        _ = (new Tree[0]).Cast<IGrass>();
+        _ = (new Grass[0]).Cast<IGrass>();
+        _ = (new Shoe[0]).Cast<IGrass>();
+    }
+}
+",
+
+VerifyCS.Diagnostic(ofTypeRule).WithLocation(10).WithArguments("int", "string"),
+VerifyCS.Diagnostic(castRule).WithLocation(11).WithArguments("string", "int"),
+VerifyCS.Diagnostic(castRule).WithLocation(12).WithArguments("int", "string"),
+
+VerifyCS.Diagnostic(castRule).WithLocation(40).WithArguments("Fruit", "Shoe"),
+VerifyCS.Diagnostic(castRule).WithLocation(41).WithArguments("Apple", "Shoe"),
+VerifyCS.Diagnostic(castRule).WithLocation(42).WithArguments("Shoe", "Fruit"),
+VerifyCS.Diagnostic(castRule).WithLocation(43).WithArguments("Shoe", "Apple"),
+
+VerifyCS.Diagnostic(castRule).WithLocation(50).WithArguments("ICar", "Grass"),
+VerifyCS.Diagnostic(castRule).WithLocation(51).WithArguments("ITree", "Grass"),
+VerifyCS.Diagnostic(castRule).WithLocation(52).WithArguments("Grass", "ICar"),
+VerifyCS.Diagnostic(castRule).WithLocation(53).WithArguments("Grass", "ITree")
+);
+        }
+
+        [Fact]
+        public async Task ArrayCSharp()
+        {
+            Assert.Throws<InvalidCastException>(()
+                => (new int[][] { new int[] { 1 } }).Cast<object[]>().ToArray());
+            Assert.Throws<InvalidCastException>(()
+                => (new[] { 1 }).Cast<string>().ToArray());
+
+            Assert.Throws<InvalidCastException>(()
+                => (new object[][] { Array.Empty<object>() }).Cast<int[]>().ToArray());
+
+            Assert.Throws<InvalidCastException>(()
+                => (new ValueType[][] { Array.Empty<ValueType>() }).Cast<int[]>().ToArray());
+
+            Assert.Throws<InvalidCastException>(()
+                => (new object[][] { Array.Empty<ValueType>() }).Cast<int[]>().ToArray());
+
+            Assert.Throws<InvalidCastException>(()
+                => (new ValueType[][] { Array.Empty<ValueType>() }).Cast<int[]>().ToArray());
+
+            Assert.Throws<InvalidCastException>(()
+                => (new int[][] { Array.Empty<int>() }).Cast<ValueType[]>().ToArray());
+
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Linq;
+
+class C
+{
+    void M()
+    {
+        Enumerable.OfType<object[]>(new int[0][]);
+        Enumerable.OfType<object[]>(new string[0][]);
+        Enumerable.OfType<object[]>(new object[0][]);
+
+        // these should all be errors, but not all implemented
+        Enumerable.OfType<int[]>(new object[0][]);
+        Enumerable.OfType<string[]>(new object[0][]);
+
+        {|#12:Enumerable.OfType<string[]>(new int[0][])|};
+        {|#13:Enumerable.OfType<string>(new int[0][])|};
+
+        // multidimensional arrays don't implement IEnumberable<T>
+
+        // IEnumerable<string[,]> != string[,]
+        {|#20:Enumerable.OfType<string[,]>(new string[0,0])|}; 
+
+        // these will throw
+        {|#21:Enumerable.OfType<string[]>(new int[0,0])|};
+        {|#22:Enumerable.OfType<string[,]>(new int[0,0])|};
+
+        // arrays of multidimensional arrays are checked, including rank
+        {|#30:Enumerable.OfType<string[]>(new string[0][,])|};
+        {|#31:Enumerable.OfType<string[,]>(new string[0][])|};
+        {|#32:Enumerable.OfType<string[]>(new int[0][,])|};
+        {|#33:Enumerable.OfType<string[,]>(new int[0][])|};
+
+        // all arrays can be cast to and from System.Array
+        Enumerable.OfType<Array>(Enumerable.Empty<Array>());
+
+        Enumerable.OfType<Array>(Enumerable.Empty<object[]>());
+        Enumerable.OfType<Array>(Enumerable.Empty<object[]>());
+        Enumerable.OfType<object[]>(Enumerable.Empty<Array>());
+        Enumerable.OfType<string[]>(Enumerable.Empty<Array>());
+
+        Enumerable.OfType<Array>(Enumerable.Empty<ValueType[]>());
+        Enumerable.OfType<ValueType[]>(Enumerable.Empty<Array>());
+
+        // but not non-arrays
+        {|#41:Enumerable.OfType<Array>(Array.Empty<int>())|};
+        Enumerable.OfType<Array>(Array.Empty<object>());
+        {|#42:Enumerable.OfType<Array>(Array.Empty<string>())|};
+        {|#43:Enumerable.OfType<Array>(Array.Empty<ValueType>())|};
+        {|#44:Enumerable.OfType<Array>(Array.Empty<Enum>())|};
+
+        {|#51:Enumerable.OfType<int>(Array.Empty<Array>())|};
+        Enumerable.OfType<object>(Array.Empty<Array>());
+        {|#52:Enumerable.OfType<string>(Array.Empty<Array>())|};
+        {|#53:Enumerable.OfType<ValueType>(Array.Empty<Array>())|};
+        {|#54:Enumerable.OfType<Enum>(Array.Empty<Array>())|};
+
+        // this might work
+        Enumerable.OfType<int[]>(Enumerable.Empty<ValueType[]>());
+        // this is not allowed, but not implemented yet
+        Enumerable.OfType<ValueType[]>(Enumerable.Empty<int[]>());
+    }
+}",
+    //   VerifyCS.Diagnostic(ofTypeRule).WithLocation(10).WithArguments("int[]", "object[]"),
+    //   VerifyCS.Diagnostic(ofTypeRule).WithLocation(11).WithArguments("string[]", "object[]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(12).WithArguments("int[]", "string[]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(13).WithArguments("int[]", "string"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(20).WithArguments("string", "string[*,*]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(21).WithArguments("int", "string[]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(22).WithArguments("int", "string[*,*]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(30).WithArguments("string[*,*]", "string[]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(31).WithArguments("string[]", "string[*,*]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(32).WithArguments("int[*,*]", "string[]"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(33).WithArguments("int[]", "string[*,*]"),
+
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(41).WithArguments("int", "System.Array"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(42).WithArguments("string", "System.Array"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(43).WithArguments("System.ValueType", "System.Array"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(44).WithArguments("System.Enum", "System.Array"),
+
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(51).WithArguments("System.Array", "int"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(52).WithArguments("System.Array", "string"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(53).WithArguments("System.Array", "System.ValueType"),
+    VerifyCS.Diagnostic(ofTypeRule).WithLocation(54).WithArguments("System.Array", "System.Enum")
+
+//  VerifyCS.Diagnostic(ofTypeRule).WithLocation(60).WithArguments("ValueType[]", "int[]")
+);
+        }
+
+        [Fact]
+        public async Task EnumCasesCSharp()
+        {
+            Assert.Throws<InvalidCastException>(() => new int[] { 1 }.Cast<Enum>().ToArray());
+
+            // this is ok!
+            _ = new StringComparison[] { StringComparison.OrdinalIgnoreCase }.Cast<Enum>().ToArray();
+            _ = new StringComparison[] { StringComparison.OrdinalIgnoreCase }.Cast<ValueType>().ToArray();
+            _ = new ValueType[] { StringComparison.OrdinalIgnoreCase }.Cast<Enum>().ToArray();
+            _ = new Enum[] { StringComparison.OrdinalIgnoreCase }.Cast<ValueType>().ToArray();
+            _ = new ValueType[] { StringComparison.OrdinalIgnoreCase }.Cast<StringComparison>().ToArray();
+            _ = new Enum[] { StringComparison.OrdinalIgnoreCase }.Cast<StringComparison>().ToArray();
+
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Linq;
+
+enum ByteEnum : byte {}
+enum IntEnum {}
+enum IntEnum2 {}
+enum UIntEnum : uint {}
+enum LongEnum : long {}
+
+class C
+{
+    void M()
+    {
+        // object is everything
+        _ = (new object[0]).Cast<IntEnum>();
+        _ = (new IntEnum[0]).Cast<object>();
+
+        // base class
+        _ = (new Enum[0]).Cast<IntEnum>();
+        _ = (new IntEnum[0]).Cast<Enum>();
+        _ = {|#10:(new int[0]).Cast<Enum>()|};
+
+        // value type
+        _ = Array.Empty<ValueType>().Cast<IntEnum>();
+        _ = (new IntEnum[0]).Cast<ValueType>();
+        _ = (new ValueType[0]).Cast<Enum>();
+        _ = (new Enum[0]).Cast<ValueType>();
+
+        // Enums with the same underlying type are OK
+        _ = (new IntEnum[0]).Cast<IntEnum2>();
+        _ = (new IntEnum2[0]).Cast<IntEnum>();
+
+        // to and from the underlying type are ok
+        _ = (new ByteEnum[0]).Cast<byte>();
+        _ = (new IntEnum[0]).Cast<int>();
+        _ = (new UIntEnum[0]).Cast<uint>();
+        _ = (new LongEnum[0]).Cast<long>();
+
+        _ = Enumerable.Empty<byte>().Cast<ByteEnum>();
+        _ = Enumerable.Empty<int>().Cast<IntEnum>();
+        _ = Enumerable.Empty<uint>().Cast<UIntEnum>();
+        _ = Enumerable.Empty<long>().Cast<LongEnum>();
+
+        // enums with different underlying types are not
+        _ = {|#20:(new IntEnum[0]).Cast<ByteEnum>()|};
+        _ = {|#21:(new IntEnum[0]).Cast<UIntEnum>()|};
+
+        _ = {|#22:(new int[0]).Cast<ByteEnum>()|};
+        _ = {|#23:(new int[0]).Cast<UIntEnum>()|};
+
+        _ = {|#24:(new IntEnum[0]).Cast<LongEnum>()|};
+        _ = {|#25:(new int[0]).Cast<LongEnum>()|};
+
+        _ = {|#26:(new ByteEnum[0]).Cast<IntEnum>()|};
+        _ = {|#27:(new UIntEnum[0]).Cast<IntEnum>()|};
+
+        _ = {|#28:(new ByteEnum[0]).Cast<int>()|};
+        _ = {|#29:(new UIntEnum[0]).Cast<int>()|};
+
+        _ = {|#30:(new LongEnum[0]).Cast<IntEnum>()|};
+        _ = {|#31:(new LongEnum[0]).Cast<int>()|};
+    }
+}",
+    VerifyCS.Diagnostic(castRule).WithLocation(10).WithArguments("int", "System.Enum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(20).WithArguments("IntEnum", "ByteEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(21).WithArguments("IntEnum", "UIntEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(22).WithArguments("int", "ByteEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(23).WithArguments("int", "UIntEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(24).WithArguments("IntEnum", "LongEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(25).WithArguments("int", "LongEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(26).WithArguments("ByteEnum", "IntEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(27).WithArguments("UIntEnum", "IntEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(28).WithArguments("ByteEnum", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(29).WithArguments("UIntEnum", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(30).WithArguments("LongEnum", "IntEnum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(31).WithArguments("LongEnum", "int")
+);
+        }
+
+        [Fact]
+        public async Task NullableValueTypeCasesCSharp()
+        {
+            _ = new ValueType[] { StringComparison.OrdinalIgnoreCase, null }.Cast<StringComparison?>().ToArray();
+
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Linq;
+
+enum ByteEnum : byte {}
+enum IntEnum {}
+enum IntEnum2 {}
+enum UIntEnum : uint {}
+enum LongEnum : long {}
+
+class C
+{
+    void M()
+    {
+        // object is everything
+        _ = (new object[0]).Cast<IntEnum?>();
+        _ = (new IntEnum?[0]).Cast<object>();
+
+        // base class
+        _ = (new Enum[0]).Cast<IntEnum?>();
+        _ = (new IntEnum?[0]).Cast<Enum>();
+        _ = {|#10:(new int?[0]).Cast<Enum>()|};
+        _ = {|#11:(new Enum[0]).Cast<int?>()|};
+
+        // value type
+        _ = (new Enum[0]).Cast<ValueType>();
+        _ = Array.Empty<ValueType>().Cast<IntEnum?>();
+        _ = (new IntEnum?[0]).Cast<ValueType>();
+        _ = (new ValueType[0]).Cast<Enum>();
+
+        // Enums with the same underlying type are OK
+        _ = (new IntEnum?[0]).Cast<IntEnum2?>();
+        _ = (new IntEnum2?[0]).Cast<IntEnum?>();
+
+        // to and from the underlying type are ok
+        _ = (new ByteEnum?[0]).Cast<byte?>();
+        _ = (new IntEnum?[0]).Cast<int?>();
+        _ = (new UIntEnum?[0]).Cast<uint?>();
+        _ = (new LongEnum?[0]).Cast<long?>();
+
+        _ = Enumerable.Empty<byte?>().Cast<ByteEnum?>();
+        _ = Enumerable.Empty<int?>().Cast<IntEnum?>();
+        _ = Enumerable.Empty<uint?>().Cast<UIntEnum?>();
+        _ = Enumerable.Empty<long?>().Cast<LongEnum?>();
+
+        // enums with different underlying types are not
+        _ = {|#20:(new IntEnum?[0]).Cast<ByteEnum?>()|};
+        _ = {|#21:(new IntEnum?[0]).Cast<UIntEnum?>()|};
+
+        _ = {|#22:(new int?[0]).Cast<ByteEnum?>()|};
+        _ = {|#23:(new int?[0]).Cast<UIntEnum?>()|};
+
+        _ = {|#24:(new IntEnum?[0]).Cast<LongEnum?>()|};
+        _ = {|#25:(new int?[0]).Cast<LongEnum?>()|};
+
+        _ = {|#26:(new ByteEnum?[0]).Cast<IntEnum?>()|};
+        _ = {|#27:(new UIntEnum?[0]).Cast<IntEnum?>()|};
+
+        _ = {|#28:(new ByteEnum?[0]).Cast<int?>()|};
+        _ = {|#29:(new UIntEnum?[0]).Cast<int?>()|};
+
+        _ = {|#30:(new LongEnum?[0]).Cast<IntEnum?>()|};
+        _ = {|#31:(new LongEnum?[0]).Cast<int?>()|};
+    }
+}",
+    VerifyCS.Diagnostic(castRule).WithLocation(10).WithArguments("int?", "System.Enum"),
+    VerifyCS.Diagnostic(castRule).WithLocation(11).WithArguments("System.Enum", "int?"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(20).WithArguments("IntEnum?", "ByteEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(21).WithArguments("IntEnum?", "UIntEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(22).WithArguments("int?", "ByteEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(23).WithArguments("int?", "UIntEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(24).WithArguments("IntEnum?", "LongEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(25).WithArguments("int?", "LongEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(26).WithArguments("ByteEnum?", "IntEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(27).WithArguments("UIntEnum?", "IntEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(28).WithArguments("ByteEnum?", "int?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(29).WithArguments("UIntEnum?", "int?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(30).WithArguments("LongEnum?", "IntEnum?"),
+    VerifyCS.Diagnostic(castRule).WithLocation(31).WithArguments("LongEnum?", "int?")
+);
+        }
+
+        [Fact]
+        public async Task GenericCastsCSharp()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Linq;
+
+struct Struct : IInterface {}
+interface IInterface {}
+interface IInterface2 {}
+
+sealed class S : IInterface {}
+sealed class Z : IInterface, IInterface2 {}
+
+class C : IInterface
+{
+    void M<T>()
+    {
+        (new T[0]).Cast<int>(); // T could be anything
+        (new int[0]).Cast<T>(); // T could be anything
+    }
+
+    void MClass<TClass>() where TClass : class
+    {
+        (new TClass[0]).Cast<int>(); // T could be object
+        (new int[0]).Cast<TClass>(); // T could be object
+    }
+
+    void MclassC<TClassC>() where TClassC : C
+    {
+        (new TClassC[0]).Cast<object>();
+        (new object[0]).Cast<TClassC>();
+
+        (new TClassC[0]).Cast<C>();
+        (new TClassC[0]).Cast<IInterface>(); 
+
+        {|#10:(new TClassC[0]).Cast<string>()|}; // C is not string
+        {|#11:(new string[0]).Cast<TClassC>()|}; // string is not C
+
+        (new C[0]).Cast<TClassC>();
+        (new IInterface[0]).Cast<TClassC>();
+
+        {|#12:(new TClassC[0]).Cast<int>()|}; // error, subclass of C can't be int
+        {|#13:(new int[0]).Cast<TClassC>()|}; // error, int can't be subclass of C
+        {|#14:(new TClassC[0]).Cast<string>()|}; // error, subclass of C can't be int
+        {|#15:(new string[0]).Cast<TClassC>()|}; // error, int can't be subclass of C
+    }
+
+    void MInterface<TInterface>() where TInterface : IInterface
+    {
+        (new TInterface[0]).Cast<IInterface>();
+        (new IInterface[0]).Cast<TInterface>();
+
+        (new TInterface[0]).Cast<object>();
+        (new object[0]).Cast<TInterface>();
+
+        {|#20:(new TInterface[0]).Cast<int>()|};
+        {|#21:(new int[0]).Cast<TInterface>()|};
+
+        {|#22:(new TInterface[0]).Cast<string>()|};
+        {|#23:(new string[0]).Cast<TInterface>()|};
+    }
+
+    void MInterface2<TInterface>() where TInterface : IInterface, IInterface2
+    {
+        (new TInterface[0]).Cast<IInterface>();
+        (new IInterface[0]).Cast<TInterface>();
+
+        (new TInterface[0]).Cast<IInterface2>();
+        (new IInterface2[0]).Cast<TInterface>();
+
+        // does implement both interfaces
+        (new Z[0]).Cast<TInterface>();
+        (new TInterface[0]).Cast<Z>();
+
+        // doesn't implement IInterface2, but a subclass could
+        (new C[0]).Cast<TInterface>();
+        (new TInterface[0]).Cast<C>();
+
+        // sealed class doesn't implement IInterface2
+        {|#30:(new S[0]).Cast<TInterface>()|};
+        {|#31:(new TInterface[0]).Cast<S>()|};
+
+        // struct class doesn't implement IInterface2
+        {|#32:(new Struct[0]).Cast<TInterface>()|};
+        {|#33:(new TInterface[0]).Cast<Struct>()|};
+
+        // ok
+        (new TInterface[0]).Cast<object>();
+        (new object[0]).Cast<TInterface>();
+
+        {|#34:(new TInterface[0]).Cast<int>()|};
+        {|#35:(new int[0]).Cast<TInterface>()|};
+
+        {|#36:(new TInterface[0]).Cast<string>()|};
+        {|#37:(new string[0]).Cast<TInterface>()|};
+    }
+
+    void MStructInterface<TStructInterface>() where TStructInterface : struct, IInterface
+    {
+        {|#40:(new TStructInterface[0]).Cast<int>()|}; // error, int doesn't implement I
+        {|#41:(new int[0]).Cast<TStructInterface>()|}; // error, I can't be cast to int
+    }
+
+    void Mstruct<TStruct>() where TStruct : struct
+    {
+        (new TStruct[0]).Cast<int>(); // int is a struct
+        (new TStruct[0]).Cast<object>(); // can always cast to object
+        {|#50:(new TStruct[0]).Cast<string>()|}; // string is not is a struct
+
+        (new int[0]).Cast<TStruct>(); // int is a struct
+        (new object[0]).Cast<TStruct>(); // can always cast to object
+        {|#51:(new string[0]).Cast<TStruct>()|}; // string is not is a struct
+    }
+}",
+    VerifyCS.Diagnostic(castRule).WithLocation(10).WithArguments("TClassC", "string"),
+    VerifyCS.Diagnostic(castRule).WithLocation(11).WithArguments("string", "TClassC"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(12).WithArguments("TClassC", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(13).WithArguments("int", "TClassC"),
+    VerifyCS.Diagnostic(castRule).WithLocation(14).WithArguments("TClassC", "string"),
+    VerifyCS.Diagnostic(castRule).WithLocation(15).WithArguments("string", "TClassC"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(20).WithArguments("TInterface", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(21).WithArguments("int", "TInterface"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(22).WithArguments("TInterface", "string"),
+    VerifyCS.Diagnostic(castRule).WithLocation(23).WithArguments("string", "TInterface"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(30).WithArguments("S", "TInterface"),
+    VerifyCS.Diagnostic(castRule).WithLocation(31).WithArguments("TInterface", "S"),
+    VerifyCS.Diagnostic(castRule).WithLocation(32).WithArguments("Struct", "TInterface"),
+    VerifyCS.Diagnostic(castRule).WithLocation(33).WithArguments("TInterface", "Struct"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(34).WithArguments("TInterface", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(35).WithArguments("int", "TInterface"),
+    VerifyCS.Diagnostic(castRule).WithLocation(36).WithArguments("TInterface", "string"),
+    VerifyCS.Diagnostic(castRule).WithLocation(37).WithArguments("string", "TInterface"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(40).WithArguments("TStructInterface", "int"),
+    VerifyCS.Diagnostic(castRule).WithLocation(41).WithArguments("int", "TStructInterface"),
+
+    VerifyCS.Diagnostic(castRule).WithLocation(50).WithArguments("TStruct", "string"),
+    VerifyCS.Diagnostic(castRule).WithLocation(51).WithArguments("string", "TStruct")
+);
+        }
+
+        [Fact]
+        public async Task NonGenericCasesVB()
+        {
+            var castRule = DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.CastRule;
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System.Linq
+
+Interface IApple
+End Interface
+
+Public Class Fruit
+End Class
+
+Public Class Orange
+    Inherits Fruit
+End Class
+
+Class Apple
+    Inherits Fruit
+    Implements IApple
+End Class
+
+NotInheritable Class Salad
+End Class
+
+Module M    
+    Sub S
+        Dim a1 = (New Integer(){}).Cast(Of Object)
+        Dim a2 = (New Object(){}).Cast(Of String)
+        Dim a3 = (New Object(){}).Cast(Of Integer)
+        Dim a4 = {|#11:(New Integer(){}).Cast(Of String)|}
+        Dim a5 = {|#12:(New String(){}).Cast(Of Integer)|}
+        
+        Dim b1 = (New Object(){}).Cast(Of Fruit)
+        Dim b2 = (New Object(){}).Cast(Of Orange)
+        Dim b3 = (New Object(){}).Cast(Of IApple)
+        Dim b4 = (New Object(){}).Cast(Of Apple)
+        Dim b5 = (New Object(){}).Cast(Of Salad)
+
+        Dim c1 = (New Fruit(){}).Cast(Of Fruit)
+        Dim c2 = (New Fruit(){}).Cast(Of Orange)
+        Dim c3 = (New Fruit(){}).Cast(Of IApple)
+        Dim c4 = (New Fruit(){}).Cast(Of Apple)
+        Dim c5 = {|#15:(New Fruit(){}).Cast(Of Salad)|}
+
+        Dim d1 = (New Orange(){}).Cast(Of Fruit)
+        Dim d2 = (New Orange(){}).Cast(Of Orange)
+        Dim d3 = (New Orange(){}).Cast(Of IApple) ' subclass of Orange could implement IApple
+        Dim d4 = {|#21:(New Orange(){}).Cast(Of Apple)|}
+        Dim d5 = {|#22:(New Orange(){}).Cast(Of Salad)|}
+        
+        Dim e1 = (New IApple(){}).Cast(Of Fruit)
+        Dim e2 = (New IApple(){}).Cast(Of Orange) ' subclass of Orange could implement IApple
+        Dim e3 = (New IApple(){}).Cast(Of IApple)
+        Dim e4 = (New IApple(){}).Cast(Of Apple)
+        Dim e5 = {|#30:(New IApple(){}).Cast(Of Salad)|}
+        
+        Dim f1 = (New Apple(){}).Cast(Of Fruit)
+        Dim f2 = {|#40:(New Apple(){}).Cast(Of Orange)|}
+        Dim f3 = (New Apple(){}).Cast(Of IApple)
+        Dim f4 = (New Apple(){}).Cast(Of Apple)
+        Dim f5 = {|#41:(New Apple(){}).Cast(Of Salad)|}
+    End Sub
+End Module
+",
+    VerifyVB.Diagnostic(castRule).WithLocation(11).WithArguments("Integer", "String"),
+    VerifyVB.Diagnostic(castRule).WithLocation(12).WithArguments("String", "Integer"),
+
+    VerifyVB.Diagnostic(castRule).WithLocation(15).WithArguments("Fruit", "Salad"),
+
+    VerifyVB.Diagnostic(castRule).WithLocation(21).WithArguments("Orange", "Apple"),
+    VerifyVB.Diagnostic(castRule).WithLocation(22).WithArguments("Orange", "Salad"),
+
+    VerifyVB.Diagnostic(castRule).WithLocation(30).WithArguments("IApple", "Salad"),
+
+    VerifyVB.Diagnostic(castRule).WithLocation(40).WithArguments("Apple", "Orange"),
+    VerifyVB.Diagnostic(castRule).WithLocation(41).WithArguments("Apple", "Salad")
+   );
+        }
+    }
+}

--- a/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
+++ b/src/Utilities/Compiler/DiagnosticCategoryAndIdRanges.txt
@@ -18,7 +18,7 @@ Usage: CA1801, CA1806, CA1816, CA2200-CA2209, CA2211-CA2260
 Naming: CA1700-CA1727
 Interoperability: CA1400-CA1422
 Maintainability: CA1500-CA1513
-Reliability: CA9998-CA9999, CA2000-CA2020
+Reliability: CA9998-CA9999, CA2000-CA2021
 Documentation: CA1200-CA1200
 
 # Microsoft CodeAnalysis API rules


### PR DESCRIPTION
Warn if use of `Enumerable.Cast<T>` would always fail at runtime or `OfType<T>()` would provably result in an empty sequence, because we can see that the input type in the sequence will never be the specified type.

RuleId: CA2019
Category: Reliability

related: https://github.com/dotnet/roslyn-analyzers/issues/3608, https://github.com/dotnet/runtime/issues/33770

- [x] Tests pass
- [x] Targeted to ~release/7.0.1xx~ main
- [x] Run against 
   - [x] dotnet/roslyn-analyzers 
   - [x] dotnet/runtime
   - [ ] dotnet/roslyn 
- [ ] Docs