### PR TITLE
Fix _RunOnCore property when running on .NET 5.0

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -64,7 +64,7 @@
       <_TestResultsXmlPath>$(_TestOutPathNoExt).xml</_TestResultsXmlPath>
       <_TestResultsHtmlPath>$(_TestOutPathNoExt).html</_TestResultsHtmlPath>
       <_RunOnCore>false</_RunOnCore>
-      <_RunOnCore Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</_RunOnCore>
+      <_RunOnCore Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</_RunOnCore>
     </PropertyGroup>
 
     <Error Text="Architecture specified in TestArchitectures is not supported: '$(_TestArchitecture)'" File="XUnit"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -64,7 +64,7 @@
       <_TestResultsXmlPath>$(_TestOutPathNoExt).xml</_TestResultsXmlPath>
       <_TestResultsHtmlPath>$(_TestOutPathNoExt).html</_TestResultsHtmlPath>
       <_RunOnCore>false</_RunOnCore>
-      <_RunOnCore Condition="$(TargetFramework.StartsWith('netcoreapp'))">true</_RunOnCore>
+      <_RunOnCore Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</_RunOnCore>
     </PropertyGroup>
 
     <Error Text="Architecture specified in TestArchitectures is not supported: '$(_TestArchitecture)'" File="XUnit"


### PR DESCRIPTION
Same change that occurred in https://github.com/dotnet/roslyn/pull/46306/files