### PR TITLE
Fix bugs in CallSiteImplicitAllocationAnalyzer

### DIFF
--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
                 {
                     // Up to net45 the System.Array.Empty<T> singleton didn't existed so an empty params array was still causing some memory allocation.
                     if (argument.IsImplicit &&
-                        (!compilationHasSystemArrayEmpty || (argument.Value as IArrayCreationOperation)?.Initializer.ElementValues.IsEmpty == true))
+                        (!compilationHasSystemArrayEmpty || (argument.Value as IArrayCreationOperation)?.Initializer.ElementValues.IsEmpty != true))
                     {
                         reportDiagnostic(node.CreateDiagnostic(ParamsParameterRule));
                     }

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -162,6 +162,34 @@ public class MyClass
         }
 
         [Fact]
+        public async Task ParamsIsPrecededByOptionalParameters()
+        {
+            var sampleProgram = @"
+using System.IO;
+using Roslyn.Utilities;
+
+public class MyClass
+{
+    static class Demo
+    {
+        [PerformanceSensitive(""uri"")]
+        static void Fun1()
+        {
+            Fun2();
+            {|#0:Fun2(args: """", i: 5)|};
+        }
+
+        static void Fun2(int i = 0, params object[] args)
+        {
+        }
+    }
+}";
+
+            await VerifyCS.VerifyAnalyzerAsync(sampleProgram,
+                VerifyCS.Diagnostic(CallSiteImplicitAllocationAnalyzer.ParamsParameterRule).WithLocation(0));
+        }
+
+        [Fact]
         [WorkItem(7995606, "http://stackoverflow.com/questions/7995606/boxing-occurrence-in-c-sharp")]
         public async Task Calling_non_overridden_virtual_methods_on_value_types()
         {

--- a/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
+++ b/src/PerformanceSensitiveAnalyzers/UnitTests/CallSiteImplicitAllocationAnalyzerTests.cs
@@ -170,18 +170,15 @@ using Roslyn.Utilities;
 
 public class MyClass
 {
-    static class Demo
+    [PerformanceSensitive(""uri"")]
+    void Fun1()
     {
-        [PerformanceSensitive(""uri"")]
-        static void Fun1()
-        {
-            Fun2();
-            {|#0:Fun2(args: """", i: 5)|};
-        }
+        Fun2();
+        {|#0:Fun2(args: """", i: 5)|};
+    }
 
-        static void Fun2(int i = 0, params object[] args)
-        {
-        }
+    void Fun2(int i = 0, params object[] args)
+    {
     }
 }";
 


### PR DESCRIPTION
The bug stated in https://github.com/microsoft/RoslynClrHeapAllocationAnalyzer/issues/84 existed in the copy of the analyzer in this repository too.

I couldn't fix it without refactoring. Relying on syntax here is very error-prone. So I switched to getting `IOperation`s. However, the analyzer is still a syntax one its base class is so.