### PR TITLE
Update comment for clarity

### DIFF
--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -41,8 +41,8 @@
 
     <PropertyGroup Condition="'$(GenerateAnalyzerRulesMissingDocumentationFile)' == ''">
       <!-- Generate rules missing documentation file by default for local builds and normal CI builds (to validate the existing files). -->
-      <!-- Skip it for internal signed builds that are kicked off after each PR merge builds for improved CI throughput. -->
       <GenerateAnalyzerRulesMissingDocumentationFile>true</GenerateAnalyzerRulesMissingDocumentationFile>
+      <!-- Skip it for internal signed builds that are kicked off after each PR merge builds for improved CI throughput. -->
       <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(Sign)' == 'true'">false</GenerateAnalyzerRulesMissingDocumentationFile>
     </PropertyGroup>
 

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -37,12 +37,7 @@
       <GenerateAnalyzerMdFile Condition="'$(GenerateAnalyzerMdFile)' == ''">true</GenerateAnalyzerMdFile>
       <GenerateAnalyzerSarifFile Condition="'$(GenerateAnalyzerSarifFile)' == ''">true</GenerateAnalyzerSarifFile>
       <GenerateAnalyzerConfigurationFile Condition="'$(GenerateAnalyzerConfigurationFile)' == ''">true</GenerateAnalyzerConfigurationFile>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(GenerateAnalyzerRulesMissingDocumentationFile)' == ''">
-      <!-- Generate rules missing documentation file by default for local builds. Skip it for CI/signed builds for improved CI throughput. -->
-      <GenerateAnalyzerRulesMissingDocumentationFile>true</GenerateAnalyzerRulesMissingDocumentationFile>
-      <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(Sign)' == 'true'">false</GenerateAnalyzerRulesMissingDocumentationFile>
+      <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(GenerateAnalyzerRulesMissingDocumentationFile)' == ''">true</GenerateAnalyzerRulesMissingDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GeneratePackagePropsFile)' == 'true'">

--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -37,7 +37,13 @@
       <GenerateAnalyzerMdFile Condition="'$(GenerateAnalyzerMdFile)' == ''">true</GenerateAnalyzerMdFile>
       <GenerateAnalyzerSarifFile Condition="'$(GenerateAnalyzerSarifFile)' == ''">true</GenerateAnalyzerSarifFile>
       <GenerateAnalyzerConfigurationFile Condition="'$(GenerateAnalyzerConfigurationFile)' == ''">true</GenerateAnalyzerConfigurationFile>
-      <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(GenerateAnalyzerRulesMissingDocumentationFile)' == ''">true</GenerateAnalyzerRulesMissingDocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(GenerateAnalyzerRulesMissingDocumentationFile)' == ''">
+      <!-- Generate rules missing documentation file by default for local builds and normal CI builds (to validate the existing files). -->
+      <!-- Skip it for internal signed builds that are kicked off after each PR merge builds for improved CI throughput. -->
+      <GenerateAnalyzerRulesMissingDocumentationFile>true</GenerateAnalyzerRulesMissingDocumentationFile>
+      <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(Sign)' == 'true'">false</GenerateAnalyzerRulesMissingDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(GeneratePackagePropsFile)' == 'true'">


### PR DESCRIPTION
The code wasn't previously working as expected. `GenerateAnalyzerRulesMissingDocumentationFile` was already true in CI builds. Now with the CI validation introduced recently, we even don't need it to be false for CI at all.