### PR TITLE
Update to Roslyn 3.8.0-4.final for testing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
-    <MicrosoftCodeAnalysisVersionForTests>3.7.0</MicrosoftCodeAnalysisVersionForTests>
+    <MicrosoftCodeAnalysisVersionForTests>3.8.0-4.final</MicrosoftCodeAnalysisVersionForTests>
     <DogfoodAnalyzersVersion>3.3.0</DogfoodAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <MicrosoftCodeAnalysisFXCopAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyzersVersion>
@@ -39,7 +39,7 @@
     <RoslynDiagnosticsAnalyzersVersion>$(DogfoodAnalyzersVersion)</RoslynDiagnosticsAnalyzersVersion>
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <!-- Roslyn Testing -->
-    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20472.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.20521.1</MicrosoftCodeAnalysisTestingVersion>
     <!-- Libs -->
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemComponentModelCompositionVersion>4.7.0</SystemComponentModelCompositionVersion>

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -2139,7 +2139,7 @@ namespace PlatformCompatDemo.SupportedUnupported
             var test = new VerifyCS.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { }
             };
@@ -2179,7 +2179,7 @@ namespace PlatformCompatDemo.SupportedUnupported
             var test = new VerifyVB.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { },
             };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexerTests.cs
@@ -846,7 +846,7 @@ public class TestClass
             var test = new VerifyCS.Test
             {
                 TestCode = source,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 LanguageVersion = LanguageVersion.Preview,
                 FixedCode = corrected,
             };
@@ -860,7 +860,7 @@ public class TestClass
             var test = new VerifyCS.Test
             {
                 TestCode = source,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 LanguageVersion = LanguageVersion.Preview,
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseReferenceEqualsWithValueTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseReferenceEqualsWithValueTypesTests.cs
@@ -343,7 +343,7 @@ End Namespace");
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -362,7 +362,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -382,7 +382,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -402,7 +402,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -423,7 +423,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -443,7 +443,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -464,7 +464,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -483,7 +483,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -503,7 +503,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -523,7 +523,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -543,7 +543,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -564,7 +564,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -585,7 +585,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -613,7 +613,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -638,7 +638,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -658,7 +658,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -679,7 +679,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -699,7 +699,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -720,7 +720,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections.Generic;
@@ -747,7 +747,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections.Generic
@@ -772,7 +772,7 @@ End Namespace",
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 using System;
 using System.Collections;
@@ -795,7 +795,7 @@ namespace TestNamespace
 
             await new VerifyVB.Test
             {
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 TestCode = @"
 Imports System
 Imports System.Collections

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
@@ -4210,7 +4210,7 @@ End Class
             {
                 TestCode = originalCode,
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 FixedCode = fixedCode,
             };
 
@@ -4224,7 +4224,7 @@ End Class
             {
                 TestCode = originalCode,
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
 
             test.ExpectedDiagnostics.AddRange(DiagnosticResult.EmptyDiagnosticResults);
@@ -4237,7 +4237,7 @@ End Class
             {
                 TestCode = originalCode,
                 LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic16,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
                 FixedCode = fixedCode
             };
 
@@ -4251,7 +4251,7 @@ End Class
             {
                 TestCode = originalCode,
                 LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic16,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
 
             test.ExpectedDiagnostics.AddRange(DiagnosticResult.EmptyDiagnosticResults);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -17,11 +17,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     {
         // Verifies that the analyzer generates the specified C# diagnostic results, if any.
         protected Task CSharpVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
-            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.Net.Net50, expected);
 
         // Verifies that the analyzer generates the specified VB diagnostic results, if any.
         protected Task VisualBasicVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
-            VisualBasicVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            VisualBasicVerifyForVersionAsync(source, null, ReferenceAssemblies.Net.Net50, expected);
 
         // Verifies that the analyzer generates the specified C# diagnostic results, if any, in an unsupported .NET version.
         protected Task CSharpVerifyAnalyzerForUnsupportedVersionAsync(string source, params DiagnosticResult[] expected) =>
@@ -33,11 +33,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         // Verifies that the fixer generates the fixes for the specified C# diagnostic results, if any.
         protected Task CSharpVerifyExpectedCodeFixDiagnosticsAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
-            CSharpVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            CSharpVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.Net.Net50, expected);
 
         // Verifies that the fixer generates the fixes for the specified VB diagnostic results, if any.
         protected Task VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
-            VisualBasicVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.NetCore.NetCoreApp50, expected);
+            VisualBasicVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.Net.Net50, expected);
 
         // Verifies that the analyzer generates the specified C# diagnostic results, if any, for the specified originalSource.
         // If fixedSource is provided, also verifies that the fixer generates the fixes for the verified diagnostic results, if any.

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
@@ -43,7 +43,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -69,7 +69,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -98,7 +98,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -120,7 +120,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -149,7 +149,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -171,7 +171,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -208,7 +208,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -236,7 +236,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -267,7 +267,7 @@ namespace TestNamespace
             var test = new VerifyCS.Test
             {
                 TestCode = csInput,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await test.RunAsync();
 
@@ -290,7 +290,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -344,7 +344,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -385,7 +385,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -425,7 +425,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
 
@@ -457,7 +457,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
 
@@ -489,7 +489,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
 
@@ -521,7 +521,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -566,7 +566,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -604,7 +604,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -642,7 +642,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -680,7 +680,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
         }
@@ -720,7 +720,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
         }
@@ -751,7 +751,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -774,7 +774,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -805,7 +805,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -828,7 +828,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -919,7 +919,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
         }
@@ -946,7 +946,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
         }
@@ -973,7 +973,7 @@ namespace TestNamespace
             var test = new VerifyCS.Test
             {
                 TestCode = csInput,
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50
             };
             await test.RunAsync();
         }
@@ -1013,7 +1013,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testCulture.RunAsync();
 
@@ -1045,7 +1045,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -1085,7 +1085,7 @@ namespace TestNamespace
             {
                 TestState = { Sources = { csInput } },
                 FixedState = { Sources = { csFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testCulture.RunAsync();
 
@@ -1117,7 +1117,7 @@ End Class
             {
                 TestState = { Sources = { vbInput } },
                 FixedState = { Sources = { vbFix } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -1146,7 +1146,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -1168,7 +1168,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }
@@ -1197,7 +1197,7 @@ namespace TestNamespace
             var testOrdinal = new VerifyCS.Test
             {
                 TestState = { Sources = { csInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal.RunAsync();
 
@@ -1219,7 +1219,7 @@ End Class
             var testOrdinal_vb = new VerifyVB.Test
             {
                 TestState = { Sources = { vbInput } },
-                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp50,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
             };
             await testOrdinal_vb.RunAsync();
         }

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
@@ -55,6 +55,10 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
             {
                 // Pointers can use 'null'
             }
+            else if (type.TypeKind == TypeKind.Error)
+            {
+                return;
+            }
             else if (type.IsValueType)
             {
                 if (type is not INamedTypeSymbol namedType


### PR DESCRIPTION
* Microsoft.CodeAnalysis.Testing was updated since https://github.com/dotnet/roslyn-sdk/pull/644 is now required
* Added tests for records in CreateTestAccessor (currently skipped since dotnet/roslyn#48096 is not available in 16.8)