### PR TITLE
Improve messaging of Platform compat analyzer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                                       isDataflowRule: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
-            SupportedOsRule, SupportedOsRule, UnsupportedOsRule);
+            SupportedOsRule, OnlySupportedOsRule, UnsupportedOsRule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1434,17 +1434,14 @@
   <data name="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle" xml:space="preserve">
     <value>Use `{0}` instead of Range-based indexers on an array</value>
   </data>
-  <data name="PlatformCompatibilityCheckTitle" xml:space="preserve">
+  <data name="PlatformCompatibilityTitle" xml:space="preserve">
     <value>Validate platform compatibility</value>
   </data>
-  <data name="PlatformCompatibilityCheckDescription" xml:space="preserve">
+  <data name="PlatformCompatibilityDescription" xml:space="preserve">
     <value>Using platform dependent API on a component makes the code no longer work across all platforms.</value>
   </data>
-  <data name="PlatformCompatibilityCheckSupportedOsVersionMessage" xml:space="preserve">
-    <value>'{0}' is supported on '{1}' {2} and later</value>
-  </data>
-  <data name="PlatformCompatibilityCheckUnsupportedOsVersionMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on '{1}' {2} and later</value>
+  <data name="PlatformCompatibilitySupportedMessage" xml:space="preserve">
+    <value>'{0}' is supported on: {1}</value>
   </data>
   <data name="DoNotUseOutAttributeStringPInvokeParametersDescription" xml:space="preserve">
     <value>String parameters passed by value with the 'OutAttribute' can destabilize the runtime if the string is an interned string.</value>
@@ -1473,13 +1470,34 @@
   <data name="AvoidAssemblyGetFilesInSingleFileMessage" xml:space="preserve">
     <value>'{0}' will throw for assemblies embedded in a single-file app</value>
   </data>
-  <data name="PlatformCompatibilityCheckUnsupportedOsMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on '{1}'</value>
+  <data name="PlatformCompatibilityUnsupportedMessage" xml:space="preserve">
+    <value>'{0}' is unsupported on: {1}</value>
   </data>
-  <data name="PlatformCompatibilityCheckSupportedOsMessage" xml:space="preserve">
-    <value>'{0}' is supported on '{1}'</value>
+  <data name="PlatformCompatibilityOnlySupportedMessage" xml:space="preserve">
+    <value>'{0}' is only supported on: {1}</value>
   </data>
   <data name="PreferStringContainsOverIndexOfCodeFixTitle" xml:space="preserve">
     <value>Replace with 'string.Contains'</value>
+  </data>
+  <data name="CallSiteCrossPlatformSuffix" xml:space="preserve">
+    <value>but this call site is reachable on all platforms.</value>
+  </data>
+  <data name="CallSiteReachableOnPlatformSuffix" xml:space="preserve">
+    <value>but this call site is reachable on {0}.</value>
+  </data>
+  <data name="CallSiteUnreachableOnPlatformSuffix" xml:space="preserve">
+    <value>but this call site is unreachable on {0}.</value>
+  </data>
+  <data name="PlatformFromVersionAndLaterSuffix" xml:space="preserve">
+    <value>'{0}' from version {1} and later, </value>
+  </data>
+  <data name="PlatformFromVersionToVersionSuffix" xml:space="preserve">
+    <value>'{0}' from version {1} to {2}, </value>
+  </data>
+  <data name="PlatformVersionAndLaterSuffix" xml:space="preserve">
+    <value>'{0}' {1} and later, </value>
+  </data>
+  <data name="PlatformVersionAndBeforeSuffix" xml:space="preserve">
+    <value>'{0}' {1} and before, </value>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Metody Dispose by měly volat SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Spolehlivost</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">Metody P/Invoke nemají být viditelné</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Když se pro komponentu použije závislé rozhraní API, kód už nebude fungovat na všech platformách.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">{0} se podporuje v {1}.</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">{0} se podporuje v {1} {2} a novějších.</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Ověřit kompatibilitu platformy</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">{0} se v {1} nepodporuje.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">{0} se v {1} {2} a novějších nepodporuje.</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose-Methoden müssen SuppressFinalize aufrufen</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Zuverlässigkeit</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes dürfen nicht sichtbar sein</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Durch die Verwendung einer plattformabhängigen API für eine Komponente funktioniert der Code nicht mehr auf allen Plattformen.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" wird für "{1}" unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" wird für "{1}" {2} und höher unterstützt.</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Plattformkompatibilität überprüfen</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" wird für "{1}" nicht unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" wird für "{1}" {2} und höher nicht unterstützt.</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Los métodos Dispose deberían llamar a SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Fiabilidad</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">Los elementos P/Invoke no deben estar visibles</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">El uso de una API dependiente de la plataforma en un componente hace que el código deje de funcionar en todas las plataformas.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" es compatible con "{1}"</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" es compatible con "{1}" {2} y versiones posteriores</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Validar la compatibilidad de la plataforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" no es compatible con "{1}"</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" no es compatible con "{1}" {2} y versiones posteriores</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Les méthodes Dispose doivent appeler SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Fiabilité</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">Les P/Invoke ne doivent pas être visibles</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">L'utilisation d'une API dépendante de la plateforme sur un composant empêche le code de fonctionner sur l'ensemble des plateformes.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' est pris en charge sur '{1}'</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' est pris en charge sur '{1}' {2} et les versions ultérieures</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Valider la compatibilité de la plateforme</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' n'est pas pris en charge sur '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' n'est pas pris en charge sur '{1}' {2} et les versions ultérieures</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -167,6 +167,21 @@
         <target state="translated">I metodi Dispose devono chiamare SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Affidabilità</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">I metodi P/Invoke non devono essere visibili</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Se si usa un'API dipendente dalla piattaforma su un componente, il codice non funziona più in tutte le piattaforme.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' è supportato in '{1}'</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' è supportato in '{1}' {2} e versioni successive</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Convalida compatibilità della piattaforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' non è supportato in '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' non è supportato in '{1}' {2} e versioni successive</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose メソッドは、SuppressFinalize を呼び出す必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">信頼性</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes は参照可能にすることはできません</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">プラットフォーム依存 API をコンポーネント上で使用すると、一部のプラットフォームでコードが動作しなくなります。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' は '{1}' でサポートされています</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' は '{1}' {2} 以降でサポートされています</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">プラットフォームの互換性の検証</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' は '{1}' ではサポートされていません</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' は '{1}' {2} 以降ではサポートされていません</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose 메서드는 SuppressFinalize를 호출해야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">안정성</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes를 표시하지 않아야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">구성 요소에서 플랫폼 종속 API를 사용하면 모든 플랫폼에서 코드가 더 이상 작동하지 않습니다.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}'은(는) '{1}'에서 지원됨</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}'은(는) '{1}' {2} 이상에서 지원됨</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">플랫폼 호환성 유효성 검사</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}'은(는) '{1}'에서 지원되지 않음</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}'은(는) '{1}' {2} 이상에서 지원되지 않음</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Metoda Dispose powinna wywoływać metodę SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Niezawodność</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">Elementy P/Invoke nie powinny być widoczne</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Użycie w składniku interfejsu API zależnego od platformy powoduje, że kod nie działa na różnych platformach.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">Element „{0}” jest obsługiwany przez system „{1}”</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">Element „{0}” jest obsługiwany przez system „{1}” {2} i nowsze</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Weryfikuj zgodność z platformą</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">Element „{0}” nie jest obsługiwany przez system „{1}”</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">Element „{0}” nie jest obsługiwany przez system „{1}” {2} i nowsze</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Os métodos Dispose devem chamar SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Confiabilidade</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes não deve ser visível</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">O uso de uma API dependente da plataforma em um componente faz com que o código não funcione mais em todas as plataformas.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' é compatível com '{1}'</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' é compatível com '{1}' {2} e posteriores</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Validar a compatibilidade da plataforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' não é compatível com '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' não é compatível com '{1}' {2} e posteriores</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Методы Dispose должны вызывать SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Надежность</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">Методы P/Invoke не должны быть видимыми</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">При использовании в компоненте API, зависящего от платформы, код больше не будет работать на всех платформах.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" поддерживается в "{1}".</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" поддерживается в "{1}" версии {2} и более поздних версиях.</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Проверка совместимости платформы</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" не поддерживается в "{1}"</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" не поддерживается в "{1}" версии {2} и более поздних версиях</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose yöntemleri tarafından SuppressFinalize çağrılmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">Güvenilirlik</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes görünür olmamalıdır</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Bileşen üzerinde platforma bağımlı API kullanmak, kodun artık tüm platformlarda çalışmamasına neden olur.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}', '{1}' üzerinde destekleniyor</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}', '{1}' {2} ve üstünde desteklenir</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Platform uyumluluğunu doğrula</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}', '{1}' üzerinde desteklenmiyor</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}', '{1}' {2} ve üstünde desteklenmez</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose 方法应调用 SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">可靠性</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">P/Invokes 应该是不可见的</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">在组件上使用依赖于平台的 API 会使代码无法用于所有平台。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">“{1}”支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">“{1}”{2} 及更高版本支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">验证平台兼容性</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">“{1}”不支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">“{1}”{2} 及更高版本不支持“{0}”</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -167,6 +167,21 @@
         <target state="translated">Dispose 方法應該呼叫 SuppressFinalize</target>
         <note />
       </trans-unit>
+      <trans-unit id="CallSiteCrossPlatformSuffix">
+        <source>but this call site is reachable on all platforms.</source>
+        <target state="new">but this call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteReachableOnPlatformSuffix">
+        <source>but this call site is reachable on {0}.</source>
+        <target state="new">but this call site is reachable on {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CallSiteUnreachableOnPlatformSuffix">
+        <source>but this call site is unreachable on {0}.</source>
+        <target state="new">but this call site is unreachable on {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CategoryReliability">
         <source>Reliability</source>
         <target state="translated">可靠性</target>
@@ -1512,34 +1527,49 @@
         <target state="translated">不應看得見 P/Invoke</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">在元件上使用相依於平台的 API，會使程式碼無法繼續在所有平台上運作。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{1}' 支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedMessage">
+        <source>'{0}' is only supported on: {1}</source>
+        <target state="new">'{0}' is only supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{1}' {2} 及更新版本皆支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilitySupportedMessage">
+        <source>'{0}' is supported on: {1}</source>
+        <target state="new">'{0}' is supported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">驗證平台相容性</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{1}' 不支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedMessage">
+        <source>'{0}' is unsupported on: {1}</source>
+        <target state="new">'{0}' is unsupported on: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{1}' {2} 及更新版本皆不支援 '{0}'</target>
+      <trans-unit id="PlatformFromVersionAndLaterSuffix">
+        <source>'{0}' from version {1} and later, </source>
+        <target state="new">'{0}' from version {1} and later, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformFromVersionToVersionSuffix">
+        <source>'{0}' from version {1} to {2}, </source>
+        <target state="new">'{0}' from version {1} to {2}, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndBeforeSuffix">
+        <source>'{0}' {1} and before, </source>
+        <target state="new">'{0}' {1} and before, </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformVersionAndLaterSuffix">
+        <source>'{0}' {1} and later, </source>
+        <target state="new">'{0}' {1} and later, </target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -76,7 +76,7 @@ class Test
             Api();
         }
 
-        [|Api()|]; // Two diagnostics expected
+        {|#0:Api()|};  // 'Test.Api()' is supported on: 'windows' from version 10.0.19041 and later, but this call site is reachable on all platforms.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -86,8 +86,8 @@ class Test
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule)
-                .WithLocation(15, 9).WithArguments("Test.Api()", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule)
+                .WithLocation(15, 9).WithArguments("Test.Api()", "'windows' from version 10.0.19041 and later, but this call site is reachable on all platforms."));
         }
 
         [Fact]
@@ -147,8 +147,8 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
             {
                 [|Target.SupportedOnWindows()|];
                 [|Target.SupportedOnWindows10()|];
-                [|Target.SupportedOnWindowsAndBrowser()|];   // expected two diagnostics - supported on windows and browser
-                [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
+                [|Target.SupportedOnWindowsAndBrowser()|];   // 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser', but this call site is reachable on all platforms.
+                [|Target.SupportedOnWindows10AndBrowser()|]; // 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser', but this call site is reachable on all platforms.
             }
 
             if (OperatingSystemHelper.IsWindows())
@@ -156,7 +156,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 Target.SupportedOnWindows();
                 [|Target.SupportedOnWindows10()|];
                 Target.SupportedOnWindowsAndBrowser();       // no diagnostic expected - the API is supported on windows, no need to warn for other platforms support
-                [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
+                [|Target.SupportedOnWindows10AndBrowser()|]; // expected two platfoms - supported on windows 10 and browser
             }
 
             if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
@@ -177,10 +177,10 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
 
             if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; // No diagnostic expected because of it was windows
+                [|Target.SupportedOnWindows()|]; // Diagnostic expected because of it might be browser not windows
                 [|Target.SupportedOnWindows10()|];
                 Target.SupportedOnWindowsAndBrowser();
-                [|Target.SupportedOnWindows10AndBrowser()|]; // two diagnostic expected windows 10 and browser
+                [|Target.SupportedOnWindows10AndBrowser()|]; // two platforms expected windows 10 and browser
             }
 
            if (OperatingSystemHelper.IsWindowsVersionAtLeast(10) || OperatingSystemHelper.IsBrowser())
@@ -209,11 +209,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(15, 17).WithArguments("Target.SupportedOnWindowsAndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(16, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(24, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(48, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -232,55 +228,49 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (OperatingSystemHelper.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindows.FunctionSupportedOnWindows11();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
-                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
+                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];  // 'TypeUnsupportedOnBrowser' is unsupported on: 'browser', but this call site is reachable on all platforms.
+                [|unsupportedOnBrowser.FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11(); 
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11()|];
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|];
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|];
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()|];  // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()' is supported on: 'windows' from version 11.0 and later, but this call site is reachable on all platforms.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|];  // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()' is supported on: 'windows' from version 11.0 to 12.0, but this call site is reachable on all platforms.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()' is supported on: 'windows' from version 11.0 to 12.0, but this call site is reachable on all platforms.
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
+                [|unsupportedOnWindows.FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
-                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|];
-                [|unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13()|];
+                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|];  // 'TypeUnsupportedOnWindowsSupportedOnWindows11' is supported on: 'windows' from version 11.0 and later, but this call site is reachable on all platform
+                [|unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13()|];  // 'TypeUnsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13()' is supported on: 'windows' from version 11.0 to 12.0, but this call site is reachable on all platforms.
 
-                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|];
+                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // 'TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12' is supported on: 'windows' from version 11.0 to 12.0, but this call site is reachable on all platforms.
             }
         }
     }
 }" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(37, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(38, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(39, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(47, 64).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(48, 17).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(50, 86).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -298,30 +288,30 @@ namespace PlatformCompatDemo.SupportedUnupported
         {
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
-                var unsupported = new TypeWithoutAttributes();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows()|];
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnBrowser()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()|];
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser()|];
+                var typeWithoutAttributes = new TypeWithoutAttributes();
+                [|typeWithoutAttributes.FunctionUnsupportedOnWindows()|];  // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on all platforms.
+                [|typeWithoutAttributes.FunctionUnsupportedOnBrowser()|];  // 'TypeWithoutAttributes.FunctionUnsupportedOnBrowser()' is unsupported on: 'browser', but this call site is reachable on all platforms.
+                typeWithoutAttributes.FunctionUnsupportedOnWindows10();
+                [|typeWithoutAttributes.FunctionUnsupportedOnWindowsAndBrowser()|];   // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser', but this call site is reachable on all platforms.
+                [|typeWithoutAttributes.FunctionUnsupportedOnWindows10AndBrowser()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser', but this call site is reachable on all platforms.
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];  // 'TypeUnsupportedOnWindows.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', but this call site is reachable on all platforms.
 
                 var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10()|];
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|];   // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows', but this call site is reachable on all platforms.
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser', but this call site is reachable on all platforms.
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
-                [|unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser()|];
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11(); // We should ignore above version of unsupported if there is no supported in between
-                [|unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser()|];
+                [|unsupportedOnWindows10.FunctionUnsupportedOnBrowser()|];  // 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnBrowser()' is unsupported on: 'browser', but this call site is reachable on all platforms.
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11();    // We should ignore child unsupported version if parent versioin is lower
+                [|unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()|];  // 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'browser', but this call site is reachable on all platforms.
 
                 var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|];
-                [|unsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|];  // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser', but this call site is reachable on all platforms.
 
                 var unsupportedOnWindows10AndBrowser = [|new TypeUnsupportedOnWindows10AndBrowser()|];
-                [|unsupportedOnWindows10AndBrowser.TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()|];
             }
         }
 
@@ -330,34 +320,34 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10) && !OperatingSystemHelper.IsBrowser())
             {
                 var unsupported = new TypeWithoutAttributes();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnBrowser();
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser();
+                [|unsupported.FunctionUnsupportedOnWindows()|];  // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on all platforms.
+                unsupported.FunctionUnsupportedOnBrowser();
+                unsupported.FunctionUnsupportedOnWindows10();
+                [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|];
+                unsupported.FunctionUnsupportedOnWindows10AndBrowser();
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnBrowser()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11AndBrowser()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnBrowser()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()|];
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()|];
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10();
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|];
+                unsupportedOnBrowser.FunctionUnsupportedOnWindows10();
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser();
+                unsupportedOnWindows10.FunctionUnsupportedOnBrowser();
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11();
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser();
 
                 var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|];
-                [|unsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|];
 
                 var unsupportedOnWindows10AndBrowser = new TypeUnsupportedOnWindows10AndBrowser();
-                unsupportedOnWindows10AndBrowser.TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11();
+                unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11();
 
                 var unsupportedCombinations = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
             }
         }
 
@@ -366,34 +356,30 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindows.FunctionSupportedOnWindows11();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
             }
         }
     }
 }" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(17, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(24, 17).WithArguments("TypeUnsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(32, 54).WithArguments("TypeUnsupportedOnWindowsAndBrowser", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(33, 17).WithArguments("TypeUnsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()", "browser"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -423,7 +409,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
                 [|Target.UnsupportedInWindows()|]; // row 22 expected diagnostic - windows unsupported
                 Target.UnsupportedInWindows10();
                 [|Target.UnsupportedOnBrowser()|]; // expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected 2 diagnostics - windows and browser unsupported
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // e'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser', but this call site is reachable on all platforms.
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
             }
 
@@ -475,8 +461,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(25, 17).WithArguments("Target.UnsupportedOnWindowsAndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -495,7 +480,7 @@ class Test
         {
             Api();
         }
-        [|Api()|]; // two diagnostics expected
+        {|#0:Api()|]; // 'Test.Api()' is only supported on: 'ios' from version 12.0 to 14.0, but this call site is reachable on all platforms.
     }
 
     [SupportedOSPlatform(""ios12.0"")]
@@ -506,8 +491,8 @@ class Test
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(14, 9)
-                .WithArguments("Test.Api()", "ios", "14.0"));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithLocation(0)
+                .WithArguments("Test.Api()", "'ios' from version 12.0 to 14.0, but this call site is reachable on all platforms."));
         }
 
         [Fact]
@@ -977,14 +962,10 @@ class Test
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(0).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(0).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(1).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(1).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(2).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(2).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(3).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(3).WithArguments("Test.M2()", "Windows")
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithLocation(0).WithArguments("Test.M2()", "'Windows', 'Linux', but this call site is reachable on all platforms."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithLocation(1).WithArguments("Test.M2()", "'Windows', 'Linux', but this call site is reachable on all platforms."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithLocation(2).WithArguments("Test.M2()", "'Windows', 'Linux', but this call site is reachable on all platforms."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithLocation(3).WithArguments("Test.M2()", "'Windows', 'Linux', but this call site is reachable on all platforms.")
             );
         }
 
@@ -1021,6 +1002,7 @@ public class WindowsSpecificApis
         }
 
         [Fact]
+
         public async Task ReintroducingApiSupport_Guarded_NotWarn()
         {
             var source = @"
@@ -1038,7 +1020,7 @@ static class Program
         }
         else
         {
-            [|Some.WindowsSpecificApi()|]; // should show 2 diagnostic
+            {|#0:Some.WindowsSpecificApi()|}; // 'Some.WindowsSpecificApi()' is supported on: 'windows' from version 10.0 and later, but this call site is reachable on 'windows'.
         }
     }
 }
@@ -1054,8 +1036,8 @@ static class Some
 " + MockAttributesCsSource + MockOperatingSystemApiSource;
 
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(16, 13)
-                .WithArguments("Some.WindowsSpecificApi()", "windows", "10.0"));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(0)
+                .WithArguments("Some.WindowsSpecificApi()", "'windows' from version 10.0 and later, but this call site is reachable on 'windows'."));
         }
 
         [Fact]
@@ -3218,7 +3200,7 @@ class Test
         }
         else
         {
-            [|M2()|]; // Two diagnostics expected
+            [|M2()|]; // 'Test.M2()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004, but this call site is reachable on all platforms.
         }
     }
 
@@ -3230,8 +3212,7 @@ class Test
     }
 }"
 + MockAttributesCsSource + MockOperatingSystemApiSource;
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(16, 13).WithArguments("Test.M2()", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
 
             var vbSource = @"
 Imports System.Runtime.Versioning
@@ -3253,8 +3234,7 @@ Class Test
     End Sub
 End Class
 " + MockRuntimeApiSourceVb + MockAttributesVbSource;
-            await VerifyAnalyzerAsyncVb(vbSource, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(10, 13).WithArguments("Private Sub M2()", "Windows"));
+            await VerifyAnalyzerAsyncVb(vbSource, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -3778,157 +3758,157 @@ namespace PlatformCompatDemo.SupportedUnupported
     public class TypeWithoutAttributes
     {
         [UnsupportedOSPlatform(""windows"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows() { }
+        public void FunctionUnsupportedOnWindows() { }
 
         [UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows10.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows10() { }
+        public void FunctionUnsupportedOnWindows10() { }
 
         [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser() { }
+        public void FunctionUnsupportedOnWindowsAndBrowser() { }
 
         [UnsupportedOSPlatform(""windows10.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser() { }
+        public void FunctionUnsupportedOnWindows10AndBrowser() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
 
         [SupportedOSPlatform(""windows"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""windows10.0"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows10() { }
+        public void FunctionSupportedOnWindows10() { }
 
         [SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows""), SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindowsAndBrowser() { }
+        public void FunctionSupportedOnWindowsAndBrowser() { }
 
         [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser() { }
+        public void FunctionSupportedOnWindows10AndBrowser() { }
     }
 
     [UnsupportedOSPlatform(""windows"")]
     public class TypeUnsupportedOnWindows {
         [UnsupportedOSPlatform(""browser"")] // more restrictive should be OK
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11AndBrowser() { }
+        public void FunctionUnsupportedOnWindows11AndBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12() { }
+        public void FunctionSupportedOnWindows11UnsupportedOnWindows12() { }
 
         [SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
     }
 
     [UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnBrowser
     {
         [UnsupportedOSPlatform(""windows"")] // more restrictive should be OK
-        public void TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows() { }
+        public void FunctionUnsupportedOnWindows() { }
 
         [UnsupportedOSPlatform(""windows10.0"")] // more restrictive should be OK
-        public void TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10() { }
+        public void FunctionUnsupportedOnWindows10() { }
         
         [SupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
         }
 
     [UnsupportedOSPlatform(""windows10.0"")]
     public class TypeUnsupportedOnWindows10
     {
         [UnsupportedOSPlatform(""browser"")] // more restrictive should be OK
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser() { }
+        public void FunctionUnsupportedOnWindows11AndBrowser() { }
     }
 
     [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnWindowsAndBrowser
     {
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
     }
 
     [UnsupportedOSPlatform(""windows10.0""), UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnWindows10AndBrowser
     {
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
     }
 
     [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
     public class TypeUnsupportedOnWindowsSupportedOnWindows11
     {
         [UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12() { }
+        public void FunctionUnsupportedOnWindows12() { }
 
         [UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionUnsupportedOnWindows12SupportedOnWindows13() { }
     }
 
     [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
     public class TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12
     {
         [SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13() { }
+        public void FunctionSupportedOnWindows13() { }
     }
     [SupportedOSPlatform(""windows"")]
     public class TypeSupportedOnWindows {
         [SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindows_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows_FunctionSupportedOnWindows11AndBrowser() { }
+        public void FunctionSupportedOnWindows11AndBrowser() { }
     }
     [SupportedOSPlatform(""browser"")]
     public class TypeSupportedOnBrowser
     {
         [SupportedOSPlatform(""windows"")]
-        public void TypeSupportedOnBrowser_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""windows11.0"")]
-        public void TypeSupportedOnBrowser_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
     }
 
     [SupportedOSPlatform(""windows10.0"")]
     public class TypeSupportedOnWindows10
     {
         [SupportedOSPlatform(""windows"")] // less restrictive should be OK
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows10_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows11AndBrowser() { }
+        public void FunctionSupportedOnWindows11AndBrowser() { }
     }
 
 
@@ -3936,14 +3916,14 @@ namespace PlatformCompatDemo.SupportedUnupported
     public class TypeSupportedOnWindowsAndBrowser
     {
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
     }
 
     [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]
     public class TypeSupportedOnWindows10AndBrowser
     {
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindows10AndBrowser_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
     }
 }
 ";

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1090,8 +1090,8 @@ static class Program
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 3 diagnostics expected
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows', but this call site is reachable on all platforms.
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];          // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is only supported on: 'tvos' 4.0 and later, but this call site is reachable on all platforms.
         UnsupportedOnBrowserType.SupportedOnBrowser();
     }
 }
@@ -1108,10 +1108,7 @@ class UnsupportedOnBrowserType
     public static void SupportedOnTvos4() {}
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(7, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "ios"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(7, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "tvos"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact, WorkItem(4168, "https://github.com/dotnet/roslyn-analyzers/issues/4168")]
@@ -1125,10 +1122,10 @@ static class Program
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 3 diagnostics expected
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'windows', 'ios', 'tvos', but this call site is reachable on all platforms.
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];  // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is only supported on: 'tvos' 4.0 and later, but this call site is reachable on all platforms.
         UnsupportedOnBrowserType.SupportedOnBrowser(); // child support ignored (should not extend)
-        UnsupportedOnBrowserType.UnsupportedOnBrowser();
+        UnsupportedOnBrowserType.UnsupportedOnBrowser1_0();
     }
 }
 
@@ -1137,10 +1134,10 @@ static class Program2
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 4 diagnostics expected
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'windows', 'ios', 'tvos', but this call site is reachable on 'browser'.
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];      // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser', but this call site is reachable on 'browser'.
         [|UnsupportedOnBrowserType.SupportedOnBrowser()|];    // only warns for parent attribute
-        [|UnsupportedOnBrowserType.UnsupportedOnBrowser()|];
+        [|UnsupportedOnBrowserType.UnsupportedOnBrowser1_0()|];
     }
 }
 
@@ -1151,9 +1148,9 @@ static class Program3
     public static void Main()
     {
         UnsupportedOnBrowserType.SupportedOnWindowsIosTvos(); // No diagnostics expected
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];  // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is only supported on: 'tvos' 4.0 and later, but this call site is reachable on 'windows'.
         UnsupportedOnBrowserType.SupportedOnBrowser();
-        UnsupportedOnBrowserType.UnsupportedOnBrowser();
+        UnsupportedOnBrowserType.UnsupportedOnBrowser1_0();
     }
 }
 
@@ -1167,23 +1164,12 @@ class UnsupportedOnBrowserType
     [SupportedOSPlatform(""browser2.0"")] 
     public static void SupportedOnBrowser() {}
     [UnsupportedOSPlatform(""browser1.0"")] 
-    public static void UnsupportedOnBrowser() {}
+    public static void UnsupportedOnBrowser1_0() {}
     [SupportedOSPlatform(""tvos4.0"")]    
     public static void SupportedOnTvos4() {}
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(9, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "ios"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(9, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "tvos"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(21, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "browser"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(21, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "ios"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(21, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()", "tvos"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(22, 9)
-                    .WithArguments("UnsupportedOnBrowserType.SupportedOnTvos4()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact, WorkItem(4168, "https://github.com/dotnet/roslyn-analyzers/issues/4168")]
@@ -1198,7 +1184,7 @@ static class Program
     public static void Main()
     {
         [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // One diagnostics expected only for parent
-        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|];   // Same here
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|];   // 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()' is only supported on: 'windows', but this call site is reachable on all platforms.
     }
 }
 
@@ -1207,7 +1193,7 @@ static class Program2
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // 2 diagnostics expected only for parent
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()' is unsupported on: 'browser', but this call site is reachable on 'browser'.
         [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|]; // Same here 
     }
 }
@@ -1233,10 +1219,7 @@ class UnsupportedOnBrowserSupportedOnWindowType
     public static void SupportedOnTvos4() {}
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(19, 9).
-                WithArguments("UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(20, 9).
-                WithArguments("UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -1378,16 +1361,16 @@ namespace CallerSupportsSubsetOfTarget
         [UnsupportedOSPlatform(""browser"")]
         public static void TestWithBrowserUnsupported()
         {
-            [|Target.SupportedOnWindows()|];
-            [|Target.SupportedOnBrowser()|];
-            [|Target.SupportedOnWindowsAndBrowser()|]; // two diagnostics expected
-            [|Target.SupportedOnWindowsAndUnsupportedOnBrowser()|];
+            [|Target.SupportedOnWindows()|];  // 'Target.SupportedOnWindows()' is only supported on: 'windows', but this call site is reachable on all platforms.
+            [|Target.SupportedOnBrowser()|];  // 'Target.SupportedOnBrowser()' is only supported on: 'browser', but this call site is unreachable on 'browser'.
+            [|Target.SupportedOnWindowsAndBrowser()|]; // 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows', but this call site is unreachable on 'browser'.
+            [|Target.SupportedOnWindowsAndUnsupportedOnBrowser()|]; // 'Target.SupportedOnWindowsAndUnsupportedOnBrowser()' is only supported on: 'windows', but this call site is reachable on all platforms.
 
-            [|Target.UnsupportedOnWindows()|];
-            [|Target.UnsupportedOnWindows11()|];
+            [|Target.UnsupportedOnWindows()|];   // Target.UnsupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on all platforms.
+            [|Target.UnsupportedOnWindows11()|]; // 'Target.UnsupportedOnWindows11()' is unsupported on: 'windows' from version 11.0 and later, but this call site is reachable on all platforms.
             Target.UnsupportedOnBrowser();
-            [|Target.UnsupportedOnWindowsAndBrowser()|];
-            [|Target.UnsupportedOnWindowsUntilWindows11()|];
+            [|Target.UnsupportedOnWindowsAndBrowser()|];     // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', but this call site is reachable on all platforms.
+            [|Target.UnsupportedOnWindowsUntilWindows11()|]; // 'Target.UnsupportedOnWindowsUntilWindows11()' is only supported on: 'windows' 11.0 and later, but this call site is reachable on all platforms.
         }
     }
 
@@ -1422,8 +1405,7 @@ namespace CallerSupportsSubsetOfTarget
     }
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(13, 13)
-                    .WithArguments("Target.SupportedOnWindowsAndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -1439,23 +1421,23 @@ namespace CallerSupportsSubsetOfTarget
         [SupportedOSPlatform(""windows""), SupportedOSPlatform(""browser"")]
         public static void TestWithWindowsAndBrowserSupported()
         {
-            [|Target.SupportedOnWindows()|];
-            [|Target.SupportedOnBrowser()|];
+            [|Target.SupportedOnWindows()|];  // 'Target.SupportedOnWindows()' is only supported on: 'windows', but this call site is reachable on 'windows', 'browser'.
+            [|Target.SupportedOnBrowser()|];  // 'Target.SupportedOnBrowser()' is only supported on: 'browser', but this call site is reachable on 'windows', 'browser'.
             Target.SupportedOnWindowsAndBrowser();
 
-            [|Target.UnsupportedOnWindows()|];
+            [|Target.UnsupportedOnWindows()|];  // 'Target.UnsupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on 'windows', 'browser'.
             [|Target.UnsupportedOnBrowser()|];
-            [|Target.UnsupportedOnWindowsAndBrowser()|];
+            [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser', but this call site is reachable on 'windows', 'browser'.
         }
         [UnsupportedOSPlatform(""browser"")]
         public static void TestWithBrowserUnsupported()
         {
-            [|Target.SupportedOnWindows()|];
-            [|Target.SupportedOnBrowser()|];
-            [|Target.SupportedOnWindowsAndBrowser()|];
+            [|Target.SupportedOnWindows()|];  // 'Target.SupportedOnWindows()' is only supported on: 'windows', but this call site is reachable on all platforms.
+            [|Target.SupportedOnBrowser()|];  // 'Target.SupportedOnBrowser()' is only supported on: 'browser', but this call site is unreachable on 'browser'.
+            [|Target.SupportedOnWindowsAndBrowser()|]; // 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows', but this call site is unreachable on 'browser'.
 
-            Target.UnsupportedOnWindows(); // if call site has now support of it and MSbuild list not containg the platform name it will not be warned
-            Target.UnsupportedOnBrowser();
+            Target.UnsupportedOnWindows();  // if call site has now support of it and MSbuild list not containg the platform name it will not be warned
+            Target.UnsupportedOnBrowser(); 
             Target.UnsupportedOnWindowsAndBrowser(); // same here
         }
     }
@@ -1482,10 +1464,7 @@ namespace CallerSupportsSubsetOfTarget
     }
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(17, 13)
-                    .WithArguments("Target.UnsupportedOnWindowsAndBrowser()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(24, 13).
-                    WithArguments("Target.SupportedOnWindowsAndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -1498,8 +1477,8 @@ static class Program
 {
     public static void Main()
     {
-        [|Some.Api1()|]; // 2 diagnostics
-        [|Some.Api2()|]; // One suppressed by unsupport
+        [|Some.Api1()|]; // 'Some.Api1()' is only supported on: 'ios' 10.0 and later, 'tvos' 4.0 and later, but this call site is reachable on all platforms.
+        [|Some.Api2()|]; // 'Some.Api2()' is only supported on: 'ios' 10.0 and later, but this call site is reachable on all platforms.
     }
 }
 
@@ -1509,12 +1488,11 @@ class Some
 {
     public static void Api1() {}
 
-    [UnsupportedOSPlatform(""tvos"")] // Not ignored
+    [UnsupportedOSPlatform(""tvos"")] // tvos suppressed, only warn for ios10.0
     public static void Api2() {}
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule)
-                .WithLocation(8, 9).WithArguments("Some.Api1()", "ios", "10.0"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -1530,21 +1508,21 @@ namespace PlatformCompatDemo.Bugs
         [SupportedOSPlatform(""windows"")]
         public void TestSupportedOnWindows()
         {
-            [|TargetSupportedOnWindows.FunctionUnsupportedOnWindows()|]; // should warn for unsupported windows
+            [|TargetSupportedOnWindows.FunctionUnsupportedOnWindows()|]; // 'TargetSupportedOnWindows.FunctionUnsupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on 'windows'.
             TargetSupportedOnWindows.FunctionUnsupportedOnBrowser();     // browser unsupport not related so ignored
 
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnWindows()|]; // Should warn only for unsupported type
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|]; // should warn for unsupported windows and browser support                                   
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnWindows()|]; // 'TargetUnsupportedOnWindows.FunctionSupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on 'windows'
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|]; // 'TargetUnsupportedOnWindows.FunctionSupportedOnWindows()' is unsupported on: 'windows', but this call site is reachable on 'windows'                                   
         }
 
         [UnsupportedOSPlatform(""windows"")]
         public void TestUnsupportedOnWindows()
         {
             TargetSupportedOnWindows.FunctionUnsupportedOnWindows();
-            [|TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()|];  // should warn supported on windows ignore unsupported on browser as this is allow list
+            [|TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()|];  // 'TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()' is only supported on: 'windows', but this call site is unreachable on 'windows'.
 
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|];  // should warn supported on browser 
-            TargetUnsupportedOnWindows.FunctionSupportedOnWindows();      // it's unsupporting Windows at the call site, so it should warn for windows support on the API
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|];  // 'TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()' is only supported on: 'browser', but this call site is reachable on all platforms.
+            TargetUnsupportedOnWindows.FunctionSupportedOnWindows();      // Function supported will be ignored as cannot widen the support
         }                                                                 
     }
 
@@ -1569,8 +1547,7 @@ namespace PlatformCompatDemo.Bugs
     }
 }
 " + MockAttributesCsSource;
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(15, 13)
-                    .WithArguments("TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -1750,8 +1727,8 @@ static class Some
                 }
             }
 " + MockAttributesCsSource;
-            await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithSpan(10, 21, 10, 29).WithArguments("M2", "Windows", "10.1.2.3"));
+            await VerifyCS.VerifyAnalyzerAsync(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).
+                WithSpan(10, 21, 10, 29).WithArguments("M2", "Windows", "10.1.2.3"));
         }
 
         public static IEnumerable<object[]> SupportedOsAttributeTestData()
@@ -1777,6 +1754,7 @@ static class Some
         [MemberData(nameof(SupportedOsAttributeTestData))]
         public async Task MethodOfOsDependentClassSuppressedWithSupportedOsAttribute(string dependentVersion, string suppressingVersion, bool warn)
         {
+            var invokeMethod = warn ? "[|OsDependentClass.M2()|]" : "OsDependentClass.M2()";
             var source = @"
 using System.Runtime.Versioning;
 
@@ -1785,30 +1763,20 @@ public class Test
     [SupportedOSPlatform(""" + suppressingVersion + @""")]
     public void M1()
     {
-        OsDependentClass odc = new OsDependentClass();
-        odc.M2();
+        " + invokeMethod + @";
     }
 }
 
 [SupportedOSPlatform(""" + dependentVersion + @""")]
 public class OsDependentClass
 {
-    public void M2()
+    public static void M2()
     {
     }
 }
 " + MockAttributesCsSource;
 
-            if (warn)
-            {
-                await VerifyAnalyzerAsyncCs(source,
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithSpan(9, 32, 9, 54).WithArguments("OsDependentClass", "Windows", "10.1.2.3"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithSpan(10, 9, 10, 17).WithArguments("OsDependentClass.M2()", "Windows", "10.1.2.3"));
-            }
-            else
-            {
-                await VerifyAnalyzerAsyncCs(source);
-            }
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         public static IEnumerable<object[]> UnsupportedAttributeTestData()
@@ -1830,39 +1798,24 @@ public class OsDependentClass
         [MemberData(nameof(UnsupportedAttributeTestData))]
         public async Task MethodOfOsDependentClassSuppressedWithUnsupportedAttribute(string dependentVersion, string suppressingVersion, bool warn)
         {
+            var invokeConstructor = warn ? "[|new OsDependentClass()|]" : "new OsDependentClass()";
             var source = @"
  using System.Runtime.Versioning;
  
-[SupportedOSPlatform(""Windows"")]
 [UnsupportedOSPlatform(""" + suppressingVersion + @""")]
 public class Test
 {
     public void M1()
     {
-        OsDependentClass odc = new OsDependentClass();
-        odc.M2();
+        OsDependentClass odc = " + invokeConstructor + @";
     }
 }
 
 [UnsupportedOSPlatform(""" + dependentVersion + @""")]
-public class OsDependentClass
-{
-    public void M2()
-    {
-    }
-}
+public class OsDependentClass { }
 " + MockAttributesCsSource;
 
-            if (warn)
-            {
-                await VerifyAnalyzerAsyncCs(source,
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(10, 32).WithArguments("OsDependentClass", "Windows", "10.1.2.3"),
-                    VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(11, 9).WithArguments("OsDependentClass.M2()", "Windows", "10.1.2.3"));
-            }
-            else
-            {
-                await VerifyAnalyzerAsyncCs(source);
-            }
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -1878,8 +1831,8 @@ public class Test
     {
         var obj = new C();
         obj.BrowserMethod();
-        C.StaticClass.LinuxMethod();
-        C.StaticClass.LinuxVersionedMethod();
+        [|C.StaticClass.LinuxMethod()|];  // 'C.StaticClass.LinuxMethod()' is unsupported on: 'linux', but this call site is reachable on 'Linux'.
+        [|C.StaticClass.LinuxVersionedMethod()|]; // 'C.StaticClass.LinuxVersionedMethod()' is unsupported on: 'linux' from version 4.8 and later, but this call site is reachable on 'Linux'.
     }
 }
 
@@ -1903,15 +1856,12 @@ public class C
 }
 " + MockAttributesCsSource;
 
-            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).
-                WithLocation(11, 9).WithArguments("C.StaticClass.LinuxMethod()", "linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).
-                WithLocation(12, 9).WithArguments("C.StaticClass.LinuxVersionedMethod()", "linux", "4.8"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
 
-        public async Task MultipleAttrbiutesOptionallySupportedListTest()
+        public async Task OptionallySupportedListDifferentCallsitesTest()
         {
             var source = @"
  using System.Runtime.Versioning;
@@ -1929,8 +1879,7 @@ public class Test
     [UnsupportedOSPlatform(""windows10.0.2000"")]
     public void SupporteWindows()
     {
-        // Warns for UnsupportedFirst, Supported
-        obj.DoesNotWorkOnWindows(); 
+        obj.DoesNotWorkOnWindows();  // 'C.DoesNotWorkOnWindows()' is supported on: 'windows' from version 10.0.1903 and later, but this call site is reachable on 'windows' 10.0.2000 and before.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -1943,14 +1892,14 @@ public class Test
     
     public void AllSupportedWarnForAll()
     {
-        obj.DoesNotWorkOnWindows();
+        obj.DoesNotWorkOnWindows();  // 'C.DoesNotWorkOnWindows()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004, but this call site is reachable on all platforms.
     }
 
     [SupportedOSPlatform(""windows10.0.2000"")]
     public void SupportedFromWindows10_0_2000()
     {
         // Should warn for [UnsupportedOSPlatform]
-        obj.DoesNotWorkOnWindows();
+        obj.DoesNotWorkOnWindows();  // 'C.DoesNotWorkOnWindows()' is unsupported on: 'windows' from version 10.0.2004 and later, but this call site is reachable on 'windows' 10.0.2000 and later.
     }
 
     [SupportedOSPlatform(""windows10.0.1904"")]
@@ -1973,16 +1922,17 @@ public class C
 }
 " + MockAttributesCsSource;
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(18, 9).WithArguments("C.DoesNotWorkOnWindows()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(18, 9).WithArguments("C.DoesNotWorkOnWindows()", "windows", "10.0.1903"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(31, 9).WithArguments("C.DoesNotWorkOnWindows()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(31, 9).WithArguments("C.DoesNotWorkOnWindows()", "windows", "10.0.1903"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(38, 9).WithArguments("C.DoesNotWorkOnWindows()", "windows", "10.0.2004"));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithSpan(17, 9, 17, 35).
+                WithArguments("C.DoesNotWorkOnWindows()", "'windows' from version 10.0.1903 and later, but this call site is reachable on 'windows' 10.0.2000 and before."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithSpan(30, 9, 30, 35).
+                WithArguments("C.DoesNotWorkOnWindows()", "'windows' from version 10.0.1903 to 10.0.2004, but this call site is reachable on all platforms."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithSpan(37, 9, 37, 35).
+                WithArguments("C.DoesNotWorkOnWindows()", "'windows' from version 10.0.2004 and later, but this call site is reachable on 'windows' 10.0.2000 and later."));
         }
 
         [Fact]
 
-        public async Task MultipleAttrbiutesSupportedOnlyWindowsListTest()
+        public async Task SupportedOnlyOnWindowsListWithDifferentCallsitesTest()
         {
             var source = @"
  using System.Runtime.Versioning;
@@ -1993,7 +1943,7 @@ public class Test
     [SupportedOSPlatform(""Linux"")]
     public void DiffferentOsWarnsForAll()
     {
-        obj.WindowsOnlyMethod();
+        obj.WindowsOnlyMethod();  // 'C.WindowsOnlyMethod()' is only supported on: 'windows' 10.0.2004 and before, but this call site is reachable on 'Linux'.
     }
 
     [SupportedOSPlatform(""windows"")]
@@ -2005,14 +1955,14 @@ public class Test
     
     public void AllSupportedWarnForAll()
     {
-        obj.WindowsOnlyMethod();
+        obj.WindowsOnlyMethod();  // 'C.WindowsOnlyMethod()' is only supported on: 'windows' 10.0.2004 and before, but this call site is reachable on all platforms.
     }
 
     [SupportedOSPlatform(""windows10.0.2000"")]
     public void SupportedFromWindows10_0_2000()
     {
         // Warns for [UnsupportedOSPlatform]
-        obj.WindowsOnlyMethod();
+        obj.WindowsOnlyMethod();  // 'C.WindowsOnlyMethod()' is unsupported on: 'windows' from version 10.0.2004 and later, but this call site is reachable on 'windows' 10.0.2000 and later.
     }
     
     [SupportedOSPlatform(""windows10.0.1904"")]
@@ -2034,11 +1984,12 @@ public class C
 }
 " + MockAttributesCsSource;
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(10, 9).WithArguments("C.WindowsOnlyMethod()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(10, 9).WithArguments("C.WindowsOnlyMethod()", "windows", "10.0.2004"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(22, 9).WithArguments("C.WindowsOnlyMethod()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(22, 9).WithArguments("C.WindowsOnlyMethod()", "windows", "10.0.2004"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(29, 9).WithArguments("C.WindowsOnlyMethod()", "windows", "10.0.2004"));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithSpan(10, 9, 10, 32).
+                WithArguments("C.WindowsOnlyMethod()", "'windows' 10.0.2004 and before, but this call site is reachable on 'Linux'."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedOsRule).WithSpan(22, 9, 22, 32).
+                WithArguments("C.WindowsOnlyMethod()", "'windows' 10.0.2004 and before, but this call site is reachable on all platforms."),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithSpan(29, 9, 29, 32).
+                WithArguments("C.WindowsOnlyMethod()", "'windows' from version 10.0.2004 and later, but this call site is reachable on 'windows' 10.0.2000 and later."));
         }
 
         [Fact]
@@ -2054,84 +2005,81 @@ namespace PlatformCompatDemo.SupportedUnupported
         public static void Supported()
         {
             var supported = new TypeWithoutAttributes();
-            [|supported.TypeWithoutAttributes_FunctionSupportedOnWindows()|];
-            [|supported.TypeWithoutAttributes_FunctionSupportedOnWindows10()|];
-            [|supported.TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser()|];
+            [|supported.FunctionSupportedOnWindows()|];
+            [|supported.FunctionSupportedOnWindows10()|];
+            [|supported.FunctionSupportedOnWindows10AndBrowser()|];
 
             var supportedOnWindows = [|new TypeSupportedOnWindows()|];
-            [|supportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnBrowser()|]; // browser support ignored
-            [|supportedOnWindows.TypeSupportedOnWindows_FunctionSupportedOnWindows11AndBrowser()|];
+            [|supportedOnWindows.FunctionSupportedOnBrowser()|]; // browser support ignored
+            [|supportedOnWindows.FunctionSupportedOnWindows11AndBrowser()|];
 
             var supportedOnBrowser = [|new TypeSupportedOnBrowser()|];
-            [|supportedOnBrowser.TypeSupportedOnBrowser_FunctionSupportedOnWindows()|];
+            [|supportedOnBrowser.FunctionSupportedOnWindows()|];
 
             var supportedOnWindows10 = [|new TypeSupportedOnWindows10()|];
-            [|supportedOnWindows10.TypeSupportedOnWindows10_FunctionSupportedOnBrowser()|]; // child function support will be ignored
+            [|supportedOnWindows10.FunctionSupportedOnBrowser()|]; // child function support will be ignored
 
             var supportedOnWindowsAndBrowser = [|new TypeSupportedOnWindowsAndBrowser()|];
-            [|supportedOnWindowsAndBrowser.TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11()|];
+            [|supportedOnWindowsAndBrowser.FunctionSupportedOnWindows11()|];
         }
 
         public static void Unsupported()
         {
             var unsupported = new TypeWithoutAttributes();
-            unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows();
-            unsupported.TypeWithoutAttributes_FunctionUnsupportedOnBrowser();
-            unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10();
-            unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser();
-            unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser();
+            unsupported.FunctionUnsupportedOnWindows();
+            unsupported.FunctionUnsupportedOnBrowser();
+            unsupported.FunctionUnsupportedOnWindows10();
+            unsupported.FunctionUnsupportedOnWindowsAndBrowser();
+            unsupported.FunctionUnsupportedOnWindows10AndBrowser();
 
             var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnBrowser();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11AndBrowser();
+            unsupportedOnWindows.FunctionUnsupportedOnBrowser();
+            unsupportedOnWindows.FunctionUnsupportedOnWindows11();
+            unsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser();
 
             var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-            unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows();
-            unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10();
+            unsupportedOnBrowser.FunctionUnsupportedOnWindows();
+            unsupportedOnBrowser.FunctionUnsupportedOnWindows10();
 
             var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
-            unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser();
-            unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11();
-            unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser();
+            unsupportedOnWindows10.FunctionUnsupportedOnBrowser();
+            unsupportedOnWindows10.FunctionUnsupportedOnWindows11();
+            unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser();
 
             var unsupportedOnWindowsAndBrowser = new TypeUnsupportedOnWindowsAndBrowser();
-            unsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11();
+            unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11();
 
             var unsupportedOnWindows10AndBrowser = new TypeUnsupportedOnWindows10AndBrowser();
-            unsupportedOnWindows10AndBrowser.TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11();
+            unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11();
         }
 
         public static void UnsupportedCombinations() // no any diagnostics as it is deny list
         {
             var withoutAttributes = new TypeWithoutAttributes();
-            withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11();
-            withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-            withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+            withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
+            withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
+            withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
             var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12();
-            unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+            unsupportedOnWindows.FunctionSupportedOnWindows11();
+            unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
+            unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
             var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-            unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+            unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
             var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11();
-            unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
-            unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13();
+            unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12();
+            unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13();
 
             var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-            unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13();
+            unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
         }
     }
 }
 " + TargetTypesForTest + MockAttributesCsSource;
 
-            await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(13, 13).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(25, 48).WithArguments("TypeSupportedOnWindowsAndBrowser", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(26, 13).WithArguments("TypeSupportedOnWindowsAndBrowser.TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         private static VerifyCS.Test PopulateTestCs(string sourceCode, params DiagnosticResult[] expected)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4021

Proposed messaging changes include:

List | Api attributes | Call site attribute | Existing Message | Ptoposed Message
-- | -- | -- | -- | --
Allow list | [SupportedOSPlatform("windows")] | No attribute | 'API' is supported on 'windows' | 'API' is only supported on: 'windows', but this call site is reachable on all platforms.
Allow list | [SupportedOSPlatform("windows")] | [UnsupportedOSPlatform("windows")] | 'API' is supported on 'windows' | 'API' is only supported on: 'windows', but this call site is is unreachable on 'windows'.
Allow list | [SupportedOSPlatform("windows")]  [SupportedOSPlatform("ios14.0")] | [SupportedOSPlatform("android")] [SupportedOSPlatform("linux")] | 2 warnings for each support  | 'API' is only supported on: 'windows', 'ios' 14.0 and later, but this call site is reachable on: 'linux', 'android'.
Allow list | [SupportedOSPlatform("windows")] [UnsupportedOSPlatform("windows10.0")] | no attribute | 'API' is unsupported on 'windows' 10.0 and later | 'API' is unsupported on: 'windows' from version 10.0 and later, but this call site is reachable on all platforms.
Allow list | [SupportedOSPlatform("windows10.0")] [UnsupportedOSPlatform("windows12.0")] | [SupportedOSPlatform("windows")] | 2 warnings for support and unsupported | 'API' is only supported on: 'windows' from version 10.0 to 12.0, but this call site is reachable on 'windows'.
Deny list | [UnsupportedOSPlatform("windows")] [SupportedOSPlatform("windows10.0")] | No Attribute | 'API' is supported on 'windows' 10.0 and later | 'API' is supported on: 'windows' from version 10.0 and later, but this call site is reachable on all platforms.
Deny list | [UnsupportedOSPlatform("windows")] | [SupportedOSPlatform("windows")] | 'API' is unsupported on 'windows' | 'API' is unsupported on: 'windows', but this call site is reachable on 'windows'.
Deny list | [UnsupportedOSPlatform("windows")] [SupportedOSPlatform("windows10.0")] [UnsupportedOSPlatform("windows12.0")] |  No attributes | 2 warnings for unsupported and supported | 'API' is supported on: 'windows' from version 10.0 to 12.0, but this call site is reachable on all platforms.

cc @jeffhandley @terrajobst @stephentoub 