### PR TITLE
Warn for platform specific type used as generic type parameter

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -535,7 +535,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private static void ReportDiagnostics(IOperation operation, SmallDictionary<string, PlatformAttributes> attributes,
             OperationBlockAnalysisContext context, ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
         {
-            var symbol = operation is IObjectCreationOperation creation ? creation.Constructor.ContainingType : GetOperationSymbol(operation);
+            var symbol = GetOperationSymbol(operation);
 
             if (symbol == null)
             {
@@ -546,8 +546,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 symbol = GetAccessorMethod(platformSpecificMembers, symbol, GetPropertyAccessors(property, operation));
             }
-
-            if (symbol is IEventSymbol iEvent)
+            else if (symbol is IEventSymbol iEvent)
             {
                 var accessor = GetEventAccessor(iEvent, operation);
                 if (accessor != null)
@@ -555,6 +554,31 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     symbol = accessor;
                 }
             }
+            else if (symbol is IMethodSymbol method)
+            {
+                var typeArguments = method.TypeArguments;
+                if (!method.IsGenericMethod && method.ReceiverType is INamedTypeSymbol namedType && namedType.IsGenericType)
+                {
+                    typeArguments = namedType.TypeArguments;
+                }
+
+                foreach (var typeArgument in typeArguments)
+                {
+                    if (platformSpecificMembers.TryGetValue(typeArgument, out var foundAttributes) &&
+                        foundAttributes != null &&
+                        foundAttributes.Any())
+                    {
+                        symbol = typeArgument;
+                        break;
+                    }
+                }
+            }
+
+            if (operation is IObjectCreationOperation creation && symbol is not ITypeSymbol)
+            {
+                symbol = creation.Constructor.ContainingType;
+            }
+
             var operationName = symbol.ToDisplayString(GetLanguageSpecificFormat(operation));
 
             foreach (var platformName in attributes.Keys)
@@ -691,6 +715,23 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             else
             {
                 CheckOperationAttributes(operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms, symbol);
+                if (symbol is IMethodSymbol method)
+                {
+                    if (method.IsGenericMethod)
+                    {
+                        foreach (var typeArgument in method.TypeArguments)
+                        {
+                            CheckOperationAttributes(operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms, typeArgument);
+                        }
+                    }
+                    else if (method.ReceiverType is INamedTypeSymbol namedType && namedType.IsGenericType)
+                    {
+                        foreach (var typeArgument in namedType.TypeArguments)
+                        {
+                            CheckOperationAttributes(operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms, typeArgument);
+                        }
+                    }
+                }
             }
 
             static void CheckOperationAttributes(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<IOperation,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -60,6 +60,42 @@ class Test
         }
 
         [Fact]
+        public async Task MethodsWithOsDependentTypeParameterGuarded()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+class WindowsOnlyType {}
+
+class GenericClass<T> {}
+
+public class Test
+{
+    void GenericMethod<T>() {}
+    void GenericMethod2<T1, T2>() {}
+    void M1()
+    {
+        if (OperatingSystemHelper.IsWindows())
+        {
+            GenericMethod<WindowsOnlyType>();
+            GenericMethod2<Test, WindowsOnlyType>();
+            GenericClass<WindowsOnlyType> obj = new GenericClass<WindowsOnlyType>();
+        }
+        else
+        {
+            [|GenericMethod<WindowsOnlyType>()|];
+            [|GenericMethod2<Test, WindowsOnlyType>()|];
+            GenericClass<WindowsOnlyType> obj = [|new GenericClass<WindowsOnlyType>()|];
+        }
+    }
+}
+" + MockAttributesCsSource + MockOperatingSystemApiSource;
+            await VerifyAnalyzerAsyncCs(csSource, s_msBuildPlatforms);
+        }
+
+        [Fact]
         public async Task SupportedUnsupportedRange_GuardedWithOr()
         {
             var source = @"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -135,6 +135,7 @@ namespace CallerTargetsBelow5_0
         public async Task MethodsWithOsDependentTypeParameterWarns()
         {
             var csSource = @"
+using System;
 using System.Runtime.Versioning;
 
 [SupportedOSPlatform(""windows"")]
@@ -148,6 +149,7 @@ public class Test
     {
         [|GenericMethod<WindowsOnlyType>()|];
         [|GenericMethod2<Test, WindowsOnlyType>()|];
+        [|GenericMethod<Action<WindowsOnlyType>>()|];
     }
 }
 " + MockAttributesCsSource;
@@ -173,6 +175,35 @@ public class Test
     {
         GenericClass<WindowsOnlyType> obj = [|new GenericClass<WindowsOnlyType>()|];
         MethodWithGenericParameter([|new GenericClass<WindowsOnlyType>()|]);
+    }
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task ApiContainingTypeHasOsDependentTypeParameterWarns()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+class WindowsOnlyType {}
+
+class GenericClass<T>
+{
+    public static void M<V>() { }
+    public static void M2() {}
+}
+
+public class Test
+{
+    void M1()
+    {
+        [|GenericClass<WindowsOnlyType>.M<int>()|];
+        [|GenericClass<WindowsOnlyType>.M2()|];
+        [|GenericClass<Action<WindowsOnlyType>>.M2()|];
     }
 }
 " + MockAttributesCsSource;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -132,6 +132,54 @@ namespace CallerTargetsBelow5_0
         }
 
         [Fact]
+        public async Task MethodsWithOsDependentTypeParameterWarns()
+        {
+            var csSource = @"
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+class WindowsOnlyType {}
+
+public class Test
+{
+    void GenericMethod<T>() {}
+    void GenericMethod2<T1, T2>() {}
+    void M1()
+    {
+        [|GenericMethod<WindowsOnlyType>()|];
+        [|GenericMethod2<Test, WindowsOnlyType>()|];
+    }
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task ConstructorWithOsDependentTypeParameterWarns()
+        {
+            var csSource = @"
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+class WindowsOnlyType {}
+
+class GenericClass<T> {}
+
+public class Test
+{
+    void MethodWithGenericParameter(GenericClass<WindowsOnlyType> a) {}
+
+    void M1()
+    {
+        GenericClass<WindowsOnlyType> obj = [|new GenericClass<WindowsOnlyType>()|];
+        MethodWithGenericParameter([|new GenericClass<WindowsOnlyType>()|]);
+    }
+}
+" + MockAttributesCsSource;
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
         public async Task OsDependentMethodsCalledWarns()
         {
             var csSource = @"


### PR DESCRIPTION
Warn when platform-specific type used as generic type parameter, useful when a type created using reflections

Fixes https://github.com/dotnet/roslyn-analyzers/issues/4362