### PR TITLE
Update repo docs for released Microsoft.CodeAnalysis.NetAnalyzers 5.0.0 NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Microsoft created a set of analyzers called [Microsoft.CodeAnalysis.FxCopAnalyze
 
 ### Microsoft.CodeAnalysis.NetAnalyzers
 
-*Latest stable version:* _Not yet released_
+*Latest stable version:* [![NuGet](https://img.shields.io/nuget/v/Microsoft.CodeAnalysis.NetAnalyzers.svg)](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers)
 
-*Latest pre-release version:* [here](https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet5&view=overview&package=Microsoft.CodeAnalysis.NetAnalyzers&protocolType=NuGet)
+*Latest pre-release version (.NET6 analyzers):* [here](https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet6&package=Microsoft.CodeAnalysis.NetAnalyzers&protocolType=NuGet)
 
 This is the **primary analyzer package** for this repo that contains all **the .NET code analysis rules (CAxxxx)** that are built into the .NET SDK starting .NET5 release. The documentation for CA rules can be found at [docs.microsoft.com/visualstudio/code-quality/code-analysis-for-managed-code-warnings](https://docs.microsoft.com/visualstudio/code-quality/code-analysis-for-managed-code-warnings).
 
@@ -154,14 +154,10 @@ See [VERSIONING.md](.//VERSIONING.md) for the versioning scheme for all analyzer
 
 ## Recommended version of Analyzer Packages
 
-Recommended Visual Studio Version: **Visual Studio 2019 16.3 RTW or later**
+Recommended Analyzer Package Version: **Version 5.0.0**, for example [Microsoft.CodeAnalysis.NetAnalyzers 5.0.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/5.0.0)
 
-Recommended Analyzer Package Version: **Version 3.3.1**, for example [Microsoft.CodeAnalysis.FxCopAnalyzers 3.3.1](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers/3.3.1)
+Required Visual Studio Version: **Visual Studio 2019 16.8 RTW or later**
 
-The documentation for FxCopAnalyzers package versions can be found at [docs.microsoft.com/visualstudio/code-quality/install-fxcop-analyzers](https://docs.microsoft.com/visualstudio/code-quality/install-fxcop-analyzers)
+Required .NET SDK Version: **.NET 5.0 SDK or later**
 
-You can also install a custom **Microsoft Code Analysis VSIX** containing these analyzers as a Visual Studio extension for all your managed projects.
-
-1. For Visual Studio 2017 15.5 or later see [here](https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.MicrosoftCodeAnalysis2017)
-
-2. For Visual Studio 2019 16.0 or later see [here](https://marketplace.visualstudio.com/items?itemName=VisualStudioPlatformTeam.MicrosoftCodeAnalysis2019)
+The documentation for .NET SDK Analyzers can be found [here](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/overview#code-quality-analysis)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -14,6 +14,14 @@ Current version of all analyzer packages that are built out of this repo are tra
 
 Released versions of analyzer packages, with the last GitHub Commit Tag and SHA are below:
 
+### Microsoft.CodeAnalysis.NetAnalyzers
+
+Sr. No. | Release         |
+--------|-----------------|
+1       | [5.0.0](https://github.com/dotnet/roslyn-analyzers/releases/tag/5.0.0)           |
+
+### Other analyzers
+
 Sr. No. |  Release Version | Commit Tag       | Commit SHA                                                                                            | Released Packages                                                                                               |
 --------|------------------|------------------|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 1       |  1.1.0           | v1.1.0    | [d96fbd4](https://github.com/dotnet/roslyn-analyzers/commit/d96fbd4e4b6c1fc5b01e3dc5af80d2b15034cc8c)   | MicrosoftCodeAnalysisAnalyzers, FxCopAnalyzers, DesktopAnalyzers, SystemRuntimeAnalyzers, SystemRuntimeInteropServicesAnalyzers, SystemSecurityCryptographyHashingAlgorithmsAnalyzers, AnalyzerPowerPack


### PR DESCRIPTION
Release: [5.0.0](https://github.com/dotnet/roslyn-analyzers/releases/tag/5.0.0)