### PR TITLE
Add CI for Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,3 +78,38 @@ jobs:
         ArtifactName: 'Windows Desktop Spanish'
       continueOnError: true
       condition: not(succeeded())
+
+- job: Ubuntu_16_04
+  strategy:
+    maxParallel: 4
+    matrix:
+      Debug:
+        _configuration: Debug
+      Release:
+        _configuration: Release
+  pool:
+    name: NetCorePublic-Pool
+    queue: BuildPool.Ubuntu.1604.amd64.Open
+  timeoutInMinutes: 40
+
+  steps:
+    - checkout: self
+      clean: true
+    - script: ./eng/common/cibuild.sh --configuration $(_configuration) --prepareMachine
+      displayName: Build and Test
+
+    - task: PublishTestResults@2
+      inputs:
+        testRunner: XUnit
+        testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_configuration)\*.xml'
+        mergeTestResults: true
+        testRunTitle: 'Ubuntu 16.04 $(_configuration)'
+      condition: always()
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_configuration)'
+        ArtifactName: 'Ubuntu 16.04 $(_configuration)'
+      continueOnError: true
+      condition: always()
+


### PR DESCRIPTION
This is a followup from https://github.com/dotnet/roslyn-analyzers/pull/4419

Is there some way I can verify that CI is working before merging this?

<!--

Make sure to run `msbuild RoslynAnalyzers.sln /t:pack` and `msbuild FxCopAnalyzeres.sln /t:pack` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.


-->
