### PR TITLE
Improve messaging for Platform Compat Analyzer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Analyzer.Utilities;
@@ -34,12 +35,15 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         internal const string RuleId = "CA1416";
         private static readonly ImmutableArray<string> s_osPlatformAttributes = ImmutableArray.Create(SupportedOSPlatformAttribute, UnsupportedOSPlatformAttribute);
 
-        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableSupportedOsMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckSupportedOsMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableSupportedOsVersionMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckSupportedOsVersionMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableUnsupportedOsMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckUnsupportedOsMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableUnsupportedOsVersionMessage = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckUnsupportedOsVersionMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
-        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityCheckDescription), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableOnlySupportedCsAllPlatform = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityOnlySupportedCsAllPlatformMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableOnlySupporteCsReachable = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityOnlySupportedCsReachableMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableOnlySupporteCsUnreachable = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityOnlySupportedCsUnreachableMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizablSupporteCsAllPlatform = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilitySupportedCsAllPlatformMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizablSupporteCsReachable = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilitySupportedCsReachableMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableUnsupportedCsAllPlatform = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityUnsupportedCsAllPlatformMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableUnsupportedCsReachable = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityUnsupportedCsReachableMessage), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
+        private static readonly LocalizableString s_localizableDescription = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityDescription), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
 
         // We are adding the new attributes into older versions of .Net 5.0, so there could be multiple referenced assemblies each with their own 
         // version of internal attribute type which will cause ambiguity, to avoid that we are comparing the attributes by their name
@@ -52,44 +56,71 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private const string OptionalSuffix = "VersionAtLeast";
         private const string Net = "net";
 
-        internal static DiagnosticDescriptor SupportedOsVersionRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static DiagnosticDescriptor OnlySupportedCsReachable = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
-                                                                                      s_localizableSupportedOsVersionMessage,
+                                                                                      s_localizableOnlySupporteCsReachable,
                                                                                       DiagnosticCategory.Interoperability,
                                                                                       RuleLevel.BuildWarning,
                                                                                       description: s_localizableDescription,
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        internal static DiagnosticDescriptor SupportedOsRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static DiagnosticDescriptor OnlySupportedCsUnreachable = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
-                                                                                      s_localizableSupportedOsMessage,
+                                                                                      s_localizableOnlySupporteCsUnreachable,
                                                                                       DiagnosticCategory.Interoperability,
                                                                                       RuleLevel.BuildWarning,
                                                                                       description: s_localizableDescription,
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        internal static DiagnosticDescriptor UnsupportedOsRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static DiagnosticDescriptor OnlySupportedCsAllPlatforms = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
-                                                                                      s_localizableUnsupportedOsMessage,
+                                                                                      s_localizableOnlySupportedCsAllPlatform,
                                                                                       DiagnosticCategory.Interoperability,
                                                                                       RuleLevel.BuildWarning,
                                                                                       description: s_localizableDescription,
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        internal static DiagnosticDescriptor UnsupportedOsVersionRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static DiagnosticDescriptor SupportedCsAllPlatforms = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
-                                                                                      s_localizableUnsupportedOsVersionMessage,
+                                                                                      s_localizablSupporteCsAllPlatform,
                                                                                       DiagnosticCategory.Interoperability,
                                                                                       RuleLevel.BuildWarning,
                                                                                       description: s_localizableDescription,
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
-            SupportedOsRule, SupportedOsVersionRule, UnsupportedOsRule, UnsupportedOsVersionRule);
+        internal static DiagnosticDescriptor SupportedCsReachable = DiagnosticDescriptorHelper.Create(RuleId,
+                                                                              s_localizableTitle,
+                                                                              s_localizablSupporteCsReachable,
+                                                                              DiagnosticCategory.Interoperability,
+                                                                              RuleLevel.BuildWarning,
+                                                                              description: s_localizableDescription,
+                                                                              isPortedFxCopRule: false,
+                                                                              isDataflowRule: false);
+
+        internal static DiagnosticDescriptor UnsupportedCsAllPlatforms = DiagnosticDescriptorHelper.Create(RuleId,
+                                                                                      s_localizableTitle,
+                                                                                      s_localizableUnsupportedCsAllPlatform,
+                                                                                      DiagnosticCategory.Interoperability,
+                                                                                      RuleLevel.BuildWarning,
+                                                                                      description: s_localizableDescription,
+                                                                                      isPortedFxCopRule: false,
+                                                                                      isDataflowRule: false);
+
+        internal static DiagnosticDescriptor UnsupportedCsReachable = DiagnosticDescriptorHelper.Create(RuleId,
+                                                                                      s_localizableTitle,
+                                                                                      s_localizableUnsupportedCsReachable,
+                                                                                      DiagnosticCategory.Interoperability,
+                                                                                      RuleLevel.BuildWarning,
+                                                                                      description: s_localizableDescription,
+                                                                                      isPortedFxCopRule: false,
+                                                                                      isDataflowRule: false);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(OnlySupportedCsReachable, OnlySupportedCsUnreachable,
+            OnlySupportedCsAllPlatforms, SupportedCsAllPlatforms, SupportedCsReachable, UnsupportedCsAllPlatforms, UnsupportedCsReachable);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -189,7 +220,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool LowerTargetsEnabled(AnalyzerOptions options, Compilation compilation, CancellationToken cancellationToken) =>
             compilation.SyntaxTrees.FirstOrDefault() is { } tree &&
-            options.GetBoolOptionValue(EditorConfigOptionNames.EnablePlatformAnalyzerOnPreNet5Target, SupportedOsRule, tree, compilation, false, cancellationToken);
+            options.GetBoolOptionValue(EditorConfigOptionNames.EnablePlatformAnalyzerOnPreNet5Target, SupportedCsAllPlatforms, tree, compilation, false, cancellationToken);
 
         private void AnalyzeOperationBlock(
             OperationBlockStartAnalysisContext context,
@@ -202,7 +233,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             ImmutableArray<string> msBuildPlatforms)
         {
             var osPlatformType = osPlatformTypeArray[0];
-            var platformSpecificOperations = PooledConcurrentDictionary<IOperation, SmallDictionary<string, PlatformAttributes>>.GetInstance();
+            var platformSpecificOperations = PooledConcurrentDictionary<IOperation, (SmallDictionary<string, PlatformAttributes> attributes,
+                SmallDictionary<string, PlatformAttributes>? csAttributes)>.GetInstance();
 
             context.RegisterOperationAction(context =>
             {
@@ -234,7 +266,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(context.Compilation);
                     var analysisResult = GlobalFlowStateAnalysis.TryGetOrComputeResult(
                         cfg, context.OwningSymbol, CreateOperationVisitor, wellKnownTypeProvider,
-                        context.Options, SupportedOsRule, performValueContentAnalysis,
+                        context.Options, SupportedCsAllPlatforms, performValueContentAnalysis,
                         pessimisticAnalysis: false,
                         context.CancellationToken, out var valueContentAnalysisResult,
                         additionalSupportedValueTypes: osPlatformTypeArray,
@@ -245,17 +277,19 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         return;
                     }
 
-                    foreach (var (platformSpecificOperation, attributes) in platformSpecificOperations)
+                    foreach (var (platformSpecificOperation, pair) in platformSpecificOperations)
                     {
                         var value = analysisResult[platformSpecificOperation.Kind, platformSpecificOperation.Syntax];
+                        var csAttributes = pair.csAttributes != null ? CopyAttributes(pair.csAttributes) : null;
 
-                        if ((value.Kind == GlobalFlowStateAnalysisValueSetKind.Known && IsKnownValueGuarded(attributes, value)) ||
-                           (value.Kind == GlobalFlowStateAnalysisValueSetKind.Unknown && HasGuardedLambdaOrLocalFunctionResult(platformSpecificOperation, attributes, analysisResult)))
+                        if ((value.Kind == GlobalFlowStateAnalysisValueSetKind.Known && IsKnownValueGuarded(pair.attributes, ref csAttributes, value)) ||
+                           (value.Kind == GlobalFlowStateAnalysisValueSetKind.Unknown && HasGuardedLambdaOrLocalFunctionResult(platformSpecificOperation,
+                            pair.attributes, ref csAttributes, analysisResult)))
                         {
                             continue;
                         }
 
-                        ReportDiagnostics(platformSpecificOperation, attributes, context, platformSpecificMembers);
+                        ReportDiagnostics(platformSpecificOperation, pair.attributes, csAttributes, context, platformSpecificMembers);
                     }
                 }
                 finally
@@ -292,7 +326,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         }
 
         private static bool HasGuardedLambdaOrLocalFunctionResult(IOperation platformSpecificOperation, SmallDictionary<string, PlatformAttributes> attributes,
-            DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult, GlobalFlowStateAnalysisValueSet> analysisResult)
+            ref SmallDictionary<string, PlatformAttributes>? csAttributes, DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult, GlobalFlowStateAnalysisValueSet> analysisResult)
         {
             if (!platformSpecificOperation.IsWithinLambdaOrLocalFunction(out var containingLambdaOrLocalFunctionOperation))
             {
@@ -312,7 +346,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 // NOTE: IsKnownValueGuarded mutates the input values, so we pass in cloned values
                 // to ensure that evaluation of each result is independent of evaluation of other parts.
                 if (localValue.Kind != GlobalFlowStateAnalysisValueSetKind.Known ||
-                    !IsKnownValueGuarded(CopyAttributes(attributes), localValue))
+                    !IsKnownValueGuarded(CopyAttributes(attributes), ref csAttributes, localValue))
                 {
                     return false;
                 }
@@ -359,13 +393,15 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return false;
         }
 
-        private static bool IsKnownValueGuarded(SmallDictionary<string, PlatformAttributes> attributes, GlobalFlowStateAnalysisValueSet value)
+        private static bool IsKnownValueGuarded(SmallDictionary<string, PlatformAttributes> attributes,
+                ref SmallDictionary<string, PlatformAttributes>? csAttributes, GlobalFlowStateAnalysisValueSet value)
         {
             using var capturedVersions = PooledDictionary<string, Version>.GetInstance(StringComparer.OrdinalIgnoreCase);
-            return IsKnownValueGuarded(attributes, value, capturedVersions);
+            return IsKnownValueGuarded(attributes, ref csAttributes, value, capturedVersions);
 
             static bool IsKnownValueGuarded(
                 SmallDictionary<string, PlatformAttributes> attributes,
+                ref SmallDictionary<string, PlatformAttributes>? csAttributes,
                 GlobalFlowStateAnalysisValueSet value,
                 PooledDictionary<string, Version> capturedVersions)
             {
@@ -440,6 +476,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     RemoveOtherSupportsOnDifferentPlatforms(attributes, info.PlatformName);
                                 }
 
+                                csAttributes = SetAsCallSiteSupportedAttribute(csAttributes, info);
                                 RemoveUnsupportsOnDifferentPlatforms(attributes, info.PlatformName);
                             }
                         }
@@ -449,6 +486,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             {
                                 // it is checking one exact platform, other unsupported should be suppressed
                                 RemoveUnsupportsOnDifferentPlatforms(attributes, info.PlatformName);
+                                csAttributes = SetAsCallSiteSupportedAttribute(csAttributes, info);
                             }
                         }
                     }
@@ -476,7 +514,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         var parentAttributes = CopyAttributes(attributes);
                         using var parentCapturedVersions = PooledDictionary<string, Version>.GetInstance(capturedVersions);
 
-                        if (!IsKnownValueGuarded(parentAttributes, parent, parentCapturedVersions))
+                        if (!IsKnownValueGuarded(parentAttributes, ref csAttributes, parent, parentCapturedVersions))
                         {
                             return false;
                         }
@@ -484,6 +522,30 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 return true;
+            }
+
+            static SmallDictionary<string, PlatformAttributes> SetAsCallSiteSupportedAttribute(SmallDictionary<string, PlatformAttributes>? csAttributes, PlatformMethodValue info)
+            {
+                if (csAttributes == null)
+                {
+                    csAttributes = new SmallDictionary<string, PlatformAttributes>();
+                }
+                if (csAttributes.TryGetValue(info.PlatformName, out var attributes))
+                {
+                    if (attributes.SupportedFirst == null)
+                    {
+                        attributes.SupportedFirst = info.Version;
+                    }
+                    else
+                    {
+                        attributes.SupportedSecond = info.Version;
+                    }
+                }
+                else
+                {
+                    csAttributes.Add(info.PlatformName, new PlatformAttributes() { SupportedFirst = info.Version });
+                }
+                return csAttributes;
             }
 
             static void RemoveUnsupportsOnDifferentPlatforms(SmallDictionary<string, PlatformAttributes> attributes, string platformName)
@@ -526,19 +588,20 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private static bool IsEmptyVersion(Version version) => version.Major == 0 && version.Minor == 0;
 
         private static void ReportDiagnosticsForAll(PooledConcurrentDictionary<IOperation,
-            SmallDictionary<string, PlatformAttributes>> platformSpecificOperations, OperationBlockAnalysisContext context,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
+            (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
+            OperationBlockAnalysisContext context, ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
         {
-            foreach (var platformSpecificOperation in platformSpecificOperations)
+            foreach (var operation in platformSpecificOperations)
             {
-                ReportDiagnostics(platformSpecificOperation.Key, platformSpecificOperation.Value, context, platformSpecificMembers);
+                ReportDiagnostics(operation.Key, operation.Value.attributes, operation.Value.csAttributes, context, platformSpecificMembers);
             }
         }
 
         private static void ReportDiagnostics(IOperation operation, SmallDictionary<string, PlatformAttributes> attributes,
-            OperationBlockAnalysisContext context, ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
+            SmallDictionary<string, PlatformAttributes>? csAttributes, OperationBlockAnalysisContext context,
+            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
         {
-            var symbol = operation is IObjectCreationOperation creation ? creation.Constructor.ContainingType : GetOperationSymbol(operation);
+            var symbol = GetOperationSymbol(operation);
 
             if (symbol == null)
             {
@@ -558,38 +621,237 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     symbol = accessor;
                 }
             }
+
+            var originalAttributes = platformSpecificMembers[symbol] ?? attributes;
+
+            if (operation is IObjectCreationOperation creation)
+            {
+                symbol = creation.Constructor.ContainingType;
+            }
+
             var operationName = symbol.ToDisplayString(GetLanguageSpecificFormat(operation));
 
-            foreach (var platformName in attributes.Keys)
+            foreach (var attribute in originalAttributes.Values)
             {
-                var attribute = attributes[platformName];
+                if (AllowList(attribute))
+                {
+                    ReportSupportedDiagnostic(operation, context, operationName, attributes, csAttributes);
+                }
+                else
+                {
+                    ReportUnsupportedDiagnostic(operation, context, operationName, attributes, csAttributes);
+                }
+                break;
+            }
 
-                if (attribute.SupportedSecond != null)
-                {
-                    ReportSupportedDiagnostic(operation, context, operationName, platformName, VersionToString(attribute.SupportedSecond));
-                }
-                else if (attribute.SupportedFirst != null)
-                {
-                    ReportSupportedDiagnostic(operation, context, operationName, platformName, VersionToString(attribute.SupportedFirst));
-                }
+            static void ReportSupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string operationName,
+                 SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? callsiteAttributes)
+            {
+                var supportedRule = GetSupportedPlatforms(attributes, out var platformNames);
+                var platforms = string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, platformNames);
+                var callSitePlatforms = string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, GetCallsitePlatforms(attributes, callsiteAttributes, out var callsite));
+                var rule = supportedRule ? SwitchSupportedRule(callsite) : SwitchRule(callsite, true);
 
-                if (attribute.UnsupportedFirst != null)
+                context.ReportDiagnostic(operation.CreateDiagnostic(rule, operationName, platforms, callSitePlatforms));
+
+                static DiagnosticDescriptor SwitchSupportedRule(Callsite callste)
+                    => callste switch
+                    {
+                        Callsite.AllPlatforms => OnlySupportedCsAllPlatforms,
+                        Callsite.Reachable => OnlySupportedCsReachable,
+                        Callsite.Unreachable => OnlySupportedCsUnreachable,
+                        _ => throw new NotImplementedException()
+                    };
+
+                static bool GetSupportedPlatforms(SmallDictionary<string, PlatformAttributes> attributes, out List<string> platformNames)
                 {
-                    ReportUnsupportedDiagnostic(operation, context, operationName, platformName, VersionToString(attribute.UnsupportedFirst));
-                }
-                else if (attribute.UnsupportedSecond != null)
-                {
-                    ReportUnsupportedDiagnostic(operation, context, operationName, platformName, VersionToString(attribute.UnsupportedSecond));
+                    var supportedRule = true;
+                    platformNames = new List<string>();
+                    foreach (var (pName, pAttribute) in attributes)
+                    {
+                        if (pAttribute.SupportedFirst != null)
+                        {
+                            var supportedVersion = pAttribute.SupportedSecond ?? pAttribute.SupportedFirst;
+                            if (pAttribute.UnsupportedFirst != null && !IsEmptyVersion(pAttribute.UnsupportedFirst))
+                            {
+                                if (IsEmptyVersion(supportedVersion))
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore,
+                                        pName, pAttribute.UnsupportedFirst));
+                                }
+                                else
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion,
+                                        pName, supportedVersion, pAttribute.UnsupportedFirst));
+                                }
+                            }
+                            else if (IsEmptyVersion(supportedVersion))
+                            {
+                                platformNames.Add($"'{pName}'");
+                            }
+                            else
+                            {
+                                platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                    MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, pName, supportedVersion));
+                            }
+                        }
+                        else if (pAttribute.UnsupportedFirst != null)
+                        {
+                            if (IsEmptyVersion(pAttribute.UnsupportedFirst))
+                            {
+                                platformNames.Add($"'{pName}'");
+                            }
+                            else
+                            {
+                                platformNames.Add(string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater,
+                                    pName, pAttribute.UnsupportedFirst));
+                            }
+                            supportedRule = false;
+                        }
+                    }
+                    return supportedRule;
                 }
             }
 
-            static void ReportSupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string name, string platformName, string? version = null) =>
-            context.ReportDiagnostic(version == null ? operation.CreateDiagnostic(SupportedOsRule, name, platformName) :
-                operation.CreateDiagnostic(SupportedOsVersionRule, name, platformName, version));
+            static DiagnosticDescriptor SwitchRule(Callsite callste, bool unsupported)
+            {
+                if (unsupported)
+                {
+                    return callste switch
+                    {
+                        Callsite.AllPlatforms => UnsupportedCsAllPlatforms,
+                        Callsite.Reachable => UnsupportedCsReachable,
+                        _ => throw new NotImplementedException()
+                    };
+                }
+                else
+                {
+                    return callste switch
+                    {
+                        Callsite.AllPlatforms => SupportedCsAllPlatforms,
+                        Callsite.Reachable => SupportedCsReachable,
+                        _ => throw new NotImplementedException()
+                    };
+                }
+            }
 
-            static void ReportUnsupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string name, string platformName, string? version = null) =>
-            context.ReportDiagnostic(version == null ? operation.CreateDiagnostic(UnsupportedOsRule, name, platformName) :
-                operation.CreateDiagnostic(UnsupportedOsVersionRule, name, platformName, version));
+            static void ReportUnsupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string operationName,
+                SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? callsiteAttributes)
+            {
+                var unsupportedRule = GetPlatformNames(attributes, out var platformNames);
+                var platforms = string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, platformNames);
+                var callSitePlatforms = string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, GetCallsitePlatforms(attributes, callsiteAttributes, out var callsite));
+                context.ReportDiagnostic(operation.CreateDiagnostic(SwitchRule(callsite, unsupportedRule), operationName, platforms, callSitePlatforms));
+
+                static bool GetPlatformNames(SmallDictionary<string, PlatformAttributes> attributes, out List<string> platformNames)
+                {
+                    platformNames = new List<string>();
+                    var unsupportedRule = true;
+                    foreach (var (pName, pAttribute) in attributes)
+                    {
+                        var unsupportedVersion = pAttribute.UnsupportedSecond ?? pAttribute.UnsupportedFirst;
+                        var supportedVersion = pAttribute.SupportedSecond ?? pAttribute.SupportedFirst;
+
+                        if (unsupportedVersion != null)
+                        {
+                            if (supportedVersion != null)
+                            {
+                                if (supportedVersion > unsupportedVersion)
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater,
+                                        pName, supportedVersion));
+                                }
+                                else
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture, MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion,
+                                        pName, supportedVersion, unsupportedVersion));
+                                }
+                                unsupportedRule = false;
+                            }
+                            else
+                            {
+                                if (IsEmptyVersion(unsupportedVersion))
+                                {
+                                    platformNames.Add($"'{pName}'");
+                                }
+                                else
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                        MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, pName, unsupportedVersion));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (supportedVersion != null)
+                            {
+                                platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                    MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, pName, supportedVersion));
+                                unsupportedRule = false;
+                            }
+                        }
+                    }
+                    return unsupportedRule;
+                }
+            }
+
+            static List<string> GetCallsitePlatforms(SmallDictionary<string, PlatformAttributes> attributes,
+                SmallDictionary<string, PlatformAttributes>? callsiteAttributes, out Callsite callsite)
+            {
+                callsite = Callsite.AllPlatforms;
+                var platformNames = new List<string>();
+                if (callsiteAttributes != null)
+                {
+                    foreach (var (pName, csAttribute) in callsiteAttributes)
+                    {
+                        var supportedVersion = csAttribute.SupportedSecond ?? csAttribute.SupportedFirst;
+                        if (supportedVersion != null)
+                        {
+                            callsite = Callsite.Reachable;
+                            if (csAttribute.UnsupportedFirst != null && !IsEmptyVersion(csAttribute.UnsupportedFirst))
+                            {
+                                if (IsEmptyVersion(supportedVersion))
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                        MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, pName, csAttribute.UnsupportedFirst));
+                                }
+                                else
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                        MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion, pName, supportedVersion, csAttribute.UnsupportedFirst));
+                                }
+                            }
+                            else if (IsEmptyVersion(supportedVersion))
+                            {
+                                platformNames.Add($"'{pName}'");
+                            }
+                            else
+                            {
+                                platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                    MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, pName, supportedVersion));
+                            }
+                        }
+                        else
+                        {
+                            var unsupportedVersion = csAttribute.UnsupportedSecond ?? csAttribute.UnsupportedFirst;
+                            if (unsupportedVersion != null && attributes.Keys.Contains(pName))
+                            {
+                                callsite = Callsite.Unreachable;
+                                if (IsEmptyVersion(unsupportedVersion))
+                                {
+                                    platformNames.Add($"'{pName}'");
+                                }
+                                else
+                                {
+                                    platformNames.Add(string.Format(CultureInfo.InvariantCulture,
+                                        MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, pName, unsupportedVersion));
+                                }
+                            }
+                        }
+                    }
+                }
+                return platformNames;
+            }
 
             static SymbolDisplayFormat GetLanguageSpecificFormat(IOperation operation) =>
                 operation.Language == LanguageNames.CSharp ? SymbolDisplayFormat.CSharpShortErrorMessageFormat : SymbolDisplayFormat.VisualBasicShortErrorMessageFormat;
@@ -606,6 +868,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                 return symbol;
             }
+        }
+
+        private enum Callsite
+        {
+            AllPlatforms,
+            Reachable,
+            Unreachable
         }
 
         private static string? VersionToString(Version version) => IsEmptyVersion(version) ? null : version.ToString();
@@ -657,8 +926,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return iEvent;
         }
 
-        private static void AnalyzeOperation(IOperation operation, OperationAnalysisContext context,
-            PooledConcurrentDictionary<IOperation, SmallDictionary<string, PlatformAttributes>> platformSpecificOperations,
+        private static void AnalyzeOperation(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<IOperation,
+            (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
             ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms)
         {
             var symbol = GetOperationSymbol(operation);
@@ -697,7 +966,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static void CheckOperationAttributes(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<IOperation,
-                SmallDictionary<string, PlatformAttributes>> platformSpecificOperations,
+                 (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
                 ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms, ISymbol symbol)
             {
                 if (TryGetOrCreatePlatformAttributes(symbol, platformSpecificMembers, out var operationAttributes))
@@ -706,14 +975,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     {
                         if (IsNotSuppressedByCallSite(operationAttributes, callSiteAttributes, msBuildPlatforms, out var notSuppressedAttributes))
                         {
-                            platformSpecificOperations.TryAdd(operation, notSuppressedAttributes);
+                            platformSpecificOperations.TryAdd(operation, (notSuppressedAttributes, callSiteAttributes));
                         }
                     }
                     else
                     {
                         if (TryCopyAttributesNotSuppressedByMsBuild(operationAttributes, msBuildPlatforms, out var copiedAttributes))
                         {
-                            platformSpecificOperations.TryAdd(operation, copiedAttributes);
+                            platformSpecificOperations.TryAdd(operation, (copiedAttributes, null));
                         }
                     }
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -901,7 +901,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     if (checkSupport)
                     {
                         var supportedVersion = attribute.SupportedSecond ?? attribute.SupportedFirst;
-                        version = supportedVersion >= version ? supportedVersion : version;
+                        version = supportedVersion != null && supportedVersion >= version ? supportedVersion : version;
                     }
                     if (version != null && !IsEmptyVersion(version))
                     {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -901,7 +901,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     if (checkSupport)
                     {
                         var supportedVersion = attribute.SupportedSecond ?? attribute.SupportedFirst;
-                        version = supportedVersion != null && supportedVersion >= version ? supportedVersion : version;
+                        if (supportedVersion != null)
+                        {
+                            version = version == null || supportedVersion >= version ? supportedVersion : version;
+                        }
+                        else
+                        {
+                            version = supportedVersion;
+                        }
                     }
                     if (version != null && !IsEmptyVersion(version))
                     {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1488,7 +1488,7 @@
   </data>
   <data name="CommaSeparator" xml:space="preserve">
     <value>, </value>
-    <comment>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</comment>
+    <comment>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</comment>
   </data>
   <data name="PlatformCompatibilityFromVersionToVersion" xml:space="preserve">
     <value>'{0}' from version {1} to {2}</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1434,17 +1434,17 @@
   <data name="UseAsSpanInsteadOfRangeIndexerOnAnArrayCodeFixTitle" xml:space="preserve">
     <value>Use `{0}` instead of Range-based indexers on an array</value>
   </data>
-  <data name="PlatformCompatibilityCheckTitle" xml:space="preserve">
+  <data name="PlatformCompatibilityTitle" xml:space="preserve">
     <value>Validate platform compatibility</value>
   </data>
-  <data name="PlatformCompatibilityCheckDescription" xml:space="preserve">
+  <data name="PlatformCompatibilityDescription" xml:space="preserve">
     <value>Using platform dependent API on a component makes the code no longer work across all platforms.</value>
   </data>
-  <data name="PlatformCompatibilityCheckSupportedOsVersionMessage" xml:space="preserve">
-    <value>'{0}' is supported on '{1}' {2} and later</value>
+  <data name="PlatformCompatibilityOnlySupportedCsUnreachableMessage" xml:space="preserve">
+    <value>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</value>
   </data>
-  <data name="PlatformCompatibilityCheckUnsupportedOsVersionMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on '{1}' {2} and later</value>
+  <data name="PlatformCompatibilityUnsupportedCsAllPlatformMessage" xml:space="preserve">
+    <value>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</value>
   </data>
   <data name="DoNotUseOutAttributeStringPInvokeParametersDescription" xml:space="preserve">
     <value>String parameters passed by value with the 'OutAttribute' can destabilize the runtime if the string is an interned string.</value>
@@ -1473,13 +1473,34 @@
   <data name="AvoidAssemblyGetFilesInSingleFileMessage" xml:space="preserve">
     <value>'{0}' will throw for assemblies embedded in a single-file app</value>
   </data>
-  <data name="PlatformCompatibilityCheckUnsupportedOsMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on '{1}'</value>
+  <data name="PlatformCompatibilityOnlySupportedCsReachableMessage" xml:space="preserve">
+    <value>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</value>
   </data>
-  <data name="PlatformCompatibilityCheckSupportedOsMessage" xml:space="preserve">
-    <value>'{0}' is supported on '{1}'</value>
+  <data name="PlatformCompatibilityOnlySupportedCsAllPlatformMessage" xml:space="preserve">
+    <value>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</value>
   </data>
   <data name="PreferStringContainsOverIndexOfCodeFixTitle" xml:space="preserve">
     <value>Replace with 'string.Contains'</value>
+  </data>
+  <data name="CommaSeparator" xml:space="preserve">
+    <value>, </value>
+  </data>
+  <data name="PlatformCompatibilityFromVersionToVersion" xml:space="preserve">
+    <value>'{0}' from version {1} to {2}</value>
+  </data>
+  <data name="PlatformCompatibilitySupportedCsAllPlatformMessage" xml:space="preserve">
+    <value>'{0}' is supported on: {1}. This call site is reachable on all platforms.</value>
+  </data>
+  <data name="PlatformCompatibilitySupportedCsReachableMessage" xml:space="preserve">
+    <value>'{0}' is supported on: {1}. This call site is reachable on: {2}.</value>
+  </data>
+  <data name="PlatformCompatibilityUnsupportedCsReachableMessage" xml:space="preserve">
+    <value>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</value>
+  </data>
+  <data name="PlatformCompatibilityVersionAndBefore" xml:space="preserve">
+    <value>'{0}' {1} and before</value>
+  </data>
+  <data name="PlatformCompatibilityVersionAndLater" xml:space="preserve">
+    <value>'{0}' {1} and later</value>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1442,9 +1442,11 @@
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsUnreachableMessage" xml:space="preserve">
     <value>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</value>
+    <comment>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</comment>
   </data>
   <data name="PlatformCompatibilityUnsupportedCsAllPlatformMessage" xml:space="preserve">
     <value>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</value>
+    <comment>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</comment>
   </data>
   <data name="DoNotUseOutAttributeStringPInvokeParametersDescription" xml:space="preserve">
     <value>String parameters passed by value with the 'OutAttribute' can destabilize the runtime if the string is an interned string.</value>
@@ -1475,35 +1477,45 @@
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsReachableMessage" xml:space="preserve">
     <value>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</value>
+    <comment>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</comment>
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsAllPlatformMessage" xml:space="preserve">
     <value>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</value>
+    <comment>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</comment>
   </data>
   <data name="PreferStringContainsOverIndexOfCodeFixTitle" xml:space="preserve">
     <value>Replace with 'string.Contains'</value>
   </data>
   <data name="CommaSeparator" xml:space="preserve">
     <value>, </value>
+    <comment>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</comment>
   </data>
   <data name="PlatformCompatibilityFromVersionToVersion" xml:space="preserve">
     <value>'{0}' from version {1} to {2}</value>
+    <comment>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</comment>
   </data>
   <data name="PlatformCompatibilitySupportedCsAllPlatformMessage" xml:space="preserve">
     <value>This call site is reachable on all platforms. '{0}' is supported on: {1}.</value>
+    <comment>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</comment>
   </data>
   <data name="PlatformCompatibilitySupportedCsReachableMessage" xml:space="preserve">
     <value>This call site is reachable on: {2}. '{0}' is supported on: {1}.</value>
+    <comment>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</comment>
   </data>
   <data name="PlatformCompatibilityUnsupportedCsReachableMessage" xml:space="preserve">
     <value>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</value>
+    <comment>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</comment>
   </data>
   <data name="PlatformCompatibilityVersionAndBefore" xml:space="preserve">
     <value>'{0}' {1} and before</value>
+    <comment>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</comment>
   </data>
   <data name="PlatformCompatibilityVersionAndLater" xml:space="preserve">
     <value>'{0}' {1} and later</value>
+    <comment>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</comment>
   </data>
   <data name="PlatformCompatibilityAllVersions" xml:space="preserve">
     <value>'{0}' all versions</value>
+    <comment>This call site is reachable on: 'Windows' all versions.</comment>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1441,10 +1441,10 @@
     <value>Using platform dependent API on a component makes the code no longer work across all platforms.</value>
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsUnreachableMessage" xml:space="preserve">
-    <value>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</value>
+    <value>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</value>
   </data>
   <data name="PlatformCompatibilityUnsupportedCsAllPlatformMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</value>
+    <value>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</value>
   </data>
   <data name="DoNotUseOutAttributeStringPInvokeParametersDescription" xml:space="preserve">
     <value>String parameters passed by value with the 'OutAttribute' can destabilize the runtime if the string is an interned string.</value>
@@ -1474,10 +1474,10 @@
     <value>'{0}' will throw for assemblies embedded in a single-file app</value>
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsReachableMessage" xml:space="preserve">
-    <value>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</value>
+    <value>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</value>
   </data>
   <data name="PlatformCompatibilityOnlySupportedCsAllPlatformMessage" xml:space="preserve">
-    <value>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</value>
+    <value>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</value>
   </data>
   <data name="PreferStringContainsOverIndexOfCodeFixTitle" xml:space="preserve">
     <value>Replace with 'string.Contains'</value>
@@ -1489,18 +1489,21 @@
     <value>'{0}' from version {1} to {2}</value>
   </data>
   <data name="PlatformCompatibilitySupportedCsAllPlatformMessage" xml:space="preserve">
-    <value>'{0}' is supported on: {1}. This call site is reachable on all platforms.</value>
+    <value>This call site is reachable on all platforms. '{0}' is supported on: {1}.</value>
   </data>
   <data name="PlatformCompatibilitySupportedCsReachableMessage" xml:space="preserve">
-    <value>'{0}' is supported on: {1}. This call site is reachable on: {2}.</value>
+    <value>This call site is reachable on: {2}. '{0}' is supported on: {1}.</value>
   </data>
   <data name="PlatformCompatibilityUnsupportedCsReachableMessage" xml:space="preserve">
-    <value>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</value>
+    <value>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</value>
   </data>
   <data name="PlatformCompatibilityVersionAndBefore" xml:space="preserve">
     <value>'{0}' {1} and before</value>
   </data>
   <data name="PlatformCompatibilityVersionAndLater" xml:space="preserve">
     <value>'{0}' {1} and later</value>
+  </data>
+  <data name="PlatformCompatibilityAllVersions" xml:space="preserve">
+    <value>'{0}' all versions</value>
   </data>
 </root>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">Metody P/Invoke nemají být viditelné</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Spolehlivost</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Při deserializaci nedůvěryhodného vstupu není deserializace objektu {0} bezpečná. Objekt {1} je buď objektem {0}, nebo je z tohoto objektu odvozený.</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">Metody P/Invoke nemají být viditelné</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Když se pro komponentu použije závislé rozhraní API, kód už nebude fungovat na všech platformách.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">{0} se podporuje v {1}.</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">{0} se podporuje v {1} {2} a novějších.</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Ověřit kompatibilitu platformy</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">{0} se v {1} nepodporuje.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">{0} se v {1} {2} a novějších nepodporuje.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes dürfen nicht sichtbar sein</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Zuverlässigkeit</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Beim Deserialisieren einer nicht vertrauenswürdigen Eingaben ist die Deserialisierung eines {0}-Objekts unsicher. "{1}" ist entweder "{0}" oder davon abgeleitet.</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes dürfen nicht sichtbar sein</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Durch die Verwendung einer plattformabhängigen API für eine Komponente funktioniert der Code nicht mehr auf allen Plattformen.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" wird für "{1}" unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" wird für "{1}" {2} und höher unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Plattformkompatibilität überprüfen</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" wird für "{1}" nicht unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" wird für "{1}" {2} und höher nicht unterstützt.</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Fiabilidad</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Cuando se deserializa una entrada que no es de confianza, no es segura la deserialización de un objeto {0}. "{1}" es {0} o se deriva de este.</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">Los elementos P/Invoke no deben estar visibles</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">El uso de una API dependiente de la plataforma en un componente hace que el código deje de funcionar en todas las plataformas.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" es compatible con "{1}"</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" es compatible con "{1}" {2} y versiones posteriores</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Validar la compatibilidad de la plataforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" no es compatible con "{1}"</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" no es compatible con "{1}" {2} y versiones posteriores</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">Los elementos P/Invoke no deben estar visibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">Les P/Invoke ne doivent pas être visibles</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Fiabilité</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Quand vous désérialisez une entrée non fiable, la désérialisation d'un objet {0} n'est pas une action sécurisée. '{1}' est égal à ou dérive de {0}</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">Les P/Invoke ne doivent pas être visibles</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">L'utilisation d'une API dépendante de la plateforme sur un composant empêche le code de fonctionner sur l'ensemble des plateformes.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' est pris en charge sur '{1}'</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' est pris en charge sur '{1}' {2} et les versions ultérieures</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Valider la compatibilité de la plateforme</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' n'est pas pris en charge sur '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' n'est pas pris en charge sur '{1}' {2} et les versions ultérieures</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">I metodi P/Invoke non devono essere visibili</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Affidabilità</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Quando si deserializza input non attendibile, la deserializzazione di un oggetto {0} non è sicura. '{1}' è {0} o deriva da esso</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">I metodi P/Invoke non devono essere visibili</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Se si usa un'API dipendente dalla piattaforma su un componente, il codice non funziona più in tutte le piattaforme.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' è supportato in '{1}'</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' è supportato in '{1}' {2} e versioni successive</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Convalida compatibilità della piattaforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' non è supportato in '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' non è supportato in '{1}' {2} e versioni successive</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -172,6 +172,11 @@
         <target state="translated">信頼性</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">信頼されていない入力を逆シリアル化する場合、{0} オブジェクトの逆シリアル化は安全ではありません。'{1}' は {0} であるか、それから派生しています</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes は参照可能にすることはできません</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">プラットフォーム依存 API をコンポーネント上で使用すると、一部のプラットフォームでコードが動作しなくなります。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' は '{1}' でサポートされています</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' は '{1}' {2} 以降でサポートされています</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">プラットフォームの互換性の検証</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' は '{1}' ではサポートされていません</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' は '{1}' {2} 以降ではサポートされていません</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes は参照可能にすることはできません</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -172,6 +172,11 @@
         <target state="translated">안정성</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">신뢰할 수 없는 입력을 역직렬화하는 경우 {0} 개체를 역직렬화하는 것은 안전하지 않습니다. '{1}'은(는) {0}이거나 이 항목에서 파생됩니다.</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes를 표시하지 않아야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">구성 요소에서 플랫폼 종속 API를 사용하면 모든 플랫폼에서 코드가 더 이상 작동하지 않습니다.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}'은(는) '{1}'에서 지원됨</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}'은(는) '{1}' {2} 이상에서 지원됨</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">플랫폼 호환성 유효성 검사</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}'은(는) '{1}'에서 지원되지 않음</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}'은(는) '{1}' {2} 이상에서 지원되지 않음</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes를 표시하지 않아야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">Elementy P/Invoke nie powinny być widoczne</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Niezawodność</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Deserializowanie obiektu {0} podczas deserializacji niezaufanych danych wejściowych nie jest bezpieczne. Element „{1}” jest elementem {0} lub pochodzi od niego</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">Elementy P/Invoke nie powinny być widoczne</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Użycie w składniku interfejsu API zależnego od platformy powoduje, że kod nie działa na różnych platformach.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">Element „{0}” jest obsługiwany przez system „{1}”</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">Element „{0}” jest obsługiwany przez system „{1}” {2} i nowsze</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Weryfikuj zgodność z platformą</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">Element „{0}” nie jest obsługiwany przez system „{1}”</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">Element „{0}” nie jest obsługiwany przez system „{1}” {2} i nowsze</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Confiabilidade</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Ao desserializar uma entrada não confiável, a desserialização de um objeto {0} não é segura. '{1}' é {0} ou deriva-se dele</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes não deve ser visível</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">O uso de uma API dependente da plataforma em um componente faz com que o código não funcione mais em todas as plataformas.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}' é compatível com '{1}'</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' é compatível com '{1}' {2} e posteriores</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Validar a compatibilidade da plataforma</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}' não é compatível com '{1}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}' não é compatível com '{1}' {2} e posteriores</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes não deve ser visível</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Надежность</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">При десериализации недоверенных входных данных десериализация объекта {0} является небезопасной. Объект "{1}" является объектом {0} или производным от него объектом.</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">Методы P/Invoke не должны быть видимыми</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">При использовании в компоненте API, зависящего от платформы, код больше не будет работать на всех платформах.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">"{0}" поддерживается в "{1}".</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" поддерживается в "{1}" версии {2} и более поздних версиях.</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Проверка совместимости платформы</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">"{0}" не поддерживается в "{1}"</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">"{0}" не поддерживается в "{1}" версии {2} и более поздних версиях</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">Методы P/Invoke не должны быть видимыми</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes görünür olmamalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -172,6 +172,11 @@
         <target state="translated">Güvenilirlik</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">Güvenilmeyen giriş seri durumdan çıkarılırken, {0} nesnesinin seri durumdan çıkarılması güvenli değildir. '{1}', {0} nesnesidir veya bu nesneden türetilmiştir</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes görünür olmamalıdır</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">Bileşen üzerinde platforma bağımlı API kullanmak, kodun artık tüm platformlarda çalışmamasına neden olur.</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{0}', '{1}' üzerinde destekleniyor</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{0}', '{1}' {2} ve üstünde desteklenir</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">Platform uyumluluğunu doğrula</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{0}', '{1}' üzerinde desteklenmiyor</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{0}', '{1}' {2} ve üstünde desteklenmez</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -172,6 +172,11 @@
         <target state="translated">可靠性</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">对不受信任的输入进行反序列化处理时，反序列化 {0} 对象是不安全的。“{1}”是或派生自 {0}</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">P/Invokes 应该是不可见的</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">在组件上使用依赖于平台的 API 会使代码无法用于所有平台。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">“{1}”支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">“{1}”{2} 及更高版本支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">验证平台兼容性</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">“{1}”不支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">“{1}”{2} 及更高版本不支持“{0}”</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">P/Invokes 应该是不可见的</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -1517,6 +1517,11 @@
         <target state="translated">不應看得見 P/Invoke</target>
         <note />
       </trans-unit>
+      <trans-unit id="PlatformCompatibilityAllVersions">
+        <source>'{0}' all versions</source>
+        <target state="new">'{0}' all versions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
         <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
@@ -1528,28 +1533,28 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
-        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
-        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
+        <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
-        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
@@ -1558,13 +1563,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
+        <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
-        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
-        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
+        <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note />
+        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
@@ -1520,7 +1520,7 @@
       <trans-unit id="PlatformCompatibilityAllVersions">
         <source>'{0}' all versions</source>
         <target state="new">'{0}' all versions</target>
-        <note />
+        <note>This call site is reachable on: 'Windows' all versions.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
@@ -1530,32 +1530,32 @@
       <trans-unit id="PlatformCompatibilityFromVersionToVersion">
         <source>'{0}' from version {1} to {2}</source>
         <target state="new">'{0}' from version {1} to {2}</target>
-        <note />
+        <note>'SupportedOnWindows1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser' .</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' all versions.'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
         <source>This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</source>
         <target state="new">This call site is unreachable on: {2}. '{0}' is only supported on: {1}.</target>
-        <note />
+        <note>This call site is unreachable on: 'browser'. 'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'SupportedOnWindows1903UnsupportedFrom2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is supported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is supported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows' 10.0.2000 and before. 'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
@@ -1565,22 +1565,22 @@
       <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
         <source>This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on all platforms. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on all platforms. 'UnsupportedOnWindows()' is unsupported on: 'windows'</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
         <source>This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</source>
         <target state="new">This call site is reachable on: {2}. '{0}' is unsupported on: {1}.</target>
-        <note />
+        <note>This call site is reachable on: 'windows', 'browser'. 'UnsupportedOnBrowser()' is unsupported on: 'browser'.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndBefore">
         <source>'{0}' {1} and before</source>
         <target state="new">'{0}' {1} and before</target>
-        <note />
+        <note>'SupportedOnWindowsUnsupportedFromWindows2004()' is only supported on: 'windows' 10.0.2004 and before.</note>
       </trans-unit>
       <trans-unit id="PlatformCompatibilityVersionAndLater">
         <source>'{0}' {1} and later</source>
         <target state="new">'{0}' {1} and later</target>
-        <note />
+        <note>'SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.</note>
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">
         <source>Review code that processes untrusted deserialized data for handling of unexpected reference cycles. An unexpected reference cycle should not cause the code to enter an infinite loop. Otherwise, an unexpected reference cycle can allow an attacker to DOS or exhaust the memory of the process when deserializing untrusted data.</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -175,7 +175,7 @@
       <trans-unit id="CommaSeparator">
         <source>, </source>
         <target state="new">, </target>
-        <note>Separator used for list of platform names. {‘windows’ 10 and later, ‘browser’, ‘Linux’}</note>
+        <note>Separator used for separating list of platform names: {API} is only supported on: {‘windows’, ‘browser’, ‘linux’}</note>
       </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -172,6 +172,11 @@
         <target state="translated">可靠性</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommaSeparator">
+        <source>, </source>
+        <target state="new">, </target>
+        <note />
+      </trans-unit>
       <trans-unit id="DataSetDataTableInDeserializableObjectGraphMessage">
         <source>When deserializing untrusted input, deserializing a {0} object is insecure. '{1}' either is or derives from {0}</source>
         <target state="translated">還原序列化不受信任的輸入時，將 {0} 物件還原序列化並不安全。'{1}' 屬於或衍生自 {0}</target>
@@ -1512,34 +1517,64 @@
         <target state="translated">不應看得見 P/Invoke</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckDescription">
+      <trans-unit id="PlatformCompatibilityDescription">
         <source>Using platform dependent API on a component makes the code no longer work across all platforms.</source>
-        <target state="translated">在元件上使用相依於平台的 API，會使程式碼無法繼續在所有平台上運作。</target>
+        <target state="new">Using platform dependent API on a component makes the code no longer work across all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsMessage">
-        <source>'{0}' is supported on '{1}'</source>
-        <target state="translated">'{1}' 支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityFromVersionToVersion">
+        <source>'{0}' from version {1} to {2}</source>
+        <target state="new">'{0}' from version {1} to {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckSupportedOsVersionMessage">
-        <source>'{0}' is supported on '{1}' {2} and later</source>
-        <target state="translated">'{1}' {2} 及更新版本皆支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsAllPlatformMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckTitle">
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsReachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityOnlySupportedCsUnreachableMessage">
+        <source>'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</source>
+        <target state="new">'{0}' is only supported on: {1}. This call site is unreachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsAllPlatformMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on all platforms.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilitySupportedCsReachableMessage">
+        <source>'{0}' is supported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is supported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityTitle">
         <source>Validate platform compatibility</source>
-        <target state="translated">驗證平台相容性</target>
+        <target state="new">Validate platform compatibility</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsMessage">
-        <source>'{0}' is unsupported on '{1}'</source>
-        <target state="translated">'{1}' 不支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsAllPlatformMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on all platforms.</target>
         <note />
       </trans-unit>
-      <trans-unit id="PlatformCompatibilityCheckUnsupportedOsVersionMessage">
-        <source>'{0}' is unsupported on '{1}' {2} and later</source>
-        <target state="translated">'{1}' {2} 及更新版本皆不支援 '{0}'</target>
+      <trans-unit id="PlatformCompatibilityUnsupportedCsReachableMessage">
+        <source>'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</source>
+        <target state="new">'{0}' is unsupported on: {1}. This call site is reachable on: {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndBefore">
+        <source>'{0}' {1} and before</source>
+        <target state="new">'{0}' {1} and before</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PlatformCompatibilityVersionAndLater">
+        <source>'{0}' {1} and later</source>
+        <target state="new">'{0}' {1} and later</target>
         <note />
       </trans-unit>
       <trans-unit id="PotentialReferenceCycleInDeserializedObjectGraphDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -76,7 +76,7 @@ class Test
             Api();
         }
 
-        [|Api()|]; // Two diagnostics expected
+        [|Api()|]; // 'Test.Api()' is supported on: 'windows' 10.0.19041 and later. This call site is reachable on all platforms.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -86,8 +86,7 @@ class Test
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule)
-                .WithLocation(15, 9).WithArguments("Test.Api()", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -105,8 +104,10 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         {
             if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|];
+                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
                 [|Target.SupportedOnWindows10()|];
+                Target.SupportedOnWindowsAndBrowser();
+                [|Target.SupportedOnWindows10AndBrowser()|]; // 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
             }
         }
     }
@@ -145,18 +146,18 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         {
             if (!OperatingSystemHelper.IsWindows())
             {
-                [|Target.SupportedOnWindows()|];
+                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
                 [|Target.SupportedOnWindows10()|];
-                [|Target.SupportedOnWindowsAndBrowser()|];   // expected two diagnostics - supported on windows and browser
+                [|Target.SupportedOnWindowsAndBrowser()|];   // Target.SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser'. This call site is reachable on all platforms.
                 [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
                 Target.SupportedOnWindows();
-                [|Target.SupportedOnWindows10()|];
+                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows'
                 Target.SupportedOnWindowsAndBrowser();       // no diagnostic expected - the API is supported on windows, no need to warn for other platforms support
-                [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
+                [|Target.SupportedOnWindows10AndBrowser()|]; // 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on: 'Windows'.
             }
 
             if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
@@ -169,7 +170,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
 
             if (OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|];
+                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Browser'
                 [|Target.SupportedOnWindows10()|];
                 Target.SupportedOnWindowsAndBrowser();   // No diagnostic expected - the API is supported on browser, no need to warn for other platforms support
                 Target.SupportedOnWindows10AndBrowser(); // The same, no diagnostic expected
@@ -177,16 +178,16 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
 
             if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; // No diagnostic expected because of it was windows
-                [|Target.SupportedOnWindows10()|];
+                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Windows', 'Browser'.
+                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Browser'.
                 Target.SupportedOnWindowsAndBrowser();
-                [|Target.SupportedOnWindows10AndBrowser()|]; // two diagnostic expected windows 10 and browser
+                [|Target.SupportedOnWindows10AndBrowser()|]; //'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on: 'Browser', 'Windows'.
             }
 
            if (OperatingSystemHelper.IsWindowsVersionAtLeast(10) || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|];
-                [|Target.SupportedOnWindows10()|]; 
+                [|Target.SupportedOnWindows()|]; //  'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Windows' 10.0 and later, 'Browser'.
+                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows' 10.0 and later, 'Browser'. 
                 Target.SupportedOnWindowsAndBrowser();
                 Target.SupportedOnWindows10AndBrowser();
             }
@@ -209,11 +210,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(15, 17).WithArguments("Target.SupportedOnWindowsAndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(16, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(24, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(48, 17).WithArguments("Target.SupportedOnWindows10AndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -232,55 +229,49 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (OperatingSystemHelper.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindows.FunctionSupportedOnWindows11();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
-                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
+                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|]; // 'TypeUnsupportedOnBrowser' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
+                [|unsupportedOnBrowser.FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11(); 
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11()|];
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|];
-                [|withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|];
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()' is supported on: 'windows' 11.0 and later. This call site is reachable on: 'Windows'.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
 
-                var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
+                var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|]; // 'TypeUnsupportedOnWindows' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
+                [|unsupportedOnWindows.FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
-                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|];
-                [|unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13()|];
+                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsSupportedOnWindows11' is supported on: 'windows' 11.0 and later. This call site is reachable on: 'Windows'.
+                [|unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13()|];
 
-                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|];
+                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // 'TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
             }
         }
     }
 }" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(37, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(38, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(39, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(47, 64).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(48, 17).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13()", "windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(50, 86).WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -299,29 +290,29 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
                 var unsupported = new TypeWithoutAttributes();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows()|];
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnBrowser()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()|];
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser()|];
+                [|unsupported.FunctionUnsupportedOnWindows()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupported.FunctionUnsupportedOnBrowser()|];
+                unsupported.FunctionUnsupportedOnWindows10();
+                [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
+                [|unsupported.FunctionUnsupportedOnWindows10AndBrowser()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];
 
                 var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()|];
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10()|];
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows'. This call site is reachable on all platforms.
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser'. This call site is reachable on all platforms.
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
-                [|unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser()|];
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11(); // We should ignore above version of unsupported if there is no supported in between
-                [|unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser()|];
+                [|unsupportedOnWindows10.FunctionUnsupportedOnBrowser()|];
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11(); // We should ignore above version of unsupported if there is no supported in between
+                [|unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()|];
 
                 var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|];
-                [|unsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
 
                 var unsupportedOnWindows10AndBrowser = [|new TypeUnsupportedOnWindows10AndBrowser()|];
-                [|unsupportedOnWindows10AndBrowser.TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()|];
             }
         }
 
@@ -330,34 +321,34 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10) && !OperatingSystemHelper.IsBrowser())
             {
                 var unsupported = new TypeWithoutAttributes();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnBrowser();
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10();
-                [|unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()|];
-                unsupported.TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser();
+                [|unsupported.FunctionUnsupportedOnWindows()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                unsupported.FunctionUnsupportedOnBrowser();
+                unsupported.FunctionUnsupportedOnWindows10();
+                [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|];
+                unsupported.FunctionUnsupportedOnWindows10AndBrowser();
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnBrowser()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11()|];
-                [|unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11AndBrowser()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnBrowser()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()|]; // 'TypeUnsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'windows'. This call site is reachable on all platforms.
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                [|unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()|];
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10();
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                unsupportedOnBrowser.FunctionUnsupportedOnWindows10();
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11();
-                unsupportedOnWindows10.TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser();
+                unsupportedOnWindows10.FunctionUnsupportedOnBrowser();
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11();
+                unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser();
 
-                var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|];
-                [|unsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()|];
+                var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|]; // 'TypeUnsupportedOnWindowsAndBrowser' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows'. This call site is reachable on all platforms.
 
                 var unsupportedOnWindows10AndBrowser = new TypeUnsupportedOnWindows10AndBrowser();
-                unsupportedOnWindows10AndBrowser.TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11();
+                unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11();
 
                 var unsupportedCombinations = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
             }
         }
 
@@ -366,34 +357,30 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                withoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
+                withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindows = new TypeUnsupportedOnWindows();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindows.TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindows.FunctionSupportedOnWindows11();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
+                unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                unsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser();
+                unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11.TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12();
+                unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13();
 
                 var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12();
-                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13();
+                unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
             }
         }
     }
 }" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(17, 17).WithArguments("TypeWithoutAttributes.TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(24, 17).WithArguments("TypeUnsupportedOnBrowser.TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows()", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(32, 54).WithArguments("TypeUnsupportedOnWindowsAndBrowser", "browser"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(33, 17).WithArguments("TypeUnsupportedOnWindowsAndBrowser.TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11()", "browser"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -413,35 +400,35 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|]; // row 15 expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
+                [|Target.UnsupportedOnBrowser()|]; // row 15 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
             }
 
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
-                [|Target.UnsupportedInWindows()|]; // row 22 expected diagnostic - windows unsupported
+                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|]; // expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected 2 diagnostics - windows and browser unsupported
+                [|Target.UnsupportedOnBrowser()|]; // 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
-                [|Target.UnsupportedInWindows()|]; // row 31 expected diagnostic - windows unsupported
+                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
                 [|Target.UnsupportedInWindows10()|]; // expected diagnostic - windows 10 unsupported
                 Target.UnsupportedOnBrowser();
                 [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - windows unsupported
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - windows 10 unsupported
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows'.
             }
 
             if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
-                [|Target.UnsupportedInWindows()|]; // row 40 expected diagnostic - windows unsupported
+                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
                 Target.UnsupportedInWindows10();
                 Target.UnsupportedOnBrowser(); 
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - windows unsupported
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
                 Target.UnsupportedOnWindows10AndBrowser();
             }
 
@@ -449,9 +436,9 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|}; // row 51 expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - browser unsupported
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
+                [|Target.UnsupportedOnBrowser()|}; // 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - browser unsupported, same
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
             }
         }
     }
@@ -475,8 +462,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(25, 17).WithArguments("Target.UnsupportedOnWindowsAndBrowser()", "browser"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -495,7 +481,7 @@ class Test
         {
             Api();
         }
-        [|Api()|]; // two diagnostics expected
+        [|Api()|]; // 'Test.Api()' is only supported on: 'ios' from version 12.0 to 14.0. This call site is reachable on all platforms.
     }
 
     [SupportedOSPlatform(""ios12.0"")]
@@ -505,9 +491,7 @@ class Test
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsVersionRule).WithLocation(14, 9)
-                .WithArguments("Test.Api()", "ios", "14.0"));
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]
@@ -701,7 +685,7 @@ class Test
 
         [Theory]
         [MemberData(nameof(OperatingSystem_IsOsNameVersionAtLeast_MethodsTestData))]
-        public async Task GuardedWith_IsOsNameVersionAtLeast_impleIfElse(string osName, string isOsMethod, string version, bool versionMatch)
+        public async Task GuardedWith_IsOsNameVersionAtLeast_SimpleIfElse(string osName, string isOsMethod, string version, bool versionMatch)
         {
             var match = versionMatch ? "OsSpecificMethod()" : "[|OsSpecificMethod()|]";
             var source = @"
@@ -977,14 +961,10 @@ class Test
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(0).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(0).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(1).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(1).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(2).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(2).WithArguments("Test.M2()", "Windows"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(3).WithArguments("Test.M2()", "Linux"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsRule).WithLocation(3).WithArguments("Test.M2()", "Windows")
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(1).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(3).WithArguments("Test.M2()", "'Windows', 'Linux'", "")
             );
         }
 
@@ -1038,7 +1018,7 @@ static class Program
         }
         else
         {
-            [|Some.WindowsSpecificApi()|]; // should show 2 diagnostic
+            {|#0:Some.WindowsSpecificApi()|}; // 'Some.WindowsSpecificApi()' is supported on: 'windows' 10.0 and later. This call site is reachable on: 'windows'.
         }
     }
 }
@@ -1054,8 +1034,8 @@ static class Some
 " + MockAttributesCsSource + MockOperatingSystemApiSource;
 
             await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedOsVersionRule).WithLocation(16, 13)
-                .WithArguments("Some.WindowsSpecificApi()", "windows", "10.0"));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(0).
+                WithArguments("Some.WindowsSpecificApi()", "'windows' 10.0 and later", "'windows'"));
         }
 
         [Fact]
@@ -3218,7 +3198,7 @@ class Test
         }
         else
         {
-            [|M2()|]; // Two diagnostics expected
+            [|M2()|]; // 'Test.M2()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004. This call site is reachable on all platforms.
         }
     }
 
@@ -3230,8 +3210,7 @@ class Test
     }
 }"
 + MockAttributesCsSource + MockOperatingSystemApiSource;
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(16, 13).WithArguments("Test.M2()", "windows"));
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
 
             var vbSource = @"
 Imports System.Runtime.Versioning
@@ -3253,8 +3232,7 @@ Class Test
     End Sub
 End Class
 " + MockRuntimeApiSourceVb + MockAttributesVbSource;
-            await VerifyAnalyzerAsyncVb(vbSource, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedOsRule).WithLocation(10, 13).WithArguments("Private Sub M2()", "Windows"));
+            await VerifyAnalyzerAsyncVb(vbSource, s_msBuildPlatforms);
         }
 
         [Fact]
@@ -3718,157 +3696,157 @@ namespace PlatformCompatDemo.SupportedUnupported
     public class TypeWithoutAttributes
     {
         [UnsupportedOSPlatform(""windows"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows() { }
+        public void FunctionUnsupportedOnWindows() { }
 
         [UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows10.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows10() { }
+        public void FunctionUnsupportedOnWindows10() { }
 
         [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsAndBrowser() { }
+        public void FunctionUnsupportedOnWindowsAndBrowser() { }
 
         [UnsupportedOSPlatform(""windows10.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindows10AndBrowser() { }
+        public void FunctionUnsupportedOnWindows10AndBrowser() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12() { }
 
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeWithoutAttributes_FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
 
         [SupportedOSPlatform(""windows"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""windows10.0"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows10() { }
+        public void FunctionSupportedOnWindows10() { }
 
         [SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows""), SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindowsAndBrowser() { }
+        public void FunctionSupportedOnWindowsAndBrowser() { }
 
         [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]
-        public void TypeWithoutAttributes_FunctionSupportedOnWindows10AndBrowser() { }
+        public void FunctionSupportedOnWindows10AndBrowser() { }
     }
 
     [UnsupportedOSPlatform(""windows"")]
     public class TypeUnsupportedOnWindows {
         [UnsupportedOSPlatform(""browser"")] // more restrictive should be OK
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnWindows_FunctionUnsupportedOnWindows11AndBrowser() { }
+        public void FunctionUnsupportedOnWindows11AndBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12() { }
+        public void FunctionSupportedOnWindows11UnsupportedOnWindows12() { }
 
         [SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindows_FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13() { }
     }
 
     [UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnBrowser
     {
         [UnsupportedOSPlatform(""windows"")] // more restrictive should be OK
-        public void TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows() { }
+        public void FunctionUnsupportedOnWindows() { }
 
         [UnsupportedOSPlatform(""windows10.0"")] // more restrictive should be OK
-        public void TypeUnsupportedOnBrowser_FunctionUnsupportedOnWindows10() { }
+        public void FunctionUnsupportedOnWindows10() { }
         
         [SupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnBrowser_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
         }
 
     [UnsupportedOSPlatform(""windows10.0"")]
     public class TypeUnsupportedOnWindows10
     {
         [UnsupportedOSPlatform(""browser"")] // more restrictive should be OK
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnBrowser() { }
+        public void FunctionUnsupportedOnBrowser() { }
 
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
 
         [UnsupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""browser"")]
-        public void TypeUnsupportedOnWindows10_FunctionUnsupportedOnWindows11AndBrowser() { }
+        public void FunctionUnsupportedOnWindows11AndBrowser() { }
     }
 
     [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnWindowsAndBrowser
     {
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindowsAndBrowser_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
     }
 
     [UnsupportedOSPlatform(""windows10.0""), UnsupportedOSPlatform(""browser"")]
     public class TypeUnsupportedOnWindows10AndBrowser
     {
         [UnsupportedOSPlatform(""windows11.0"")]
-        public void TypeUnsupportedOnWindows10AndBrowser_FunctionUnsupportedOnWindows11() { }
+        public void FunctionUnsupportedOnWindows11() { }
     }
 
     [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
     public class TypeUnsupportedOnWindowsSupportedOnWindows11
     {
         [UnsupportedOSPlatform(""windows12.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12() { }
+        public void FunctionUnsupportedOnWindows12() { }
 
         [UnsupportedOSPlatform(""windows12.0""), SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11_FunctionUnsupportedOnWindows12SupportedOnWindows13() { }
+        public void FunctionUnsupportedOnWindows12SupportedOnWindows13() { }
     }
 
     [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0""), UnsupportedOSPlatform(""windows12.0"")]
     public class TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12
     {
         [SupportedOSPlatform(""windows13.0"")]
-        public void TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12_FunctionSupportedOnWindows13() { }
+        public void FunctionSupportedOnWindows13() { }
     }
     [SupportedOSPlatform(""windows"")]
     public class TypeSupportedOnWindows {
         [SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindows_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows_FunctionSupportedOnWindows11AndBrowser() { }
+        public void FunctionSupportedOnWindows11AndBrowser() { }
     }
     [SupportedOSPlatform(""browser"")]
     public class TypeSupportedOnBrowser
     {
         [SupportedOSPlatform(""windows"")]
-        public void TypeSupportedOnBrowser_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""windows11.0"")]
-        public void TypeSupportedOnBrowser_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
     }
 
     [SupportedOSPlatform(""windows10.0"")]
     public class TypeSupportedOnWindows10
     {
         [SupportedOSPlatform(""windows"")] // less restrictive should be OK
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows() { }
+        public void FunctionSupportedOnWindows() { }
 
         [SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows10_FunctionSupportedOnBrowser() { }
+        public void FunctionSupportedOnBrowser() { }
 
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
 
         [SupportedOSPlatform(""windows11.0""), SupportedOSPlatform(""browser"")]
-        public void TypeSupportedOnWindows10_FunctionSupportedOnWindows11AndBrowser() { }
+        public void FunctionSupportedOnWindows11AndBrowser() { }
     }
 
 
@@ -3876,7 +3854,7 @@ namespace PlatformCompatDemo.SupportedUnupported
     public class TypeSupportedOnWindowsAndBrowser
     {
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
-        public void TypeSupportedOnWindowsAndBrowser_FunctionSupportedOnWindows11() { }
+        public void FunctionSupportedOnWindows11() { }
     }
 
     [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -922,7 +922,7 @@ class Test
         }
         else
         {
-            {|#0:M2()|};
+            [|M2()|];
         }
 
         if(RuntimeInformation.IsOSPlatform(windowsPlatform))
@@ -931,7 +931,7 @@ class Test
         }
         else
         {
-            {|#1:M2()|};
+            [|M2()|];
         }
 
         if (unknown.HasValue)
@@ -945,11 +945,11 @@ class Test
 
         if(RuntimeInformation.IsOSPlatform(platform))
         {
-            {|#2:M2()|};
+            [|M2()|];
         }
         else
         {
-            {|#3:M2()|};
+            [|M2()|];
         }
     }
 
@@ -960,12 +960,7 @@ class Test
     }
 }" + MockAttributesCsSource + MockOperatingSystemApiSource;
 
-            await VerifyAnalyzerAsyncCs(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(1).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Test.M2()", "'Windows', 'Linux'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(3).WithArguments("Test.M2()", "'Windows', 'Linux'", "")
-            );
+            await VerifyAnalyzerAsyncCs(source);
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -76,7 +76,7 @@ class Test
             Api();
         }
 
-        [|Api()|]; // 'Test.Api()' is supported on: 'windows' 10.0.19041 and later. This call site is reachable on all platforms.
+        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is supported on: 'windows' 10.0.19041 and later.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -104,10 +104,10 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         {
             if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
+                [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Windows', 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
                 Target.SupportedOnWindowsAndBrowser();
-                [|Target.SupportedOnWindows10AndBrowser()|]; // 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
+                [|Target.SupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions, 'Browser'. 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
             }
         }
     }
@@ -146,18 +146,18 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         {
             if (!OperatingSystemHelper.IsWindows())
             {
-                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
+                [|Target.SupportedOnWindows()|]; // This call site is reachable on all platforms. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
-                [|Target.SupportedOnWindowsAndBrowser()|];   // Target.SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser'. This call site is reachable on all platforms.
+                [|Target.SupportedOnWindowsAndBrowser()|];   // This call site is reachable on all platforms. 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'windows', 'browser'.
                 [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
                 Target.SupportedOnWindows();
-                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows'
+                [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
                 Target.SupportedOnWindowsAndBrowser();       // no diagnostic expected - the API is supported on windows, no need to warn for other platforms support
-                [|Target.SupportedOnWindows10AndBrowser()|]; // 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on: 'Windows'.
+                [|Target.SupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
             }
 
             if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
@@ -170,7 +170,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
 
             if (OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Browser'
+                [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
                 Target.SupportedOnWindowsAndBrowser();   // No diagnostic expected - the API is supported on browser, no need to warn for other platforms support
                 Target.SupportedOnWindows10AndBrowser(); // The same, no diagnostic expected
@@ -178,16 +178,16 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
 
             if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Windows', 'Browser'.
-                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Browser'.
+                [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Windows', 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
+                [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
                 Target.SupportedOnWindowsAndBrowser();
-                [|Target.SupportedOnWindows10AndBrowser()|]; //'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on: 'Browser', 'Windows'.
+                [|Target.SupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
             }
 
            if (OperatingSystemHelper.IsWindowsVersionAtLeast(10) || OperatingSystemHelper.IsBrowser())
             {
-                [|Target.SupportedOnWindows()|]; //  'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'Windows' 10.0 and later, 'Browser'.
-                [|Target.SupportedOnWindows10()|]; // 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows' 10.0 and later, 'Browser'. 
+                [|Target.SupportedOnWindows()|]; //  This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
+                [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. 
                 Target.SupportedOnWindowsAndBrowser();
                 Target.SupportedOnWindows10AndBrowser();
             }
@@ -238,7 +238,7 @@ namespace PlatformCompatDemo.SupportedUnupported
                 unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12();
                 unsupportedOnWindows.FunctionSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13();
 
-                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|]; // 'TypeUnsupportedOnBrowser' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
+                var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|]; // This call site is reachable on: 'Browser'. 'TypeUnsupportedOnBrowser' is unsupported on: 'browser'.
                 [|unsupportedOnBrowser.FunctionSupportedOnBrowser()|]; // warn for unsupported browser type
 
                 var unsupportedOnWindowsSupportedOnWindows11 = new TypeUnsupportedOnWindowsSupportedOnWindows11(); 
@@ -252,20 +252,20 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (OperatingSystemHelper.IsWindows())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
-                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()' is supported on: 'windows' 11.0 and later. This call site is reachable on: 'Windows'.
-                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
-                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()|]; // This call site is reachable on: 'Windows' all versions. 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()' is supported on: 'windows' 11.0 and later.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // This call site is reachable on: 'Windows' all versions. 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()' is supported on: 'windows' from version 11.0 to 12.0.
+                [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()|]; // This call site is reachable on: 'Windows' all versions. 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12SupportedOnWindows13()' is supported on: 'windows' from version 11.0 to 12.0.
 
-                var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|]; // 'TypeUnsupportedOnWindows' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
+                var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|]; // This call site is reachable on: 'Windows'. 'TypeUnsupportedOnWindows' is unsupported on: 'windows'.
                 [|unsupportedOnWindows.FunctionSupportedOnWindows11()|];  // should only warn for unsupported type, function attribute ignored
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
                 unsupportedOnBrowser.FunctionSupportedOnBrowser();
 
-                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsSupportedOnWindows11' is supported on: 'windows' 11.0 and later. This call site is reachable on: 'Windows'.
+                var unsupportedOnWindowsSupportedOnWindows11 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11()|]; // This call site is reachable on: 'Windows' all versions. 'TypeUnsupportedOnWindowsSupportedOnWindows11' is supported on: 'windows' 11.0 and later.
                 [|unsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13()|];
 
-                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // 'TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12' is supported on: 'windows' from version 11.0 to 12.0. This call site is reachable on: 'Windows'.
+                var unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12 = [|new TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12()|]; // This call site is reachable on: 'Windows' all versions. 'TypeUnsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12' is supported on: 'windows' from version 11.0 to 12.0.
             }
         }
     }
@@ -290,18 +290,18 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
                 var unsupported = new TypeWithoutAttributes();
-                [|unsupported.FunctionUnsupportedOnWindows()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupported.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
                 [|unsupported.FunctionUnsupportedOnBrowser()|];
                 unsupported.FunctionUnsupportedOnWindows10();
-                [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
-                [|unsupported.FunctionUnsupportedOnWindows10AndBrowser()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'.
+                [|unsupported.FunctionUnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'.
 
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
                 [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];
 
                 var unsupportedOnBrowser = [|new TypeUnsupportedOnBrowser()|];
-                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows'. This call site is reachable on all platforms.
-                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows'.
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser'.
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
                 [|unsupportedOnWindows10.FunctionUnsupportedOnBrowser()|];
@@ -309,7 +309,7 @@ namespace PlatformCompatDemo.SupportedUnupported
                 [|unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()|];
 
                 var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|];
-                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser'.
 
                 var unsupportedOnWindows10AndBrowser = [|new TypeUnsupportedOnWindows10AndBrowser()|];
                 [|unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()|];
@@ -321,7 +321,7 @@ namespace PlatformCompatDemo.SupportedUnupported
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10) && !OperatingSystemHelper.IsBrowser())
             {
                 var unsupported = new TypeWithoutAttributes();
-                [|unsupported.FunctionUnsupportedOnWindows()|]; // 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupported.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
                 unsupported.FunctionUnsupportedOnBrowser();
                 unsupported.FunctionUnsupportedOnWindows10();
                 [|unsupported.FunctionUnsupportedOnWindowsAndBrowser()|];
@@ -330,10 +330,10 @@ namespace PlatformCompatDemo.SupportedUnupported
                 var unsupportedOnWindows = [|new TypeUnsupportedOnWindows()|];
                 [|unsupportedOnWindows.FunctionUnsupportedOnBrowser()|];
                 [|unsupportedOnWindows.FunctionUnsupportedOnWindows11()|];
-                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()|]; // 'TypeUnsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindows.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'windows'.
 
                 var unsupportedOnBrowser = new TypeUnsupportedOnBrowser();
-                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
                 unsupportedOnBrowser.FunctionUnsupportedOnWindows10();
 
                 var unsupportedOnWindows10 = new TypeUnsupportedOnWindows10();
@@ -341,8 +341,8 @@ namespace PlatformCompatDemo.SupportedUnupported
                 unsupportedOnWindows10.FunctionUnsupportedOnWindows11();
                 unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser();
 
-                var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|]; // 'TypeUnsupportedOnWindowsAndBrowser' is unsupported on: 'windows'. This call site is reachable on all platforms.
-                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindowsAndBrowser' is unsupported on: 'windows'.
+                [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows'.
 
                 var unsupportedOnWindows10AndBrowser = new TypeUnsupportedOnWindows10AndBrowser();
                 unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11();
@@ -400,35 +400,35 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|]; // row 15 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
+                [|Target.UnsupportedOnBrowser()|]; // row 15 This call site is reachable on all platforms. 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'browser'.
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'.
             }
 
             if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
-                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+                [|Target.UnsupportedInWindows()|]; // This call site is reachable on all platforms. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|]; // 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on all platforms.
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
+                [|Target.UnsupportedOnBrowser()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'.
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
             }
 
             if (OperatingSystemHelper.IsWindows())
             {
-                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
+                [|Target.UnsupportedInWindows()|]; // This call site is reachable on: 'Windows'. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 [|Target.UnsupportedInWindows10()|]; // expected diagnostic - windows 10 unsupported
                 Target.UnsupportedOnBrowser();
                 [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - windows unsupported
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'windows' 10.0 and later. This call site is reachable on: 'Windows'.
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'windows' 10.0 and later.
             }
 
             if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10))
             {
-                [|Target.UnsupportedInWindows()|]; // 'Target.UnsupportedInWindows()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
+                [|Target.UnsupportedInWindows()|]; // This call site is reachable on: 'Windows'. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 Target.UnsupportedInWindows10();
                 Target.UnsupportedOnBrowser(); 
-                [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'. This call site is reachable on: 'Windows'.
+                [|Target.UnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on: 'Windows'. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'.
                 Target.UnsupportedOnWindows10AndBrowser();
             }
 
@@ -436,9 +436,9 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
-                [|Target.UnsupportedOnBrowser()|}; // 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
+                [|Target.UnsupportedOnBrowser()|}; // This call site is reachable on: 'Browser'. 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'.
                 [|Target.UnsupportedOnWindowsAndBrowser()|]; // expected diagnostic - browser unsupported, same
-                [|Target.UnsupportedOnWindows10AndBrowser()|]; // 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'Browser'.
+                [|Target.UnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Browser'. 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'.
             }
         }
     }
@@ -481,7 +481,7 @@ class Test
         {
             Api();
         }
-        [|Api()|]; // 'Test.Api()' is only supported on: 'ios' from version 12.0 to 14.0. This call site is reachable on all platforms.
+        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'ios' from version 12.0 to 14.0.
     }
 
     [SupportedOSPlatform(""ios12.0"")]
@@ -1018,7 +1018,7 @@ static class Program
         }
         else
         {
-            {|#0:Some.WindowsSpecificApi()|}; // 'Some.WindowsSpecificApi()' is supported on: 'windows' 10.0 and later. This call site is reachable on: 'windows'.
+            {|#0:Some.WindowsSpecificApi()|}; // This call site is reachable on: 'windows' all versions. 'Some.WindowsSpecificApi()' is supported on: 'windows' 10.0 and later.
         }
     }
 }
@@ -1035,7 +1035,7 @@ static class Some
 
             await VerifyAnalyzerAsyncCs(source,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(0).
-                WithArguments("Some.WindowsSpecificApi()", "'windows' 10.0 and later", "'windows'"));
+                WithArguments("Some.WindowsSpecificApi()", "'windows' 10.0 and later", "'windows' all versions"));
         }
 
         [Fact]
@@ -3198,7 +3198,7 @@ class Test
         }
         else
         {
-            [|M2()|]; // 'Test.M2()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004. This call site is reachable on all platforms.
+            [|M2()|]; // This call site is reachable on all platforms. 'Test.M2()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.
         }
     }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1342,14 +1342,14 @@ namespace CallerSupportsSubsetOfTarget
         {
             {|#0:Target.SupportedOnWindows()|}; // This call site is reachable on all platforms. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
             {|#1:Target.SupportedOnBrowser()|}; // This call site is unreachable on: 'browser'. 'Target.SupportedOnBrowser()' is only supported on: 'browser'.
-            {|#2:Target.SupportedOnWindowsAndBrowser()|}; // This call site is unreachable on: 'browser'. 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.
-            {|#3:Target.SupportedOnWindowsAndUnsupportedOnBrowser()|}; // This call site is reachable on all platforms. 'Target.SupportedOnWindowsAndUnsupportedOnBrowser()' is only supported on: 'windows'.
+            [|Target.SupportedOnWindowsAndBrowser()|]; // This call site is unreachable on: 'browser'. 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.
+            {|#2:Target.SupportedOnWindowsAndUnsupportedOnBrowser()|}; // This call site is reachable on all platforms. 'Target.SupportedOnWindowsAndUnsupportedOnBrowser()' is only supported on: 'windows'.
 
-            {|#4:Target.UnsupportedOnWindows()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'.
-            {|#5:Target.UnsupportedOnWindows11()|};
+            {|#3:Target.UnsupportedOnWindows()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'.
+            {|#4:Target.UnsupportedOnWindows11()|};
             Target.UnsupportedOnBrowser();
-            {|#6:Target.UnsupportedOnWindowsAndBrowser()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'.
-            {|#7:Target.UnsupportedOnWindowsUntilWindows11()|};
+            {|#5:Target.UnsupportedOnWindowsAndBrowser()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'.
+            {|#6:Target.UnsupportedOnWindowsUntilWindows11()|};
         }
     }
 
@@ -1387,12 +1387,11 @@ namespace CallerSupportsSubsetOfTarget
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).WithArguments("Target.SupportedOnWindows()", "'windows'", ""),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(1).WithArguments("Target.SupportedOnBrowser()", "'browser'", "'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(2).WithArguments("Target.SupportedOnWindowsAndBrowser()", "'browser', 'windows'", "'browser'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(3).WithArguments("Target.SupportedOnWindowsAndUnsupportedOnBrowser()", "'windows'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(4).WithArguments("Target.UnsupportedOnWindows()", "'windows'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(5).WithArguments("Target.UnsupportedOnWindows11()", "'windows' 11.0 and later", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(6).WithArguments("Target.UnsupportedOnWindowsAndBrowser()", "'windows'", ""),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsAllPlatforms).WithLocation(7).WithArguments("Target.UnsupportedOnWindowsUntilWindows11()", "'windows' 11.0 and later", ""));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Target.SupportedOnWindowsAndUnsupportedOnBrowser()", "'windows'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(3).WithArguments("Target.UnsupportedOnWindows()", "'windows'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(4).WithArguments("Target.UnsupportedOnWindows11()", "'windows' 11.0 and later", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(5).WithArguments("Target.UnsupportedOnWindowsAndBrowser()", "'windows'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsAllPlatforms).WithLocation(6).WithArguments("Target.UnsupportedOnWindowsUntilWindows11()", "'windows' 11.0 and later", ""));
         }
 
         [Fact]
@@ -1883,7 +1882,6 @@ public class C
         }
 
         [Fact]
-
         public async Task MultipleAttrbiutesOptionallySupportedListTest()
         {
             var source = @"
@@ -1955,7 +1953,6 @@ public class C
         }
 
         [Fact]
-
         public async Task MultipleAttrbiutesSupportedOnlyWindowsListTest()
         {
             var source = @"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -142,8 +142,8 @@ public class Test
     [SupportedOSPlatform(""Linux"")]
     public void M1()
     {
-        [|WindowsOnly()|];
-        [|Unsupported()|];  // 'Test.Unsupported()' is unsupported on: 'Linux' 4.1 and later. This call site is reachable on: 'Linux'.
+        [|WindowsOnly()|];  // This call site is reachable on: 'Linux'. 'Test.WindowsOnly()' is only supported on: 'Windows' 10.1.1.1 and later.
+        [|Unsupported()|];  // This call site is reachable on: 'Linux' all versions. 'Test.Unsupported()' is unsupported on: 'Linux' 4.1 and later.
     }
     
     [UnsupportedOSPlatform(""Linux4.1"")]
@@ -1069,7 +1069,7 @@ static class Program
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'. This call site is reachable on all platforms.
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // This call site is reachable on all platforms. 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'.
         [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
         UnsupportedOnBrowserType.SupportedOnBrowser();
     }
@@ -1101,7 +1101,7 @@ static class Program
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'. This call site is reachable on all platforms.
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // This call site is reachable on all platforms. 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'.
         [|UnsupportedOnBrowserType.SupportedOnTvos4()|];
         UnsupportedOnBrowserType.SupportedOnBrowser(); // child support ignored (should not extend)
         UnsupportedOnBrowserType.UnsupportedOnBrowser();
@@ -1113,10 +1113,10 @@ static class Program2
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'. This call site is reachable on: 'browser'.
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];  // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'. This call site is reachable on: 'browser'.
-        [|UnsupportedOnBrowserType.SupportedOnBrowser()|];    // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'. This call site is reachable on: 'browser'.
-        [|UnsupportedOnBrowserType.UnsupportedOnBrowser()|];  // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'. This call site is reachable on: 'browser'.
+        [|UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()|]; // This call site is reachable on: 'browser'. 'UnsupportedOnBrowserType.SupportedOnWindowsIosTvos()' is only supported on: 'ios', 'tvos', 'windows'.
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|];  // This call site is reachable on: 'browser'. 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'.
+        [|UnsupportedOnBrowserType.SupportedOnBrowser()|];    // This call site is reachable on: 'browser'. 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'.
+        [|UnsupportedOnBrowserType.UnsupportedOnBrowser()|];  // This call site is reachable on: 'browser'. 'UnsupportedOnBrowserType.SupportedOnTvos4()' is unsupported on: 'browser'.
     }
 }
 
@@ -1127,7 +1127,7 @@ static class Program3
     public static void Main()
     {
         UnsupportedOnBrowserType.SupportedOnWindowsIosTvos(); // No diagnostics expected
-        [|UnsupportedOnBrowserType.SupportedOnTvos4()|]; // 'UnsupportedOnBrowserType.SupportedOnTvos4()' is only supported on: 'tvos' 4.0 and later. This call site is reachable on: 'windows'.
+        [|UnsupportedOnBrowserType.SupportedOnTvos4()|]; // This call site is reachable on: 'windows'. 'UnsupportedOnBrowserType.SupportedOnTvos4()' is only supported on: 'tvos' 4.0 and later.
         UnsupportedOnBrowserType.SupportedOnBrowser();
         UnsupportedOnBrowserType.UnsupportedOnBrowser();
     }
@@ -1163,7 +1163,7 @@ static class Program
     public static void Main()
     {
         [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // One diagnostics expected only for parent, same as below
-        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|];   // 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()' is only supported on: 'windows'. This call site is reachable on all platforms.
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|];   // This call site is reachable on all platforms. 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()' is only supported on: 'windows'.
     }
 }
 
@@ -1172,7 +1172,7 @@ static class Program2
 {
     public static void Main()
     {
-        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()' is unsupported on: 'browser'. This call site is reachable on: 'browser'.
+        [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()|]; // This call site is reachable on: 'browser'. 'UnsupportedOnBrowserSupportedOnWindowType.SupportedOnIosTvos()' is unsupported on: 'browser'.
         [|UnsupportedOnBrowserSupportedOnWindowType.SupportedOnTvos4()|]; // Same here 
     }
 }
@@ -1340,15 +1340,15 @@ namespace CallerSupportsSubsetOfTarget
         [UnsupportedOSPlatform(""browser"")]
         public static void TestWithBrowserUnsupported()
         {
-            {|#0:Target.SupportedOnWindows()|}; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
-            {|#1:Target.SupportedOnBrowser()|}; // 'Target.SupportedOnBrowser()' is only supported on: 'browser'. This call site is unreachable on: 'browser'.
-            {|#2:Target.SupportedOnWindowsAndBrowser()|}; // Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'. This call site is unreachable on: 'browser'.
-            {|#3:Target.SupportedOnWindowsAndUnsupportedOnBrowser()|}; // 'Target.SupportedOnWindowsAndUnsupportedOnBrowser()' is only supported on: 'windows'. This call site is reachable on all platforms.
+            {|#0:Target.SupportedOnWindows()|}; // This call site is reachable on all platforms. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
+            {|#1:Target.SupportedOnBrowser()|}; // This call site is unreachable on: 'browser'. 'Target.SupportedOnBrowser()' is only supported on: 'browser'.
+            {|#2:Target.SupportedOnWindowsAndBrowser()|}; // This call site is unreachable on: 'browser'. 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.
+            {|#3:Target.SupportedOnWindowsAndUnsupportedOnBrowser()|}; // This call site is reachable on all platforms. 'Target.SupportedOnWindowsAndUnsupportedOnBrowser()' is only supported on: 'windows'.
 
-            {|#4:Target.UnsupportedOnWindows()|}; // 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+            {|#4:Target.UnsupportedOnWindows()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'.
             {|#5:Target.UnsupportedOnWindows11()|};
             Target.UnsupportedOnBrowser();
-            {|#6:Target.UnsupportedOnWindowsAndBrowser()|}; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'. This call site is reachable on all platforms.
+            {|#6:Target.UnsupportedOnWindowsAndBrowser()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows'.
             {|#7:Target.UnsupportedOnWindowsUntilWindows11()|};
         }
     }
@@ -1408,20 +1408,20 @@ namespace CallerSupportsSubsetOfTarget
         [SupportedOSPlatform(""windows""), SupportedOSPlatform(""browser"")]
         public static void TestWithWindowsAndBrowserSupported()
         {
-            [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'windows', 'browser'.
-            [|Target.SupportedOnBrowser()|]; // 'Target.SupportedOnBrowser()' is only supported on: 'browser'. This call site is reachable on: 'windows', 'browser'.
+            [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'windows', 'browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
+            [|Target.SupportedOnBrowser()|]; // This call site is reachable on: 'windows', 'browser'. 'Target.SupportedOnBrowser()' is only supported on: 'browser'.
             Target.SupportedOnWindowsAndBrowser();
 
-            [|Target.UnsupportedOnWindows()|]; // 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on: 'windows', 'browser'.
-            [|Target.UnsupportedOnBrowser()|]; // 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'windows', 'browser'.
-            [|Target.UnsupportedOnWindowsAndBrowser()|]; // 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'. This call site is reachable on: 'windows', 'browser'.
+            [|Target.UnsupportedOnWindows()|]; // This call site is reachable on: 'windows', 'browser'. 'Target.UnsupportedOnWindows()' is unsupported on: 'windows'.
+            [|Target.UnsupportedOnBrowser()|]; // This call site is reachable on: 'windows', 'browser'. 'Target.UnsupportedOnBrowser()' is unsupported on: 'browser'.
+            [|Target.UnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on: 'windows', 'browser'. 'Target.UnsupportedOnWindowsAndBrowser()' is unsupported on: 'windows', 'browser'.
         }
         [UnsupportedOSPlatform(""browser"")]
         public static void TestWithBrowserUnsupported()
         {
-            [|Target.SupportedOnWindows()|]; // 'Target.SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
-            [|Target.SupportedOnBrowser()|]; // 'Target.SupportedOnBrowser()' is only supported on: 'browser'. This call site is unreachable on: 'browser'.
-            [|Target.SupportedOnWindowsAndBrowser()|]; // 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'. This call site is unreachable on: 'browser'.
+            [|Target.SupportedOnWindows()|]; // This call site is reachable on all platforms. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
+            [|Target.SupportedOnBrowser()|]; // This call site is unreachable on: 'browser'. 'Target.SupportedOnBrowser()' is only supported on: 'browser'.
+            [|Target.SupportedOnWindowsAndBrowser()|]; // This call site is unreachable on: 'browser'. 'Target.SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'.
 
             Target.UnsupportedOnWindows(); // if call site has now support of it and MSbuild list not containg the platform name it will not be warned
             Target.UnsupportedOnBrowser();
@@ -1464,8 +1464,8 @@ static class Program
 {
     public static void Main()
     {
-        [|Some.Api1()|]; // 'Some.Api1()' is only supported on: 'ios' 10.0 and later, 'tvos' 4.0 and later. This call site is reachable on all platforms.
-        [|Some.Api2()|]; // 'Some.Api2()' is only supported on: 'ios' 10.0 and later. This call site is reachable on all platforms.
+        [|Some.Api1()|]; // This call site is reachable on all platforms. 'Some.Api1()' is only supported on: 'ios' 10.0 and later, 'tvos' 4.0 and later.
+        [|Some.Api2()|]; // This call site is reachable on all platforms. 'Some.Api2()' is only supported on: 'ios' 10.0 and later.
     }
 }
 
@@ -1495,10 +1495,10 @@ namespace PlatformCompatDemo.Bugs
         [SupportedOSPlatform(""windows"")]
         public void TestSupportedOnWindows()
         {
-            [|TargetSupportedOnWindows.FunctionUnsupportedOnWindows()|]; // 'TargetSupportedOnWindows.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on: 'windows'.
+            [|TargetSupportedOnWindows.FunctionUnsupportedOnWindows()|]; // This call site is reachable on: 'windows'. 'TargetSupportedOnWindows.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
             TargetSupportedOnWindows.FunctionUnsupportedOnBrowser();     // browser unsupport not related so ignored
 
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnWindows()|]; // 'TargetUnsupportedOnWindows.FunctionSupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on: 'windows'.
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnWindows()|]; // This call site is reachable on: 'windows'. 'TargetUnsupportedOnWindows.FunctionSupportedOnWindows()' is unsupported on: 'windows'.
             [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|]; // should warn for unsupported windows and browser support                                   
         }
 
@@ -1507,8 +1507,8 @@ namespace PlatformCompatDemo.Bugs
         {
             TargetSupportedOnWindows.FunctionUnsupportedOnWindows();
             [|TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()|];  // should warn supported on windows ignore unsupported on browser as this is allow list
-                                                                          // 'TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()' is only supported on: 'windows'. This call site is unreachable on: 'windows'.
-            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|];  // 'TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()' is only supported on: 'browser'. This call site is reachable on all platforms. 
+                                                                          // This call site is unreachable on: 'windows'. 'TargetSupportedOnWindows.FunctionUnsupportedOnBrowser()' is only supported on: 'windows'.
+            [|TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()|];  // This call site is reachable on all platforms. 'TargetUnsupportedOnWindows.FunctionSupportedOnBrowser()' is only supported on: 'browser'. 
             TargetUnsupportedOnWindows.FunctionSupportedOnWindows();      // it's unsupporting Windows at the call site, so it should warn for windows support on the API
         }                                                                 
     }
@@ -1863,19 +1863,15 @@ public class Test
 public class C
 {
     [UnsupportedOSPlatform(""browser"")]
-    public void BrowserMethod()
-    {
-    }
+    public void BrowserMethod() { }
     
     [UnsupportedOSPlatform(""linux4.8"")]
-    internal static class StaticClass{
-        public static void LinuxVersionedMethod()
-        {
-        }
+    internal static class StaticClass
+    {
+        public static void LinuxVersionedMethod() { }
+        
         [UnsupportedOSPlatform(""linux"")]
-        public static void LinuxMethod()
-        {
-        }
+        public static void LinuxMethod() { }
     }
 }
 " + MockAttributesCsSource;
@@ -1883,7 +1879,7 @@ public class C
             await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).
                 WithLocation(11, 9).WithArguments("C.StaticClass.LinuxMethod()", "'linux'", "'Linux'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).
-                WithLocation(12, 9).WithArguments("C.StaticClass.LinuxVersionedMethod()", "'linux' 4.8 and later", "'Linux'"));
+                WithLocation(12, 9).WithArguments("C.StaticClass.LinuxVersionedMethod()", "'linux' 4.8 and later", "'Linux' all versions"));
         }
 
         [Fact]
@@ -1907,7 +1903,7 @@ public class Test
     public void SupporteWindows()
     {
         // Warns for UnsupportedFirst, Supported
-        obj.DoesNotWorkOnWindows(); // 'C.DoesNotWorkOnWindows()' is supported on: 'windows' 10.0.1903 and later. This call site is reachable on: 'windows' 10.0.2000 and before.
+        obj.DoesNotWorkOnWindows(); // This call site is reachable on: 'windows' 10.0.2000 and before. 'C.DoesNotWorkOnWindows()' is supported on: 'windows' 10.0.1903 and later.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -1920,14 +1916,14 @@ public class Test
     
     public void AllSupportedWarnForAll()
     {
-        obj.DoesNotWorkOnWindows(); // 'C.DoesNotWorkOnWindows()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004. This call site is reachable on all platforms.
+        obj.DoesNotWorkOnWindows(); // This call site is reachable on all platforms. 'C.DoesNotWorkOnWindows()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004.
     }
 
     [SupportedOSPlatform(""windows10.0.2000"")]
     public void SupportedFromWindows10_0_2000()
     {
         // Should warn for [UnsupportedOSPlatform]
-        obj.DoesNotWorkOnWindows(); // 'C.DoesNotWorkOnWindows()' is unsupported on: 'windows' 10.0.2004 and later. This call site is reachable on: 'windows' 10.0.2000 and later.
+        obj.DoesNotWorkOnWindows(); // This call site is reachable on: 'windows' 10.0.2000 and later. 'C.DoesNotWorkOnWindows()' is unsupported on: 'windows' 10.0.2004 and later.
     }
 
     [SupportedOSPlatform(""windows10.0.1904"")]
@@ -1971,7 +1967,7 @@ public class Test
     [SupportedOSPlatform(""Linux"")]
     public void DiffferentOsWarnsForAll()
     {
-        {|#0:obj.WindowsOnlyUnsupportedFrom2004()|}; // 'C.WindowsOnlyUnsupportedFrom2004()' is only supported on: 'windows' 10.0.2004 and before. This call site is reachable on: 'Linux'.
+        {|#0:obj.WindowsOnlyUnsupportedFrom2004()|}; // This call site is reachable on: 'Linux'. 'C.WindowsOnlyUnsupportedFrom2004()' is only supported on: 'windows' 10.0.2004 and before.
     }
 
     [SupportedOSPlatform(""windows"")]
@@ -1983,14 +1979,14 @@ public class Test
     
     public void AllSupportedWarnForAll()
     {
-        {|#1:obj.WindowsOnlyUnsupportedFrom2004()|}; // 'C.WindowsOnlyUnsupportedFrom2004()' is only supported on: 'windows' 10.0.2004 and before. This call site is reachable on all platforms.
+        {|#1:obj.WindowsOnlyUnsupportedFrom2004()|}; // This call site is reachable on all platforms. 'C.WindowsOnlyUnsupportedFrom2004()' is only supported on: 'windows' 10.0.2004 and before.
     }
 
     [SupportedOSPlatform(""windows10.0.2000"")]
     public void SupportedFromWindows10_0_2000()
     {
         // Warns for [UnsupportedOSPlatform]
-        {|#2:obj.WindowsOnlyUnsupportedFrom2004()|}; //  'C.WindowsOnlyUnsupportedFrom2004()' is unsupported on: 'windows' 10.0.2004 and later. This call site is reachable on: 'windows' 10.0.2000 and later.
+        {|#2:obj.WindowsOnlyUnsupportedFrom2004()|}; //  This call site is reachable on: 'windows' 10.0.2000 and later. 'C.WindowsOnlyUnsupportedFrom2004()' is unsupported on: 'windows' 10.0.2004 and later.
     }
     
     [SupportedOSPlatform(""windows10.0.1904"")]
@@ -2033,22 +2029,22 @@ namespace PlatformCompatDemo.SupportedUnupported
         public static void Supported()
         {
             var supported = new TypeWithoutAttributes();
-            {|#0:supported.FunctionSupportedOnWindows()|}; // 'TypeWithoutAttributes.FunctionSupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on all platforms.
-            {|#1:supported.FunctionSupportedOnWindows10()|}; // 'TypeWithoutAttributes.FunctionSupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. This call site is reachable on all platforms.
-            [|supported.FunctionSupportedOnWindows10AndBrowser()|]; // 'TypeWithoutAttributes.FunctionSupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
+            {|#0:supported.FunctionSupportedOnWindows()|}; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionSupportedOnWindows()' is only supported on: 'windows'.
+            {|#1:supported.FunctionSupportedOnWindows10()|}; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionSupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
+            [|supported.FunctionSupportedOnWindows10AndBrowser()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionSupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
 
-            var supportedOnWindows = {|#2:new TypeSupportedOnWindows()|}; // 'TypeSupportedOnWindows' is only supported on: 'windows'. This call site is reachable on all platforms.
+            var supportedOnWindows = {|#2:new TypeSupportedOnWindows()|}; // This call site is reachable on all platforms. 'TypeSupportedOnWindows' is only supported on: 'windows'.
             {|#3:supportedOnWindows.FunctionSupportedOnBrowser()|}; // browser support ignored
-            {|#4:supportedOnWindows.FunctionSupportedOnWindows11AndBrowser()|}; //'TypeSupportedOnWindows.FunctionSupportedOnWindows11AndBrowser()' is only supported on: 'windows' 11.0 and later. This call site is reachable on all platforms.
+            {|#4:supportedOnWindows.FunctionSupportedOnWindows11AndBrowser()|}; //This call site is reachable on all platforms. 'TypeSupportedOnWindows.FunctionSupportedOnWindows11AndBrowser()' is only supported on: 'windows' 11.0 and later.
 
             var supportedOnBrowser = {|#5:new TypeSupportedOnBrowser()|};
-            [|supportedOnBrowser.FunctionSupportedOnWindows()|]; // 'TypeSupportedOnBrowser.FunctionSupportedOnWindows()' is only supported on: 'browser'. This call site is reachable on all platforms.
+            [|supportedOnBrowser.FunctionSupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeSupportedOnBrowser.FunctionSupportedOnWindows()' is only supported on: 'browser'.
 
-            var supportedOnWindows10 = [|new TypeSupportedOnWindows10()|]; // 'TypeSupportedOnWindows10' is only supported on: 'windows' 10.0 and later. This call site is reachable on all platforms.
+            var supportedOnWindows10 = [|new TypeSupportedOnWindows10()|]; // This call site is reachable on all platforms. 'TypeSupportedOnWindows10' is only supported on: 'windows' 10.0 and later.
             {|#6:supportedOnWindows10.FunctionSupportedOnBrowser()|}; // child function support will be ignored
 
-            var supportedOnWindowsAndBrowser = [|new TypeSupportedOnWindowsAndBrowser()|]; // 'TypeSupportedOnWindowsAndBrowser' is only supported on: 'windows', 'browser'. This call site is reachable on all platforms.
-            [|supportedOnWindowsAndBrowser.FunctionSupportedOnWindows11()|]; // 'TypeSupportedOnWindowsAndBrowser.FunctionSupportedOnWindows11()' is only supported on: 'windows' 11.0 and later, 'browser'. This call site is reachable on all platforms.
+            var supportedOnWindowsAndBrowser = [|new TypeSupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'TypeSupportedOnWindowsAndBrowser' is only supported on: 'windows', 'browser'.
+            [|supportedOnWindowsAndBrowser.FunctionSupportedOnWindows11()|]; // This call site is reachable on all platforms. 'TypeSupportedOnWindowsAndBrowser.FunctionSupportedOnWindows11()' is only supported on: 'windows' 11.0 and later, 'browser'.
         }
 
         public static void Unsupported()
@@ -2137,19 +2133,19 @@ namespace PlatformCompatDemo.SupportedUnupported
         public static void Unsupported()
         {
             var unsupportedOnBrowser = {|#0:new TypeUnsupportedOnBrowser()|};
-            [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|];   // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows'. This call site is reachable on all platforms.
-            [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser', 'windows' 10.0 and later. This call site is reachable on all platforms.
+            [|unsupportedOnBrowser.FunctionUnsupportedOnWindows()|];   // This call site is reachable on all platforms. 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows()' is unsupported on: 'browser', 'windows'.
+            [|unsupportedOnBrowser.FunctionUnsupportedOnWindows10()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnBrowser.FunctionUnsupportedOnWindows10()' is unsupported on: 'browser', 'windows' 10.0 and later.
 
             var unsupportedOnWindows10 = {|#1:new TypeUnsupportedOnWindows10()|};
-            [|unsupportedOnWindows10.FunctionUnsupportedOnBrowser()|];   // 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnBrowser()' is unsupported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
+            [|unsupportedOnWindows10.FunctionUnsupportedOnBrowser()|];   // This call site is reachable on all platforms. 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnBrowser()' is unsupported on: 'windows' 10.0 and later, 'browser'.
             {|#2:unsupportedOnWindows10.FunctionUnsupportedOnWindows11()|};
-            [|unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()|]; // 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
+            [|unsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindows10.FunctionUnsupportedOnWindows11AndBrowser()' is unsupported on: 'windows' 10.0 and later, 'browser'.
 
-            var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|]; // 'TypeUnsupportedOnWindowsAndBrowser' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
-            [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser'. This call site is reachable on all platforms.
+            var unsupportedOnWindowsAndBrowser = [|new TypeUnsupportedOnWindowsAndBrowser()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindowsAndBrowser' is unsupported on: 'windows', 'browser'.
+            [|unsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindowsAndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows', 'browser'.
 
-            var unsupportedOnWindows10AndBrowser = [|new TypeUnsupportedOnWindows10AndBrowser()|]; // 'TypeUnsupportedOnWindows10AndBrowser' is unsupported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
-            [|unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()|];  // 'TypeUnsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.
+            var unsupportedOnWindows10AndBrowser = [|new TypeUnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on all platforms. 'TypeUnsupportedOnWindows10AndBrowser' is unsupported on: 'windows' 10.0 and later, 'browser'.
+            [|unsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()|];  // This call site is reachable on all platforms. 'TypeUnsupportedOnWindows10AndBrowser.FunctionUnsupportedOnWindows11()' is unsupported on: 'windows' 10.0 and later, 'browser'.
         }
 
         public static void UnsupportedCombinations()
@@ -2208,6 +2204,204 @@ namespace PlatformCompatDemo.SupportedUnupported
                 WithArguments("TypeUnsupportedOnWindowsSupportedOnWindows11.FunctionUnsupportedOnWindows12SupportedOnWindows13()", "'windows' 11.0 and later", ""));
         }
 
+        [Fact]
+        public async Task CallSiteCrossPlatform_CallsSupportedUnsupported_VersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+
+public class Test
+{
+    public void CrossPlatformTest()
+    {
+        {|#0:DenyList.UnsupportedWindows()|}; // This call site is reachable on all platforms. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows'.
+        {|#1:DenyList.UnsupportedWindows10()|}; // This call site is reachable on all platforms. 'DenyList.UnsupportedWindows10()' is unsupported on: 'windows' 10.0 and later.
+        {|#2:DenyList.UnsupportedSupportedWindows8To10()|}; // This call site is reachable on all platforms. 'DenyList.UnsupportedSupportedWindows8To10()' is supported on: 'windows' from version 8.0 to 10.0.
+        {|#3:AllowList.WindowsOnly()|}; // This call site is reachable on all platforms. 'AllowList.WindowsOnly()' is only supported on: 'windows'.
+        {|#4:AllowList.Windows10Only()|}; // This call site is reachable on all platforms. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        {|#5:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is reachable on all platforms. 'AllowList.WindowsOnlyUnsupportedFrom10()' is only supported on: 'windows' 10.0 and before.
+        {|#6:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on all platforms. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(1).WithArguments("DenyList.UnsupportedWindows10()", "'windows' 10.0 and later", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsAllPlatforms).WithLocation(2).WithArguments("DenyList.UnsupportedSupportedWindows8To10()", "'windows' from version 8.0 to 10.0", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(3).WithArguments("AllowList.WindowsOnly()", "'windows'", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(4).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(5).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and before", ""),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(6).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", ""));
+        }
+
+        [Fact]
+        public async Task CallSiteWindowsOnly_CallsSupportedUnsupported_VersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+ 
+public class Test
+{   
+    [SupportedOSPlatform(""windows"")]
+    public void SupportedWindowsTest()
+    {
+        {|#0:DenyList.UnsupportedWindows()|}; // This call site is reachable on: 'windows'. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows'.
+        {|#1:DenyList.UnsupportedWindows10()|}; // This call site is reachable on: 'windows' all versions. 'DenyList.UnsupportedWindows10()' is unsupported on: 'windows' 10.0 and later.
+        {|#2:DenyList.UnsupportedSupportedWindows8To10()|}; // This call site is reachable on: 'windows' all versions. 'DenyList.UnsupportedSupportedWindows8To10()' is supported on: 'windows' from version 8.0 to 10.0.
+        AllowList.WindowsOnly();
+        {|#3:AllowList.Windows10Only()|}; // This call site is reachable on: 'windows' all versions. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        {|#4:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is reachable on: 'windows' all versions. 'AllowList.WindowsOnlyUnsupportedFrom10()' is unsupported on: 'windows' 10.0 and later.
+        {|#5:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on: 'windows' all versions. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows'", "'windows'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(1).WithArguments("DenyList.UnsupportedWindows10()", "'windows' 10.0 and later", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(2).WithArguments("DenyList.UnsupportedSupportedWindows8To10()", "'windows' from version 8.0 to 10.0", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(3).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(4).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and later", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(5).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", "'windows' all versions"));
+        }
+
+        [Fact]
+        public async Task CallSiteWindows9Only_CallsSupportedUnsupported_VersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+ 
+public class Test
+{
+    [SupportedOSPlatform(""windows9.0"")]
+    public void SupportedWindows10Test()
+    {
+        {|#0:DenyList.UnsupportedWindows()|}; // This call site is reachable on: 'windows' 9.0 and later. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows' all versions.
+        {|#1:DenyList.UnsupportedWindows10()|}; // This call site is reachable on: 'windows' 9.0 and later. 'DenyList.UnsupportedWindows10()' is unsupported on: 'windows' 10.0 and later.
+        {|#2:DenyList.UnsupportedSupportedWindows8To10()|}; // This call site is reachable on: 'windows' 9.0 and later. 'DenyList.UnsupportedSupportedWindows8To10()' is unsupported on: 'windows' 10.0 and later.
+        AllowList.WindowsOnly();
+        {|#3:AllowList.Windows10Only()|}; // This call site is reachable on: 'windows' 9.0 and later. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        {|#4:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is reachable on: 'windows' 9.0 and later. 'AllowList.WindowsOnlyUnsupportedFrom10()' is unsupported on: 'windows' 10.0 and later.
+        {|#5:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on: 'windows' 9.0 and later. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows' all versions", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(1).WithArguments("DenyList.UnsupportedWindows10()", "'windows' 10.0 and later", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(2).WithArguments("DenyList.UnsupportedSupportedWindows8To10()", "'windows' 10.0 and later", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(3).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(4).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and later", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(5).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", "'windows' 9.0 and later"));
+        }
+
+        [Fact]
+        public async Task CallSiteAllowList_CallsSupportedUnsupportedVersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+ 
+public class Test
+{   
+    [SupportedOSPlatform(""windows"")]
+    [UnsupportedOSPlatform(""windows10.0"")]
+    public void SupportedWindowsUnsupported10Test()
+    {
+        {|#0:DenyList.UnsupportedWindows()|}; // This call site is reachable on: 'windows' 10.0 and before. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows' all versions.
+        DenyList.UnsupportedWindows10();
+        {|#1:DenyList.UnsupportedSupportedWindows8To10()|}; // This call site is reachable on: 'windows' 10.0 and before. 'DenyList.UnsupportedSupportedWindows8To10()' is supported on: 'windows' 8.0 and later.
+        AllowList.WindowsOnly(); 
+        {|#2:AllowList.Windows10Only()|}; // This call site is reachable on: 'windows' 10.0 and before. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        AllowList.WindowsOnlyUnsupportedFrom10();
+        {|#3:AllowList.Windows10OnlyUnsupportedFrom11()|}; // row16: This call site is reachable on: 'windows' 10.0 and before. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+
+    [SupportedOSPlatform(""windows10.0"")]
+    [UnsupportedOSPlatform(""windows11.0"")]
+    public void SupportedWindows10Unsupported11Test()
+    {
+        {|#4:DenyList.UnsupportedWindows()|}; // This call site is reachable on: 'windows' from version 10.0 to 11.0. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows' all versions.
+        {|#5:DenyList.UnsupportedWindows10()|}; // This call site is reachable on: 'windows' from version 10.0 to 11.0. 'DenyList.UnsupportedWindows10()' is unsupported on: 'windows' 10.0 and later.
+        {|#6:DenyList.UnsupportedSupportedWindows8To10()|}; //  This call site is reachable on: 'windows' from version 10.0 to 11.0. 'DenyList.UnsupportedSupportedWindows8To10()' is unsupported on: 'windows' 10.0 and later.
+        AllowList.WindowsOnly(); 
+        AllowList.Windows10Only();
+        {|#7:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is reachable on: 'windows' from version 10.0 to 11.0. 'AllowList.WindowsOnlyUnsupportedFrom10()' is unsupported on: 'windows' 10.0 and later.
+        AllowList.Windows10OnlyUnsupportedFrom11();
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows' all versions", "'windows' 10.0 and before"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(1).WithArguments("DenyList.UnsupportedSupportedWindows8To10()", "'windows' 8.0 and later", "'windows' 10.0 and before"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(2).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", "'windows' 10.0 and before"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(3).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", "'windows' 10.0 and before"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(4).WithArguments("DenyList.UnsupportedWindows()", "'windows' all versions", "'windows' from version 10.0 to 11.0"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(5).WithArguments("DenyList.UnsupportedWindows10()", "'windows' 10.0 and later", "'windows' from version 10.0 to 11.0"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(6).WithArguments("DenyList.UnsupportedSupportedWindows8To10()", "'windows' 10.0 and later", "'windows' from version 10.0 to 11.0"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(7).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and later", "'windows' from version 10.0 to 11.0"));
+        }
+
+        [Fact]
+        public async Task CallSiteUnsupportedWindows_CallsSupportedUnsupported_VersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+ 
+public class Test
+{   
+    [UnsupportedOSPlatform(""windows"")]
+    public void UnsupportedWindowsTest()
+    {
+        DenyList.UnsupportedWindows();
+        DenyList.UnsupportedWindows10();
+        DenyList.UnsupportedSupportedWindows8To10();
+        {|#0:AllowList.WindowsOnly()|}; // This call site is unreachable on: 'windows'. 'AllowList.WindowsOnly()' is only supported on: 'windows'.
+        {|#1:AllowList.Windows10Only()|}; // This call site is unreachable on: 'windows' all versions. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        {|#2:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is unreachable on: 'windows' all versions. 'AllowList.WindowsOnlyUnsupportedFrom10()' is only supported on: 'windows' 10.0 and before.
+        {|#3:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is unreachable on: 'windows' all versions. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(0).WithArguments("AllowList.WindowsOnly()", "'windows'", "'windows'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(1).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(2).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and before", "'windows' all versions"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(3).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", "'windows' all versions"));
+        }
+
+        [Fact]
+        public async Task CallSiteUnsupportsWindows9_CallsSupportedUnsupported_VersionedVersionlessAPIs()
+        {
+            var source = @"
+ using System.Runtime.Versioning;
+ 
+public class Test
+{
+    [UnsupportedOSPlatform(""windows9.0"")]
+    public void UnsupportedWindows9Test()
+    {
+        DenyList.UnsupportedWindows(); // TODO fix come later: This call site is reachable on: 'windows' 9.0 and before. 'DenyList.UnsupportedWindows()' is unsupported on: 'windows' all versions.
+        DenyList.UnsupportedWindows10();
+        DenyList.UnsupportedSupportedWindows8To10(); // This call site is reachable on: 'windows' 9.0 and before. 'DenyList.UnsupportedSupportedWindows8To10()' is unsupported on: 'windows' 8.0 and before.
+        {|#0:AllowList.WindowsOnly()|}; // This call site is unreachable on: 'windows' 9.0 and later. 'AllowList.WindowsOnly()' is only supported on: 'windows' all versions.
+        {|#1:AllowList.Windows10Only()|}; // This call site is unreachable on: 'windows' 9.0 and later. 'AllowList.Windows10Only()' is only supported on: 'windows' 10.0 and later.
+        {|#2:AllowList.WindowsOnlyUnsupportedFrom10()|}; // This call site is unreachable on: 'windows' 9.0 and later. 'AllowList.WindowsOnlyUnsupportedFrom10()' is only supported on: 'windows' 10.0 and before.
+        {|#3:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is unreachable on: 'windows' 9.0 and later. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
+    }
+}
+" + AllowDenyListTestClasses + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(0).WithArguments("AllowList.WindowsOnly()", "'windows' all versions", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(1).WithArguments("AllowList.Windows10Only()", "'windows' 10.0 and later", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(2).WithArguments("AllowList.WindowsOnlyUnsupportedFrom10()", "'windows' 10.0 and before", "'windows' 9.0 and later"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(3).WithArguments("AllowList.Windows10OnlyUnsupportedFrom11()", "'windows' from version 10.0 to 11.0", "'windows' 9.0 and later"));
+        }
+
         private static VerifyCS.Test PopulateTestCs(string sourceCode, params DiagnosticResult[] expected)
         {
             var test = new VerifyCS.Test
@@ -2260,6 +2454,38 @@ namespace PlatformCompatDemo.SupportedUnupported
             test.ExpectedDiagnostics.AddRange(expected);
             return test;
         }
+
+        private readonly string AllowDenyListTestClasses = @"
+public class DenyList
+{
+    [UnsupportedOSPlatform(""windows10.0"")]
+    public static void UnsupportedWindows10() { }
+
+    [UnsupportedOSPlatform(""windows"")]
+    public static void UnsupportedWindows() { }
+    
+    [UnsupportedOSPlatform(""windows"")]
+    [SupportedOSPlatform(""windows8.0"")]
+    [UnsupportedOSPlatform(""windows10.0"")]
+    public static void UnsupportedSupportedWindows8To10() { }
+}
+    
+public class AllowList
+{
+    [SupportedOSPlatform(""windows10.0"")]
+    public static void Windows10Only() { }
+
+    [SupportedOSPlatform(""windows"")]
+    public static void WindowsOnly() { }
+
+    [SupportedOSPlatform(""windows"")]
+    [UnsupportedOSPlatform(""windows10.0"")]
+    public static void WindowsOnlyUnsupportedFrom10() { }
+    
+    [SupportedOSPlatform(""windows10.0"")]
+    [UnsupportedOSPlatform(""windows11.0"")]
+    public static void Windows10OnlyUnsupportedFrom11() { }
+}";
 
         private readonly string MockAttributesCsSource = @"
 namespace System.Runtime.Versioning


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4021
This PR only has messaging updates, no any functional change or bugfix
The messages update into the following structure:
List | Messaging structure
-- | -- 
Allow list | '{0}' is only supported on: {1}. This call site is reachable on all platforms. 
Allow list | '{0}' is only supported on: {1}. This call site is unreachable on: {2}.
Allow list | '{0}' is only supported on: {1}. This call site is reachable on: {2}. 
Deny list | '{0}' is unsupported on: {1}, This call site is reachable on all platforms.
Deny list | '{0}' is unsupported on: {1}, This call site is reachable on: {2}.
Deny list | '{0}' is supported on: {1}, This call site is reachable on all platforms.
Deny list | '{0}' is supported on: {1}, This call site is reachable on: {2}.

Examples: 

- `'SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'. This call site is reachable on all platforms.`
- `'SupportedOnWindowsUnsupportedOnWindows2004()' is only supported on: 'windows' 10.0.2004 and before. This call site is reachable on: 'Windows'.`
- `SupportedOnWindows()' is only supported on: 'windows'. This call site is reachable on: 'windows', 'browser'.`
- `'SupportedOnWindowsAndBrowser()' is only supported on: 'browser', 'windows'. This call site is unreachable on: 'browser'.`
- `'UnsupportedOnWindows()' is unsupported on: 'windows'. This call site is reachable on all platforms.`
- `'UnsupportedOnBrowser()' is unsupported on: 'browser'. This call site is reachable on: 'windows', 'browser'.`
- `'UnsupportedOnWindowsSupportedOn1903UnsupportedOn2004()' is supported on: 'windows' from version 10.0.1903 to 10.0.2004. This call site is reachable on all platforms.`
- `'UnsupportedOnWindowsSupportedOn1903()' is supported on: 'windows' 10.0.1903 and later. This call site is reachable on: 'windows' 10.0.2000 and before`

cc @jeffhandley @stephentoub  @terrajobst 