### PR TITLE
Fix fast-path cache

### DIFF
--- a/eng/Analyzers_NonShippingRules.ruleset
+++ b/eng/Analyzers_NonShippingRules.ruleset
@@ -32,4 +32,9 @@
   <Rules AnalyzerId="xunit.analyzers" RuleNamespace="Xunit.Analyzers">
     <Rule Id="xUnit1004" Action="Hidden" /> <!-- allow skipped tests, but also enable the refactoring to enable them -->
   </Rules>
+
+  <Rules AnalyzerId="Roslyn.Diagnostics.Analyzers" RuleNamespace="Ignored">
+    <Rule Id="RS0043" Action="None" /> <!-- Do not call 'GetTestAccessor()': does not apply to test code -->
+  </Rules>
+
 </RuleSet>

--- a/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
+++ b/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
@@ -270,6 +270,29 @@ public namespace MyNamespace
             Assert.Equal("SomeValue4", options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.NamedType]["MyClass"]);
         }
 
+        [Fact]
+        [WorkItem(1242125, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242125")]
+        public void FastPathDoesNotCache()
+        {
+            var compilation = GetCompilation(@"
+using System;
+
+public namespace MyNamespace
+{
+    public class MyClass {}
+}");
+
+            var namedTypeSymbol = (INamedTypeSymbol)compilation.GetSymbolsWithName("MyClass").Single();
+
+            var options = SymbolNamesWithValueOption<Unit>.Empty;
+
+            // Check for containment
+            var contained = options.Contains(namedTypeSymbol);
+            Assert.False(contained);
+            Assert.Empty(options.GetTestAccessor().WildcardMatchResult);
+            Assert.Empty(options.GetTestAccessor().SymbolToDeclarationId);
+        }
+
         [Theory]
         // Symbol name
         [InlineData("My*", "MyCompany")]

--- a/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
+++ b/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
@@ -59,9 +59,9 @@ namespace Analyzer.Utilities.UnitTests.Options
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Equal(symbolNames.Length, options._names.Count);
-            Assert.Empty(options._symbols);
-            Assert.Empty(options._wildcardNamesBySymbolKind);
+            Assert.Equal(symbolNames.Length, options.GetTestAccessor().Names.Count);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Empty(options.GetTestAccessor().WildcardNamesBySymbolKind);
         }
 
         [Fact]
@@ -93,9 +93,9 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Empty(options._symbols);
-            Assert.Empty(options._wildcardNamesBySymbolKind);
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Empty(options.GetTestAccessor().WildcardNamesBySymbolKind);
         }
 
         [Fact]
@@ -127,9 +127,9 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Equal(symbolNames.Length, options._symbols.Count);
-            Assert.Empty(options._wildcardNamesBySymbolKind);
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Equal(symbolNames.Length, options.GetTestAccessor().Symbols.Count);
+            Assert.Empty(options.GetTestAccessor().WildcardNamesBySymbolKind);
         }
 
         [Fact]
@@ -149,9 +149,9 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Empty(options._symbols);
-            Assert.Empty(options._wildcardNamesBySymbolKind);
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Empty(options.GetTestAccessor().WildcardNamesBySymbolKind);
         }
 
         [Fact]
@@ -169,9 +169,9 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Empty(options._symbols);
-            Assert.Empty(options._wildcardNamesBySymbolKind);
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Empty(options.GetTestAccessor().WildcardNamesBySymbolKind);
         }
 
         [Fact]
@@ -191,16 +191,16 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Empty(options._symbols);
-            Assert.Single(options._wildcardNamesBySymbolKind);
-            Assert.Equal(symbolNames.Length, options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].Count);
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyField"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyProperty"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyEvent"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyMethod("));
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Single(options.GetTestAccessor().WildcardNamesBySymbolKind);
+            Assert.Equal(symbolNames.Length, options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].Count);
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyField"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyProperty"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyEvent"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds].ContainsKey("MyNamespace.MyClass.MyMethod("));
         }
 
         [Fact]
@@ -220,15 +220,15 @@ public namespace MyNamespace
             var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
 
             // Assert
-            Assert.Empty(options._names);
-            Assert.Empty(options._symbols);
-            Assert.Equal(symbolNames.Length, options._wildcardNamesBySymbolKind.Count);
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.Namespace].ContainsKey("MyNamespace"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.NamedType].ContainsKey("MyNamespace.MyClass"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.Field].ContainsKey("MyNamespace.MyClass.MyField"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.Property].ContainsKey("MyNamespace.MyClass.MyProperty"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.Event].ContainsKey("MyNamespace.MyClass.MyEvent"));
-            Assert.True(options._wildcardNamesBySymbolKind[SymbolKind.Method].ContainsKey("MyNamespace.MyClass.MyMethod("));
+            Assert.Empty(options.GetTestAccessor().Names);
+            Assert.Empty(options.GetTestAccessor().Symbols);
+            Assert.Equal(symbolNames.Length, options.GetTestAccessor().WildcardNamesBySymbolKind.Count);
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.Namespace].ContainsKey("MyNamespace"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.NamedType].ContainsKey("MyNamespace.MyClass"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.Field].ContainsKey("MyNamespace.MyClass.MyField"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.Property].ContainsKey("MyNamespace.MyClass.MyProperty"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.Event].ContainsKey("MyNamespace.MyClass.MyEvent"));
+            Assert.True(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.Method].ContainsKey("MyNamespace.MyClass.MyMethod("));
         }
 
         [Fact]
@@ -259,15 +259,15 @@ public namespace MyNamespace
                 });
 
             // Assert
-            Assert.Single(options._names);
-            Assert.Equal("SomeValue1", options._names["MyClass"]);
-            Assert.Single(options._symbols);
-            Assert.Equal("SomeValue2", options._symbols[namedTypeSymbol]);
-            Assert.Equal(2, options._wildcardNamesBySymbolKind.Count);
-            Assert.Single(options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds]);
-            Assert.Equal("SomeValue3", options._wildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds]["MyClass"]);
-            Assert.Single(options._wildcardNamesBySymbolKind[SymbolKind.NamedType]);
-            Assert.Equal("SomeValue4", options._wildcardNamesBySymbolKind[SymbolKind.NamedType]["MyClass"]);
+            Assert.Single(options.GetTestAccessor().Names);
+            Assert.Equal("SomeValue1", options.GetTestAccessor().Names["MyClass"]);
+            Assert.Single(options.GetTestAccessor().Symbols);
+            Assert.Equal("SomeValue2", options.GetTestAccessor().Symbols[namedTypeSymbol]);
+            Assert.Equal(2, options.GetTestAccessor().WildcardNamesBySymbolKind.Count);
+            Assert.Single(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds]);
+            Assert.Equal("SomeValue3", options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolNamesWithValueOption<Unit>.AllKinds]["MyClass"]);
+            Assert.Single(options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.NamedType]);
+            Assert.Equal("SomeValue4", options.GetTestAccessor().WildcardNamesBySymbolKind[SymbolKind.NamedType]["MyClass"]);
         }
 
         [Theory]
@@ -345,7 +345,7 @@ public namespace MyCompany.MyProduct.MyFeature
 
             // Assert
             Assert.True(isFound);
-            Assert.True(options._wildcardMatchResult.ContainsKey(symbol));
+            Assert.True(options.GetTestAccessor().WildcardMatchResult.ContainsKey(symbol));
 
             static ISymbol FindSymbol(Compilation compilation, string symbolName)
             {

--- a/src/Utilities/Compiler/Options/SymbolNamesWithValueOption.cs
+++ b/src/Utilities/Compiler/Options/SymbolNamesWithValueOption.cs
@@ -22,9 +22,8 @@ namespace Analyzer.Utilities
         public static readonly SymbolNamesWithValueOption<TValue> Empty = new SymbolNamesWithValueOption<TValue>();
         internal static KeyValuePair<string, TValue> NoWildcardMatch => default;
 
-#pragma warning disable CA1051 // Do not declare visible instance fields
-        internal /* for testing purposes */ readonly ImmutableDictionary<string, TValue> _names;
-        internal /* for testing purposes */ readonly ImmutableDictionary<ISymbol, TValue> _symbols;
+        private readonly ImmutableDictionary<string, TValue> _names;
+        private readonly ImmutableDictionary<ISymbol, TValue> _symbols;
 
         /// <summary>
         /// Dictionary holding per symbol kind the wildcard entry with its suffix.
@@ -46,15 +45,14 @@ namespace Analyzer.Utilities
         /// Property ->
         ///     Analyzer.Utilities.SymbolNamesWithValueOption.MyProperty -> ""
         /// </example>
-        internal /* for testing purposes */ readonly ImmutableDictionary<SymbolKind, ImmutableDictionary<string, TValue>> _wildcardNamesBySymbolKind;
+        private readonly ImmutableDictionary<SymbolKind, ImmutableDictionary<string, TValue>> _wildcardNamesBySymbolKind;
 
         /// <summary>
         /// Cache for the wildcard matching algorithm. The current implementation can be slow so we want to make sure that once a match is performed we save its result.
         /// </summary>
-        internal /* for testing purposes */ readonly ConcurrentDictionary<ISymbol, KeyValuePair<string, TValue>> _wildcardMatchResult = new ConcurrentDictionary<ISymbol, KeyValuePair<string, TValue>>();
+        private readonly ConcurrentDictionary<ISymbol, KeyValuePair<string, TValue>> _wildcardMatchResult = new ConcurrentDictionary<ISymbol, KeyValuePair<string, TValue>>();
 
-        internal /* for testing purposes */ readonly ConcurrentDictionary<ISymbol, string> _symbolToDeclarationId = new ConcurrentDictionary<ISymbol, string>();
-#pragma warning restore CA1051 // Do not declare visible instance fields
+        private readonly ConcurrentDictionary<ISymbol, string> _symbolToDeclarationId = new ConcurrentDictionary<ISymbol, string>();
 
         private SymbolNamesWithValueOption(ImmutableDictionary<string, TValue> names, ImmutableDictionary<ISymbol, TValue> symbols,
             ImmutableDictionary<SymbolKind, ImmutableDictionary<string, TValue>> wildcardNamesBySymbolKind)
@@ -338,6 +336,32 @@ namespace Analyzer.Utilities
 
                 return declarationIdWithoutPrefix;
             }
+        }
+
+        internal TestAccessor GetTestAccessor()
+        {
+            return new TestAccessor(this);
+        }
+
+        [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Does not apply to test accessors")]
+        internal readonly struct TestAccessor
+        {
+            private readonly SymbolNamesWithValueOption<TValue> _symbolNamesWithValueOption;
+
+            internal TestAccessor(SymbolNamesWithValueOption<TValue> symbolNamesWithValueOption)
+            {
+                _symbolNamesWithValueOption = symbolNamesWithValueOption;
+            }
+
+            internal ref readonly ImmutableDictionary<string, TValue> Names => ref _symbolNamesWithValueOption._names;
+
+            internal ref readonly ImmutableDictionary<ISymbol, TValue> Symbols => ref _symbolNamesWithValueOption._symbols;
+
+            internal ref readonly ImmutableDictionary<SymbolKind, ImmutableDictionary<string, TValue>> WildcardNamesBySymbolKind => ref _symbolNamesWithValueOption._wildcardNamesBySymbolKind;
+
+            internal ref readonly ConcurrentDictionary<ISymbol, KeyValuePair<string, TValue>> WildcardMatchResult => ref _symbolNamesWithValueOption._wildcardMatchResult;
+
+            internal ref readonly ConcurrentDictionary<ISymbol, string> SymbolToDeclarationId => ref _symbolNamesWithValueOption._symbolToDeclarationId;
         }
 
         /// <summary>

--- a/src/Utilities/Compiler/Options/SymbolNamesWithValueOption.cs
+++ b/src/Utilities/Compiler/Options/SymbolNamesWithValueOption.cs
@@ -275,7 +275,6 @@ namespace Analyzer.Utilities
             if (_wildcardNamesBySymbolKind.IsEmpty)
             {
                 firstMatch = NoWildcardMatch;
-                _wildcardMatchResult.AddOrUpdate(symbol, firstMatch, (s, match) => NoWildcardMatch);
                 return false;
             }
 


### PR DESCRIPTION
For default **.editorconfig** scenarios, `SymbolNamesWithValueOption<TValue>.Empty` is used. This has an empty set of wildcard match names, but still caches symbols. Since the `Empty` value is static, this means the process keeps a cached copy of _all_ symbols for which `Contains` is called until the process runs out of memory.

This issue is also the reason why other `ConditionalWeakTable<TKey, TValue>` instances were never releasing values, since the `Compilation` keys were retaining strong roots through this path.

Fixes [AB#1242125](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1242125)