### PR TITLE
Remove AppHosts from tools

### DIFF
--- a/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj
+++ b/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj
@@ -3,5 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NonShipping>true</NonShipping>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 </Project>

--- a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NonShipping>true</NonShipping>
+    <UseAppHost>false</UseAppHost>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>

--- a/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
+++ b/src/Tools/GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NonShipping>true</NonShipping>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseAppHost>false</UseAppHost>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
   </PropertyGroup>  
   <ItemGroup>


### PR DESCRIPTION
The tool projects are building the apphost, but we always invoke the tool through `dotnet tool.dll` instead of the apphost (`tool`). Removing the apphost should have no effects.

Keeping the AppHosts introduces additional prebuilts for source build and it would be nice to not have to maintain this patch in source-build. See https://github.com/dotnet/source-build/issues/1905 for more details.