### PR TITLE
bumping the version number to match 5.0.2 release

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>3.3.1</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
-    <NetAnalyzersVersionPrefix>5.0.0</NetAnalyzersVersionPrefix>
+    <NetAnalyzersVersionPrefix>5.0.2</NetAnalyzersVersionPrefix>
     <NetAnalyzersPreReleaseVersionLabel>rtm</NetAnalyzersPreReleaseVersionLabel>
     <AnalyzerUtilitiesVersionPrefix>$(VersionPrefix)</AnalyzerUtilitiesVersionPrefix>
     <!--


### PR DESCRIPTION
This way, when we upload this package to nuget folks will be able to reference it explicitly
