### PR TITLE
Fix RS1024: Do not report when SymbolEqualityComparer.Default is passed

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
@@ -171,7 +171,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         if (symbolEqualityComparerType != null &&
                             possibleMethodTypes.Contains(method.ContainingType.OriginalDefinition) &&
                             HasFirstTypeArgumentSymbolType(method, symbolType) &&
-                            !invocationOperation.Arguments.Any(arg => arg.Type != null && arg.Type.Equals(symbolEqualityComparerType)))
+                            !invocationOperation.Arguments.Any(arg => IsSymbolType(arg.Value, symbolEqualityComparerType)))
                         {
                             context.ReportDiagnostic(invocationOperation.CreateDiagnostic(CollectionRule));
                         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -831,5 +831,34 @@ End Class",
                 },
             }.RunAsync();
         }
+
+        [Fact, WorkItem(4469, "https://github.com/dotnet/roslyn-analyzers/issues/4469")]
+        public async Task RS1024_EnumerableContainsSymbolEqualityComparerDefault()
+        {
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+public class C
+{
+    public void M(IEnumerable<ISymbol> e, ISymbol symbol)
+    {
+        [|e.Contains(symbol)|];
+        e.Contains(symbol, SymbolEqualityComparer.Default);
+    }
+}",
+                        SymbolEqualityComparerStubCSharp,
+                    },
+                },
+            }.RunAsync();
+        }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -833,7 +833,7 @@ End Class",
         }
 
         [Fact, WorkItem(4469, "https://github.com/dotnet/roslyn-analyzers/issues/4469")]
-        public async Task RS1024_EnumerableContainsSymbolEqualityComparerDefault()
+        public async Task RS1024_SymbolEqualityComparerDefault()
         {
             await new VerifyCS.Test
             {
@@ -849,10 +849,14 @@ using Microsoft.CodeAnalysis;
 
 public class C
 {
-    public void M(IEnumerable<ISymbol> e, ISymbol symbol)
+    public void M(IEnumerable<ISymbol> e, ISymbol symbol, INamedTypeSymbol type)
     {
-        [|e.Contains(symbol)|];
         e.Contains(symbol, SymbolEqualityComparer.Default);
+
+        var asyncMethods = type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(x => x.IsAsync)
+            .ToLookup(x => x.ContainingType, x => x, SymbolEqualityComparer.Default);
     }
 }",
                         SymbolEqualityComparerStubCSharp,


### PR DESCRIPTION
Fix #4469 and fix #4412