### PR TITLE
Remove mock APIs used for PC analyzer as now we can use new APIs in 5.0

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -136,13 +136,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                 var typeName = WellKnownTypeNames.SystemOperatingSystem;
 
-                // TODO: remove 'typeName + "Helper"' after tests able to consume the real new APIs
-                if (!context.Compilation.TryGetOrCreateTypeByMetadataName(typeName + "Helper", out var operatingSystemType))
+                if (!context.Compilation.TryGetOrCreateTypeByMetadataName(typeName, out var operatingSystemType))
                 {
-                    if (!context.Compilation.TryGetOrCreateTypeByMetadataName(typeName, out operatingSystemType))
-                    {
-                        return;
-                    }
+                    return;
                 }
 
                 var osPlatformType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeInteropServicesOSPlatform);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -34,13 +34,13 @@ class Test
 {
     public void Api_Usage()
     {
-        if (OperatingSystemHelper.IsAndroidVersionAtLeast(" + arguments + @"))
+        if (OperatingSystem.IsAndroidVersionAtLeast(" + arguments + @"))
         {
             Api();
         }
         [|Api()|];
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(" + arguments + @", platform : ""Android""))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(" + arguments + @", platform : ""Android""))
         {
             Api();
         }
@@ -51,10 +51,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Android12.0.2.521"")]
-    void Api()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void Api() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -77,7 +75,7 @@ public class Test
     void GenericMethod2<T1, T2>() {}
     void M1()
     {
-        if (OperatingSystemHelper.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
             GenericMethod<WindowsOnlyType>();
             GenericMethod2<Test, WindowsOnlyType>();
@@ -91,7 +89,7 @@ public class Test
         }
     }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(csSource, s_msBuildPlatforms);
         }
 
@@ -114,7 +112,7 @@ public class Test
     void GenericMethod<T1, T2>() {}
     void M1()
     {
-        if (OperatingSystemHelper.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
             [|WindowsOnlyMethod<BrowserOnlyType>()|];  // should flag for BrowserOnlyType parameter
             [|GenericMethod<WindowsOnlyType, BrowserOnlyType>()|]; // same
@@ -126,7 +124,7 @@ public class Test
         }
     }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(csSource, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(24, 13).WithArguments("BrowserOnlyType", "'browser'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(25, 13).WithArguments("WindowsOnlyType", "'windows'"));
@@ -143,8 +141,8 @@ class Test
 {
     public void Api_Usage()
     {
-        if (!OperatingSystemHelper.IsWindows() ||
-            OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 19041))
+        if (!OperatingSystem.IsWindows() ||
+            OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041))
         {
             Api();
         }
@@ -154,10 +152,8 @@ class Test
 
     [UnsupportedOSPlatform(""windows"")]
     [SupportedOSPlatform(""windows10.0.19041"")]
-    void Api()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void Api() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -175,7 +171,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
     {
         public static void TestWithGuardMethods()
         {
-            if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
+            if (OperatingSystem.IsWindows() || OperatingSystem.IsBrowser())
             {
                 [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Windows', 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
@@ -199,7 +195,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]
         public static void SupportedOnWindows10AndBrowser() { }
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -217,7 +213,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
     {
         public static void TestWithGuardMethods()
         {
-            if (!OperatingSystemHelper.IsWindows())
+            if (!OperatingSystem.IsWindows())
             {
                 [|Target.SupportedOnWindows()|]; // This call site is reachable on all platforms. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
@@ -225,7 +221,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 [|Target.SupportedOnWindows10AndBrowser()|]; // expected two diagnostics - supported on windows 10 and browser
             }
 
-            if (OperatingSystemHelper.IsWindows())
+            if (OperatingSystem.IsWindows())
             {
                 Target.SupportedOnWindows();
                 [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
@@ -233,7 +229,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 [|Target.SupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
             }
 
-            if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+            if (OperatingSystem.IsWindowsVersionAtLeast(10))
             {
                 Target.SupportedOnWindows();
                 Target.SupportedOnWindows10();
@@ -241,7 +237,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 Target.SupportedOnWindows10AndBrowser(); // the same, no diagnostic expected
             }
 
-            if (OperatingSystemHelper.IsBrowser())
+            if (OperatingSystem.IsBrowser())
             {
                 [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|];
@@ -249,7 +245,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 Target.SupportedOnWindows10AndBrowser(); // The same, no diagnostic expected
             }
 
-            if (OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsBrowser())
+            if (OperatingSystem.IsWindows() || OperatingSystem.IsBrowser())
             {
                 [|Target.SupportedOnWindows()|]; // This call site is reachable on: 'Windows', 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
@@ -257,7 +253,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
                 [|Target.SupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.SupportedOnWindows10AndBrowser()' is only supported on: 'windows' 10.0 and later, 'browser'.
             }
 
-           if (OperatingSystemHelper.IsWindowsVersionAtLeast(10) || OperatingSystemHelper.IsBrowser())
+           if (OperatingSystem.IsWindowsVersionAtLeast(10) || OperatingSystem.IsBrowser())
             {
                 [|Target.SupportedOnWindows()|]; //  This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows()' is only supported on: 'windows'.
                 [|Target.SupportedOnWindows10()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later. 
@@ -281,7 +277,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundSupported
         [SupportedOSPlatform(""windows10.0""), SupportedOSPlatform(""browser"")]
         public static void SupportedOnWindows10AndBrowser() { }
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -299,7 +295,7 @@ namespace PlatformCompatDemo.SupportedUnupported
     {
         public static void UnsupportedCombinations()
         {
-            if (OperatingSystemHelper.IsBrowser())
+            if (OperatingSystem.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
                 withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
@@ -322,7 +318,7 @@ namespace PlatformCompatDemo.SupportedUnupported
                 unsupportedOnWindowsSupportedOnWindows11UnsupportedOnWindows12.FunctionSupportedOnWindows13();
             }
 
-            if (OperatingSystemHelper.IsWindows())
+            if (OperatingSystem.IsWindows())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
                 [|withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()|]; // This call site is reachable on: 'Windows' all versions. 'TypeWithoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11()' is supported on: 'windows' 11.0 and later.
@@ -342,7 +338,7 @@ namespace PlatformCompatDemo.SupportedUnupported
             }
         }
     }
-}" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
+}" + TargetTypesForTest;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -360,7 +356,7 @@ namespace PlatformCompatDemo.SupportedUnupported
     {
         public static void UnsupportedSingleCondition()
         {
-            if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10))
             {
                 var unsupported = new TypeWithoutAttributes();
                 [|unsupported.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
@@ -391,7 +387,7 @@ namespace PlatformCompatDemo.SupportedUnupported
 
         public static void UnsupportedWithAnd()
         {
-            if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10) && !OperatingSystemHelper.IsBrowser())
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10) && !OperatingSystem.IsBrowser())
             {
                 var unsupported = new TypeWithoutAttributes();
                 [|unsupported.FunctionUnsupportedOnWindows()|]; // This call site is reachable on all platforms. 'TypeWithoutAttributes.FunctionUnsupportedOnWindows()' is unsupported on: 'windows'.
@@ -427,7 +423,7 @@ namespace PlatformCompatDemo.SupportedUnupported
 
         public static void UnsupportedCombinations()
         {
-            if (!OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsBrowser())
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsBrowser())
             {
                 var withoutAttributes = new TypeWithoutAttributes();
                 withoutAttributes.FunctionUnsupportedOnWindowsSupportedOnWindows11();
@@ -451,7 +447,7 @@ namespace PlatformCompatDemo.SupportedUnupported
             }
         }
     }
-}" + TargetTypesForTest + MockAttributesCsSource + MockOperatingSystemApiSource;
+}" + TargetTypesForTest;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -469,7 +465,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
     {
         public static void TestWithGuardMethods()
         {
-            if (!OperatingSystemHelper.IsWindows())
+            if (!OperatingSystem.IsWindows())
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
@@ -478,7 +474,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'browser'.
             }
 
-            if (!OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10))
             {
                 [|Target.UnsupportedInWindows()|]; // This call site is reachable on all platforms. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 Target.UnsupportedInWindows10();
@@ -487,7 +483,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // expected diagnostic - browser unsupported
             }
 
-            if (OperatingSystemHelper.IsWindows())
+            if (OperatingSystem.IsWindows())
             {
                 [|Target.UnsupportedInWindows()|]; // This call site is reachable on: 'Windows'. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 [|Target.UnsupportedInWindows10()|]; // expected diagnostic - windows 10 unsupported
@@ -496,7 +492,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
                 [|Target.UnsupportedOnWindows10AndBrowser()|]; // This call site is reachable on: 'Windows' all versions. 'Target.UnsupportedOnWindows10AndBrowser()' is unsupported on: 'windows' 10.0 and later.
             }
 
-            if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10))
             {
                 [|Target.UnsupportedInWindows()|]; // This call site is reachable on: 'Windows'. 'Target.UnsupportedInWindows()' is unsupported on: 'windows'.
                 Target.UnsupportedInWindows10();
@@ -505,7 +501,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
                 Target.UnsupportedOnWindows10AndBrowser();
             }
 
-            if (OperatingSystemHelper.IsBrowser())
+            if (OperatingSystem.IsBrowser())
             {
                 Target.UnsupportedInWindows();
                 Target.UnsupportedInWindows10();
@@ -533,7 +529,7 @@ namespace PlatformCompatDemo.Bugs.GuardsAroundUnsupported
         [UnsupportedOSPlatform(""windows10.0""), UnsupportedOSPlatform(""browser"")]
         public static void UnsupportedOnWindows10AndBrowser() { }
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -549,8 +545,8 @@ class Test
 {
     public void Api_Usage()
     {
-        if (OperatingSystemHelper.IsIOSVersionAtLeast(12,0) &&
-           !OperatingSystemHelper.IsIOSVersionAtLeast(14,0))
+        if (OperatingSystem.IsIOSVersionAtLeast(12,0) &&
+           !OperatingSystem.IsIOSVersionAtLeast(14,0))
         {
             Api();
         }
@@ -559,10 +555,8 @@ class Test
 
     [SupportedOSPlatform(""ios12.0"")]
     [UnsupportedOSPlatform(""ios14.0"")]
-    void Api()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void Api() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -578,7 +572,7 @@ class Test
 {
     void M1()
     {
-        if(!OperatingSystemHelper.IsBrowser())
+        if(!OperatingSystem.IsBrowser())
         {
             NotForBrowser();
             [|NotForIos12OrLater()|];
@@ -589,7 +583,7 @@ class Test
             [|NotForBrowser()|];
         }
 
-        if(OperatingSystemHelper.IsOSPlatform(""Browser""))
+        if(OperatingSystem.IsOSPlatform(""Browser""))
         {
             [|NotForBrowser()|];
         }
@@ -598,7 +592,7 @@ class Test
             NotForBrowser();
         }
         
-        if(OperatingSystemHelper.IsIOS())
+        if(OperatingSystem.IsIOS())
         {
             [|NotForIos12OrLater()|];
         }
@@ -607,7 +601,7 @@ class Test
             NotForIos12OrLater();
         }
 
-        if(OperatingSystemHelper.IsIOSVersionAtLeast(12,1))
+        if(OperatingSystem.IsIOSVersionAtLeast(12,1))
         {
             [|NotForIos12OrLater()|];
         }
@@ -616,7 +610,7 @@ class Test
             NotForIos12OrLater();
         }
 
-        if(OperatingSystemHelper.IsIOS() && !OperatingSystemHelper.IsIOSVersionAtLeast(12,0))
+        if(OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(12,0))
         {
             NotForIos12OrLater();
         }
@@ -627,15 +621,11 @@ class Test
     }
 
     [UnsupportedOSPlatform(""browser"")]
-    void NotForBrowser()
-    {
-    }
+    void NotForBrowser() { }
 
     [UnsupportedOSPlatform(""ios12.1"")]
-    void NotForIos12OrLater()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void NotForIos12OrLater() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -653,7 +643,7 @@ class Test
 {
     void M1()
     {
-        Debug.Assert(!OperatingSystemHelper.IsBrowser());
+        Debug.Assert(!OperatingSystem.IsBrowser());
 
         NotForBrowser();
         [|NotForIos12OrLater()|];
@@ -661,7 +651,7 @@ class Test
 
     void M2()
     {
-        Debug.Assert(OperatingSystemHelper.IsBrowser());
+        Debug.Assert(OperatingSystem.IsBrowser());
 
         NotForIos12OrLater();
         [|NotForBrowser()|];
@@ -669,64 +659,60 @@ class Test
 
     void M3()
     {
-        Debug.Assert(OperatingSystemHelper.IsOSPlatform(""Browser""));
+        Debug.Assert(OperatingSystem.IsOSPlatform(""Browser""));
         [|NotForBrowser()|];
     }
 
     void M4()
     {
-        Debug.Assert(!OperatingSystemHelper.IsOSPlatform(""Browser""));
+        Debug.Assert(!OperatingSystem.IsOSPlatform(""Browser""));
         NotForBrowser();
     }
 
     void M5()
     {
-        Debug.Assert(OperatingSystemHelper.IsIOS());
+        Debug.Assert(OperatingSystem.IsIOS());
         [|NotForIos12OrLater()|];
     }
 
     void M6()
     {
-        Debug.Assert(!OperatingSystemHelper.IsIOS());
+        Debug.Assert(!OperatingSystem.IsIOS());
         NotForIos12OrLater();
     }
 
     void M7()
     {
-        Debug.Assert(OperatingSystemHelper.IsIOSVersionAtLeast(12,1));
+        Debug.Assert(OperatingSystem.IsIOSVersionAtLeast(12,1));
         [|NotForIos12OrLater()|];
     }
 
     void M8()
     {
-        Debug.Assert(!OperatingSystemHelper.IsIOSVersionAtLeast(12,1));
+        Debug.Assert(!OperatingSystem.IsIOSVersionAtLeast(12,1));
         NotForIos12OrLater();
     }
 
     void M9()
     {
-        Debug.Assert(OperatingSystemHelper.IsIOS());
-        Debug.Assert(!OperatingSystemHelper.IsIOSVersionAtLeast(12,0));
+        Debug.Assert(OperatingSystem.IsIOS());
+        Debug.Assert(!OperatingSystem.IsIOSVersionAtLeast(12,0));
         
         NotForIos12OrLater();
     }
 
     void M10()
     {
-        Debug.Assert(!(OperatingSystemHelper.IsIOS() && !OperatingSystemHelper.IsIOSVersionAtLeast(12,0)));
+        Debug.Assert(!(OperatingSystem.IsIOS() && !OperatingSystem.IsIOSVersionAtLeast(12,0)));
         [|NotForIos12OrLater()|];
     }
 
     [UnsupportedOSPlatform(""browser"")]
-    void NotForBrowser()
-    {
-    }
+    void NotForBrowser() { }
 
     [UnsupportedOSPlatform(""ios12.1"")]
-    void NotForIos12OrLater()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void NotForIos12OrLater() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -769,7 +755,7 @@ class Test
 {
     void M1()
     {
-        if(OperatingSystemHelper." + isOsMethod + @"VersionAtLeast(" + version + @"))
+        if(OperatingSystem." + isOsMethod + @"VersionAtLeast(" + version + @"))
         {
             " + match + @";
         }
@@ -780,10 +766,8 @@ class Test
     }
 
     [SupportedOSPlatform(""" + osName + @""")]
-    void OsSpecificMethod()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void OsSpecificMethod() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -826,7 +810,7 @@ class Test
 {
     void M1()
     {
-        if(OperatingSystemHelper." + isOsMethod + @"())
+        if(OperatingSystem." + isOsMethod + @"())
         {
             OsSpecificMethod();
         }
@@ -837,10 +821,8 @@ class Test
     }
 
     [SupportedOSPlatform(""" + osName + @""")]
-    void OsSpecificMethod()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void OsSpecificMethod() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -856,7 +838,7 @@ class Test
 {
     void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatform(""Windows""))
+        if(OperatingSystem.IsOSPlatform(""Windows""))
         {
             M2();
         }
@@ -865,7 +847,7 @@ class Test
             [|M2()|];
         }
 
-        if(OperatingSystemHelper.IsOSPlatform(""Windows8.0""))
+        if(OperatingSystem.IsOSPlatform(""Windows8.0""))
         {
             M2();
         }
@@ -876,10 +858,8 @@ class Test
     }
 
     [SupportedOSPlatform(""windows"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -906,10 +886,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -936,10 +914,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -967,10 +943,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -1028,10 +1002,8 @@ class Test
 
     [SupportedOSPlatform(""Windows"")]
     [SupportedOSPlatform(""Linux"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -1048,7 +1020,7 @@ static class Program
 {
     public static void Main()
     {
-        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+        if (OperatingSystem.IsWindowsVersionAtLeast(10))
         {
             [|WindowsSpecificApis.WindowsOnlyMethod()|];
         }
@@ -1064,7 +1036,7 @@ public class WindowsSpecificApis
     [SupportedOSPlatform(""windows10.1.2.3"")]
     public static void WindowsOnlyMethod() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1080,7 +1052,7 @@ static class Program
 {
     public static void Main()
     {
-        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+        if (OperatingSystem.IsWindowsVersionAtLeast(10))
         {
             Some.WindowsSpecificApi();
         }
@@ -1095,11 +1067,9 @@ static class Some
 {
     [UnsupportedOSPlatform(""windows"")]
     [SupportedOSPlatform(""windows10.0"")]
-    public static void WindowsSpecificApi()
-    {
-    }
+    public static void WindowsSpecificApi() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
 
             await VerifyAnalyzerAsyncCs(source,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(0).
@@ -1118,15 +1088,13 @@ public class Test
     public void M1()
     {
         [|M2()|];
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
             M2();
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -1136,14 +1104,13 @@ Imports System
 Public Class Test
     Public Sub M1()
         [|M2()|]
-        If OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3) Then M2()
+        If OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3) Then M2()
     End Sub
 
     <SupportedOSPlatform(""Windows10.1.2.3"")>
     Public Sub M2()
     End Sub
-End Class
-" + MockAttributesVbSource + MockRuntimeApiSourceVb;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -1159,21 +1126,19 @@ public class Test
     public void M1()
     {
         [|M2()|];
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
             M2();
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 10, 1, 2, 3))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 10, 1, 2, 3))
             [|M2()|];
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
             M2();
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 8, 1, 2, 3))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 8, 1, 2, 3))
             [|M2()|];        
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1188,7 +1153,7 @@ class Test
 {
     void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             M2();
         }
@@ -1199,10 +1164,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -1219,7 +1182,7 @@ class Test
     [SupportedOSPlatform(""Windows"")]
     void M1()
     {
-        if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0))
+        if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 0))
         {
             [|M2()|];
             M3();
@@ -1232,15 +1195,11 @@ class Test
     }
 
     [SupportedOSPlatform(""MacOs12.2.3"")]
-    void M2()
-    {
-    }
+    void M2() { }
 
     [UnsupportedOSPlatform(""Windows10.0"")]
-    void M3 ()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M3() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1256,7 +1215,7 @@ class Test
     [SupportedOSPlatform(""Windows"")]
     void M1()
     {
-        if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10, 1, 2, 3))
+        if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 1, 2, 3))
         {
             [|M2()|];
             M3();
@@ -1267,7 +1226,7 @@ class Test
             [|M3()|];
         }
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"",10,1,3))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"",10,1,3))
         {
             [|M3()|];
             M2();
@@ -1280,14 +1239,11 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
+    void M2() { }
+
     [UnsupportedOSPlatform(""Windows10.1.2.3"")]
-    void M3 ()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M3() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -1297,7 +1253,7 @@ Imports System
 Class Test
     <SupportedOSPlatform(""Windows"")>
     Private Sub M1()
-        If OperatingSystemHelper.IsWindows() AndAlso Not OperatingSystemHelper.IsWindowsVersionAtLeast(10, 1, 2, 3) Then
+        If OperatingSystem.IsWindows() AndAlso Not OperatingSystem.IsWindowsVersionAtLeast(10, 1, 2, 3) Then
             [|M2()|]
             M3()
         Else
@@ -1305,7 +1261,7 @@ Class Test
             [|M3()|]
         End If
 
-        If OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"",10,1,3) Then
+        If OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"",10,1,3) Then
             [|M3()|]
             M2()
         Else
@@ -1321,8 +1277,7 @@ Class Test
     <UnsupportedOSPlatform(""Windows10.1.2.3"")>
     Private Sub M3()
     End Sub
-End Class
-" + MockAttributesVbSource + MockRuntimeApiSourceVb;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -1338,7 +1293,7 @@ public class Test2
     public void M1()
     {
         PlatformEnum val = [|PlatformEnum.Windows10|];
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10))
         {
             M2(PlatformEnum.Windows10);
         }
@@ -1363,7 +1318,7 @@ public enum PlatformEnum
     Linux48,
     NoPlatform
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1388,7 +1343,7 @@ public class Test
     
     public void M1()
     {
-        if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(8, 0, 19222)) 
+        if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(8, 0, 19222)) 
         {
             WindowsOnlyPropertyGetter = true;
             var val = WindowsOnlyPropertyGetter;
@@ -1411,7 +1366,7 @@ public class Test
         return option;
     }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1424,14 +1379,12 @@ using System;
 
 class C
 {
-    public static object Property { get; } = OperatingSystemHelper.IsWindows() ? null : new A();
+    public static object Property { get; } = OperatingSystem.IsWindows() ? null : new A();
 }
 
 [UnsupportedOSPlatform(""windows"")]
-class A
-{
-}
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+class A { }
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1444,14 +1397,12 @@ using System;
 
 class C
 {
-    public static object Property { get; } = OperatingSystemHelper.IsWindows() ? [|new A()|] : null;
+    public static object Property { get; } = OperatingSystem.IsWindows() ? [|new A()|] : null;
 }
 
 [UnsupportedOSPlatform(""windows"")]
-class A
-{
-}
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+class A { }
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1464,14 +1415,12 @@ using System;
 
 class C
 {
-    private static object _field = OperatingSystemHelper.IsWindows() ? null : new A();
+    private static object _field = OperatingSystem.IsWindows() ? null : new A();
 }
 
 [UnsupportedOSPlatform(""windows"")]
-class A
-{
-}
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+class A { }
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1484,14 +1433,12 @@ using System;
 
 class C
 {
-    private static object _field = OperatingSystemHelper.IsWindows() ? [|new A()|] : null;
+    private static object _field = OperatingSystem.IsWindows() ? [|new A()|] : null;
 }
 
 [UnsupportedOSPlatform(""windows"")]
-class A
-{
-}
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+class A { }
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1506,7 +1453,7 @@ public class Test
 {
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             C instance = new C();
             instance.M2();
@@ -1522,14 +1469,11 @@ public class Test
 public class C
 {
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public C()
-    {
-    }
-    public void M2()
-    {
-    }
+    public C() { }
+
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1544,7 +1488,7 @@ public class Test
 {
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             OsDependentClass odc = new OsDependentClass();
             odc.Method2();
@@ -1559,11 +1503,9 @@ public class Test
 [SupportedOSPlatform(""Windows10.1.2.3"")]
 public class OsDependentClass
 {
-    public void Method2()
-    {
-    }
+    public void Method2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -1572,7 +1514,7 @@ Imports System
 
 Public Class Test
     Public Sub M1()
-        If OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) Then
+        If OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) Then
             Dim odc As OsDependentClass = New OsDependentClass()
             odc.M2()
         Else
@@ -1586,8 +1528,7 @@ End Class
 Public Class OsDependentClass
     Public Sub M2()
     End Sub
-End Class
-" + MockRuntimeApiSourceVb + MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -1604,7 +1545,7 @@ public class Test
     {
         void Test()
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
             {
                 M2();
             }
@@ -1617,11 +1558,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1635,7 +1574,7 @@ public class Test
 {
     void M()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             LocalM(true);
         }
@@ -1653,12 +1592,12 @@ public class Test
                 [|WindowsOnlyMethod()|];
             }
             
-            if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+            if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
             {
                 WindowsOnlyMethod();
             }
 
-            if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10,0))
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10,0))
             {
                 UnsupportedWindows10();
             }
@@ -1669,15 +1608,11 @@ public class Test
         }
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void WindowsOnlyMethod()
-    {
-    }
+    public void WindowsOnlyMethod() { }
     [UnsupportedOSPlatform(""Windows10.0"")]
-    public void UnsupportedWindows10()
-    {
-    }
+    public void UnsupportedWindows10() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1694,7 +1629,7 @@ public class Test
     {
         LocalM();
 
-        if (!OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 10, 2))
+        if (!OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 10, 2))
         {
             LocalM();
         }
@@ -1706,7 +1641,7 @@ public class Test
         {
             [|WindowsOnlyMethod()|];
 
-            if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+            if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
             {
                 WindowsOnlyMethod();
             }
@@ -1715,7 +1650,7 @@ public class Test
                 [|WindowsOnlyMethod()|];
             }
 
-            if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10,0))
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10,0))
             {
                 UnsupportedWindows10();
             }
@@ -1727,16 +1662,12 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void WindowsOnlyMethod()
-    {
-    }
+    public void WindowsOnlyMethod() { }
 
     [UnsupportedOSPlatform(""Windows10.0"")]
-    public void UnsupportedWindows10()
-    {
-    }
+    public void UnsupportedWindows10() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1751,12 +1682,12 @@ public class Test
 {
     void M()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             LocalM();
         }
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             LocalM();
         }
@@ -1767,7 +1698,7 @@ public class Test
         {
             WindowsOnlyMethod();
 
-            if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+            if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
             {
                 WindowsOnlyMethod();
             }
@@ -1776,7 +1707,7 @@ public class Test
                 WindowsOnlyMethod();
             }
 
-            if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10,0))
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10,0))
             {
                 UnsupportedWindows10();
             }
@@ -1788,16 +1719,12 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void WindowsOnlyMethod()
-    {
-    }
+    public void WindowsOnlyMethod() { }
 
     [UnsupportedOSPlatform(""Windows10.0"")]
-    public void UnsupportedWindows10()
-    {
-    }
+    public void UnsupportedWindows10() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1815,7 +1742,7 @@ public class Test
         // Warn inside local function escaped as delegate.
         void LocalFunction()
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -1829,13 +1756,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1853,7 +1778,7 @@ public class Test
         // Warn inside local function escaped as delegate indirectly from another local function.
         void LocalFunction()
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -1873,13 +1798,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1897,7 +1820,7 @@ public class Test
         // Warn inside local function escaped as delegate indirectly from a lambda invoked inside a local function.
         void LocalFunction()
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -1922,13 +1845,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1952,7 +1873,7 @@ public class Test
         // Escaped as delegate, can potentially be invoked from unguarded context.
         M3(LocalFunction);
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             // Invoked directly from guarded context.
             LocalFunction();
@@ -1960,13 +1881,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1994,9 +1913,9 @@ public class Test
             LocalFunction();
         }
 
-        if(OperatingSystemHelper.IsWindows())
+        if(OperatingSystem.IsWindows())
         {
-            if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 // Invoked multiple times directly from guarded context.
                 LocalFunction();
@@ -2012,16 +1931,12 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows"")]
-    public void WindowsOnly()
-    {
-    }
+    public void WindowsOnly() { }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void Windows10OrLaterOnly()
-    {
-    }
+    public void Windows10OrLaterOnly() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2043,7 +1958,7 @@ public class Test
 
         // Unguarded call before guarded call - should warn.
         LocalFunction();
-        if(OperatingSystemHelper.IsWindows())
+        if(OperatingSystem.IsWindows())
         {
             LocalFunction();
         }
@@ -2058,18 +1973,16 @@ public class Test
 
         // Guarded call before unguarded call - should warn.
         LocalFunction();
-        if(OperatingSystemHelper.IsWindows())
+        if(OperatingSystem.IsWindows())
         {
             LocalFunction();
         }
     }
 
     [SupportedOSPlatform(""Windows"")]
-    public void WindowsOnly()
-    {
-    }
+    public void WindowsOnly() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2094,7 +2007,7 @@ public class Test
         {
         }
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             LocalFunction();
         }
@@ -2104,11 +2017,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2126,7 +2037,7 @@ public class Test
         // Do not warn inside unused local function.
         void LocalFunction()
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2138,11 +2049,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2157,7 +2066,7 @@ public class Test
 {
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
         {
             void Test() => M2();
             Test();
@@ -2170,7 +2079,7 @@ public class Test
 
         Action action = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
             {
                 M2();
             }
@@ -2183,11 +2092,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2205,7 +2112,7 @@ public class Test
         // Warn inside lambda escaped as delegate argument.
         M3(a: () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2217,13 +2124,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2241,7 +2146,7 @@ public class Test
         // Warn inside lambda escaped as delegate.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2255,13 +2160,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2279,7 +2182,7 @@ public class Test
         // Warn inside lambda escaped as delegate indirectly from another lambda.
         Action a1 = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2299,13 +2202,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2323,7 +2224,7 @@ public class Test
         // Warn inside lambda escaped as delegate indirectly from a local function invoked inside a lambda.
         Action a1 = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2348,13 +2249,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2374,7 +2273,7 @@ public class Test
         // Warn inside lambda escaped via field.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2389,13 +2288,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3() { _field(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2413,7 +2310,7 @@ public class Test
         // Warn inside lambda escaped via return value.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2427,11 +2324,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2449,7 +2344,7 @@ public class Test
         // Warn inside lambda escaped via conversion.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2464,13 +2359,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(object a) { ((Action)a)(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2488,7 +2381,7 @@ public class Test
         // Warn inside lambda escaped via out argument.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2503,11 +2396,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2531,7 +2422,7 @@ public class Test
         // Escaped as delegate, can potentially be invoked from unguarded context.
         M3(a);
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             // Invoked directly from guarded context.
             a();
@@ -2539,13 +2430,11 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2563,7 +2452,7 @@ public class Test
         // Warn inside unused lambda.
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 M2();
             }
@@ -2575,11 +2464,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2602,9 +2489,9 @@ public class Test
             [|Windows10OrLaterOnly()|];
         };
 
-        if(OperatingSystemHelper.IsWindows())
+        if(OperatingSystem.IsWindows())
         {
-            if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+            if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
             {
                 // Invoked multiple times directly from guarded context.
                 a();
@@ -2625,16 +2512,12 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows"")]
-    public void WindowsOnly()
-    {
-    }
+    public void WindowsOnly() { }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void Windows10OrLaterOnly()
-    {
-    }
+    public void Windows10OrLaterOnly() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2659,7 +2542,7 @@ public class Test
         {
         };
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             a();
         }
@@ -2669,11 +2552,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2690,7 +2571,7 @@ public class Test
     {
         Action a = () =>
         {
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
             {
                 LocalFunction();
             }
@@ -2706,11 +2587,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2733,7 +2612,7 @@ public class Test
                 M2();
             };
 
-            if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+            if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
             {
                 a();
             }
@@ -2743,11 +2622,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2765,7 +2642,7 @@ class Test
     void M1()
     {
         Greetings();
-        if (OperatingSystemHelper.IsBrowser())
+        if (OperatingSystem.IsBrowser())
         {
             SupportedOnBrowser();
         }
@@ -2781,7 +2658,7 @@ class Test
     [UnsupportedOSPlatform(""browser"")]
     void UnsupportedOnBrowser() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2801,7 +2678,7 @@ public class Test
 
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             SampleEvent += M3;
         }
@@ -2813,7 +2690,7 @@ public class Test
 
     public void M2()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             SampleEvent?.Invoke();
         }
@@ -2823,14 +2700,10 @@ public class Test
         }
     }
 
-    public void M3()
-    {
-    }
-    public void M4()
-    {
-    }
+    public void M3() { }
+    public void M4() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2846,12 +2719,11 @@ public class Test
     public delegate void Del();
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void DelegateMethod()
-    {
-    }
+    public void DelegateMethod() { }
+
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11, 0))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11, 0))
         {
             Del handler = DelegateMethod;
             handler();
@@ -2863,7 +2735,7 @@ public class Test
         }
     }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2880,19 +2752,19 @@ class Test
     {
         [|M2()|];
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             M2();
         }
-        else if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(8, 0, 19222))
+        else if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(8, 0, 19222))
         {
             [|M2()|];
         }
-        else if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222))
+        else if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222))
         {
             [|M2()|];
         }
-        else if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 12))
+        else if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 12))
         {
             M2();
         }
@@ -2903,10 +2775,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2922,17 +2792,15 @@ public class Test
     public void M1()
     {
         [|M2()|];
-        if(!OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
+        if(!OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
             [|M2()|];
         else
             M2();
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2948,19 +2816,17 @@ public class Test
     public void M1()
     {
         [|M2()|];
-        if(!OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
+        if(!OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
             [|M2()|];
-        else if(OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222))
+        else if(OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222))
             M2();
         else
             M2();
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -2976,16 +2842,14 @@ public class Test
     public void M1()
     {
         [|M2()|];
-        if(!OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
+        if(!OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3))
             return;
         M2();
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -2995,15 +2859,14 @@ Imports System
 Public Class Test
     Public Sub M1()
         [|M2()|]
-        If Not OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3) Then Return
+        If Not OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 1, 2, 3) Then Return
         M2()
     End Sub
 
     <SupportedOSPlatform(""Windows10.1.2.3"")>
     Public Sub M2()
     End Sub
-End Class
-" + MockAttributesVbSource + MockRuntimeApiSourceVb;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -3018,25 +2881,25 @@ public class Test
 {
     public void M1()
     {
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) &&
-           (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) &&
+           (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)))
         {
             M2();
         }
 
-        if((OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)) &&
-           OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 12))
+        if((OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)) &&
+           OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 12))
         {
             M2();
         }
 
-        if((OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)) &&
-           OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 12))
+        if((OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)) &&
+           OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 12))
         {
             [|M2()|];
         }
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) && 1 == 1)
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) && 1 == 1)
         {
             M2();
         }
@@ -3044,11 +2907,9 @@ public class Test
         [|M2()|];
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3065,8 +2926,8 @@ public class Test
     {
         [|M2()|];
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) &&
-           (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) &&
+           (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)))
         {
             M2();
         }
@@ -3075,8 +2936,8 @@ public class Test
             [|M2()|];
         }
 
-        if((OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)) &&
-           OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 12))
+        if((OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)) &&
+           OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 12))
         {
             [|M2()|];
         }
@@ -3086,11 +2947,9 @@ public class Test
         }
     }
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3105,31 +2964,29 @@ public class Test
 {
     public void M1()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
-           (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
+           (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)))
         {
             [|M2()|];
         }
 
-        if(OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222) || 
-            OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if(OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222) || 
+            OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             M2();
         }
 
-        if(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 12) || 
-            OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if(OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 12) || 
+            OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             [|M2()|];
         }
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3144,8 +3001,8 @@ public class Test
 {
     public void M1()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
-           OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
+           OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             M2();
         }
@@ -3156,11 +3013,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3175,8 +3030,8 @@ public class Test
 {
     public void M1()
     {
-        if (!(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
-           OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11)))
+        if (!(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
+           OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11)))
         {
             [|M2()|];
         }
@@ -3187,11 +3042,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3206,20 +3059,20 @@ public class Test
 {
     public void M1()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
-           OperatingSystemHelper.IsLinux())
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
+           OperatingSystem.IsLinux())
         {
             [|M2()|]; //12
         }
-        else if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        else if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             M2();
         }
         else
             [|M2()|];
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
-           (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2) ||
+           (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)))
         {
             [|M2()|];
         }
@@ -3228,8 +3081,8 @@ public class Test
             [|M2()|];
         }
 
-        if((OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222)) || 
-            OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        if((OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222)) || 
+            OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
             [|M2()|]; //34
         }
@@ -3240,11 +3093,9 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 }
-" + MockAttributesCsSource + MockOperatingSystemApiSource;
+";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3259,8 +3110,8 @@ class Test
 {
     void M1()
     {       
-        if ((!OperatingSystemHelper.IsWindows() || OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 1903)) &&
-            (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 2004)))
+        if ((!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 1903)) &&
+            (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 2004)))
         {
             M2(); 
         }
@@ -3273,11 +3124,8 @@ class Test
     [UnsupportedOSPlatform(""windows"")]
     [SupportedOSPlatform(""windows10.0.1903"")]
     [UnsupportedOSPlatform(""windows10.0.2004"")]
-    void M2()
-    {
-    }
-}"
-+ MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
 
             var vbSource = @"
@@ -3286,7 +3134,7 @@ Imports System
 
 Class Test
     Private Sub M1()
-        If (Not OperatingSystemHelper.IsWindows() OrElse OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 1903)) AndAlso (OperatingSystemHelper.IsWindows() AndAlso Not OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 2004)) Then
+        If (Not OperatingSystem.IsWindows() OrElse OperatingSystem.IsWindowsVersionAtLeast(10, 0, 1903)) AndAlso (OperatingSystem.IsWindows() AndAlso Not OperatingSystem.IsWindowsVersionAtLeast(10, 0, 2004)) Then
             M2()
         Else
             [|M2()|]
@@ -3298,8 +3146,7 @@ Class Test
     <UnsupportedOSPlatform(""Windows10.0.2004"")>
     Private Sub M2()
     End Sub
-End Class
-" + MockRuntimeApiSourceVb + MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource, s_msBuildPlatforms);
         }
 
@@ -3314,15 +3161,15 @@ class Test
 {
     void M1()
     {
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 8))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 8))
         {
             [|M2()|];
 
-            if (OperatingSystemHelper.IsWindows() && !OperatingSystemHelper.IsWindowsVersionAtLeast(12, 0, 19222))
+            if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(12, 0, 19222))
             {
                 [|M2()|];
             }
-            else if (!OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
+            else if (!OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2, 1))
             {
                 [|M2()|];
             } 
@@ -3342,10 +3189,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -3369,21 +3214,17 @@ class Test
         // Should still warn for Windows10.1.2.3 
         [|M2()|];
 
-        Debug.Assert(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2));
+        Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2));
         M2();
         M3();
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
+    void M2() { }
 
     [SupportedOSPlatform(""Windows"")]
-    void M3()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M3() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -3394,15 +3235,14 @@ Imports System
 Class Test
     Private Sub M1()
         [|M2()|]
-        Debug.Assert(OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
+        Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         M2()
     End Sub
 
     <SupportedOSPlatform(""Windows10.1.2.3"")>
     Private Sub M2()
     End Sub
-End Class
-" + MockAttributesVbSource + MockRuntimeApiSourceVb;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -3417,8 +3257,8 @@ class Test
 {
     void M1()
     {
-        var x1 = OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11);
-        var x2 = OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Linux"", 1);
+        var x1 = OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11);
+        var x2 = OperatingSystem.IsOSPlatformVersionAtLeast(""Linux"", 1);
 
         if (x1)
         {
@@ -3435,10 +3275,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3454,17 +3292,15 @@ class Test
     void M1()
     {
         var v11 = 11;
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", v11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", v11))
         {
             M2();
         }
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3480,17 +3316,15 @@ class Test
     void M1()
     {
         var platform = ""Windows"";
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(platform, 11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(platform, 11))
         {
             [|M2()|];
         }
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3507,7 +3341,7 @@ class Test
     {
         [|M2()|];
 
-        if (OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11))
+        if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11))
         {
             M2();
 
@@ -3534,10 +3368,8 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+    void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -3548,7 +3380,7 @@ Class Test
     Private Sub M1(ByVal flag1 As Boolean, ByVal flag2 As Boolean)
         [|M2()|]
 
-        If OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"", 11) Then
+        If OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 11) Then
             M2()
 
             If flag1 OrElse flag2 Then
@@ -3570,8 +3402,7 @@ Class Test
     <SupportedOSPlatform(""Windows10.1.2.3"")>
     Private Sub M2()
     End Sub
-End Class
-" + MockRuntimeApiSourceVb + MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -3599,15 +3430,13 @@ class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    void M2()
-    {
-    }
+    void M2() { }
 
     bool IsWindows11OrLater()
     {
-        return OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"",10,2,3,4);
+        return OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"",10,2,3,4);
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive\nbuild_property.TargetFramework = net5");
         }
@@ -3634,7 +3463,7 @@ class Test
 
     public void GuardedCalls()
     {
-        if (OperatingSystemHelper.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
             Action a = () =>
             {
@@ -3654,7 +3483,7 @@ class Test
 
     public void AssertedCalls()
     {
-        Debug.Assert(OperatingSystemHelper.IsWindows());
+        Debug.Assert(OperatingSystem.IsWindows());
 
         Action a = () =>
         {
@@ -3670,7 +3499,7 @@ class Test
 
         DelegateAsArgument(() => [|WindowsOnly()|]); // Warns, couldn'd analyze
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source);
         }
@@ -3697,7 +3526,7 @@ class Test
 
     public void GuardedCalls()
     {
-        if (OperatingSystemHelper.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
             Action a = () =>
             {
@@ -3716,7 +3545,7 @@ class Test
 
     public void AssertedCalls()
     {
-        Debug.Assert(OperatingSystemHelper.IsWindows());
+        Debug.Assert(OperatingSystem.IsWindows());
 
         Action a = () =>
         {
@@ -3731,7 +3560,7 @@ class Test
 
         DelegateAsArgument(() => WindowsOnly());
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive");
         }
@@ -3778,7 +3607,7 @@ namespace Repro
         [SupportedOSPlatform(""windows"")]
         public static IEnumerable<int> GetProcesses() => throw null;
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3800,7 +3629,7 @@ namespace Repro
         {
             for (var i = 0; i < 2; i++)
             {
-                if (OperatingSystemHelper.IsWindows())
+                if (OperatingSystem.IsWindows())
                 {
                     WindowsSupported();
                 }
@@ -3810,7 +3639,7 @@ namespace Repro
         [SupportedOSPlatform(""windows"")]
         public static void WindowsSupported() { }
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3830,7 +3659,7 @@ namespace Repro
     {
         public static void M()
         {
-            if (OperatingSystemHelper.IsWindows())
+            if (OperatingSystem.IsWindows())
             {
                 for (var i = 0; i < 2; i++)
                 {
@@ -3842,7 +3671,7 @@ namespace Repro
         [SupportedOSPlatform(""windows"")]
         public static void WindowsSupported() { }
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -3874,10 +3703,10 @@ class Test
 
     bool IsWindows11OrLater()
     {
-        return OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"",10,2,3,4) ||
-            OperatingSystemHelper.IsOSPlatformVersionAtLeast(""Windows"",11);
+        return OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"",10,2,3,4) ||
+            OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"",11);
     }
-}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive");
         }
@@ -3959,7 +3788,7 @@ namespace PlatformCompatDemo.SupportedUnupported
         
         [SupportedOSPlatform(""browser"")]
         public void FunctionSupportedOnBrowser() { }
-        }
+    }
 
     [UnsupportedOSPlatform(""windows10.0"")]
     public class TypeUnsupportedOnWindows10
@@ -4055,113 +3884,6 @@ namespace PlatformCompatDemo.SupportedUnupported
         [SupportedOSPlatform(""windows11.0"")] // more restrictive should be OK
         public void TypeSupportedOnWindows10AndBrowser_FunctionSupportedOnWindows11() { }
     }
-}
-";
-
-        private readonly string MockOperatingSystemApiSource = @"
-namespace System
-{
-    public sealed class OperatingSystemHelper
-    {
-#pragma warning disable CA1801, IDE0060 // Review unused parameters
-        public static bool IsOSPlatform(string platform) { return true; }
-        public static bool IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0) { return true; }
-        public static bool IsBrowser() { return true; }
-        public static bool IsLinux() { return true; }
-        public static bool IsFreeBSD() { return true; }
-        public static bool IsFreeBSDVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { return true; }
-        public static bool IsAndroid() { return true; }
-        public static bool IsAndroidVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { return true; }
-        public static bool IsIOS() { return true; }
-        public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) { return true; }
-        public static bool IsMacOS() { return true; }
-        public static bool IsMacOSVersionAtLeast(int major, int minor = 0, int build = 0) { return true; }
-        public static bool IsTvOS() { return true; }
-        public static bool IsTvOSVersionAtLeast(int major, int minor = 0, int build = 0) { return true; }
-        public static bool IsWatchOS() { return true; }
-        public static bool IsWatchOSVersionAtLeast(int major, int minor = 0, int build = 0) { return true; }
-        public static bool IsWindows() { return true; }
-        public static bool IsWindowsVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0) { return true; }
-#pragma warning restore CA1801, IDE0060 // Review unused parameters
-    }
 }";
-
-        private readonly string MockRuntimeApiSourceVb = @"
-Namespace System
-    Public NotInheritable Class OperatingSystemHelper
-        Public Shared Function IsOSPlatform(ByVal platform As String) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsOSPlatformVersionAtLeast(ByVal platform As String, ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0, ByVal Optional revision As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsBrowser() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsLinux() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsFreeBSD() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsFreeBSDVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0, ByVal Optional revision As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsAndroid() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsAndroidVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0, ByVal Optional revision As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsIOS() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsIOSVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsMacOS() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsMacOSVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsTvOS() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsTvOSVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsWatchOS() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsWatchOSVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0) As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsWindows() As Boolean
-            Return True
-        End Function
-
-        Public Shared Function IsWindowsVersionAtLeast(ByVal major As Integer, ByVal Optional minor As Integer = 0, ByVal Optional build As Integer = 0, ByVal Optional revision As Integer = 0) As Boolean
-            Return True
-        End Function
-    End Class
-End Namespace
-";
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -29,15 +29,11 @@ using System.Runtime.InteropServices;
 public class Test
 {
     [[|SupportedOSPlatform(""Linux"", ""Windows"")|]]
-    public void MethodWithTwoArguments()
-    {
-    }
+    public void MethodWithTwoArguments() { }
+
     [UnsupportedOSPlatform([|new string[]{""Linux"", ""Windows""}|])]
-    public void MethodWithArrayArgument()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void MethodWithArrayArgument() { }
+}";
 
             await VerifyAnalyzerAsyncCs(csSource);
         }
@@ -80,8 +76,7 @@ namespace CallerTargetsBelow5_0
         [SupportedOSPlatform(""windows"")]
         public static void WindowsOnlyMethod() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, tfm);
         }
 
@@ -126,8 +121,7 @@ namespace CallerTargetsBelow5_0
         [SupportedOSPlatform(""windows"")]
         public static void WindowsOnlyMethod() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, tfmAndOption);
         }
 
@@ -139,20 +133,19 @@ using System;
 using System.Runtime.Versioning;
 
 [SupportedOSPlatform(""windows"")]
-class WindowsOnlyType {}
+class WindowsOnlyType { }
 
 public class Test
 {
-    void GenericMethod<T>() {}
-    void GenericMethod2<T1, T2>() {}
+    void GenericMethod<T>() { }
+    void GenericMethod2<T1, T2>() { }
     void M1()
     {
         [|GenericMethod<WindowsOnlyType>()|];
         [|GenericMethod2<Test, WindowsOnlyType>()|];
         [|GenericMethod<Action<WindowsOnlyType>>()|];
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(csSource);
         }
 
@@ -163,9 +156,9 @@ public class Test
 using System.Runtime.Versioning;
 
 [SupportedOSPlatform(""windows"")]
-class WindowsOnlyType {}
+class WindowsOnlyType { }
 
-class GenericClass<T> {}
+class GenericClass<T> { }
 
 public class Test
 {
@@ -176,8 +169,7 @@ public class Test
         GenericClass<WindowsOnlyType> obj = [|new GenericClass<WindowsOnlyType>()|];
         MethodWithGenericParameter([|new GenericClass<WindowsOnlyType>()|]);
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(csSource);
         }
 
@@ -189,12 +181,12 @@ using System;
 using System.Runtime.Versioning;
 
 [SupportedOSPlatform(""windows"")]
-class WindowsOnlyType {}
+class WindowsOnlyType { }
 
 class GenericClass<T>
 {
     public static void M<V>() { }
-    public static void M2() {}
+    public static void M2() { }
     public static int Field;
     public static int Property {get;}
     public static event EventHandler SampleEvent
@@ -217,8 +209,7 @@ public class Test
         var val = [|GenericClass<WindowsOnlyType>.Property|];
         [|GenericClass<WindowsOnlyType>.SampleEvent|] += WindowsEventHandler;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(csSource);
         }
 
@@ -277,8 +268,7 @@ namespace WindowsOnlyAssembly
             }
         }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(csSource);
         }
 
@@ -290,12 +280,12 @@ using System;
 using System.Runtime.Versioning;
 
 [SupportedOSPlatform(""windows"")]
-class WindowsOnlyType {}
+class WindowsOnlyType { }
 
 class GenericClass<T>
 {
     public static void M<V>() { }
-    public static void M2() {}
+    public static void M2() { }
 }
 
 class GenericType<T> { }
@@ -313,8 +303,7 @@ public class Test
         [|GenericClass<GenericType<Action<GenericClass<GenericClass<GenericType<Action<GenericClass<WindowsOnlyType>>>>>>>>.M2()|];
         GenericClass<GenericType<Action<GenericClass<GenericClass<GenericType<Action<GenericClass<int>>>>>>>>.M2();
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(csSource);
         }
 
@@ -334,15 +323,11 @@ public class Test
     }
     
     [UnsupportedOSPlatform(""Linux4.1"")]
-    public void Unsupported()
-    {
-    }
+    public void Unsupported() { }
+
     [SupportedOSPlatform(""Windows10.1.1.1"")]
-    public void WindowsOnly()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void WindowsOnly() { }
+}";
             await VerifyAnalyzerAsyncCs(csSource);
 
             var vbSource = @"
@@ -362,8 +347,7 @@ Public Class Test
     <UnsupportedOSPlatform(""Linux4.1"")>
     Public Sub Unsupported()
     End Sub
-End Class
-" + MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -388,40 +372,31 @@ public class Test
         UnattributedFunction();
     }
     public void UnattributedFunction() { }
+
     [UnsupportedOSPlatform(""Windows"")]
-    public void NotForWindows()
-    {
-    }
+    public void NotForWindows() { }
+
     [SupportedOSPlatform(""Windows10"")]
-    public void Windows10()
-    {
-    }
+    public void Windows10() { }
+
     [SupportedOSPlatform(""Windows1.2.3.4.5"")]
-    public void Windows1_2_3_4_5()
-    {
-    }
+    public void Windows1_2_3_4_5() { }
+
     [SupportedOSPlatform(""Ios-4.1"")]
-    public void UnsupportedOSPlatformIosDash4_1()
-    {
-    }
+    public void UnsupportedOSPlatformIosDash4_1() { }
+
     [SupportedOSPlatform(""Ios*4.1"")]
-    public void UnsupportedOSPlatformIosStar4_1()
-    {
-    }
+    public void UnsupportedOSPlatformIosStar4_1() { }
+
     [SupportedOSPlatform(null)]
-    public void UnsupportedOSPlatformWithNullString()
-    {
-    }
+    public void UnsupportedOSPlatformWithNullString() { }
+
     [SupportedOSPlatform(""Linu4.1"")]
-    public void SupportedLinu4_1()
-    {
-    }
+    public void SupportedLinu4_1() { }
+
     [UnsupportedOSPlatform("""")]
-    public void UnsupportedWithEmptyString()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void UnsupportedWithEmptyString() { }
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -453,8 +428,7 @@ public class Test
     {
         return option;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -504,8 +478,7 @@ public class Test
     {
         return option;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -553,8 +526,7 @@ Public Class Test
     Public Function M2(ByVal[option] As Boolean) As Boolean
         Return[option]
     End Function
-End Class
-" + MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -581,8 +553,7 @@ public class Test
     {
         return option;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -620,8 +591,7 @@ public enum PlatformEnum
     [SupportedOSPlatform(""linux4.8"")]
     Linux48,
     NoPlatform
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -655,8 +625,7 @@ public enum PlatformEnum
     [SupportedOSPlatform(""Linux4.8"")]
     Linux48,
     NoPlatform
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -678,11 +647,10 @@ End Class
 Public Enum PlatformEnum
     <SupportedOSPlatform(""Windows10.0"")>
     Windows10
-    < SupportedOSPlatform(""Linux4.8"") >
+    <SupportedOSPlatform(""Linux4.8"") >
     Linux48
     NoPlatform
-End Enum
-" + MockAttributesVbSource;
+End Enum";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -715,8 +683,7 @@ public class Test
     {
         return option;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -737,11 +704,8 @@ public class Test
 public class B
 {
     [SupportedOSPlatform(""Windows10.1.1.1"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -766,12 +730,9 @@ namespace Ns
     public class B
     {
         [SupportedOSPlatform(""Windows10.1.1.1"")]
-        public void M2()
-        {
-        }
+        public void M2() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -792,8 +753,7 @@ Namespace Ns
         Public Sub M2()
         End Sub
     End Class
-End Namespace
-" + MockAttributesVbSource;
+End Namespace";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -815,14 +775,10 @@ public class Test
 public class C
 {
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public C()
-    {
-    }
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public C() { }
+
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -843,11 +799,8 @@ public class Test
 [SupportedOSPlatform(""Windows10.1.2.3"")]
 public class OsDependentClass
 {
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -865,7 +818,7 @@ Public Class OsDependentClass
     Public Sub M2()
     End Sub
 End Class
-" + MockAttributesVbSource;
+";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -887,11 +840,8 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -914,11 +864,8 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -942,13 +889,10 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -970,11 +914,8 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -999,11 +940,8 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1029,11 +967,8 @@ public class C
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1057,13 +992,10 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
+    public void M2() { }
 
     public void M3(Action a) { a(); }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1085,11 +1017,8 @@ public class Test
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1117,11 +1046,8 @@ public class Test
         [|SampleEvent|]?.Invoke();
     }
 
-    public void M3()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M3() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
 
             var vbSource = @"
@@ -1143,8 +1069,7 @@ Public Class Test
 
     Public Sub M3()
     End Sub
-End Class"
-+ MockAttributesVbSource;
+End Class";
             await VerifyAnalyzerAsyncVb(vbSource);
         }
 
@@ -1171,8 +1096,7 @@ public class C
         [|Test.WindowsOnlyEvent|] += WindowsEventHandler;
         [|Test.WindowsOnlyEvent|] -= WindowsEventHandler;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1218,8 +1142,7 @@ public class Test
         WindowsOnlyEventAdd -= WindowsEventHandler;
         [|WindowsOnlyEventRemove|] -= WindowsEventHandler;
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1234,16 +1157,14 @@ public class Test
     public delegate void Del(); // The attribute not supported on delegates, so no tests for that
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
-    public void DelegateMethod()
-    {
-    }
+    public void DelegateMethod() { }
+
     public void M1()
     {
         Del handler = [|DelegateMethod|];
         handler();
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1272,8 +1193,7 @@ class UnsupportedOnBrowserType
     public static void SupportedOnBrowser() {}
     [SupportedOSPlatform(""tvos4.0"")]    
     public static void SupportedOnTvos4() {}
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1333,8 +1253,7 @@ class UnsupportedOnBrowserType
     public static void UnsupportedOnBrowser() {}
     [SupportedOSPlatform(""tvos4.0"")]    
     public static void SupportedOnTvos4() {}
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1383,8 +1302,7 @@ class UnsupportedOnBrowserSupportedOnWindowType
     public static void SupportedOnIosTvos() {}
     [SupportedOSPlatform(""tvos4.0"")]    // same here
     public static void SupportedOnTvos4() {}
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1417,8 +1335,7 @@ namespace CallerSupportsSubsetOfTarget
         [SupportedOSPlatform(""browser""), SupportedOSPlatform(""windows"")]
         public static void SupportedOnWindowsAndBrowser() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1443,8 +1360,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
         public static void UnsupportedOnWindowsUntilWindows11() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1478,8 +1394,7 @@ namespace CallerUnsupportsSubsetOfTarget
         [SupportedOSPlatform(""windows"")]
         public static void FunctionSupportedOnWindowsSameVersion() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1509,8 +1424,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         [SupportedOSPlatform(""windows"")]
         public static void FunctionSupportedOnWindowsSameVersion() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
@@ -1569,8 +1483,7 @@ namespace CallerSupportsSubsetOfTarget
         [UnsupportedOSPlatform(""windows""), SupportedOSPlatform(""windows11.0"")]
         public static void UnsupportedOnWindowsUntilWindows11() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).WithArguments("Target.SupportedOnWindows()", "'windows'", ""),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(1).WithArguments("Target.SupportedOnBrowser()", "'browser'", "'browser'"),
@@ -1635,8 +1548,7 @@ namespace CallerSupportsSubsetOfTarget
         [UnsupportedOSPlatform(""windows""), UnsupportedOSPlatform(""browser"")]
         public static void UnsupportedOnWindowsAndBrowser() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1663,8 +1575,7 @@ class Some
 
     [UnsupportedOSPlatform(""tvos"")] // Not ignored, suppresses parent
     public static void Api2() {}
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1718,8 +1629,7 @@ namespace PlatformCompatDemo.Bugs
         [SupportedOSPlatform(""browser"")]
         public static void FunctionSupportedOnBrowser() { }
     }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1750,8 +1660,7 @@ namespace PlatformCompatDemo
 
     [UnsupportedOSPlatform(""linux"")] // must be ignored
     public class NonLinuxApis { }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1780,11 +1689,8 @@ namespace PlatformCompatDemo
     }
 
     [SupportedOSPlatform(""browser"")]
-    public class BrowserApis
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public class BrowserApis { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1808,8 +1714,7 @@ class SomeWindowsSpecific
 {
     [UnsupportedOSPlatform(""windows"")] // This will not be ignored
     public static void NotForWindows() { }
-}
-" + MockAttributesCsSource;
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1827,19 +1732,15 @@ static class Program
         [|Some.Windows10SpecificApi()|];
         WindowsSpecificApi();
     }
-    public static void WindowsSpecificApi()
-    {
-    }
+
+    public static void WindowsSpecificApi() { }
 }
 
 [SupportedOSPlatform(""windows10.0"")] // This attribute will not be ignored
 static class Some
 {
-    public static void Windows10SpecificApi()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public static void Windows10SpecificApi() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
@@ -1862,46 +1763,34 @@ static class Program
 static class Some
 {
     [SupportedOSPlatform(""windows11.0"")]
-    public static void WindowsSpecificApi11()
-    {
-    }
+    public static void WindowsSpecificApi11() { }
 
     [SupportedOSPlatform(""windows1.0"")]
-    public static void WindowsSpecificApi1()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public static void WindowsSpecificApi1() { }
+}";
             await VerifyAnalyzerAsyncCs(source);
         }
 
-        [Fact(Skip = "TODO: enable when tests could consume new attribute applied to runtime assemblies")]
+        [Fact]
         public async Task MethodOfOsDependentAssemblyCalledWithoutSuppressionWarns()
         {
             var source = @"
-            using System.Runtime.Versioning;
-            using ns;
-            public class Test
-            {
-                public void M1()
-                {
-                    OsDependentClass odc = new OsDependentClass();
-                    odc.M2();
-                }
-            }
-            [assembly:SupportedOSPlatform(""Windows10.1.2.3"")]
-            namespace ns
-            {
-                public class OsDependentClass
-                {
-                    public void M2()
-                    {
-                    }
-                }
-            }
-" + MockAttributesCsSource;
-            await VerifyCS.VerifyAnalyzerAsync(source,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithSpan(10, 21, 10, 29).WithArguments("M2", "Windows", "10.1.2.3"));
+using System.Threading;
+
+namespace ns
+{
+    public class Test
+    {
+        public void M1()
+        {
+            var foo = {|#0:new Overlapped()|};
+            var result = {|#1:foo.AsyncResult|};
+        }
+    }
+}
+";
+            await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).WithArguments("Overlapped", "'windows'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(1).WithArguments("Overlapped.AsyncResult", "'windows'"));
         }
 
         public static IEnumerable<object[]> SupportedOsAttributeTestData()
@@ -1943,11 +1832,8 @@ public class Test
 [SupportedOSPlatform(""" + platform + version + @""")]
 public class OsDependentClass
 {
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
 
             if (warn)
             {
@@ -1999,11 +1885,8 @@ public class Test
 [UnsupportedOSPlatform(""" + platform + version + @""")]
 public class OsDependentClass
 {
-    public void M2()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void M2() { }
+}";
 
             if (warn)
             {
@@ -2059,8 +1942,7 @@ public class C
         [UnsupportedOSPlatform(""linux"")]
         public static void LinuxMethod() { }
     }
-}
-" + MockAttributesCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).
                 WithLocation(11, 9).WithArguments("C.StaticClass.LinuxMethod()", "'linux'", "'Linux'"),
@@ -2125,11 +2007,8 @@ public class C
     [UnsupportedOSPlatform(""windows"")]
     [SupportedOSPlatform(""windows10.0.1903"")]
     [UnsupportedOSPlatform(""windows10.0.2004"")]
-    public void DoesNotWorkOnWindows()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void DoesNotWorkOnWindows() { }
+}";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsReachable).WithLocation(18, 9).
                 WithArguments("C.DoesNotWorkOnWindows()", "'windows' 10.0.1903 and later", "'windows' 10.0.2000 and before"),
@@ -2186,11 +2065,8 @@ public class C
 {
     [SupportedOSPlatform(""windows"")]
     [UnsupportedOSPlatform(""windows10.0.2004"")]
-    public void WindowsOnlyUnsupportedFrom2004()
-    {
-    }
-}
-" + MockAttributesCsSource;
+    public void WindowsOnlyUnsupportedFrom2004() { }
+}";
             await VerifyAnalyzerAsyncCs(source,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(0).
                 WithArguments("C.WindowsOnlyUnsupportedFrom2004()", "'windows' 10.0.2004 and before", "'Linux'"),
@@ -2285,7 +2161,7 @@ namespace PlatformCompatDemo.SupportedUnupported
         }
     }
 }
-" + TargetTypesForTest + MockAttributesCsSource;
+" + TargetTypesForTest;
 
             await VerifyAnalyzerAsyncCs(source,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).
@@ -2353,7 +2229,7 @@ namespace PlatformCompatDemo.SupportedUnupported
         }
     }
 }
-" + TargetTypesForTest + MockAttributesCsSource;
+" + TargetTypesForTest;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(0).
@@ -2407,7 +2283,7 @@ public class Test
         {|#6:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on all platforms. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows'", ""),
@@ -2439,7 +2315,7 @@ public class Test
         {|#5:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on: 'windows' all versions. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows'", "'windows'"),
@@ -2470,7 +2346,7 @@ public class Test
         {|#5:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is reachable on: 'windows' 9.0 and later. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows' all versions", "'windows' 9.0 and later"),
@@ -2515,7 +2391,7 @@ public class Test
         AllowList.Windows10OnlyUnsupportedFrom11();
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("DenyList.UnsupportedWindows()", "'windows' all versions", "'windows' 10.0 and before"),
@@ -2548,7 +2424,7 @@ public class Test
         {|#3:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is unreachable on: 'windows' all versions. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(0).WithArguments("AllowList.WindowsOnly()", "'windows'", "'windows'"),
@@ -2577,7 +2453,7 @@ public class Test
         {|#3:AllowList.Windows10OnlyUnsupportedFrom11()|}; // This call site is unreachable on: 'windows' 9.0 and later. 'AllowList.Windows10OnlyUnsupportedFrom11()' is only supported on: 'windows' from version 10.0 to 11.0.
     }
 }
-" + AllowDenyListTestClasses + MockAttributesCsSource;
+" + AllowDenyListTestClasses;
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsUnreachable).WithLocation(0).WithArguments("AllowList.WindowsOnly()", "'windows' all versions", "'windows' 9.0 and later"),
@@ -2670,101 +2546,5 @@ public class AllowList
     [UnsupportedOSPlatform(""windows11.0"")]
     public static void Windows10OnlyUnsupportedFrom11() { }
 }";
-
-        private readonly string MockAttributesCsSource = @"
-namespace System.Runtime.Versioning
-{
-    public abstract class OSPlatformAttribute : Attribute
-    {
-        private protected OSPlatformAttribute(string platformName)
-        {
-            PlatformName = platformName;
-        }
-
-        public string PlatformName { get; }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly,
-                    AllowMultiple = false, Inherited = false)]
-    public sealed class TargetPlatformAttribute : OSPlatformAttribute
-    {
-        public TargetPlatformAttribute(string platformName) : base(platformName)
-        { }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Event |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Field |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
-    public sealed class SupportedOSPlatformAttribute : OSPlatformAttribute
-    {
-        public SupportedOSPlatformAttribute(string platformName) : base(platformName)
-        { }
-    }
-
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Event |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Field |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
-    public sealed class UnsupportedOSPlatformAttribute : OSPlatformAttribute
-    {
-        public UnsupportedOSPlatformAttribute(string platformName) : base(platformName)
-        { }
-    }
-}
-";
-
-        private readonly string MockAttributesVbSource = @"
-Namespace System.Runtime.Versioning
-    Public MustInherit Class OSPlatformAttribute
-        Inherits Attribute
-
-        Private Protected Sub New(ByVal platformName As String)
-            PlatformName = platformName
-        End Sub
-
-        Public ReadOnly Property PlatformName As String
-    End Class
-
-    <AttributeUsage(AttributeTargets.Assembly, AllowMultiple:=False, Inherited:=False)>
-    Public NotInheritable Class TargetPlatformAttribute
-        Inherits OSPlatformAttribute
-
-        Public Sub New(ByVal platformName As String)
-            MyBase.New(platformName)
-        End Sub
-    End Class
-
-    <AttributeUsage(AttributeTargets.Assembly Or AttributeTargets.[Class] Or AttributeTargets.Constructor Or AttributeTargets.[Event] Or AttributeTargets.Method Or AttributeTargets.[Module] Or AttributeTargets.[Property] Or AttributeTargets.Field Or AttributeTargets.Struct, AllowMultiple:=True, Inherited:=False)>
-    Public NotInheritable Class SupportedOSPlatformAttribute
-        Inherits OSPlatformAttribute
-
-        Public Sub New(ByVal platformName As String)
-            MyBase.New(platformName)
-        End Sub
-    End Class
-
-    <AttributeUsage(AttributeTargets.Assembly Or AttributeTargets.[Class] Or AttributeTargets.Constructor Or AttributeTargets.[Event] Or AttributeTargets.Method Or AttributeTargets.[Module] Or AttributeTargets.[Property] Or AttributeTargets.Field Or AttributeTargets.Struct, AllowMultiple:=True, Inherited:=False)>
-    Public NotInheritable Class UnsupportedOSPlatformAttribute
-        Inherits OSPlatformAttribute
-
-        Public Sub New(ByVal platformName As String)
-            MyBase.New(platformName)
-        End Sub
-    End Class
-End Namespace
-";
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4061

Remove Mock class, attributes used for testing Platform Compatibility Analyzer