### PR TITLE
Update Versions.props to enable releasing NetAnalyzers 5.0.1 package

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>3.3.2</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
-    <NetAnalyzersVersionPrefix>6.0.0</NetAnalyzersVersionPrefix>
+    <NetAnalyzersVersionPrefix>5.0.1</NetAnalyzersVersionPrefix>
     <NetAnalyzersPreReleaseVersionLabel>preview1</NetAnalyzersPreReleaseVersionLabel>
     <AnalyzerUtilitiesVersionPrefix>$(VersionPrefix)</AnalyzerUtilitiesVersionPrefix>
     <!--

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
-        "version": "6.0.0",
+        "version": "5.0.1",
         "language": "en-US"
       },
       "rules": {
@@ -290,7 +290,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.NetAnalyzers",
-        "version": "6.0.0",
+        "version": "5.0.1",
         "language": "en-US"
       },
       "rules": {
@@ -5068,7 +5068,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers",
-        "version": "6.0.0",
+        "version": "5.0.1",
         "language": "en-US"
       },
       "rules": {


### PR DESCRIPTION
This PR enables seamless migration from `3.x` FxCop analyzers packages published out of master to a stable NetAnalyzers package by following steps at https://docs.microsoft.com/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers

Will revert this PR as soon as we get a signed build candidate for publishing 5.0.1 package for latest bug fixes. We need to finalize our long term story on which branch do we target bug fixes to existing analyzers versus add new .NET vNext analyzers.

