### PR TITLE
Find tainted data parameter SyntaxNodes more robustly, and don't treat ASP.NET MVC Controller property setter parameters as tainted

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
@@ -3669,6 +3669,25 @@ public class MyController
         }
 
         [Fact]
+        public async Task AspNetMvcController_HasPropertySetter()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.Data.SqlClient;
+
+public class MyController
+{
+    public void DoSomething(string input)
+    {
+    }
+
+    public string AString 
+    {
+        set { _ = value; }
+    }
+}");
+        }
+
+        [Fact]
         public async Task TaintFunctionArguments()
         {
             await VerifyCSharpWithDependenciesAsync(@"

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -120,6 +120,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 if (this.DataFlowAnalysisContext.SourceInfos.IsSourceParameter(parameter, WellKnownTypeProvider))
                 {
                     // Location of the parameter, so we can track where the tainted data appears in code.
+                    // The parameter itself may not have any DeclaringSyntaxReferences, e.g. 'value' inside property setters.
                     SyntaxNode parameterSyntaxNode;
                     if (!parameter.DeclaringSyntaxReferences.IsEmpty)
                     {
@@ -131,6 +132,9 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                     }
                     else
                     {
+                        // Unless there are others, the only case we have for parameters being tainted data sources is inside
+                        // ASP.NET Core MVC controller action methods (see WebInputSources.cs), so those parameters should
+                        // always be declared somewhere.
                         Debug.Fail("Can we have a tainted data parameter with no syntax references?");
                         return ValueDomain.UnknownOrMayBeValue;
                     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -119,7 +119,23 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             {
                 if (this.DataFlowAnalysisContext.SourceInfos.IsSourceParameter(parameter, WellKnownTypeProvider))
                 {
-                    return TaintedDataAbstractValue.CreateTainted(parameter, parameter.DeclaringSyntaxReferences[0].GetSyntax(), this.OwningSymbol);
+                    // Location of the parameter, so we can track where the tainted data appears in code.
+                    SyntaxNode parameterSyntaxNode;
+                    if (!parameter.DeclaringSyntaxReferences.IsEmpty)
+                    {
+                        parameterSyntaxNode = parameter.DeclaringSyntaxReferences[0].GetSyntax();
+                    }
+                    else if (!parameter.ContainingSymbol.DeclaringSyntaxReferences.IsEmpty)
+                    {
+                        parameterSyntaxNode = parameter.ContainingSymbol.DeclaringSyntaxReferences[0].GetSyntax();
+                    }
+                    else
+                    {
+                        Debug.Fail("Can we have a tainted data parameter with no syntax references?");
+                        return ValueDomain.UnknownOrMayBeValue;
+                    }
+
+                    return TaintedDataAbstractValue.CreateTainted(parameter, parameterSyntaxNode, this.OwningSymbol);
                 }
 
                 return ValueDomain.UnknownOrMayBeValue;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -89,7 +89,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                         if (methodSymbol.DeclaredAccessibility != Accessibility.Public
                             || methodSymbol.IsConstructor()
                             || methodSymbol.IsStatic
-                            || methodSymbol.MethodKind == MethodKind.PropertySet
+                            || methodSymbol.MethodKind != MethodKind.Ordinary
                             || methodSymbol.HasDerivedMethodAttribute(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcNonActionAttribute)))
                         {
                             return false;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -89,6 +89,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                         if (methodSymbol.DeclaredAccessibility != Accessibility.Public
                             || methodSymbol.IsConstructor()
                             || methodSymbol.IsStatic
+                            || methodSymbol.MethodKind == MethodKind.PropertySet
                             || methodSymbol.HasDerivedMethodAttribute(wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftAspNetCoreMvcNonActionAttribute)))
                         {
                             return false;


### PR DESCRIPTION
Fixes #4495