### PR TITLE
PostRelease activities after release of new analyzer packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -252,6 +252,25 @@ dotnet_code_quality.CA1720.api_surface = public
 # CA1715: Identifiers should have correct prefix
 dotnet_code_quality.CA1715.exclude_single_letter_type_parameters = true
 
+# CA1002: Do not expose generic lists
+dotnet_diagnostic.CA1002.severity = suggestion
+
+# CA1024: Use properties where appropriate
+dotnet_diagnostic.CA1024.severity = suggestion
+
+# CA1033: Interface methods should be callable by child types
+dotnet_diagnostic.CA1033.severity = suggestion
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = suggestion
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = suggestion
+
+# CA1725: Parameter names should match base declaration
+# TODO: Enable this rule as warning and fix violations.
+dotnet_diagnostic.CA1725.severity = suggestion
+
 ### Configuration for PublicAPI analyzers executed on this repo ###
 [*.{cs,vb}]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -261,6 +261,9 @@ dotnet_diagnostic.CA1024.severity = suggestion
 # CA1033: Interface methods should be callable by child types
 dotnet_diagnostic.CA1033.severity = suggestion
 
+# CA1307: Specify StringComparison for clarity
+dotnet_diagnostic.CA1307.severity = suggestion
+
 # CA1711: Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1711.severity = suggestion
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,12 +19,12 @@ assignees: ''
 
 _OR_
 
-**NuGet Package**: [Microsoft.CodeAnalysis.FxCopAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers)
+**NuGet Package**: [Microsoft.CodeAnalysis.NetAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers)
 
-**Version**: v3.3.1 (Latest)
+**Version**: 5.0.1 (Latest)
 
 <!--
-NOTE: FxCopAnalyzers package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers', that ships with the .NET SDK.
+NOTE: `Microsoft.CodeAnalysis.FxCopAnalyzers` package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers', that ships with the .NET SDK.
       Please refer to https://docs.microsoft.com/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers to migrate to .NET analyzers.
 -->
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,9 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
+    <!-- CA1014: Mark assemblies with CLSCompliant -->
+    <NoWarn>$(NoWarn),CA1014</NoWarn>
+    
     <!--
       Make sure any documentation comments which are included in code get checked for syntax during the build, but do
       not report warnings for missing comments.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,9 +23,6 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <!-- CA1014: Mark assemblies with CLSCompliant -->
-    <NoWarn>$(NoWarn),CA1014</NoWarn>
-    
     <!--
       Make sure any documentation comments which are included in code get checked for syntax during the build, but do
       not report warnings for missing comments.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You do not need to manually install this NuGet package to your project if you ar
 
 ### Microsoft.CodeAnalysis.FxCopAnalyzers
 
+**NOTE:** Starting version `3.3.2`, `Microsoft.CodeAnalysis.FxCopAnalyzers` has been **deprecated** in favor of `Microsoft.CodeAnalysis.NetAnalyzers`. Documentation to migrate from FxCopAnalyzers to NetAnalyzers is available [here](https://docs.microsoft.com/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers).
+
 *Latest stable version:* [![NuGet](https://img.shields.io/nuget/v/Microsoft.CodeAnalysis.FxCopAnalyzers.svg)](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers)
 
 *Latest pre-release version:* [here](https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet5&view=overview&package=Microsoft.CodeAnalysis.FxCopAnalyzers&protocolType=NuGet)
@@ -154,7 +156,7 @@ See [VERSIONING.md](.//VERSIONING.md) for the versioning scheme for all analyzer
 
 ## Recommended version of Analyzer Packages
 
-Recommended Analyzer Package Version: **Version 5.0.0**, for example [Microsoft.CodeAnalysis.NetAnalyzers 5.0.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/5.0.0)
+Recommended Analyzer Package Version: [![NuGet](https://img.shields.io/nuget/v/Microsoft.CodeAnalysis.NetAnalyzers.svg)](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers)
 
 Required Visual Studio Version: **Visual Studio 2019 16.8 RTW or later**
 

--- a/RoslynAnalyzers.sln
+++ b/RoslynAnalyzers.sln
@@ -164,6 +164,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSha
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes", "src\PerformanceSensitiveAnalyzers\CSharp\CodeFixes\Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes.csproj", "{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateAnalyzerNuspec", "src\Tools\GenerateAnalyzerNuspec\GenerateAnalyzerNuspec.csproj", "{81E21880-3F26-42DC-9423-9DACB8933597}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{046419a7-c60d-40ff-ad7e-2bae461b7ce5}*SharedItemsImports = 5
@@ -423,6 +425,10 @@ Global
 		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81E21880-3F26-42DC-9423-9DACB8933597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81E21880-3F26-42DC-9423-9DACB8933597}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81E21880-3F26-42DC-9423-9DACB8933597}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81E21880-3F26-42DC-9423-9DACB8933597}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -494,6 +500,7 @@ Global
 		{4C362C30-C4B1-4C4B-A545-DBF67C7E9153} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
 		{8197A037-FF9E-4660-8C6D-2F722FEA0C10} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
 		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+		{81E21880-3F26-42DC-9423-9DACB8933597} = {DB2DD702-8301-4FC6-B8C0-029C7DCC2931}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FC44ACA9-AEA3-4EE6-881C-2E08ED281B5F}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -19,6 +19,7 @@ Released versions of analyzer packages, with the last GitHub Commit Tag and SHA 
 Sr. No. | Release         |
 --------|-----------------|
 1       | [5.0.0](https://github.com/dotnet/roslyn-analyzers/releases/tag/5.0.0)           |
+2       | [5.0.1](https://github.com/dotnet/roslyn-analyzers/releases/tag/5.0.1)           |
 
 ### Other analyzers
 
@@ -62,3 +63,4 @@ Sr. No. |  Release Version | Commit Tag       | Commit SHA                      
 36       | 3.3.0-beta2.final (pre-release)             | v3.3.0-beta2.final          | [303d517](https://github.com/dotnet/roslyn-analyzers/commit/303d517d74aaaade61c2e46c9d8965c23758ee7d)   | Microsoft.CodeAnalysis.FxCopAnalyzers, Microsoft.CodeAnalysis.VersionCheckAnalyzer, Microsoft.CodeQuality.Analyzers, Microsoft.NetCore.Analyzers, Microsoft.NetFramework.Analyzers, Roslyn.Diagnostics.Analyzers, Microsoft.CodeAnalysis.PublicApiAnalyzers, Microsoft.CodeAnalysis.BannedApiAnalyzers
 37       | 3.3.0             | v3.3.0          | [0a95f9e](https://github.com/dotnet/roslyn-analyzers/commit/0a95f9e9a53519ee3cd59b9cf96be6326ef9955b)   | Microsoft.CodeAnalysis.Analyzers, Microsoft.CodeAnalysis.AnalyzerUtilities, Microsoft.CodeAnalysis.FxCopAnalyzers, Microsoft.CodeAnalysis.Metrics, Microsoft.CodeAnalysis.VersionCheckAnalyzer, Microsoft.CodeQuality.Analyzers, Microsoft.NetCore.Analyzers, Microsoft.NetFramework.Analyzers, Roslyn.Diagnostics.Analyzers, Microsoft.CodeAnalysis.PublicApiAnalyzers, Microsoft.CodeAnalysis.BannedApiAnalyzers
 38       | 3.3.1             | v3.3.1          | [49efc9e](https://github.com/dotnet/roslyn-analyzers/commit/49efc9eea7aaa303190beb5b3ea554604fb5ce9d)   | Microsoft.CodeAnalysis.Analyzers, Microsoft.CodeAnalysis.AnalyzerUtilities, Microsoft.CodeAnalysis.FxCopAnalyzers, Microsoft.CodeAnalysis.VersionCheckAnalyzer, Microsoft.CodeQuality.Analyzers, Microsoft.NetCore.Analyzers, Microsoft.NetFramework.Analyzers, Roslyn.Diagnostics.Analyzers, Microsoft.CodeAnalysis.PublicApiAnalyzers, Microsoft.CodeAnalysis.BannedApiAnalyzers
+39       | 3.3.2             | v3.3.2          | [4e0e1e8](https://github.com/dotnet/roslyn-analyzers/commit/4e0e1e855864587991a39e1e974dc53af094f4db)   | Microsoft.CodeAnalysis.Analyzers, Microsoft.CodeAnalysis.AnalyzerUtilities, Microsoft.CodeAnalysis.FxCopAnalyzers, Microsoft.CodeAnalysis.VersionCheckAnalyzer, Microsoft.CodeQuality.Analyzers, Microsoft.NetCore.Analyzers, Microsoft.NetFramework.Analyzers, Roslyn.Diagnostics.Analyzers, Microsoft.CodeAnalysis.PublicApiAnalyzers, Microsoft.CodeAnalysis.BannedApiAnalyzers

--- a/eng/Analyzers_ShippingRules.ruleset
+++ b/eng/Analyzers_ShippingRules.ruleset
@@ -6,6 +6,8 @@
   <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
     <!-- ValidateArgumentsOfPublicMethods - only useful for libraries with supported public API surface, we don't have any -->
     <Rule Id="CA1062" Action="None" />
+    <!-- CA1014: Mark assemblies with CLSCompliant -->
+    <Rule Id="CA1014" Action="None" />
   </Rules>
   
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.3.2</VersionPrefix>
+    <VersionPrefix>3.3.3</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
-    <NetAnalyzersVersionPrefix>5.0.1</NetAnalyzersVersionPrefix>
+    <NetAnalyzersVersionPrefix>5.0.2</NetAnalyzersVersionPrefix>
     <NetAnalyzersPreReleaseVersionLabel>preview1</NetAnalyzersPreReleaseVersionLabel>
     <AnalyzerUtilitiesVersionPrefix>$(VersionPrefix)</AnalyzerUtilitiesVersionPrefix>
     <!--
@@ -29,8 +29,8 @@
     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.7.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
     <MicrosoftCodeAnalysisVersionForTests>3.8.0-4.final</MicrosoftCodeAnalysisVersionForTests>
     <DogfoodAnalyzersVersion>3.3.1</DogfoodAnalyzersVersion>
+    <DogfoodNetAnalyzersVersion>5.0.1</DogfoodNetAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
-    <MicrosoftCodeAnalysisFXCopAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisFXCopAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <RoslynDiagnosticsAnalyzersVersion>$(DogfoodAnalyzersVersion)</RoslynDiagnosticsAnalyzersVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,9 +8,6 @@
 
     <DefineConstants Condition="'$(BUILDING_VSIX)' == 'true'">$(DefineConstants),BUILDING_VSIX</DefineConstants>
     <DefineConstants Condition="'$(LEGACY_CODE_METRICS_MODE)' == 'true'">$(DefineConstants),LEGACY_CODE_METRICS_MODE</DefineConstants>
-
-    <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <!-- Test runner configuration -->
@@ -19,6 +16,12 @@
   </ItemGroup>
 
   <!-- Code analyzers -->
+  <PropertyGroup>
+    <!-- Enable all the latest CA rules from 'Microsoft.CodeAnalysis.NetAnalyzers' as build warnings by default. Specific rules are disabled or downgraded in repo's editorconfig. -->
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(DogfoodNetAnalyzersVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,9 @@
 
     <DefineConstants Condition="'$(BUILDING_VSIX)' == 'true'">$(DefineConstants),BUILDING_VSIX</DefineConstants>
     <DefineConstants Condition="'$(LEGACY_CODE_METRICS_MODE)' == 'true'">$(DefineConstants),LEGACY_CODE_METRICS_MODE</DefineConstants>
+
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
   <!-- Test runner configuration -->
@@ -17,7 +20,7 @@
 
   <!-- Code analyzers -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(MicrosoftCodeAnalysisFXCopAnalyzersVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(DogfoodNetAnalyzersVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsAnalyzersVersion)" />

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -369,7 +369,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                                         {
                                             symbol = semanticModel.GetSymbolInfo(argument, context.CancellationToken).Symbol;
                                             if (symbol != null &&
-#pragma warning disable CA1508 // Avoid dead conditional code - TODO: File an issue.
+#pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/4519
                                                 symbol.Kind == SymbolKind.Field &&
 #pragma warning restore CA1508 // Avoid dead conditional code
                                                 _symbolKind.Equals(symbol.ContainingType) &&

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -369,7 +369,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                                         {
                                             symbol = semanticModel.GetSymbolInfo(argument, context.CancellationToken).Symbol;
                                             if (symbol != null &&
+#pragma warning disable CA1508 // Avoid dead conditional code - TODO: File an issue.
                                                 symbol.Kind == SymbolKind.Field &&
+#pragma warning restore CA1508 // Avoid dead conditional code
                                                 _symbolKind.Equals(symbol.ContainingType) &&
                                                 !s_supportedSymbolKinds.Contains(symbol.Name))
                                             {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReportDiagnosticAnalyzer.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
             private ImmutableDictionary<INamedTypeSymbol, ImmutableArray<IFieldSymbol>> _supportedDescriptorFieldsMap;
 
-            public ReportDiagnosticCompilationAnalyzer(ImmutableHashSet<INamedTypeSymbol> contextTypes, INamedTypeSymbol diagnosticType, INamedTypeSymbol diagnosticDescriptorType, INamedTypeSymbol diagnosticAnalyzer, INamedTypeSymbol diagnosticAnalyzerAttribute)
+            protected ReportDiagnosticCompilationAnalyzer(ImmutableHashSet<INamedTypeSymbol> contextTypes, INamedTypeSymbol diagnosticType, INamedTypeSymbol diagnosticDescriptorType, INamedTypeSymbol diagnosticAnalyzer, INamedTypeSymbol diagnosticAnalyzerAttribute)
                 : base(diagnosticAnalyzer, diagnosticAnalyzerAttribute)
             {
                 _contextTypes = contextTypes;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -605,7 +605,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -786,7 +786,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -77,7 +77,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.FxCopAnalyzers/Microsoft.CodeAnalysis.FxCopAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VersionCheckAnalyzer",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -29,7 +29,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -1930,7 +1930,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -2098,7 +2098,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -2306,7 +2306,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -5185,7 +5185,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -5273,7 +5273,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -5361,7 +5361,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -5467,7 +5467,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -5514,7 +5514,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.sarif
+++ b/src/Microsoft.CodeAnalysis.VersionCheckAnalyzer/Microsoft.CodeAnalysis.VersionCheckAnalyzer.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VersionCheckAnalyzer",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.sarif
+++ b/src/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Humanizer",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -1915,7 +1915,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -2083,7 +2083,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeQuality.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.sarif
+++ b/src/Microsoft.NetCore.Analyzers/Microsoft.NetCore.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -2884,7 +2884,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -2972,7 +2972,7 @@
     {
       "tool": {
         "name": "Microsoft.NetCore.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.sarif
+++ b/src/Microsoft.NetFramework.Analyzers/Microsoft.NetFramework.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -111,7 +111,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -158,7 +158,7 @@
     {
       "tool": {
         "name": "Microsoft.NetFramework.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypeNamesShouldNotMatchNamespaces.cs
@@ -156,7 +156,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 lock (s_lock)
                 {
+#pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/3861
                     if (s_wellKnownSystemNamespaceTable == null)
+#pragma warning restore CA1508 // Avoid dead conditional code
                     {
                         #region List of Well known System Namespaces
                         var wellKnownSystemNamespaces = new List<string>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             private readonly DisposeAnalysisHelper _disposeAnalysisHelper;
 
-            public DisposableFieldAnalyzer(Compilation compilation)
+            protected DisposableFieldAnalyzer(Compilation compilation)
             {
                 DisposeAnalysisHelper.TryGetOrCreate(compilation, out _disposeAnalysisHelper!);
                 RoslynDebug.Assert(_disposeAnalysisHelper != null);

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.Fixer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
         private abstract class ChangeSymbolAction : CodeAction
         {
-            public ChangeSymbolAction(string title, string equivalenceKey, Solution solution, ISymbol symbol)
+            protected ChangeSymbolAction(string title, string equivalenceKey, Solution solution, ISymbol symbol)
             {
                 Title = title;
                 EquivalenceKey = equivalenceKey;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/InsecureDeserializationTypeDecider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/InsecureDeserializationTypeDecider.cs
@@ -183,6 +183,7 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
 
             if (this.InsecureTypeSymbols.Count == 0)
             {
+                results = ImmutableArray<InsecureObjectGraphResult>.Empty;
                 return false;
             }
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
-        "version": "5.0.1",
+        "version": "5.0.2",
         "language": "en-US"
       },
       "rules": {
@@ -290,7 +290,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.NetAnalyzers",
-        "version": "5.0.1",
+        "version": "5.0.2",
         "language": "en-US"
       },
       "rules": {
@@ -5068,7 +5068,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers",
-        "version": "5.0.1",
+        "version": "5.0.2",
         "language": "en-US"
       },
       "rules": {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscoresTests.cs
@@ -1,6 +1,7 @@
 
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
@@ -1084,7 +1085,7 @@ End Class",
                 SymbolKind.MemberParameter => IdentifiersShouldNotContainUnderscoresAnalyzer.MemberParameterRule,
                 SymbolKind.TypeTypeParameter => IdentifiersShouldNotContainUnderscoresAnalyzer.TypeTypeParameterRule,
                 SymbolKind.MethodTypeParameter => IdentifiersShouldNotContainUnderscoresAnalyzer.MethodTypeParameterRule,
-                _ => throw new System.Exception("Unknown Symbol Kind"),
+                _ => throw new NotSupportedException("Unknown Symbol Kind"),
             };
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DataSetDataTableInWebSerializableObjectGraphTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DataSetDataTableInWebSerializableObjectGraphTests.cs
@@ -90,7 +90,9 @@ public class MyClass
 
         private static async Task VerifyServiceModelCSharpAsync(string source, params DiagnosticResult[] expected)
         {
+#pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+#pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
             var csharpTest = new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default.AddAssemblies(
@@ -108,7 +110,9 @@ public class MyClass
 
         private static async Task VerifyWebServicesCSharpAsync(string source, params DiagnosticResult[] expected)
         {
+#pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+#pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
             var csharpTest = new VerifyCS.Test
             {
                 ReferenceAssemblies = ReferenceAssemblies.NetFramework.Net472.Default.AddAssemblies(

--- a/src/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
+++ b/src/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -184,7 +184,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -193,7 +193,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
+++ b/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -227,7 +227,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/SpecializedEnumerableCreationAnalyzer.cs
@@ -97,7 +97,7 @@ namespace Roslyn.Diagnostics.Analyzers
             private readonly INamedTypeSymbol _genericEnumerableSymbol;
             private readonly IMethodSymbol _genericEmptyEnumerableSymbol;
 
-            public AbstractCodeBlockStartedAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
+            protected AbstractCodeBlockStartedAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
             {
                 _genericEnumerableSymbol = genericEnumerableSymbol;
                 _genericEmptyEnumerableSymbol = genericEmptyEnumerableSymbol;
@@ -120,7 +120,7 @@ namespace Roslyn.Diagnostics.Analyzers
             protected INamedTypeSymbol GenericEnumerableSymbol { get; }
             private readonly IMethodSymbol _genericEmptyEnumerableSymbol;
 
-            public AbstractSyntaxAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
+            protected AbstractSyntaxAnalyzer(INamedTypeSymbol genericEnumerableSymbol, IMethodSymbol genericEmptyEnumerableSymbol)
             {
                 this.GenericEnumerableSymbol = genericEnumerableSymbol;
                 _genericEmptyEnumerableSymbol = genericEmptyEnumerableSymbol;

--- a/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -175,7 +175,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.CSharp.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {
@@ -338,7 +338,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.VisualBasic.Analyzers",
-        "version": "3.3.2",
+        "version": "3.3.3",
         "language": "en-US"
       },
       "rules": {

--- a/src/Test.Utilities/.editorconfig
+++ b/src/Test.Utilities/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -29,7 +29,9 @@ namespace Test.Utilities
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA5364 // Do Not Use Deprecated Security Protocols
                 {
+#pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
                 }
             }
 

--- a/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
@@ -25,7 +25,9 @@ namespace Test.Utilities
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA5364 // Do Not Use Deprecated Security Protocols
                 {
+#pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
                 }
             }
 

--- a/src/Test.Utilities/WorkItemAttribute.cs
+++ b/src/Test.Utilities/WorkItemAttribute.cs
@@ -5,7 +5,7 @@ using System;
 namespace Test.Utilities
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
-    public class WorkItemAttribute : Attribute
+    public sealed class WorkItemAttribute : Attribute
     {
         public WorkItemAttribute(int id, string source)
         {

--- a/src/TestReferenceAssembly/.editorconfig
+++ b/src/TestReferenceAssembly/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA5394: Do not use insecure randomness
+dotnet_diagnostic.CA5394.severity = none

--- a/src/Tools/.editorconfig
+++ b/src/Tools/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none

--- a/src/Tools/GenerateAnalyzerNuspec/Program.cs
+++ b/src/Tools/GenerateAnalyzerNuspec/Program.cs
@@ -58,7 +58,7 @@ foreach (string entry in metadataList)
         result.AppendLine($"    <{name}>{value}</{name}>");
     }
 
-#pragma warning disable CA1508 // Avoid dead conditional code - TODO: File a bug
+#pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/4520
     if (name == "version")
 #pragma warning restore CA1508
     {

--- a/src/Tools/GenerateAnalyzerNuspec/Program.cs
+++ b/src/Tools/GenerateAnalyzerNuspec/Program.cs
@@ -58,7 +58,9 @@ foreach (string entry in metadataList)
         result.AppendLine($"    <{name}>{value}</{name}>");
     }
 
+#pragma warning disable CA1508 // Avoid dead conditional code - TODO: File a bug
     if (name == "version")
+#pragma warning restore CA1508
     {
         version = value;
     }

--- a/src/Tools/ReleaseNotesUtil/FixerExtensions.cs
+++ b/src/Tools/ReleaseNotesUtil/FixerExtensions.cs
@@ -96,7 +96,7 @@ namespace ReleaseNotesUtil
                 int metadataToken = BitConverter.ToInt32(methodBodyIL, 1);
                 MethodBase? calledMethod = method.Module.ResolveMethod(metadataToken);
                 if (calledMethod != null
-                    && calledMethod?.DeclaringType?.FullName == "System.Threading.Tasks.Task"
+                    && calledMethod.DeclaringType?.FullName == "System.Threading.Tasks.Task"
                     && calledMethod.Name == "get_CompletedTask")
                 {
                     return false;

--- a/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
+++ b/src/Utilities/Compiler/Extensions/SymbolVisibility.cs
@@ -4,7 +4,9 @@ using System;
 
 namespace Analyzer.Utilities.Extensions
 {
+#pragma warning disable CA1027 // Mark enums with FlagsAttribute
     internal enum SymbolVisibility
+#pragma warning restore CA1027 // Mark enums with FlagsAttribute
     {
         Public = 0,
         Internal = 1,

--- a/src/Utilities/Compiler/Lightup/.editorconfig
+++ b/src/Utilities/Compiler/Lightup/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = none

--- a/src/Utilities/Compiler/Lightup/LightupHelpers.cs
+++ b/src/Utilities/Compiler/Lightup/LightupHelpers.cs
@@ -7,8 +7,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
-#pragma warning disable CA2201 // Do not raise reserved exception types - 'throw new NullReferenceException()' is used in this file
-
 namespace Analyzer.Utilities.Lightup
 {
     internal static class LightupHelpers

--- a/src/Utilities/Compiler/Lightup/LightupHelpers.cs
+++ b/src/Utilities/Compiler/Lightup/LightupHelpers.cs
@@ -7,6 +7,8 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 
+#pragma warning disable CA2201 // Do not raise reserved exception types - 'throw new NullReferenceException()' is used in this file
+
 namespace Analyzer.Utilities.Lightup
 {
     internal static class LightupHelpers

--- a/src/Utilities/Compiler/Lightup/NullableContext.cs
+++ b/src/Utilities/Compiler/Lightup/NullableContext.cs
@@ -17,7 +17,9 @@ namespace Analyzer.Utilities.Lightup
         /// <summary>
         /// Nullable warnings and annotations are explicitly turned off at this location.
         /// </summary>
+#pragma warning disable CA1008 // Enums should have zero value - Rename zero valued field to 'None'
         Disabled = 0,
+#pragma warning restore CA1008 // Enums should have zero value
 
         /// <summary>
         /// Nullable warnings are enabled and will be reported at this file location.

--- a/src/Utilities/Compiler/RuleLevel.cs
+++ b/src/Utilities/Compiler/RuleLevel.cs
@@ -4,7 +4,11 @@
 
 namespace Microsoft.CodeAnalysis
 {
+#pragma warning disable CA1008 // Enums should have zero value
+#pragma warning disable CA1027 // Mark enums with FlagsAttribute
     internal enum RuleLevel
+#pragma warning restore CA1027 // Mark enums with FlagsAttribute
+#pragma warning restore CA1008 // Enums should have zero value
     {
         /// <summary>
         /// Correctness rule which should have <b>no false positives</b>, and is extremely likely to be fixed by users.

--- a/src/Utilities/Compiler/SmallDictionary.cs
+++ b/src/Utilities/Compiler/SmallDictionary.cs
@@ -142,7 +142,9 @@ namespace Analyzer.Utilities
             public override Node Next { get; }
         }
 
+#pragma warning disable CA1708 // Identifiers should differ by more than case
         private sealed class AvlNodeHead : AvlNode
+#pragma warning restore CA1708 // Identifiers should differ by more than case
         {
             public Node next;
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/PropertySetAnalysis.PropertySetDataFlowOperationVisitor.cs
@@ -570,11 +570,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                         (containingType, false),
                         out string containingTypeName))
                 {
-                    if (hazardousUsageTypeNames == null)
-                    {
-                        hazardousUsageTypeNames = PooledHashSet<string>.GetInstance();
-                    }
-
+                    hazardousUsageTypeNames = PooledHashSet<string>.GetInstance();
                     hazardousUsageTypeNames.Add(containingTypeName);
                 }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataSymbolMap.cs
@@ -109,10 +109,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         /// <returns>Relevant infos for the given type.</returns>
         public IEnumerable<TInfo> GetInfosForType(INamedTypeSymbol namedTypeSymbol)
         {
-            Debug.Assert(namedTypeSymbol != null);
-
             if (namedTypeSymbol == null)
             {
+                Debug.Fail("Expected non-null 'namedTypeSymbol'");
+
                 yield break;
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -286,9 +286,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 // Check if we are starting a try region which has one or more associated catch/filter regions.
                 // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
+#pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/4408
                 if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
-                    block.EnclosingRegion?.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
+                    block.EnclosingRegion.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
                     block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
+#pragma warning restore CA1508 // Avoid dead conditional code
                 {
                     MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
                 }


### PR DESCRIPTION
Also migrated dogfood analyzers from FxCopAnalyzers to NetAnalayzers, with AnalysisMode = AllEnabledByDefault, which enabled additional CA analyzers in the repo. I have fixed/disabled the additional analyzers as appropriate.
