### PR TITLE
Update PR template to reflect the deletion of FxCopAnalyzers.sln

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Make sure to run `msbuild RoslynAnalyzers.sln /t:pack` and `msbuild FxCopAnalyzers.sln /t:pack` in the repository root when
+Make sure to run `msbuild RoslynAnalyzers.sln /t:pack` in the repository root when
 you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.
 
 - Adding a new diagnostic analyzer or a code fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Make sure to run `msbuild /t:pack` in the repository root when
+Make sure to run `msbuild /t:pack /v:m` in the repository root when
 you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.
 
 - Adding a new diagnostic analyzer or a code fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 
-Make sure to run `msbuild RoslynAnalyzers.sln /t:pack` in the repository root when
+Make sure to run `msbuild /t:pack` in the repository root when
 you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.
 
 - Adding a new diagnostic analyzer or a code fix


### PR DESCRIPTION
<!--

Make sure to run `msbuild RoslynAnalyzers.sln /t:pack` and `msbuild FxCopAnalyzers.sln /t:pack` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.


-->
