### PR TITLE
Fix nullability for SymbolNamesWithValueOption

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldHaveCorrectSuffix.cs
@@ -171,13 +171,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         }
 
         private static bool TryGetTypeSuffix(IEnumerable<INamedTypeSymbol> typeSymbols, ImmutableDictionary<INamedTypeSymbol, SuffixInfo> hardcodedMap,
-            SymbolNamesWithValueOption<string> userMap, [NotNullWhen(true)] out SuffixInfo? suffixInfo)
+            SymbolNamesWithValueOption<string?> userMap, [NotNullWhen(true)] out SuffixInfo? suffixInfo)
         {
             foreach (var type in typeSymbols)
             {
                 // User specific mapping has higher priority than hardcoded one
                 if (userMap.TryGetValue(type.OriginalDefinition, out var suffix) &&
-                    !string.IsNullOrWhiteSpace(suffix))
+                    !RoslynString.IsNullOrWhiteSpace(suffix))
                 {
                     suffixInfo = SuffixInfo.Create(suffix, canSuffixBeCollection: false);
                     return true;

--- a/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
+++ b/src/Utilities.UnitTests/Options/SymbolNamesWithValueOptionTests.cs
@@ -19,7 +19,7 @@ namespace Analyzer.Utilities.UnitTests.Options
         public void WhenNoSymbolNames_ReturnsEmpty()
         {
             // Arrange & act
-            var options = SymbolNamesWithValueOption<Unit>.Create(ImmutableArray<string>.Empty, GetCompilation(), null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(ImmutableArray<string>.Empty, GetCompilation(), null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Equal(SymbolNamesWithValueOption<Unit>.Empty, options);
@@ -37,7 +37,7 @@ namespace Analyzer.Utilities.UnitTests.Options
                 {
                     callCount++;
                 }
-                return new SymbolNamesWithValueOption<Unit>.NameParts(symbolName);
+                return new SymbolNamesWithValueOption<Unit>.NameParts(symbolName, Unit.Default);
             }
 
             // Act
@@ -56,7 +56,7 @@ namespace Analyzer.Utilities.UnitTests.Options
             var symbolNames = ImmutableArray.Create("MyNamespace", "MyClass", "MyMethod()", "MyProperty", "MyEvent", "MyField");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Equal(symbolNames.Length, options.GetTestAccessor().Names.Count);
@@ -90,7 +90,7 @@ public namespace MyNamespace
                 "MyNamespace.MyClass.MyMethod()");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -124,7 +124,7 @@ public namespace MyNamespace
                 "M:MyNamespace.MyClass.MyMethod()");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -146,7 +146,7 @@ public namespace MyNamespace
                 "M:MyNamespace.MyClass.MyMethod()");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -166,7 +166,7 @@ public namespace MyNamespace
                 "*a*");     // more than one wildcard symbol
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -188,7 +188,7 @@ public namespace MyNamespace
                 "MyNamespace.MyClass.MyMethod(*");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -217,7 +217,7 @@ public namespace MyNamespace
                 "M:MyNamespace.MyClass.MyMethod(*");
 
             // Act
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Assert
             Assert.Empty(options.GetTestAccessor().Names);
@@ -361,7 +361,7 @@ public namespace MyCompany.MyProduct.MyFeature
 }");
             var symbolNames = ImmutableArray.Create(patternName);
             var symbol = FindSymbol(compilation, symbolName);
-            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, null);
+            var options = SymbolNamesWithValueOption<Unit>.Create(symbolNames, compilation, null, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default));
 
             // Act
             var isFound = options.Contains(symbol);

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -11,6 +11,9 @@
   <PropertyGroup Condition="'$(MicrosoftCodeAnalysisVersion)' == '' OR '$(MicrosoftCodeAnalysisVersion)' &gt;= '3.3'">
     <DefineConstants>$(DefineConstants),CODEANALYSIS_V3_OR_BETTER</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MicrosoftCodeAnalysisVersion)' == '' OR '$(MicrosoftCodeAnalysisVersion)' &gt;= '3.7'">
+    <DefineConstants>$(DefineConstants),CODEANALYSIS_V3_7_OR_BETTER</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(MicrosoftCodeAnalysisVersion)' != '1.2.1'">
     <DefineConstants>$(DefineConstants);HAS_IOPERATION</DefineConstants>
     <HasIOperation>true</HasIOperation>

--- a/src/Utilities/Compiler/Extensions/KeyValuePairExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/KeyValuePairExtensions.cs
@@ -11,5 +11,11 @@ namespace Analyzer.Utilities.Extensions
             key = pair.Key;
             value = pair.Value;
         }
+
+        public static KeyValuePair<TKey?, TValue?> AsNullable<TKey, TValue>(this KeyValuePair<TKey, TValue> pair)
+        {
+            // This conversion is safe
+            return pair!;
+        }
     }
 }

--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -93,7 +93,7 @@ namespace Analyzer.Utilities
         {
             var optionKeyPrefix = MapOptionKindToKeyPrefix(kind);
 
-            T optionValue;
+            T? optionValue;
             if (rule != null)
             {
                 if (TryGetSpecificOptionValue(rule.Id, optionKeyPrefix, out optionValue) ||

--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -26,7 +26,7 @@ namespace Analyzer.Utilities
         protected abstract bool TryGetOptionValue(string optionKeyPrefix, string? optionKeySuffix, string optionName, [NotNullWhen(returnValue: true)] out string? valueString);
 
         [return: MaybeNull, NotNullIfNotNull("defaultValue")]
-        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
+        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
             if (TryGetOptionValue(optionName, kind, rule, tryParseValue, defaultValue, out var value))
             {

--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -25,8 +25,7 @@ namespace Analyzer.Utilities
         public abstract bool IsEmpty { get; }
         protected abstract bool TryGetOptionValue(string optionKeyPrefix, string? optionKeySuffix, string optionName, [NotNullWhen(returnValue: true)] out string? valueString);
 
-        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
-        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
+        public T GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
             if (TryGetOptionValue(optionName, kind, rule, tryParseValue, defaultValue, out var value))
             {
@@ -62,7 +61,7 @@ namespace Analyzer.Utilities
             return false;
         }
 
-        public bool TryGetOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, [MaybeNullWhen(false), NotNullIfNotNull("defaultValue")] out T value)
+        public bool TryGetOptionValue<T>(string optionName, OptionKind kind, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, T defaultValue, out T value)
         {
             if (this.IsEmpty)
             {

--- a/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AggregateCategorizedAnalyzerConfigOptions.cs
@@ -83,8 +83,7 @@ namespace Analyzer.Utilities
             }
         }
 
-        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
-        public T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
+        public T GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality)
         {
             if (TryGetOptionValue(optionName, kind, tree, rule, tryParseValue, defaultValue, out var value))
             {
@@ -94,7 +93,7 @@ namespace Analyzer.Utilities
             return defaultValue;
         }
 
-        private bool TryGetOptionValue<T>(string optionName, OptionKind kind, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, [MaybeNullWhen(false), NotNullIfNotNull("defaultValue")] out T value)
+        private bool TryGetOptionValue<T>(string optionName, OptionKind kind, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, T defaultValue, [MaybeNullWhen(false)] out T value)
         {
             if (ReferenceEquals(this, Empty))
             {

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#nullable enable
-
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -267,7 +265,7 @@ namespace Analyzer.Utilities
             SyntaxTree tree,
             Compilation compilation,
             CancellationToken cancellationToken)
-            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.NullCheckValidationMethods, rule, tree, compilation, cancellationToken, namePrefix: "M:");
+            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.NullCheckValidationMethods, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken, namePrefix: "M:");
 
         public static SymbolNamesWithValueOption<Unit> GetAdditionalStringFormattingMethodsOption(
             this AnalyzerOptions options,
@@ -275,7 +273,7 @@ namespace Analyzer.Utilities
             SyntaxTree tree,
             Compilation compilation,
             CancellationToken cancellationToken)
-            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalStringFormattingMethods, rule, tree, compilation, cancellationToken, namePrefix: "M:");
+            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalStringFormattingMethods, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken, namePrefix: "M:");
 
         public static bool IsConfiguredToSkipAnalysis(
             this AnalyzerOptions options,
@@ -330,7 +328,7 @@ namespace Analyzer.Utilities
                 Compilation compilation,
                 CancellationToken cancellationToken)
                 => TryGetSyntaxTreeForOption(symbol, out var tree)
-                    ? options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.ExcludedSymbolNames, rule, tree, compilation, cancellationToken)
+                    ? options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.ExcludedSymbolNames, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken)
                     : SymbolNamesWithValueOption<Unit>.Empty;
 
             static SymbolNamesWithValueOption<Unit> GetExcludedTypeNamesWithDerivedTypesOption(
@@ -340,7 +338,7 @@ namespace Analyzer.Utilities
                 Compilation compilation,
                 CancellationToken cancellationToken)
                 => TryGetSyntaxTreeForOption(symbol, out var tree)
-                    ? options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.ExcludedTypeNamesWithDerivedTypes, rule, tree, compilation, cancellationToken, namePrefix: "T:")
+                    ? options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.ExcludedTypeNamesWithDerivedTypes, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken, namePrefix: "T:")
                     : SymbolNamesWithValueOption<Unit>.Empty;
         }
 
@@ -358,9 +356,9 @@ namespace Analyzer.Utilities
             SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
-            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.DisallowedSymbolNames, rule, tree, compilation, cancellationToken);
+            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.DisallowedSymbolNames, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken);
 
-        public static SymbolNamesWithValueOption<string> GetAdditionalRequiredSuffixesOption(
+        public static SymbolNamesWithValueOption<string?> GetAdditionalRequiredSuffixesOption(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
             ISymbol symbol,
@@ -368,23 +366,23 @@ namespace Analyzer.Utilities
             CancellationToken cancellationToken)
         => options.GetAdditionalRequiredSuffixesOption(rule, symbol.Locations[0].SourceTree, compilation, cancellationToken);
 
-        public static SymbolNamesWithValueOption<string> GetAdditionalRequiredSuffixesOption(
+        public static SymbolNamesWithValueOption<string?> GetAdditionalRequiredSuffixesOption(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
             SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
         {
-            return options.GetSymbolNamesWithValueOption(EditorConfigOptionNames.AdditionalRequiredSuffixes, rule, tree, compilation, cancellationToken, namePrefix: "T:", getTypeAndSuffixFunc: GetParts);
+            return options.GetSymbolNamesWithValueOption(EditorConfigOptionNames.AdditionalRequiredSuffixes, rule, tree, compilation, getTypeAndSuffixFunc: GetParts, cancellationToken, namePrefix: "T:");
 
-            static SymbolNamesWithValueOption<string>.NameParts GetParts(string name)
+            static SymbolNamesWithValueOption<string?>.NameParts GetParts(string name)
             {
                 var split = name.Split(new[] { "->" }, StringSplitOptions.RemoveEmptyEntries);
 
                 // If we don't find exactly one '->', we assume that there is no given suffix.
                 if (split.Length != 2)
                 {
-                    return new SymbolNamesWithValueOption<string>.NameParts(name);
+                    return new SymbolNamesWithValueOption<string?>.NameParts(name, null);
                 }
 
                 // Note that we do not validate if the suffix will give a valid class name.
@@ -399,19 +397,19 @@ namespace Analyzer.Utilities
                     {
                         if (trimmedSuffix[i] != ' ')
                         {
-                            return new SymbolNamesWithValueOption<string>.NameParts(split[0], trimmedSuffix);
+                            return new SymbolNamesWithValueOption<string?>.NameParts(split[0], trimmedSuffix);
                         }
                     }
 
                     // Replace the special empty suffix symbol by an empty string
-                    return new SymbolNamesWithValueOption<string>.NameParts(split[0], string.Empty);
+                    return new SymbolNamesWithValueOption<string?>.NameParts(split[0], string.Empty);
                 }
 
-                return new SymbolNamesWithValueOption<string>.NameParts(split[0], trimmedSuffix);
+                return new SymbolNamesWithValueOption<string?>.NameParts(split[0], trimmedSuffix);
             }
         }
 
-        public static SymbolNamesWithValueOption<INamedTypeSymbol> GetAdditionalRequiredGenericInterfaces(
+        public static SymbolNamesWithValueOption<INamedTypeSymbol?> GetAdditionalRequiredGenericInterfaces(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
             ISymbol symbol,
@@ -419,23 +417,23 @@ namespace Analyzer.Utilities
             CancellationToken cancellationToken)
         => options.GetAdditionalRequiredGenericInterfaces(rule, symbol.Locations[0].SourceTree, compilation, cancellationToken);
 
-        public static SymbolNamesWithValueOption<INamedTypeSymbol> GetAdditionalRequiredGenericInterfaces(
+        public static SymbolNamesWithValueOption<INamedTypeSymbol?> GetAdditionalRequiredGenericInterfaces(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
             SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
         {
-            return options.GetSymbolNamesWithValueOption(EditorConfigOptionNames.AdditionalRequiredGenericInterfaces, rule, tree, compilation, cancellationToken, namePrefix: "T:", getTypeAndSuffixFunc: x => GetParts(x, compilation));
+            return options.GetSymbolNamesWithValueOption(EditorConfigOptionNames.AdditionalRequiredGenericInterfaces, rule, tree, compilation, getTypeAndSuffixFunc: x => GetParts(x, compilation), cancellationToken, namePrefix: "T:");
 
-            static SymbolNamesWithValueOption<INamedTypeSymbol>.NameParts GetParts(string name, Compilation compilation)
+            static SymbolNamesWithValueOption<INamedTypeSymbol?>.NameParts GetParts(string name, Compilation compilation)
             {
                 var split = name.Split(new[] { "->" }, StringSplitOptions.RemoveEmptyEntries);
 
                 // If we don't find exactly one '->', we assume that there is no given suffix.
                 if (split.Length != 2)
                 {
-                    return new SymbolNamesWithValueOption<INamedTypeSymbol>.NameParts(name);
+                    return new SymbolNamesWithValueOption<INamedTypeSymbol?>.NameParts(name, null);
                 }
 
                 var genericInterfaceFullName = split[1].Trim();
@@ -452,10 +450,10 @@ namespace Analyzer.Utilities
                     !namedType.IsGenericType)
                 {
                     // Invalid matching type so we assume there was no associated type
-                    return new SymbolNamesWithValueOption<INamedTypeSymbol>.NameParts(split[0]);
+                    return new SymbolNamesWithValueOption<INamedTypeSymbol?>.NameParts(split[0], null);
                 }
 
-                return new SymbolNamesWithValueOption<INamedTypeSymbol>.NameParts(split[0], namedType);
+                return new SymbolNamesWithValueOption<INamedTypeSymbol?>.NameParts(split[0], namedType);
             }
         }
 
@@ -466,7 +464,7 @@ namespace Analyzer.Utilities
             Compilation compilation,
             string defaultForcedValue,
             CancellationToken cancellationToken)
-            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalInheritanceExcludedSymbolNames, rule, tree, compilation, cancellationToken, optionForcedValue: defaultForcedValue);
+            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalInheritanceExcludedSymbolNames, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken, optionForcedValue: defaultForcedValue);
 
         public static SymbolNamesWithValueOption<Unit> GetAdditionalUseResultsMethodsOption(
             this AnalyzerOptions options,
@@ -474,7 +472,7 @@ namespace Analyzer.Utilities
             SyntaxTree tree,
             Compilation compilation,
             CancellationToken cancellationToken)
-            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalUseResultsMethods, rule, tree, compilation, cancellationToken, namePrefix: "M:");
+            => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.AdditionalUseResultsMethods, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), cancellationToken, namePrefix: "M:");
 
         private static SymbolNamesWithValueOption<TValue> GetSymbolNamesWithValueOption<TValue>(
             this AnalyzerOptions options,
@@ -482,12 +480,11 @@ namespace Analyzer.Utilities
             DiagnosticDescriptor rule,
             SyntaxTree? tree,
             Compilation compilation,
+            Func<string, SymbolNamesWithValueOption<TValue>.NameParts> getTypeAndSuffixFunc,
             CancellationToken cancellationToken,
             string? namePrefix = null,
             string? optionDefaultValue = null,
-            string? optionForcedValue = null,
-            Func<string, SymbolNamesWithValueOption<TValue>.NameParts>? getTypeAndSuffixFunc = null)
-            where TValue : notnull
+            string? optionForcedValue = null)
         {
             var analyzerConfigOptions = options.GetOrComputeCategorizedAnalyzerConfigOptions(compilation, cancellationToken);
             return analyzerConfigOptions.GetOptionValue(optionName, tree, rule, TryParse, defaultValue: GetDefaultValue());

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#nullable disable warnings
+#nullable enable
 
 using System;
 using System.Collections.Immutable;
@@ -355,7 +355,7 @@ namespace Analyzer.Utilities
         public static SymbolNamesWithValueOption<Unit> GetDisallowedSymbolNamesWithValueOption(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
-            SyntaxTree tree,
+            SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
             => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.DisallowedSymbolNames, rule, tree, compilation, cancellationToken);
@@ -371,7 +371,7 @@ namespace Analyzer.Utilities
         public static SymbolNamesWithValueOption<string> GetAdditionalRequiredSuffixesOption(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
-            SyntaxTree tree,
+            SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
         {
@@ -422,7 +422,7 @@ namespace Analyzer.Utilities
         public static SymbolNamesWithValueOption<INamedTypeSymbol> GetAdditionalRequiredGenericInterfaces(
             this AnalyzerOptions options,
             DiagnosticDescriptor rule,
-            SyntaxTree tree,
+            SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken)
         {
@@ -480,7 +480,7 @@ namespace Analyzer.Utilities
             this AnalyzerOptions options,
             string optionName,
             DiagnosticDescriptor rule,
-            SyntaxTree tree,
+            SyntaxTree? tree,
             Compilation compilation,
             CancellationToken cancellationToken,
             string? namePrefix = null,
@@ -671,6 +671,9 @@ namespace Analyzer.Utilities
                     if (fileName.Equals(".editorconfig", StringComparison.OrdinalIgnoreCase))
                     {
                         var text = additionalFile.GetText(cancellationToken);
+                        if (text is null)
+                            return CompilationCategorizedAnalyzerConfigOptions.Empty;
+
                         return EditorConfigParser.Parse(text);
                     }
                 }

--- a/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
@@ -47,7 +47,7 @@ namespace Analyzer.Utilities
         bool IsEmpty { get; }
 
         [return: MaybeNull, NotNullIfNotNull("defaultValue")]
-        T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
+        T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
     }
 
     internal static class CategorizedAnalyzerConfigOptionsExtensions

--- a/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/ICategorizedAnalyzerConfigOptions.cs
@@ -46,8 +46,7 @@ namespace Analyzer.Utilities
     {
         bool IsEmpty { get; }
 
-        [return: MaybeNull, NotNullIfNotNull("defaultValue")]
-        T/*??*/ GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, [MaybeNull] T/*??*/ defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
+        T GetOptionValue<T>(string optionName, SyntaxTree? tree, DiagnosticDescriptor? rule, TryParseValue<T> tryParseValue, T defaultValue, OptionKind kind = OptionKind.DotnetCodeQuality);
     }
 
     internal static class CategorizedAnalyzerConfigOptionsExtensions


### PR DESCRIPTION
* Support global options in Roslyn 3.7+
* Fix nullability for `SymbolNamesWithValueOption`

Fixes #4350