### PR TITLE
Add support for category-specific AnalysisLevel properties

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1382,7 +1382,7 @@ $@"<Project>{GetCommonContents(packageName, categories)}{GetPackageSpecificConte
 
                             propertyStr += $@"
       <!-- Default '{analysisLevelPropName}' to the core 'AnalysisLevel' and compute '{analysisLevelPrefixPropName}', '{analysisLevelSuffixPropName}' and '{effectiveAnalysisLevelPropName}' -->
-      <{analysisLevelPropName} Condition=""$({analysisLevelPropName}) == ''"">$(AnalysisLevel)</{analysisLevelPropName}>
+      <{analysisLevelPropName} Condition=""'$({analysisLevelPropName})' == ''"">$(AnalysisLevel)</{analysisLevelPropName}>
 
       <!-- {analysisLevelPropName} can also contain compound values with a prefix and suffix separated by a '-' character.
            The prefix indicates the core AnalysisLevel for '{category}' rules and the suffix indicates the bucket of


### PR DESCRIPTION
Implements category specific AnalysisLevel properties as per https://github.com/dotnet/roslyn/issues/49250#issuecomment-742901055.

Users would now be able to specify the core AnalysisLevel and override category specific AnalysisLevel for each category.

```xml
<AnalysisLevel>5-minimum</AnalysisLevel>
<AnalysisLevelSecurity>latest-all</AnalysisLevelSecurity>
<AnalysisLevelPerformance>preview-recommended</AnalysisLevelPerformance>
<AnalysisLevelGlobalization>5-none</AnalysisLevelGlobalization>
```

1. The post-build tool now generates category-specific global configs for each supported analysis mode
2. The tool also generates category-specific `AddGlobalAnalyzerConfigForPackage` targets so that if user overrides a category-specific AnalysisLevel property, we pass in both the configs
3. Category-specific config files have a higher precedence compared to category-agnostic config file. This is done via setting the `global_level` property as per the feature https://github.com/dotnet/roslyn/issues/48634, which is currently in code review: https://github.com/dotnet/roslyn/pull/49834

## Testing

Verified that setting the above matrix of category-agnostic and category-specific AnalysisLevel property leads to correct global config files being passed to the compiler. Currently, we get warnings about conflicting entries for same diagnostic ID in different config files, but that would be resolved with https://github.com/dotnet/roslyn/pull/49834
