### PR TITLE
Fix CA2119 to report only on correct interface members

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
@@ -55,7 +55,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             }
 
             // look for implementations of interfaces members declared on this type
-            foreach (var iface in type.AllInterfaces)
+            var directInterfacesAndTheirInterfaces = type.Interfaces.SelectMany(i => Enumerable.Repeat(i, 1).Concat(i.AllInterfaces))
+                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            foreach (INamedTypeSymbol iface in directInterfacesAndTheirInterfaces)
             {
                 // only matters if the interface is defined to be internal
                 if (iface.DeclaredAccessibility != Accessibility.Internal)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfaces.cs
@@ -46,37 +46,42 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             var type = (INamedTypeSymbol)context.Symbol;
 
             // Only classes can have overridable members, and furthermore, only consider classes that can be subclassed outside this assembly. Note: Internal types can still be subclassed in this assembly, and also in other assemblies that have access to internal types in this assembly via [InternalsVisibleTo] (recall that this permission must be whitelisted in this assembly). In both of these cases, there should be no security vulnerabilities introduced by overriding methods, hence these types can be ignored.
-            if (type.TypeKind == TypeKind.Class &&
-                !type.IsSealed &&
-                type.GetResultantVisibility().IsAtLeastAsVisibleAs(SymbolVisibility.Public) &&
-                (!type.Constructors.Any() || type.Constructors.Any(c => c.GetResultantVisibility().IsAtLeastAsVisibleAs(SymbolVisibility.Public))))
+            if (type.TypeKind != TypeKind.Class ||
+                type.IsSealed ||
+                !type.GetResultantVisibility().IsAtLeastAsVisibleAs(SymbolVisibility.Public) ||
+                type.Constructors.Any() && !type.Constructors.Any(c => c.GetResultantVisibility().IsAtLeastAsVisibleAs(SymbolVisibility.Public)))
             {
-                // look for implementations of interfaces members declared on this type
-                foreach (var iface in type.AllInterfaces)
-                {
-                    // only matters if the interface is defined to be internal
-                    if (iface.DeclaredAccessibility == Accessibility.Internal)
-                    {
-                        // look for implementation of interface members
-                        foreach (var imember in iface.GetMembers())
-                        {
-                            var member = type.FindImplementationForInterfaceMember(imember);
+                return;
+            }
 
-                            // only matters if member can be overridden
-                            if (member != null && CanBeOverridden(member))
-                            {
-                                if (member.ContainingType != null && member.ContainingType.Equals(type))
-                                {
-                                    context.ReportDiagnostic(member.CreateDiagnostic(Rule));
-                                }
-                                else
-                                {
-                                    // we have a member and its not declared on this type?
-                                    // must be implicit implementation of base member
-                                    context.ReportDiagnostic(type.CreateDiagnostic(Rule));
-                                }
-                            }
-                        }
+            // look for implementations of interfaces members declared on this type
+            foreach (var iface in type.AllInterfaces)
+            {
+                // only matters if the interface is defined to be internal
+                if (iface.DeclaredAccessibility != Accessibility.Internal)
+                {
+                    continue;
+                }
+
+                // look for implementation of interface members
+                foreach (var imember in iface.GetMembers())
+                {
+                    var member = type.FindImplementationForInterfaceMember(imember);
+                    // only matters if member can be overridden
+                    if (member == null || !CanBeOverridden(member))
+                    {
+                        continue;
+                    }
+
+                    if (member.ContainingType != null && member.ContainingType.Equals(type))
+                    {
+                        context.ReportDiagnostic(member.CreateDiagnostic(Rule));
+                    }
+                    else
+                    {
+                        // we have a member and its not declared on this type?
+                        // must be implicit implementation of base member
+                        context.ReportDiagnostic(type.CreateDiagnostic(Rule));
                     }
                 }
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -495,9 +495,9 @@ Namespace NS
     End Interface
 
     Public Class C
-        Implements [|IInternal|]
+        Implements IInternal
 
-        Public Overridable Sub Method1()
+        Public Overridable Sub [|Method1|]() Implements IInternal.Method1
         End Sub
     End Class
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -467,6 +467,46 @@ End Namespace");
 
         // sealed overrides - no diagnostic
 
+        [Fact, WorkItem(4566, "https://github.com/dotnet/roslyn-analyzers/issues/4566")]
+        public async Task CA2119_BaseClassInterface_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+namespace NS
+{
+    internal interface IInternal
+    {
+        void Method1();
+    }
+
+    public class C : IInternal
+    {
+        public virtual void [|Method1|]() { }
+    }
+
+    public class InheritFromC : C
+    {
+    }
+}");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Namespace NS
+    Friend Interface IInternal
+        Sub Method1()
+    End Interface
+
+    Public Class C
+        Implements IInternal
+
+        Public Overridable Sub [|Method1|]()
+        End Sub
+    End Class
+
+    Public Class InheritFromC
+        Inherits C
+    End Class
+End Namespace");
+        }
+
         private static DiagnosticResult GetCSharpResultAt(int line, int column)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column);

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/SealMethodsThatSatisfyPrivateInterfacesTests.cs
@@ -495,9 +495,9 @@ Namespace NS
     End Interface
 
     Public Class C
-        Implements IInternal
+        Implements [|IInternal|]
 
-        Public Overridable Sub [|Method1|]()
+        Public Overridable Sub Method1()
         End Sub
     End Class
 


### PR DESCRIPTION
Fix #4566

Feel free to drop 1st commit if you don't want it to be included in this fix.