### PR TITLE
CA1416 Do not warn for OS dependent messages for creating NotSupportedExceptions

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -165,10 +165,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     m.ReturnType.Equals(osPlatformType) &&
                     m.Parameters.Length == 1 &&
                     m.Parameters[0].Type.SpecialType == SpecialType.System_String);
+                var notSupportedExceptionType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotSupportedException);
 
                 context.RegisterOperationBlockStartAction(
                     context => AnalyzeOperationBlock(context, guardMethods, runtimeIsOSPlatformMethod, osPlatformCreateMethod,
-                                    osPlatformType, stringType, platformSpecificMembers, msBuildPlatforms));
+                                    osPlatformType, stringType, platformSpecificMembers, msBuildPlatforms, notSupportedExceptionType));
             });
 
             static ImmutableArray<IMethodSymbol> GetOperatingSystemGuardMethods(IMethodSymbol? runtimeIsOSPlatformMethod, INamedTypeSymbol operatingSystemType)
@@ -223,15 +224,21 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             INamedTypeSymbol? osPlatformType,
             INamedTypeSymbol stringType,
             ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers,
-            ImmutableArray<string> msBuildPlatforms)
+            ImmutableArray<string> msBuildPlatforms,
+            ITypeSymbol? notSupportedExceptionType)
         {
+            if (context.IsMethodNotImplementedOrSupported(checkPlatformNotSupprted: true))
+            {
+                return;
+            }
+
             var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
             var platformSpecificOperations = PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, PlatformAttributes> attributes,
                 SmallDictionary<string, PlatformAttributes>? csAttributes)>.GetInstance();
 
             context.RegisterOperationAction(context =>
             {
-                AnalyzeOperation(context.Operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms);
+                AnalyzeOperation(context.Operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms, notSupportedExceptionType);
             },
             OperationKind.MethodReference,
             OperationKind.EventReference,
@@ -932,8 +939,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static void AnalyzeOperation(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>,
             (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms)
+            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms,
+            ITypeSymbol? notSupportedExceptionType)
         {
+            if (operation.Parent is IArgumentOperation argumentOperation && UsedInCreatingNotSupportedException(argumentOperation, notSupportedExceptionType))
+            {
+                return;
+            }
+
             var symbol = GetOperationSymbol(operation);
 
             if (symbol == null || symbol is ITypeSymbol type && type.SpecialType != SpecialType.None)
@@ -1032,6 +1045,18 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     }
                 }
             }
+        }
+
+        private static bool UsedInCreatingNotSupportedException(IArgumentOperation operation, ITypeSymbol? notSupportedExceptionType)
+        {
+            if (operation.Parent is IObjectCreationOperation creation &&
+                operation.Parameter.Type.SpecialType == SpecialType.System_String &&
+                creation.Type.DerivesFrom(notSupportedExceptionType, baseTypesOnly: true, checkTypeParameterConstraints: false))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool TryCopyAttributesNotSuppressedByMsBuild(SmallDictionary<string, PlatformAttributes> operationAttributes,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -1564,7 +1564,7 @@ public class Test
             await VerifyAnalyzerAsyncCs(source);
         }
 
-        [Fact(Skip = "TODO: Failing because we cannot detect the correct local invocation being called")]
+        [Fact]
         public async Task LocalFunctionCallsPlatformDependentMember_InvokedFromDifferentContext()
         {
             var source = @"
@@ -1574,24 +1574,17 @@ public class Test
 {
     void M()
     {
+        LocalM();
         if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
         {
-            LocalM(true);
+            LocalM();
         }
-        LocalM(false);
         return;
 
-        void LocalM(bool suppressed)
+        void LocalM()
         {
-            if (suppressed)
-            {
-                WindowsOnlyMethod();
-            }
-            else
-            {
-                [|WindowsOnlyMethod()|];
-            }
-            
+            [|WindowsOnlyMethod()|];
+           
             if (OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2))
             {
                 WindowsOnlyMethod();
@@ -1607,13 +1600,14 @@ public class Test
             }
         }
     }
+
     [SupportedOSPlatform(""Windows10.1.2.3"")]
     public void WindowsOnlyMethod() { }
     [UnsupportedOSPlatform(""Windows10.0"")]
     public void UnsupportedWindows10() { }
 }
 ";
-            await VerifyAnalyzerAsyncCs(source);
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -126,6 +126,208 @@ namespace CallerTargetsBelow5_0
         }
 
         [Fact]
+        public async Task OnlyThrowsNotSupportedWithOsDependentStringNotWarns()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""Browser"")]
+public class Test
+{
+    private static string s_message = ""Browser not supported"";
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static void ThrowPnseWithStringArgument() { throw new PlatformNotSupportedException(s_message); }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static void ThrowNotSupportedWithStringArgument() { throw new NotSupportedException(s_message); }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static void ThrowPnseWithStringAndExceptionArgument() { throw new PlatformNotSupportedException(s_message, new Exception(s_message)); }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static void ThrowPnseDefaultConstructor() { throw new PlatformNotSupportedException(); }
+}";
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task ThrowNotSupportedWithOtherOsDependentApiUsageNotWarns()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+[assembly: SupportedOSPlatform(""browser"")]
+
+public static class SR
+{
+    public static string Message {get; set;}
+}
+
+[UnsupportedOSPlatform(""browser"")]
+public class Test
+{
+    void ThrowWithStringArgument()
+    {
+        [|SR.Message|] = ""Warns not reachable on Browser"";
+        throw new PlatformNotSupportedException(SR.Message);
+    }
+
+    void ThrowNotSupportedWithStringArgument()
+    {
+        [|SR.Message|] = ""Warns not reachable on Browser"";
+        throw new NotSupportedException(SR.Message);
+    }
+    
+    void ThrowWithNoArgument()
+    {
+        [|SR.Message|] = ""Warns not reachable on Browser"";
+        throw new PlatformNotSupportedException();
+    }
+    
+    void ThrowWithStringAndExceptionConstructor()
+    {
+        [|SR.Message|] = ""Warns not reachable on Browser"";
+        throw new PlatformNotSupportedException(SR.Message, new Exception());
+    }
+    
+    void ThrowWithAnotherExceptionUsingResourceString()
+    {
+        [|SR.Message|] = ""Warns not reachable on Browser"";
+        throw new PlatformNotSupportedException(SR.Message, new Exception([|SR.Message|]));
+    }
+}";
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task ThrowNotSupportedWithOtherStatementAndWithinConditionNotWarns()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+public static class Windows
+{
+    public static string Message {get; set;}
+}
+
+[SupportedOSPlatform(""browser"")]
+public static class SR
+{
+    public static string Message {get; set;}
+    public static void M1() { }
+}
+
+public class Test
+{
+    void ThrowWithStringConstructor()
+    {
+        [|SR.M1()|];
+        if (!OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(SR.Message);
+        }
+        SR.M1();
+
+        [|Windows.Message|] = ""Warns supported only on Windows"";
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new NotSupportedException(Windows.Message);
+        }
+        Windows.Message = ""It is windows!"";
+    }
+
+    void ThrowWithOtherConstructorWarnsForInnnerException()
+    {
+        [|SR.M1()|];
+        if (!OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException();
+        }
+        SR.M1();
+
+        [|Windows.Message|] = ""Warns supported only on Windows"";
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new NotSupportedException(Windows.Message, new Exception([|Windows.Message|]));
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task CreateNotSupportedWithOsDependentStringNotWarns()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""Browser"")]
+public class Test
+{
+    private static string s_message = ""Browser not supported"";
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static Exception GetPnseWithStringArgument() { return new PlatformNotSupportedException(s_message); }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static Exception GetNotSupportedWithStringArgument()
+    {
+        [|s_message|] = ""Warns not reachable on Browser"";
+        return new NotSupportedException(s_message); 
+    }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static Exception ThrowPnseWithStringWarnsForInnerException()
+    { 
+        return new PlatformNotSupportedException(s_message, new Exception([|s_message|]));
+    }
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static Exception ThrowPnseDefaultConstructor() { return new PlatformNotSupportedException(); }
+}";
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
+        public async Task ThrowNotSupportedWarnsForNonStringArgument()
+        {
+            var csSource = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows"")]
+public class WindowsOnlyException : Exception 
+{
+    public WindowsOnlyException() { }
+    public WindowsOnlyException(string message) { }
+    public static string Message {get; set;}
+}
+
+public class Test
+{
+    void ThrowWindowsOnlyExceptionWarns()
+    {
+        [|WindowsOnlyException.Message|] = ""Warns for message and exception"";
+        throw [|new WindowsOnlyException([|WindowsOnlyException.Message|])|];
+    }
+
+    void ThrowWithWindowsOnlyInnnerExceptionWarns()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new NotSupportedException(WindowsOnlyException.Message, [|new WindowsOnlyException()|]);
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(csSource);
+        }
+
+        [Fact]
         public async Task MethodsWithOsDependentTypeParameterWarns()
         {
             var csSource = @"

--- a/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
+++ b/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
@@ -11,7 +11,7 @@ namespace Analyzer.Utilities.Extensions
     internal static class OperationBlockAnalysisContextExtension
     {
 #pragma warning disable RS1012 // Start action has no registered actions.
-        public static bool IsMethodNotImplementedOrSupported(this OperationBlockStartAnalysisContext context)
+        public static bool IsMethodNotImplementedOrSupported(this OperationBlockStartAnalysisContext context, bool checkPlatformNotSupprted = false)
 #pragma warning restore RS1012 // Start action has no registered actions.
         {
             // Note that VB method bodies with 1 action have 3 operations.
@@ -53,8 +53,10 @@ namespace Analyzer.Utilities.Extensions
                     descendants[0] is IThrowOperation throwOperation &&
                     throwOperation.GetThrownExceptionType() is ITypeSymbol createdExceptionType)
                 {
-                    if (Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException), createdExceptionType.OriginalDefinition)
-                        || Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotSupportedException), createdExceptionType.OriginalDefinition))
+                    if (Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException), createdExceptionType.OriginalDefinition) ||
+                        Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotSupportedException), createdExceptionType.OriginalDefinition) ||
+                        (checkPlatformNotSupprted &&
+                        Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemPlatformNotSupportedException), createdExceptionType.OriginalDefinition)))
                     {
                         return true;
                     }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -233,6 +233,7 @@ namespace Analyzer.Utilities
         public const string SystemObsoleteAttribute = "System.ObsoleteAttribute";
         public const string SystemOperatingSystem = "System.OperatingSystem";
         public const string SystemOutOfMemoryException = "System.OutOfMemoryException";
+        public const string SystemPlatformNotSupportedException = "System.PlatformNotSupportedException";
         public const string SystemRandom = "System.Random";
         public const string SystemRange = "System.Range";
         public const string SystemReadOnlyMemory1 = "System.ReadOnlyMemory`1";


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4545

We should ignore diagnostics in throw statements as they are not platform specific operation and causing false positives, i made sure it ignores exception messages for a block not only just throwing, but having some other statements too, i think this will be more useful for conditional throwing like:
```csharp
[SupportedOSPlatform("browser")]
public static class SR
{
    public static string Message {get; set;}
    public static void M1() { }
}

public class Test
{
    void ConditionallyThrowWithStringConstructor()
    {
        SR.M1(); // warns 
        if (!OperatingSystem.IsBrowser())
        {
            throw new PlatformNotSupportedException(SR.Message); // not warns
        }
        SR.M1() // not warns
    }
}
```
We might want to merge it into 5.0.XX cc @jeffhandley 
