### PR TITLE
Remove stale TODO comment

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidation.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidation.cs
@@ -112,8 +112,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                                             return;
                                         }
 
-                                        // TODO(LINCHE): This is an issue tracked by #2009. We filter extraneous based on IsImplicit.
-                                        var targetOperations = ImmutableArray.ToImmutableArray(blockOperation.Descendants()).WithoutFullyImplicitOperations();
+                                        var targetOperations = blockOperation.Descendants().ToImmutableArray().WithoutFullyImplicitOperations();
                                         alwaysReturnTrue = AlwaysReturnTrue(targetOperations);
                                         break;
                                 }


### PR DESCRIPTION
Fix #2009

Testing on `master`, it seems we now have 4 children: the variable, the return and the 2 implicit operations `Label` and `Return` mentioned in the `Expected behavior` section.