### PR TITLE
Adding code fix for CA1820 when it is a member invocation

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
@@ -48,10 +48,14 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             return node.IsKind(SyntaxKind.InvocationExpression);
         }
 
-        protected override SyntaxNode GetInvocationTarget(SyntaxNode node)
+        protected override SyntaxNode? GetInvocationTarget(SyntaxNode node)
         {
-            MemberAccessExpressionSyntax expression = (MemberAccessExpressionSyntax)((InvocationExpressionSyntax)node).Expression;
-            return expression.Expression;
+            if (node is InvocationExpressionSyntax invocationExpression && invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression)
+            {
+                return memberAccessExpression.Expression;
+            }
+
+            return default;
         }
     }
 }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public class CSharpTestForEmptyStringsUsingStringLengthFixer : TestForEmptyStringsUsingStringLengthFixer
     {
-        protected override SyntaxNode GetBinaryExpression(SyntaxNode node)
+        protected override SyntaxNode GetExpression(SyntaxNode node)
         {
             return node is ArgumentSyntax argumentSyntax ? argumentSyntax.Expression : node;
         }
@@ -36,6 +36,22 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
         protected override SyntaxNode GetRightOperand(SyntaxNode binaryExpressionSyntax)
         {
             return ((BinaryExpressionSyntax)binaryExpressionSyntax).Right;
+        }
+
+        protected override bool IsFixableBinaryExpression(SyntaxNode node)
+        {
+            return (node is BinaryExpressionSyntax) && (IsEqualsOperator(node) || IsNotEqualsOperator(node));
+        }
+
+        protected override bool IsFixableInvocationExpression(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.InvocationExpression);
+        }
+
+        protected override SyntaxNode GetInvocationTarget(SyntaxNode node)
+        {
+            MemberAccessExpressionSyntax expression = (MemberAccessExpressionSyntax)((InvocationExpressionSyntax)node).Expression;
+            return expression.Expression;
         }
     }
 }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpTestForEmptyStringsUsingStringLength.Fixer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     /// CA1820: Test for empty strings using string length
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
-    public class CSharpTestForEmptyStringsUsingStringLengthFixer : TestForEmptyStringsUsingStringLengthFixer
+    public sealed class CSharpTestForEmptyStringsUsingStringLengthFixer : TestForEmptyStringsUsingStringLengthFixer
     {
         protected override SyntaxNode GetExpression(SyntaxNode node)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             SyntaxNode expressionSyntax = GetExpression(node);
 
-            if (!IsFixableBinaryExpression(node) && !IsFixableInvocationExpression(node))
+            if (!IsFixableBinaryExpression(expressionSyntax) && !IsFixableInvocationExpression(expressionSyntax))
             {
                 return;
             }
@@ -139,7 +139,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             SyntaxNode replacementAnnotatedSyntax = replacementSyntax.WithAdditionalAnnotations(Formatter.Annotation);
 
-            editor.ReplaceNode(fixResolution.Target, replacementAnnotatedSyntax);
+            editor.ReplaceNode(fixResolution.ExpressionSyntax, replacementAnnotatedSyntax);
 
             return editor.GetChangedDocument();
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -43,8 +43,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             if (resolution != null)
             {
                 var methodInvocationAction = CodeAction.Create(MicrosoftNetCoreAnalyzersResources.TestForEmptyStringsUsingStringLengthMessage,
-                async ct => await ConvertToMethodInvocation(context, resolution).ConfigureAwait(false),
-                equivalenceKey: "TestForEmptyStringCorrectlyUsingIsNullOrEmpty");
+                    async ct => await ConvertToMethodInvocation(context, resolution).ConfigureAwait(false),
+                    equivalenceKey: "TestForEmptyStringCorrectlyUsingIsNullOrEmpty");
 
                 context.RegisterCodeFix(methodInvocationAction, context.Diagnostics);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLength.Fixer.cs
@@ -76,7 +76,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             }
             else if (IsFixableInvocationExpression(expressionSyntax))
             {
-                SyntaxNode target = GetInvocationTarget(expressionSyntax);
+                SyntaxNode? target = GetInvocationTarget(expressionSyntax);
+
+                if (target == null)
+                {
+                    return null;
+                }
+
                 return new FixResolution(expressionSyntax, target, true);
             }
 
@@ -155,7 +161,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         protected abstract bool IsNotEqualsOperator(SyntaxNode node);
         protected abstract SyntaxNode GetLeftOperand(SyntaxNode binaryExpressionSyntax);
         protected abstract SyntaxNode GetRightOperand(SyntaxNode binaryExpressionSyntax);
-        protected abstract SyntaxNode GetInvocationTarget(SyntaxNode node);
+        protected abstract SyntaxNode? GetInvocationTarget(SyntaxNode node);
 
         private sealed class FixResolution
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
@@ -1003,5 +1003,41 @@ End Class
                 CodeActionEquivalenceKey = "TestForEmptyStringCorrectlyUsingStringLength",
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task CA1820_FixTestEmptyStringsUsingStringLength_WhenStringEqualsMethodIsUsed()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return [|s.Equals(string.Empty)|];
     }
 }
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.IsNullOrEmpty(s);
+    }
+}
+");
+            await VerifyVB.VerifyCodeFixAsync(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return [|s.Equals(String.Empty)|]
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+    }
+}
+

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/TestForEmptyStringsUsingStringLengthTests.Fixer.cs
@@ -1005,7 +1005,7 @@ End Class
         }
 
         [Fact]
-        public async Task CA1820_FixTestEmptyStringsUsingStringLength_WhenStringEqualsMethodIsUsed()
+        public async Task CA1820_FixTestEmptyStringsUsingStringLength_WhenStringEqualsMethodIsUsedWithStringEmpty()
         {
             await VerifyCS.VerifyCodeFixAsync(@"
 public class A
@@ -1034,6 +1034,76 @@ End Class
 Public Class A
     Public Function Compare(s As String) As Boolean
         Return String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public async Task CA1820_FixTestEmptyStringsUsingStringLength_WhenStringEqualsMethodIsUsedWithEmptyLiteral()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return [|s.Equals("""")|];
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return string.IsNullOrEmpty(s);
+    }
+}
+");
+            await VerifyVB.VerifyCodeFixAsync(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return [|s.Equals("""")|]
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return String.IsNullOrEmpty(s)
+    End Function
+End Class
+");
+        }
+
+        [Fact]
+        public async Task CA1820_FixTestEmptyStringsUsingStringLength_WhenNotStringEqualsMethodIsUsed()
+        {
+            await VerifyCS.VerifyCodeFixAsync(@"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return ![|s.Equals(string.Empty)|];
+    }
+}
+", @"
+public class A
+{
+    public bool Compare(string s)
+    {
+        return !string.IsNullOrEmpty(s);
+    }
+}
+");
+            await VerifyVB.VerifyCodeFixAsync(@"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return Not [|s.Equals(String.Empty)|]
+    End Function
+End Class
+", @"
+Public Class A
+    Public Function Compare(s As String) As Boolean
+        Return Not String.IsNullOrEmpty(s)
     End Function
 End Class
 ");

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
@@ -44,10 +44,10 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         End Function
 
         Protected Overrides Function GetInvocationTarget(node As SyntaxNode) As SyntaxNode
-            If (TypeOf node Is InvocationExpressionSyntax) Then
-                Dim invocationExpression = DirectCast(node, InvocationExpressionSyntax)
-                If (TypeOf invocationExpression.Expression Is MemberAccessExpressionSyntax) Then
-                    Dim memberAccessExpression = DirectCast(invocationExpression.Expression, MemberAccessExpressionSyntax)
+            Dim invocationExpression = TryCast(node, InvocationExpressionSyntax)
+            If invocationExpression IsNot Nothing Then
+                Dim memberAccessExpression = TryCast(invocationExpression.Expression, MemberAccessExpressionSyntax)
+                If memberAccessExpression IsNot Nothing Then
                     Return memberAccessExpression.Expression
                 End If
             End If

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
@@ -44,8 +44,14 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         End Function
 
         Protected Overrides Function GetInvocationTarget(node As SyntaxNode) As SyntaxNode
-            Dim memberAccessExpression = DirectCast(DirectCast(node, InvocationExpressionSyntax).Expression, MemberAccessExpressionSyntax)
-            Return memberAccessExpression.Expression
+            If (TypeOf node Is InvocationExpressionSyntax) Then
+                Dim invocationExpression = DirectCast(node, InvocationExpressionSyntax)
+                If (TypeOf invocationExpression.Expression Is MemberAccessExpressionSyntax) Then
+                    Dim memberAccessExpression = DirectCast(invocationExpression.Expression, MemberAccessExpressionSyntax)
+                    Return memberAccessExpression.Expression
+                End If
+            End If
+            Return Nothing
         End Function
     End Class
 End Namespace

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicTestForEmptyStringsUsingStringLength.Fixer.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
     Public NotInheritable Class BasicTestForEmptyStringsUsingStringLengthFixer
         Inherits TestForEmptyStringsUsingStringLengthFixer
-        Protected Overrides Function GetBinaryExpression(node As SyntaxNode) As SyntaxNode
+        Protected Overrides Function GetExpression(node As SyntaxNode) As SyntaxNode
             Dim argumentSyntax = TryCast(node, ArgumentSyntax)
             Return If(argumentSyntax IsNot Nothing, argumentSyntax.GetExpression(), node)
         End Function
@@ -33,6 +33,19 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
         Protected Overrides Function GetRightOperand(binaryExpressionSyntax As SyntaxNode) As SyntaxNode
             Return DirectCast(binaryExpressionSyntax, BinaryExpressionSyntax).Right
+        End Function
+
+        Protected Overrides Function IsFixableBinaryExpression(node As SyntaxNode) As Boolean
+            Return (TypeOf node Is BinaryExpressionSyntax) AndAlso (IsEqualsOperator(node) Or IsNotEqualsOperator(node))
+        End Function
+
+        Protected Overrides Function IsFixableInvocationExpression(node As SyntaxNode) As Boolean
+            Return node.IsKind(SyntaxKind.InvocationExpression)
+        End Function
+
+        Protected Overrides Function GetInvocationTarget(node As SyntaxNode) As SyntaxNode
+            Dim memberAccessExpression = DirectCast(DirectCast(node, InvocationExpressionSyntax).Expression, MemberAccessExpressionSyntax)
+            Return memberAccessExpression.Expression
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #4537

Added new code path to emit a code fix for CA 1820 when then code is in the following form in addition to a binary expression:
```
String s = "Hello";
if (s.Equals(string.Empty))
{
    // do something
}
```
