### PR TITLE
Do not report on awaitable-awaiter patterns

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriate.cs
@@ -56,6 +56,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 var taskTypes = taskTypesBuilder.ToImmutable();
 
+                var inotifyCompletionType = context.Compilation.GetOrCreateTypeByMetadataName(
+                    WellKnownTypeNames.SystemRuntimeCompilerServicesINotifyCompletion);
+                var icriticalNotifyCompletionType = context.Compilation.GetOrCreateTypeByMetadataName(
+                    WellKnownTypeNames.SystemRuntimeCompilerServicesICriticalNotifyCompletion);
+
                 context.RegisterOperationBlockStartAction(context =>
                 {
                     if (context.OwningSymbol is not IMethodSymbol methodSymbol ||
@@ -73,6 +78,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     // Ensure that the method is non-generic, non-virtual/override, has no overloads and doesn't have special names: 'GetHashCode' or 'GetEnumerator'.
                     // Also avoid generating this diagnostic if the method body has any invocation expressions.
                     // Also avoid implicit interface implementation (explicit are handled through the member accessibility)
+                    // Also avoid GetAwaiter and GetResult from awaitable-awaiter patterns.
                     if (methodSymbol.IsGenericMethod ||
                         methodSymbol.IsVirtual ||
                         methodSymbol.IsOverride ||
@@ -80,7 +86,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                         methodSymbol.Name == GetEnumeratorName ||
                         methodSymbol.ContainingType.GetMembers(methodSymbol.Name).Length > 1 ||
                         taskTypes.Contains(methodSymbol.ReturnType.OriginalDefinition) ||
-                        methodSymbol.IsImplementationOfAnyImplicitInterfaceMember())
+                        methodSymbol.IsImplementationOfAnyImplicitInterfaceMember() ||
+                        methodSymbol.IsGetAwaiterFromAwaitablePattern(inotifyCompletionType, icriticalNotifyCompletionType) ||
+                        methodSymbol.IsGetResultFromAwaiterPattern(inotifyCompletionType, icriticalNotifyCompletionType))
                     {
                         return;
                     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UsePropertiesWhereAppropriateTests.cs
@@ -478,6 +478,65 @@ End Class
 ");
         }
 
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaiterPattern_INotifyCompletion_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaiter : INotifyCompletion
+{
+    public object GetResult() => null;
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+}");
+        }
+
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaiterPattern_ICriticalNotifyCompletion_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaiter : ICriticalNotifyCompletion
+{
+    public object GetResult() => null;
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+    public void UnsafeOnCompleted(Action continuation) => throw null;
+}");
+        }
+
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaitablePattern_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaitable
+{
+    public DummyAwaiter GetAwaiter() => new DummyAwaiter();
+}
+
+public class DummyAwaiter : INotifyCompletion
+{
+    public void GetResult()
+    {
+    }
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+}");
+        }
+
         private static DiagnosticResult GetCA1024CSharpResultAt(int line, int column, string methodName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -1286,6 +1286,69 @@ public class C
             }.RunAsync();
         }
 
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaiterPattern_INotifyCompletion_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaiter : INotifyCompletion
+{
+    public void GetResult()
+    {
+    }
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+}");
+        }
+
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaiterPattern_ICriticalNotifyCompletion_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaiter : ICriticalNotifyCompletion
+{
+    public void GetResult()
+    {
+    }
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+    public void UnsafeOnCompleted(Action continuation) => throw null;
+}");
+        }
+
+        [Fact, WorkItem(4623, "https://github.com/dotnet/roslyn-analyzers/issues/4623")]
+        public async Task AwaitablePattern_NoDiagnostic()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Runtime.CompilerServices;
+
+public class DummyAwaitable
+{
+    public DummyAwaiter GetAwaiter() => new DummyAwaiter();
+}
+
+public class DummyAwaiter : INotifyCompletion
+{
+    public void GetResult()
+    {
+    }
+
+    public bool IsCompleted => false;
+
+    public void OnCompleted(Action continuation) => throw null;
+}");
+        }
+
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
             => VerifyCS.Diagnostic()
                 .WithLocation(line, column)

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -717,5 +717,48 @@ namespace Analyzer.Utilities.Extensions
                    "<Main>$" => true,
                    _ => false
                };
+
+        public static bool IsGetAwaiterFromAwaitablePattern([NotNullWhen(true)] this IMethodSymbol? method,
+            [NotNullWhen(true)] INamedTypeSymbol? inotifyCompletionType,
+            [NotNullWhen(true)] INamedTypeSymbol? icriticalNotifyCompletionType)
+        {
+            if (method is null
+                || !method.Name.Equals("GetAwaiter", StringComparison.Ordinal)
+                || method.Parameters.Length != 0)
+            {
+                return false;
+            }
+
+            var returnType = method.ReturnType?.OriginalDefinition;
+            if (returnType is null)
+            {
+                return false;
+            }
+
+            return returnType.DerivesFrom(inotifyCompletionType) ||
+                returnType.DerivesFrom(icriticalNotifyCompletionType);
+        }
+
+        public static bool IsGetResultFromAwaiterPattern(
+            [NotNullWhen(true)] this IMethodSymbol? method,
+            [NotNullWhen(true)] INamedTypeSymbol? inotifyCompletionType,
+            [NotNullWhen(true)] INamedTypeSymbol? icriticalNotifyCompletionType)
+        {
+            if (method is null
+                || !method.Name.Equals("GetResult", StringComparison.Ordinal)
+                || method.Parameters.Length != 0)
+            {
+                return false;
+            }
+
+            var containingType = method.ContainingType?.OriginalDefinition;
+            if (containingType is null)
+            {
+                return false;
+            }
+
+            return containingType.DerivesFrom(inotifyCompletionType) ||
+                containingType.DerivesFrom(icriticalNotifyCompletionType);
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IPropertySymbolExtensions.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -13,5 +15,22 @@ namespace Analyzer.Utilities.Extensions
         /// </summary>
         public static bool IsAutoProperty(this IPropertySymbol propertySymbol)
             => propertySymbol.ContainingType.GetMembers().OfType<IFieldSymbol>().Any(f => f.IsImplicitlyDeclared && propertySymbol.Equals(f.AssociatedSymbol));
+
+        public static bool IsIsCompletedFromAwaiterPattern(
+            [NotNullWhen(true)] this IPropertySymbol? property,
+            [NotNullWhen(true)] INamedTypeSymbol? inotifyCompletionType,
+            [NotNullWhen(true)] INamedTypeSymbol? icriticalNotifyCompletionType)
+        {
+            if (property is null
+                || !property.Name.Equals("IsCompleted", StringComparison.Ordinal)
+                || property.Type?.SpecialType != SpecialType.System_Boolean)
+            {
+                return false;
+            }
+
+            var containingType = property.ContainingType?.OriginalDefinition;
+            return containingType.DerivesFrom(inotifyCompletionType)
+                || containingType.DerivesFrom(icriticalNotifyCompletionType);
+        }
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -251,6 +251,8 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeCompilerServicesCallerMemberNameAttribute = "System.Runtime.CompilerServices.CallerMemberNameAttribute";
         public const string SystemRuntimeCompilerServicesCompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string SystemRuntimeCompilerServicesConfiguredValueTaskAwaitable1 = "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1";
+        public const string SystemRuntimeCompilerServicesICriticalNotifyCompletion = "System.Runtime.CompilerServices.ICriticalNotifyCompletion";
+        public const string SystemRuntimeCompilerServicesINotifyCompletion = "System.Runtime.CompilerServices.INotifyCompletion";
         public const string SystemRuntimeCompilerServicesInternalsVisibleToAttribute = "System.Runtime.CompilerServices.InternalsVisibleToAttribute";
         public const string SystemRuntimeCompilerServicesRestrictedInternalsVisibleToAttribute = "System.Runtime.CompilerServices.RestrictedInternalsVisibleToAttribute";
         public const string SystemRuntimeCompilerServicesTypeForwardedToAttribute = "System.Runtime.CompilerServices.TypeForwardedToAttribute";


### PR DESCRIPTION
Fix #4623

There is a first commit meant to ensure all code related to skipping the analysis is contained in the `ShouldAnalyze` method instead of being in multiple place. I suggest to review it first.