### PR TITLE
Bump NetAnalyzers version to 5.0.3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>3.3.3</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
-    <NetAnalyzersVersionPrefix>5.0.2</NetAnalyzersVersionPrefix>
+    <NetAnalyzersVersionPrefix>5.0.3</NetAnalyzersVersionPrefix>
     <NetAnalyzersPreReleaseVersionLabel>preview1</NetAnalyzersPreReleaseVersionLabel>
     <AnalyzerUtilitiesVersionPrefix>$(VersionPrefix)</AnalyzerUtilitiesVersionPrefix>
     <!--

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
-        "version": "5.0.2",
+        "version": "5.0.3",
         "language": "en-US"
       },
       "rules": {
@@ -463,7 +463,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.NetAnalyzers",
-        "version": "5.0.2",
+        "version": "5.0.3",
         "language": "en-US"
       },
       "rules": {
@@ -5060,7 +5060,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers",
-        "version": "5.0.2",
+        "version": "5.0.3",
         "language": "en-US"
       },
       "rules": {


### PR DESCRIPTION
Bump NetAnalyzers version to 5.0.3 as the version released with 5.0.2 .NET SDK is shipping from release/5.0.2xxx branch which has older analyzers as compared to master branch
