### PR TITLE
Ensure CA1835 preserves nullability

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpPreferStreamAsyncMemoryOverloads.Fixer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.NetCore.Analyzers.Runtime;
 
@@ -14,30 +14,44 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     [ExportCodeFixProvider(LanguageNames.CSharp)]
     public sealed class CSharpPreferStreamAsyncMemoryOverloadsFixer : PreferStreamAsyncMemoryOverloadsFixer
     {
-        protected override IArgumentOperation? GetArgumentByPositionOrName(ImmutableArray<IArgumentOperation> args, int index, string name, out bool isNamed)
+        protected override SyntaxNode? GetArgumentByPositionOrName(IInvocationOperation invocation, int index, string name, out bool isNamed)
         {
             isNamed = false;
 
-            // The expected position is beyond the total arguments, so we don't expect to find the argument in the array
-            if (index >= args.Length)
+            if (index < invocation.Arguments.Length &&
+                invocation.Syntax is InvocationExpressionSyntax expression)
             {
-                return null;
-            }
-            // If the argument in the specified index does not have a name, then it is in its expected position
-            else if (args[index].Syntax is ArgumentSyntax argNode && argNode.NameColon == null)
-            {
-                return args[index];
-            }
-            // Otherwise, find it by name
-            else
-            {
-                isNamed = true;
-                return args.FirstOrDefault(argOperation =>
+                var args = invocation.Arguments;
+                // If the argument in the specified index does not have a name, then it is in its expected position
+                if (args[index].Syntax is ArgumentSyntax argNode && argNode.NameColon == null)
                 {
-                    return argOperation.Syntax is ArgumentSyntax argNode &&
-                           argNode.NameColon?.Name?.Identifier.ValueText == name;
-                });
+                    return args[index].Syntax;
+                }
+                // The argument in the specified index does not have a name but is part of a nullable expression
+                else if (args[index].Syntax is IdentifierNameSyntax identifierNameNode &&
+                    identifierNameNode.Identifier.Value.Equals(name) &&
+                    identifierNameNode.Parent is PostfixUnaryExpressionSyntax nullableExpression)
+                {
+                    return nullableExpression;
+                }
+                // Otherwise, find it by name
+                else
+                {
+                    IArgumentOperation? operation = args.FirstOrDefault(argOperation =>
+                    {
+                        return argOperation.Syntax is ArgumentSyntax argNode &&
+                               argNode.NameColon?.Name?.Identifier.ValueText == name;
+                    });
+
+                    if (operation != null)
+                    {
+                        isNamed = true;
+                        return operation.Syntax;
+                    }
+                }
             }
+
+            return null;
         }
 
         protected override bool IsSystemNamespaceImported(IReadOnlyList<SyntaxNode> importList)
@@ -54,18 +68,70 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 
         protected override bool IsPassingZeroAndBufferLength(SemanticModel model, SyntaxNode bufferValueNode, SyntaxNode offsetValueNode, SyntaxNode countValueNode)
         {
-            return
-                // First argument should be an identifier name node
-                bufferValueNode is IdentifierNameSyntax firstArgumentIdentifierName &&
+            // First argument should be an identifier name node
+            if (bufferValueNode is ArgumentSyntax arg1 &&
+                arg1.Expression is IdentifierNameSyntax firstArgumentIdentifierName)
+            {
                 // Second argument should be a literal expression node with a constant value of zero
-                model.GetConstantValue(offsetValueNode) is Optional<object> optionalValue && optionalValue.HasValue && optionalValue.Value is 0 &&
-                // Third argument should be a member access node...
-                countValueNode is MemberAccessExpressionSyntax thirdArgumentMemberAccessExpression &&
-                thirdArgumentMemberAccessExpression.Expression is IdentifierNameSyntax thirdArgumentIdentifierName &&
-                // whose identifier is that of the first argument...
-                firstArgumentIdentifierName.Identifier.ValueText == thirdArgumentIdentifierName.Identifier.ValueText &&
-                // and the member name is `Length`
-                thirdArgumentMemberAccessExpression.Name.Identifier.ValueText == WellKnownMemberNames.LengthPropertyName;
+                if (offsetValueNode is ArgumentSyntax arg2 &&
+                    arg2.Expression is LiteralExpressionSyntax literal &&
+                    literal.Token.Value is int value && value == 0)
+                {
+                    // Third argument should be a member access node...
+                    if (countValueNode is ArgumentSyntax arg3 &&
+                        arg3.Expression is MemberAccessExpressionSyntax thirdArgumentMemberAccessExpression &&
+                        thirdArgumentMemberAccessExpression.Expression is IdentifierNameSyntax thirdArgumentIdentifierName &&
+                        // whose identifier is that of the first argument...
+                        firstArgumentIdentifierName.Identifier.ValueText == thirdArgumentIdentifierName.Identifier.ValueText &&
+                        // and the member name is `Length`
+                        thirdArgumentMemberAccessExpression.Name.Identifier.ValueText == WellKnownMemberNames.LengthPropertyName)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        protected override SyntaxNode GetNodeWithNullability(IInvocationOperation invocation)
+        {
+            if (invocation.Syntax is InvocationExpressionSyntax invocationExpression &&
+                invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression &&
+                memberAccessExpression.Expression is PostfixUnaryExpressionSyntax postfixUnaryExpression)
+            {
+                return postfixUnaryExpression;
+            }
+
+            return invocation.Instance.Syntax;
+        }
+
+        protected override SyntaxNode GetNamedArgument(SyntaxGenerator generator, SyntaxNode node, bool isNamed, string newName)
+        {
+            if (isNamed)
+            {
+                SyntaxNode actualNode = node;
+
+                if (node is ArgumentSyntax argument)
+                {
+                    actualNode = argument.Expression;
+                }
+
+                return generator.Argument(name: newName, RefKind.None, actualNode);
+            }
+
+            return node;
+        }
+
+        protected override SyntaxNode GetNamedMemberInvocation(SyntaxGenerator generator, SyntaxNode node, string memberName)
+        {
+            SyntaxNode actualNode = node;
+
+            if (node is ArgumentSyntax argument)
+            {
+                actualNode = argument.Expression;
+            }
+
+            return generator.MemberAccessExpression(actualNode.WithoutTrivia(), memberName);
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     {
         // Verifies that the analyzer generates the specified C# diagnostic results, if any.
         protected Task CSharpVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
-            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.Net.Net50, expected);
+            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.Net.Net50, CodeAnalysis.CSharp.LanguageVersion.CSharp7_3, expected);
 
         // Verifies that the analyzer generates the specified VB diagnostic results, if any.
         protected Task VisualBasicVerifyAnalyzerAsync(string source, params DiagnosticResult[] expected) =>
@@ -25,7 +25,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         // Verifies that the analyzer generates the specified C# diagnostic results, if any, in an unsupported .NET version.
         protected Task CSharpVerifyAnalyzerForUnsupportedVersionAsync(string source, params DiagnosticResult[] expected) =>
-            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, expected);
+            CSharpVerifyForVersionAsync(source, null, ReferenceAssemblies.NetCore.NetCoreApp20, CodeAnalysis.CSharp.LanguageVersion.CSharp7_3, expected);
 
         // Verifies that the analyzer generates the specified VB diagnostic results, if any, in an unsupported .NET version.
         protected Task VisualBasicVerifyAnalyzerForUnsupportedVersionAsync(string source, params DiagnosticResult[] expected) =>
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         // Verifies that the fixer generates the fixes for the specified C# diagnostic results, if any.
         protected Task CSharpVerifyExpectedCodeFixDiagnosticsAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
-            CSharpVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.Net.Net50, expected);
+            CSharpVerifyForVersionAsync(originalSource, fixedSource, ReferenceAssemblies.Net.Net50, CodeAnalysis.CSharp.LanguageVersion.CSharp7_3, expected);
 
         // Verifies that the fixer generates the fixes for the specified VB diagnostic results, if any.
         protected Task VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(string originalSource, string fixedSource, params DiagnosticResult[] expected) =>
@@ -41,12 +41,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         // Verifies that the analyzer generates the specified C# diagnostic results, if any, for the specified originalSource.
         // If fixedSource is provided, also verifies that the fixer generates the fixes for the verified diagnostic results, if any.
-        private Task CSharpVerifyForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, params DiagnosticResult[] expected)
+        protected Task CSharpVerifyForVersionAsync(string originalSource, string fixedSource, ReferenceAssemblies version, CodeAnalysis.CSharp.LanguageVersion languageVersion, params DiagnosticResult[] expected)
         {
             var test = new VerifyCS.Test
             {
                 TestCode = originalSource,
                 ReferenceAssemblies = version,
+                LanguageVersion = languageVersion
             };
 
             if (!string.IsNullOrEmpty(fixedSource))
@@ -110,6 +111,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             yield return new object[] { "buffer, 0, buffer.Length, CancellationToken.None",
                                         "buffer, CancellationToken.None" };
         }
+
         public static IEnumerable<object[]> CSharpUnnamedArgumentsPartialBufferTestData()
         {
             yield return new object[] { "buffer, 1, buffer.Length",

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -780,6 +780,47 @@ class C
             return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalSource, fixedSource, GetCSharpResult(12, 74, 12, 254));
         }
 
+
+        [Fact]
+        public Task CS_Fixer_PreserveNullability()
+        {
+            string originalSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    async void M(FileStream? stream, byte[]? buffer)
+    {
+        await stream!.ReadAsync(buffer!, offset: 0, count: buffer!.Length).ConfigureAwait(false);
+    }
+}
+";
+            string fixedSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    async void M(FileStream? stream, byte[]? buffer)
+    {
+        await (stream!).ReadAsync((buffer!).AsMemory(start: 0, length: buffer!.Length)).ConfigureAwait(false);
+    }
+}
+";
+
+            return CSharpVerifyForVersionAsync(
+                originalSource,
+                fixedSource,
+                ReferenceAssemblies.Net.Net50,
+                CodeAnalysis.CSharp.LanguageVersion.CSharp8,
+                GetCSharpResult(11, 15, 11, 75));
+        }
+
         #endregion
 
         #region VB - Diagnostic

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -780,7 +780,6 @@ class C
             return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalSource, fixedSource, GetCSharpResult(12, 74, 12, 254));
         }
 
-
         [Fact]
         public Task CS_Fixer_PreserveNullability()
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -784,6 +784,7 @@ class C
         [Fact]
         public Task CS_Fixer_PreserveNullability()
         {
+            // The differences with the WriteAsync test are "condition ? 0 : 1" and "buffer!.Length".
             string originalSource = @"
 #nullable enable
 using System;
@@ -792,9 +793,9 @@ using System.Threading.Tasks;
 
 public class C
 {
-    async void M(FileStream? stream, byte[]? buffer)
+    async void M(FileStream? stream, byte[]? buffer, bool condition)
     {
-        await stream!.ReadAsync(buffer!, offset: 0, count: buffer!.Length).ConfigureAwait(false);
+        await stream!.ReadAsync(buffer!, offset: condition ? 0 : 1, count: buffer!.Length).ConfigureAwait(false);
     }
 }
 ";
@@ -806,9 +807,9 @@ using System.Threading.Tasks;
 
 public class C
 {
-    async void M(FileStream? stream, byte[]? buffer)
+    async void M(FileStream? stream, byte[]? buffer, bool condition)
     {
-        await (stream!).ReadAsync((buffer!).AsMemory(start: 0, length: buffer!.Length)).ConfigureAwait(false);
+        await (stream!).ReadAsync((buffer!).AsMemory(start: condition ? 0 : 1, length: buffer!.Length)).ConfigureAwait(false);
     }
 }
 ";
@@ -818,7 +819,7 @@ public class C
                 fixedSource,
                 ReferenceAssemblies.Net.Net50,
                 CodeAnalysis.CSharp.LanguageVersion.CSharp8,
-                GetCSharpResult(11, 15, 11, 75));
+                GetCSharpResult(11, 15, 11, 91));
         }
 
         #endregion

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -821,6 +821,49 @@ public class C
                 GetCSharpResult(11, 15, 11, 91));
         }
 
+        [Fact]
+        public Task CS_Fixer_PreserveNullabilityWithCancellationTOken()
+        {
+            // The differences with the WriteAsync test are "condition ? 0 : 1" and "buffer!.Length".
+            string originalSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class C
+{
+    async void M(FileStream? stream, byte[]? buffer, bool condition, CancellationToken ct)
+    {
+        await stream!.ReadAsync(buffer!, offset: condition ? 0 : 1, count: buffer!.Length, ct).ConfigureAwait(false);
+    }
+}
+";
+            string fixedSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class C
+{
+    async void M(FileStream? stream, byte[]? buffer, bool condition, CancellationToken ct)
+    {
+        await (stream!).ReadAsync((buffer!).AsMemory(start: condition ? 0 : 1, length: buffer!.Length), ct).ConfigureAwait(false);
+    }
+}
+";
+
+            return CSharpVerifyForVersionAsync(
+                originalSource,
+                fixedSource,
+                ReferenceAssemblies.Net.Net50,
+                CodeAnalysis.CSharp.LanguageVersion.CSharp8,
+                GetCSharpResult(12, 15, 12, 95));
+        }
+
         #endregion
 
         #region VB - Diagnostic

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -743,6 +743,7 @@ class C
         [Fact]
         public Task CS_Fixer_PreserveNullability()
         {
+            // The difference with the ReadAsync test is buffer?.Length
             string originalSource = @"
 #nullable enable
 using System;
@@ -753,7 +754,7 @@ public class C
 {
     async ValueTask M(Stream? stream, byte[]? buffer)
     {
-        await stream!.WriteAsync(buffer!, offset: 0, count: buffer!.Length).ConfigureAwait(false);
+        await stream!.WriteAsync(buffer!, offset: 0, count: buffer?.Length ?? 0).ConfigureAwait(false);
     }
 }
 ";
@@ -767,7 +768,7 @@ public class C
 {
     async ValueTask M(Stream? stream, byte[]? buffer)
     {
-        await (stream!).WriteAsync((buffer!).AsMemory(start: 0, length: buffer!.Length)).ConfigureAwait(false);
+        await (stream!).WriteAsync((buffer!).AsMemory(start: 0, length: buffer?.Length ?? 0)).ConfigureAwait(false);
     }
 }
 ";
@@ -777,7 +778,7 @@ public class C
                 fixedSource,
                 ReferenceAssemblies.Net.Net50,
                 CodeAnalysis.CSharp.LanguageVersion.CSharp8,
-                GetCSharpResult(11, 15, 11, 76));
+                GetCSharpResult(11, 15, 11, 81));
         }
 
         #endregion

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -781,6 +781,49 @@ public class C
                 GetCSharpResult(11, 15, 11, 81));
         }
 
+        [Fact]
+        public Task CS_Fixer_PreserveNullabilityWithCancellationToken()
+        {
+            // The difference with the ReadAsync test is buffer?.Length
+            string originalSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class C
+{
+    async ValueTask M(Stream? stream, byte[]? buffer, CancellationToken ct)
+    {
+        await stream!.WriteAsync(buffer!, offset: 0, count: buffer?.Length ?? 0, ct).ConfigureAwait(false);
+    }
+}
+";
+            string fixedSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class C
+{
+    async ValueTask M(Stream? stream, byte[]? buffer, CancellationToken ct)
+    {
+        await (stream!).WriteAsync((buffer!).AsMemory(start: 0, length: buffer?.Length ?? 0), ct).ConfigureAwait(false);
+    }
+}
+";
+
+            return CSharpVerifyForVersionAsync(
+                originalSource,
+                fixedSource,
+                ReferenceAssemblies.Net.Net50,
+                CodeAnalysis.CSharp.LanguageVersion.CSharp8,
+                GetCSharpResult(12, 15, 12, 85));
+        }
+
         #endregion
 
         #region VB - Diagnostic

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -740,6 +740,46 @@ class C
             return CSharpVerifyExpectedCodeFixDiagnosticsAsync(originalSource, fixedSource, GetCSharpResult(12, 74, 12, 255));
         }
 
+        [Fact]
+        public Task CS_Fixer_PreserveNullability()
+        {
+            string originalSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    async ValueTask M(Stream? stream, byte[]? buffer)
+    {
+        await stream!.WriteAsync(buffer!, offset: 0, count: buffer!.Length).ConfigureAwait(false);
+    }
+}
+";
+            string fixedSource = @"
+#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+public class C
+{
+    async ValueTask M(Stream? stream, byte[]? buffer)
+    {
+        await (stream!).WriteAsync((buffer!).AsMemory(start: 0, length: buffer!.Length)).ConfigureAwait(false);
+    }
+}
+";
+
+            return CSharpVerifyForVersionAsync(
+                originalSource,
+                fixedSource,
+                ReferenceAssemblies.Net.Net50,
+                CodeAnalysis.CSharp.LanguageVersion.CSharp8,
+                GetCSharpResult(11, 15, 11, 76));
+        }
+
         #endregion
 
         #region VB - Diagnostic

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -1,8 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Operations
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.NetCore.Analyzers.Runtime
@@ -14,23 +14,39 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
         Inherits PreferStreamAsyncMemoryOverloadsFixer
 
-        Protected Overrides Function GetArgumentByPositionOrName(args As ImmutableArray(Of IArgumentOperation), index As Integer, name As String, ByRef isNamed As Boolean) As IArgumentOperation
+        Protected Overrides Function GetArgumentByPositionOrName(invocation As IInvocationOperation, index As Integer, name As String, ByRef isNamed As Boolean) As SyntaxNode
+
             isNamed = False
-            If index >= args.Length Then
-                Return Nothing
-            Else
+
+            If index < invocation.Arguments.Length Then
+
+                Dim args = invocation.Arguments
+
                 Dim argNode = TryCast(args(index).Syntax, SimpleArgumentSyntax)
+
                 If argNode IsNot Nothing AndAlso argNode.NameColonEquals Is Nothing Then
-                    Return args(index)
+                    'If the argument in the specified index does not have a name, then it is in its expected position
+                    Return args(index).Syntax
+
                 Else
-                    isNamed = True
-                    Return args.FirstOrDefault(
+                    'Otherwise, find it by name
+
+                    Dim operation = args.FirstOrDefault(
                         Function(argOperation)
                             argNode = TryCast(argOperation.Syntax, SimpleArgumentSyntax)
                             Return argNode.NameColonEquals?.Name?.Identifier.ValueText = name
                         End Function)
+
+                    If operation IsNot Nothing Then
+                        isNamed = True
+                        Return operation.Syntax
+                    End If
+
                 End If
             End If
+
+            Return Nothing
+
         End Function
 
         Protected Overrides Function IsSystemNamespaceImported(importList As IReadOnlyList(Of SyntaxNode)) As Boolean
@@ -62,27 +78,45 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Protected Overrides Function IsPassingZeroAndBufferLength(model As SemanticModel, bufferValueNode As SyntaxNode, offsetValueNode As SyntaxNode, countValueNode As SyntaxNode) As Boolean
 
             ' First argument should be an identifier name node
-            Dim firstArgumentIdentifierName = TryCast(bufferValueNode, IdentifierNameSyntax)
+            Dim arg1 = TryCast(bufferValueNode, ArgumentSyntax)
+            If arg1 Is Nothing Then
+                Return False
+            End If
+
+            Dim firstArgumentIdentifierName = TryCast(arg1.GetExpression(), IdentifierNameSyntax)
             If firstArgumentIdentifierName Is Nothing Then
                 Return False
             End If
 
             ' Second argument should be a literal expression node with a constant value...
-            Dim optionalValue As [Optional](Of Object) = model.GetConstantValue(offsetValueNode)
+            Dim arg2 = TryCast(offsetValueNode, ArgumentSyntax)
+            If arg2 Is Nothing Then
+                Return False
+            End If
+
+            Dim literal = TryCast(arg2.GetExpression(), LiteralExpressionSyntax)
+            If literal Is Nothing Then
+                Return False
+            End If
 
             ' And must be an integer...
-            If Not optionalValue.HasValue Or TypeOf optionalValue.Value IsNot Integer Then
+            If TypeOf literal.Token.Value IsNot Integer Then
                 Return False
             End If
 
             ' with a value of zero
-            Dim value = DirectCast(optionalValue.Value, Integer)
+            Dim value = DirectCast(literal.Token.Value, Integer)
             If value <> 0 Then
                 Return False
             End If
 
             ' Third argument should be a member access node...
-            Dim thirdArgumentMemberAccessExpression = TryCast(countValueNode, MemberAccessExpressionSyntax)
+            Dim arg3 = TryCast(countValueNode, ArgumentSyntax)
+            If arg3 Is Nothing Then
+                Return False
+            End If
+
+            Dim thirdArgumentMemberAccessExpression = TryCast(arg3.GetExpression(), MemberAccessExpressionSyntax)
             If thirdArgumentMemberAccessExpression Is Nothing Then
                 Return False
             End If
@@ -99,5 +133,46 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
         End Function
 
+        Protected Overrides Function GetNodeWithNullability(invocation As IInvocationOperation) As SyntaxNode
+
+            Return invocation.Instance.Syntax
+
+        End Function
+
+        Protected Overrides Function GetNamedArgument(generator As SyntaxGenerator, node As SyntaxNode, isNamed As Boolean, newName As String) As SyntaxNode
+
+            If isNamed Then
+
+                Dim actualNode = node
+
+                Dim argument = TryCast(node, ArgumentSyntax)
+
+                If argument IsNot Nothing Then
+
+                    actualNode = argument.GetExpression()
+
+                End If
+
+                Return generator.Argument(newName, RefKind.None, actualNode)
+
+            End If
+
+            Return node
+
+        End Function
+
+        Protected Overrides Function GetNamedMemberInvocation(generator As SyntaxGenerator, node As SyntaxNode, memberName As String) As SyntaxNode
+
+            Dim actualNode = node
+
+            Dim argument = TryCast(node, ArgumentSyntax)
+            If argument IsNot Nothing Then
+                actualNode = argument.GetExpression()
+            End If
+
+            Return generator.MemberAccessExpression(actualNode.WithoutTrivia(), memberName)
+
+        End Function
     End Class
+
 End Namespace

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -15,112 +15,84 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Inherits PreferStreamAsyncMemoryOverloadsFixer
 
         Protected Overrides Function GetArgumentByPositionOrName(invocation As IInvocationOperation, index As Integer, name As String, ByRef isNamed As Boolean) As SyntaxNode
-
             isNamed = False
-
             If index < invocation.Arguments.Length Then
-
                 Dim args = invocation.Arguments
-
                 Dim argNode = TryCast(args(index).Syntax, SimpleArgumentSyntax)
-
                 If argNode IsNot Nothing AndAlso argNode.NameColonEquals Is Nothing Then
                     'If the argument in the specified index does not have a name, then it is in its expected position
                     Return args(index).Syntax
-
                 Else
                     'Otherwise, find it by name
-
                     Dim operation = args.FirstOrDefault(
                         Function(argOperation)
                             argNode = TryCast(argOperation.Syntax, SimpleArgumentSyntax)
                             Return argNode.NameColonEquals?.Name?.Identifier.ValueText = name
                         End Function)
-
                     If operation IsNot Nothing Then
                         isNamed = True
                         Return operation.Syntax
                     End If
-
                 End If
             End If
-
             Return Nothing
-
         End Function
 
         Protected Overrides Function IsSystemNamespaceImported(importList As IReadOnlyList(Of SyntaxNode)) As Boolean
-
             For Each import As SyntaxNode In importList
-
                 Dim importsStatement = TryCast(import, ImportsStatementSyntax)
                 If importsStatement IsNot Nothing Then
-
                     For Each clause As ImportsClauseSyntax In importsStatement.ImportsClauses
-
                         Dim simpleClause = TryCast(clause, SimpleImportsClauseSyntax)
                         If simpleClause IsNot Nothing Then
-
                             Dim identifier = TryCast(simpleClause.Name, IdentifierNameSyntax)
                             If identifier IsNot Nothing AndAlso identifier.Identifier.Text = "System" Then
                                 Return True
                             End If
-
                         End If
                     Next
                 End If
             Next
-
             Return False
-
         End Function
 
         Protected Overrides Function IsPassingZeroAndBufferLength(model As SemanticModel, bufferValueNode As SyntaxNode, offsetValueNode As SyntaxNode, countValueNode As SyntaxNode) As Boolean
-
             ' First argument should be an identifier name node
             Dim arg1 = TryCast(bufferValueNode, ArgumentSyntax)
             If arg1 Is Nothing Then
                 Return False
             End If
-
             Dim firstArgumentIdentifierName = TryCast(arg1.GetExpression(), IdentifierNameSyntax)
             If firstArgumentIdentifierName Is Nothing Then
                 Return False
             End If
-
             ' Second argument should be a literal expression node with a constant value...
             Dim arg2 = TryCast(offsetValueNode, ArgumentSyntax)
             If arg2 Is Nothing Then
                 Return False
             End If
-
             Dim literal = TryCast(arg2.GetExpression(), LiteralExpressionSyntax)
             If literal Is Nothing Then
                 Return False
             End If
-
             ' And must be an integer...
             If TypeOf literal.Token.Value IsNot Integer Then
                 Return False
             End If
-
             ' with a value of zero
             Dim value = DirectCast(literal.Token.Value, Integer)
             If value <> 0 Then
                 Return False
             End If
-
             ' Third argument should be a member access node...
             Dim arg3 = TryCast(countValueNode, ArgumentSyntax)
             If arg3 Is Nothing Then
                 Return False
             End If
-
             Dim thirdArgumentMemberAccessExpression = TryCast(arg3.GetExpression(), MemberAccessExpressionSyntax)
             If thirdArgumentMemberAccessExpression Is Nothing Then
                 Return False
             End If
-
             ' whose identifier is an identifier name node, and its value is the same as the value of first argument, and the member name is `Length`
             Dim thirdArgumentIdentifierName = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
             If thirdArgumentIdentifierName IsNot Nothing And
@@ -128,50 +100,33 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                 thirdArgumentMemberAccessExpression.Name.Identifier.Text = WellKnownMemberNames.LengthPropertyName Then
                 Return True
             End If
-
             Return False
-
         End Function
 
         Protected Overrides Function GetNodeWithNullability(invocation As IInvocationOperation) As SyntaxNode
-
+            ' VB does not have nullability, return the syntax node untouched
             Return invocation.Instance.Syntax
-
         End Function
 
         Protected Overrides Function GetNamedArgument(generator As SyntaxGenerator, node As SyntaxNode, isNamed As Boolean, newName As String) As SyntaxNode
-
             If isNamed Then
-
                 Dim actualNode = node
-
                 Dim argument = TryCast(node, ArgumentSyntax)
-
                 If argument IsNot Nothing Then
-
                     actualNode = argument.GetExpression()
-
                 End If
-
                 Return generator.Argument(newName, RefKind.None, actualNode)
-
             End If
-
             Return node
-
         End Function
 
         Protected Overrides Function GetNamedMemberInvocation(generator As SyntaxGenerator, node As SyntaxNode, memberName As String) As SyntaxNode
-
             Dim actualNode = node
-
             Dim argument = TryCast(node, ArgumentSyntax)
             If argument IsNot Nothing Then
                 actualNode = argument.GetExpression()
             End If
-
             Return generator.MemberAccessExpression(actualNode.WithoutTrivia(), memberName)
-
         End Function
     End Class
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/3826

<!--

Make sure to run `msbuild /t:pack /v:m` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.

-->
