### PR TITLE
Fix warning while running Markdownlint

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,8 +113,9 @@ jobs:
       condition: always()
 
 - job: Markdownlint
-  pool:
-      vmImage: ubuntu-latest
+ pool:
+    name: NetCorePublic-Pool
+    queue: BuildPool.Ubuntu.1604.amd64.Open
   steps:
     - script: sudo npm install -g markdownlint-cli
       displayName: Install markdownlint-cli


### PR DESCRIPTION
Fix warning while running Markdownlint: `##[warning]Ubuntu-latest pipelines will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816`
