### PR TITLE
Workaround warning in Markdownlint job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,7 @@ jobs:
 
 - job: Markdownlint
   pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-18.04
   steps:
     - script: sudo npm install -g markdownlint-cli
       displayName: Install markdownlint-cli


### PR DESCRIPTION
Replaces #4666

I'm not sure why the fix in #4666 didn't work. But that's another way that seems to work.