### PR TITLE
Add test: InstanceMemberUsedInXml_NoDiagnostic

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -115,7 +115,10 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     // Workaround for https://github.com/dotnet/roslyn/issues/27564
                     blockStartContext.RegisterOperationAction(operationContext =>
                     {
-                        isInstanceReferenced = true;
+                        if (!operationContext.IsOperationNoneRoot())
+                        {
+                            isInstanceReferenced = true;
+                        }
                     }, OperationKind.None);
 
                     blockStartContext.RegisterOperationBlockEndAction(blockEndContext =>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -112,6 +112,12 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                         }
                     }, OperationKind.InstanceReference);
 
+                    // Workaround for https://github.com/dotnet/roslyn/issues/27564
+                    blockStartContext.RegisterOperationAction(operationContext =>
+                    {
+                        isInstanceReferenced = true;
+                    }, OperationKind.None);
+
                     blockStartContext.RegisterOperationBlockEndAction(blockEndContext =>
                     {
                         if (!isInstanceReferenced)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -115,7 +115,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                     // Workaround for https://github.com/dotnet/roslyn/issues/27564
                     blockStartContext.RegisterOperationAction(operationContext =>
                     {
-                        if (!operationContext.IsOperationNoneRoot())
+                        if (!operationContext.Operation.IsOperationNoneRoot())
                         {
                             isInstanceReferenced = true;
                         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -1357,6 +1357,22 @@ public class DummyAwaiter : INotifyCompletion
 }");
         }
 
+        [Fact]
+        public async Task InstanceMemberUsedInXml_NoDiagnostic()
+        {
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Public Class C
+    Public Property Language As String
+    Private Sub M()
+        Dim x =
+<Workspace>
+    <Project Language=<%= Me.Language %>>
+    </Project>
+</Workspace>
+        End Sub
+End Class");
+        }
+
         private DiagnosticResult GetCSharpResultAt(int line, int column, string symbolName)
 #pragma warning disable RS0030 // Do not used banned APIs
             => VerifyCS.Diagnostic()


### PR DESCRIPTION
This false positive was caught in dotnet/roslyn.