### PR TITLE
Fix outdated rule id in comments

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/Documentation/CSharpAvoidUsingCrefTagsWithAPrefix.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/Documentation/CSharpAvoidUsingCrefTagsWithAPrefix.Fixer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeQuality.Analyzers.Documentation;
 namespace Microsoft.CodeQuality.CSharp.Analyzers.Documentation
 {
     /// <summary>
-    /// RS0010: Avoid using cref tags with a prefix
+    /// CA1200: Avoid using cref tags with a prefix
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public class CSharpAvoidUsingCrefTagsWithAPrefixFixer : AvoidUsingCrefTagsWithAPrefixFixer

--- a/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/Documentation/CSharpAvoidUsingCrefTagsWithAPrefix.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeQuality.Analyzers/Documentation/CSharpAvoidUsingCrefTagsWithAPrefix.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeQuality.Analyzers.Documentation;
 namespace Microsoft.CodeQuality.CSharp.Analyzers.Documentation
 {
     /// <summary>
-    /// RS0010: Avoid using cref tags with a prefix
+    /// CA1200: Avoid using cref tags with a prefix
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpAvoidUsingCrefTagsWithAPrefixAnalyzer : AvoidUsingCrefTagsWithAPrefixAnalyzer

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefix.Fixer.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.CodeQuality.Analyzers.Documentation
 {
     /// <summary>
-    /// RS0010: Avoid using cref tags with a prefix
+    /// CA1200: Avoid using cref tags with a prefix
     /// </summary>
     public abstract class AvoidUsingCrefTagsWithAPrefixFixer : CodeFixProvider
     {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefix.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefix.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.CodeQuality.Analyzers.Documentation
 {
     /// <summary>
-    /// RS0010: Avoid using cref tags with a prefix
+    /// CA1200: Avoid using cref tags with a prefix
     /// </summary>
     public abstract class AvoidUsingCrefTagsWithAPrefixAnalyzer : DiagnosticAnalyzer
     {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Documentation/AvoidUsingCrefTagsWithAPrefixTests.cs
@@ -58,9 +58,9 @@ class C
     public void F() { }
 }
 ",
-    // Test0.cs(3,21): warning RS0010: Avoid using cref tags with a prefix
+    // Test0.cs(3,21): warning CA1200: Avoid using cref tags with a prefix
     GetCSharpResultAt(3, 21),
-    // Test0.cs(3,55): warning RS0010: Avoid using cref tags with a prefix
+    // Test0.cs(3,55): warning CA1200: Avoid using cref tags with a prefix
     GetCSharpResultAt(3, 55));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
@@ -72,9 +72,9 @@ Class C
     End Sub
 End Class
 ",
-    // Test0.vb(3,21): warning RS0010: Avoid using cref tags with a prefix
+    // Test0.vb(3,21): warning CA1200: Avoid using cref tags with a prefix
     GetBasicResultAt(3, 21),
-    // Test0.vb(3,55): warning RS0010: Avoid using cref tags with a prefix
+    // Test0.vb(3,55): warning CA1200: Avoid using cref tags with a prefix
     GetBasicResultAt(3, 55));
         }
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/Documentation/BasicAvoidUsingCrefTagsWithAPrefix.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/Documentation/BasicAvoidUsingCrefTagsWithAPrefix.Fixer.vb
@@ -7,7 +7,7 @@ Imports Microsoft.CodeQuality.Analyzers.Documentation
 
 Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation
     ''' <summary>
-    ''' RS0010: Avoid using cref tags with a prefix
+    ''' CA1200: Avoid using cref tags with a prefix
     ''' </summary>
     <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
     Public NotInheritable Class BasicAvoidUsingCrefTagsWithAPrefixFixer

--- a/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/Documentation/BasicAvoidUsingCrefTagsWithAPrefix.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/Documentation/BasicAvoidUsingCrefTagsWithAPrefix.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeQuality.Analyzers.Documentation
 
 Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.Documentation
     ''' <summary>
-    ''' RS0010: Avoid using cref tags with a prefix
+    ''' CA1200: Avoid using cref tags with a prefix
     ''' </summary>
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicAvoidUsingCrefTagsWithAPrefixAnalyzer


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/blob/4bbb229fda9e3e2bdf9389350ade042237075cec/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs#L16

Not of much value, but did it anyway as a small cleanup.