### PR TITLE
draft - enable ca1508

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -270,6 +270,8 @@ dotnet_diagnostic.CA1309.severity = suggestion
 # TODO: Enable this rule as warning and fix violations.
 dotnet_diagnostic.CA1725.severity = suggestion
 
+dotnet_diagnostic.CA1508.severity = warning
+
 ### Configuration for PublicAPI analyzers executed on this repo ###
 [*.{cs,vb}]
 


### PR DESCRIPTION
It's not enabled currently due to AllEnabledByDefault bug for which the fix isn't shipped yet. This PR isn't meant to be merged, but to check if there are any false positive to CA1508 in case any of them can be fixed before the next release.