### PR TITLE
CA1416 handle call-site empty sets causing warnings when TFM attributes applied

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Analyzer.Utilities;
 
 namespace Microsoft.NetCore.Analyzers.InteropServices
 {
@@ -22,15 +23,28 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         ///  - UnsupportedFirst - keeps the lowest version of [UnsupportedOSPlatform] attribute found
         ///  - UnsupportedSecond - keeps the second lowest version of [UnsupportedOSPlatform] attribute found
         /// </summary>
-        private class PlatformAttributes
+        private class Versions
         {
             public Version? SupportedFirst { get; set; }
             public Version? SupportedSecond { get; set; }
             public Version? UnsupportedFirst { get; set; }
             public Version? UnsupportedSecond { get; set; }
-            public Callsite Callsite { get; set; }
-            public bool HasAttribute() => SupportedFirst != null || UnsupportedFirst != null ||
+            public bool IsSet() => SupportedFirst != null || UnsupportedFirst != null ||
                         SupportedSecond != null || UnsupportedSecond != null;
+        }
+
+        private class PlatformAttributes
+        {
+            public PlatformAttributes() { }
+
+            public PlatformAttributes(Callsite callsite, SmallDictionary<string, Versions> platforms)
+            {
+                Callsite = callsite;
+                Platforms = platforms;
+            }
+
+            public SmallDictionary<string, Versions>? Platforms { get; set; }
+            public Callsite Callsite { get; set; }
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         SupportedSecond != null || UnsupportedSecond != null;
         }
 
-        private class PlatformAttributes
+        private sealed class PlatformAttributes
         {
             public PlatformAttributes() { }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Data.cs
@@ -28,6 +28,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             public Version? SupportedSecond { get; set; }
             public Version? UnsupportedFirst { get; set; }
             public Version? UnsupportedSecond { get; set; }
+            public Callsite Callsite { get; set; }
             public bool HasAttribute() => SupportedFirst != null || UnsupportedFirst != null ||
                         SupportedSecond != null || UnsupportedSecond != null;
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -233,8 +233,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
-            var platformSpecificOperations = PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, Versions> attributes,
-                SmallDictionary<string, Versions>? csAttributes)>.GetInstance();
+            var platformSpecificOperations = PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>,
+                (SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? csAttributes)>.GetInstance();
 
             context.RegisterOperationAction(context =>
             {
@@ -251,7 +251,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 try
                 {
-                    if (platformSpecificOperations.IsEmpty || guardMethods.IsEmpty ||
+                    if (platformSpecificOperations.IsEmpty ||
+                        guardMethods.IsEmpty ||
                         !(context.OperationBlocks.GetControlFlowGraph() is { } cfg))
                     {
                         return;
@@ -416,7 +417,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     attribute.UnsupportedFirst = null;
                                 }
 
-                                if (attribute.UnsupportedSecond != null && attribute.UnsupportedSecond <= info.Version)
+                                if (attribute.UnsupportedSecond != null &&
+                                    attribute.UnsupportedSecond <= info.Version)
                                 {
                                     attribute.UnsupportedSecond = null;
                                 }
@@ -1064,8 +1066,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             platformSpecificOperations.TryAdd(new KeyValuePair<IOperation, ISymbol>(operation, symbol), (notSuppressedAttributes, callSiteAttributes.Platforms));
                         }
                     }
-                    else if (callSiteAttributes.Callsite != Callsite.Empty &&
-                        TryCopyAttributesNotSuppressedByMsBuild(operationAttributes.Platforms!, msBuildPlatforms, out var copiedAttributes))
+                    else if (TryCopyAttributesNotSuppressedByMsBuild(operationAttributes.Platforms!, msBuildPlatforms, out var copiedAttributes))
                     {
                         platformSpecificOperations.TryAdd(new KeyValuePair<IOperation, ISymbol>(operation, symbol), (copiedAttributes, null));
                     }
@@ -1174,8 +1175,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 diagnosticAttribute.SupportedFirst = (Version)attributeToCheck.Clone();
                             }
 
-                            if (attribute.UnsupportedFirst != null && (!mandatorySupportFound.Value ||
-                                !(SuppressedByCallSiteSupported(attribute, callSiteAttribute.SupportedFirst) ||
+                            if (attribute.UnsupportedFirst != null &&
+                                (!mandatorySupportFound.Value ||
+                                  !(SuppressedByCallSiteSupported(attribute, callSiteAttribute.SupportedFirst) ||
                                   SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))))
                             {
                                 diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
@@ -1257,7 +1259,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         }
                     }
                     else if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase) &&
-                        !callSiteAttributes.Values.Any(v => v.SupportedFirst != null))
+                             !callSiteAttributes.Values.Any(v => v.SupportedFirst != null))
                     {
                         // if MsBuild list contain the platform and call site has no any other supported attribute it means global, so need to warn
                         diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1505,21 +1505,17 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             }
                         }
                     }
-                    // For allow list if child narrowing supported platfroms by having less platforms support than parent,
-                    // not existing parent platforms should be removed
+
                     if (notFoundPlatforms.Count > 0)
                     {
+                        // For allow list if child narrowing supported platforms by having less platforms support than parent,
+                        // not existing parent platforms should be removed
                         if (supportFound)
                         {
-                            childAttributes = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
-                            foreach (var (platform, attributes) in pAttributes)
+                            foreach (var platform in notFoundPlatforms)
                             {
-                                if (!notFoundPlatforms.Contains(platform))
-                                {
-                                    childAttributes.Add(platform, attributes);
-                                }
+                                parentAttributes.Platforms!.Remove(platform);
                             }
-                            parentAttributes.Platforms = childAttributes;
                         }
                         else
                         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -159,7 +159,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         m.Parameters[0].Type.Equals(osPlatformType));
 
                 var guardMethods = GetOperatingSystemGuardMethods(runtimeIsOSPlatformMethod, operatingSystemType);
-                var platformSpecificMembers = new ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?>();
+                var platformSpecificMembers = new ConcurrentDictionary<ISymbol, PlatformAttributes>();
                 var osPlatformCreateMethod = osPlatformType?.GetMembers("Create").OfType<IMethodSymbol>().FirstOrDefault(m =>
                     m.IsStatic &&
                     m.ReturnType.Equals(osPlatformType) &&
@@ -223,7 +223,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             IMethodSymbol? osPlatformCreateMethod,
             INamedTypeSymbol? osPlatformType,
             INamedTypeSymbol stringType,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers,
+            ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers,
             ImmutableArray<string> msBuildPlatforms,
             ITypeSymbol? notSupportedExceptionType)
         {
@@ -233,8 +233,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             var osPlatformTypeArray = osPlatformType != null ? ImmutableArray.Create(osPlatformType) : ImmutableArray<INamedTypeSymbol>.Empty;
-            var platformSpecificOperations = PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, PlatformAttributes> attributes,
-                SmallDictionary<string, PlatformAttributes>? csAttributes)>.GetInstance();
+            var platformSpecificOperations = PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, Versions> attributes,
+                SmallDictionary<string, Versions>? csAttributes)>.GetInstance();
 
             context.RegisterOperationAction(context =>
             {
@@ -251,12 +251,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 try
                 {
-                    if (platformSpecificOperations.IsEmpty)
-                    {
-                        return;
-                    }
-
-                    if (guardMethods.IsEmpty || !(context.OperationBlocks.GetControlFlowGraph() is { } cfg))
+                    if (platformSpecificOperations.IsEmpty || guardMethods.IsEmpty ||
+                        !(context.OperationBlocks.GetControlFlowGraph() is { } cfg))
                     {
                         return;
                     }
@@ -319,8 +315,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             });
         }
 
-        private static bool HasGuardedLambdaOrLocalFunctionResult(IOperation platformSpecificOperation, SmallDictionary<string, PlatformAttributes> attributes,
-            ref SmallDictionary<string, PlatformAttributes>? csAttributes, DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult, GlobalFlowStateAnalysisValueSet> analysisResult)
+        private static bool HasGuardedLambdaOrLocalFunctionResult(IOperation platformSpecificOperation, SmallDictionary<string, Versions> attributes,
+            ref SmallDictionary<string, Versions>? csAttributes, DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult, GlobalFlowStateAnalysisValueSet> analysisResult)
         {
             if (!platformSpecificOperation.IsWithinLambdaOrLocalFunction(out var containingLambdaOrLocalFunctionOperation))
             {
@@ -387,15 +383,15 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return false;
         }
 
-        private static bool IsKnownValueGuarded(SmallDictionary<string, PlatformAttributes> attributes,
-                ref SmallDictionary<string, PlatformAttributes>? csAttributes, GlobalFlowStateAnalysisValueSet value)
+        private static bool IsKnownValueGuarded(SmallDictionary<string, Versions> attributes,
+                ref SmallDictionary<string, Versions>? csAttributes, GlobalFlowStateAnalysisValueSet value)
         {
             using var capturedVersions = PooledDictionary<string, Version>.GetInstance(StringComparer.OrdinalIgnoreCase);
             return IsKnownValueGuarded(attributes, ref csAttributes, value, capturedVersions);
 
             static bool IsKnownValueGuarded(
-                SmallDictionary<string, PlatformAttributes> attributes,
-                ref SmallDictionary<string, PlatformAttributes>? csAttributes,
+                SmallDictionary<string, Versions> attributes,
+                ref SmallDictionary<string, Versions>? csAttributes,
                 GlobalFlowStateAnalysisValueSet value,
                 PooledDictionary<string, Version> capturedVersions)
             {
@@ -408,26 +404,21 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         {
                             if (info.Negated)
                             {
-                                if (attribute.UnsupportedFirst != null)
+                                if (attribute.UnsupportedFirst != null &&
+                                    attribute.UnsupportedFirst >= info.Version)
                                 {
-                                    if (attribute.UnsupportedFirst >= info.Version)
+                                    if (DenyList(attribute))
                                     {
-                                        if (DenyList(attribute))
-                                        {
-                                            attribute.SupportedFirst = null;
-                                            attribute.SupportedSecond = null;
-                                            attribute.UnsupportedSecond = null;
-                                        }
-                                        attribute.UnsupportedFirst = null;
-                                    }
-                                }
-
-                                if (attribute.UnsupportedSecond != null)
-                                {
-                                    if (attribute.UnsupportedSecond <= info.Version)
-                                    {
+                                        attribute.SupportedFirst = null;
+                                        attribute.SupportedSecond = null;
                                         attribute.UnsupportedSecond = null;
                                     }
+                                    attribute.UnsupportedFirst = null;
+                                }
+
+                                if (attribute.UnsupportedSecond != null && attribute.UnsupportedSecond <= info.Version)
+                                {
+                                    attribute.UnsupportedSecond = null;
                                 }
 
                                 if (!IsEmptyVersion(info.Version))
@@ -474,14 +465,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 RemoveUnsupportsOnDifferentPlatforms(attributes, info.PlatformName);
                             }
                         }
-                        else
+                        else if (!info.Negated)
                         {
-                            if (!info.Negated)
-                            {
-                                // it is checking one exact platform, other unsupported should be suppressed
-                                RemoveUnsupportsOnDifferentPlatforms(attributes, info.PlatformName);
-                                csAttributes = SetAsCallSiteSupportedAttribute(csAttributes, info);
-                            }
+                            // it is checking one exact platform, other unsupported should be suppressed
+                            RemoveUnsupportsOnDifferentPlatforms(attributes, info.PlatformName);
+                            csAttributes = SetAsCallSiteSupportedAttribute(csAttributes, info);
                         }
                     }
                 }
@@ -491,7 +479,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     foreach (var attribute in attributes)
                     {
                         // if any of the attributes is not suppressed
-                        if (attribute.Value.HasAttribute())
+                        if (attribute.Value.IsSet())
                         {
                             return false;
                         }
@@ -518,11 +506,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return true;
             }
 
-            static SmallDictionary<string, PlatformAttributes> SetAsCallSiteSupportedAttribute(SmallDictionary<string, PlatformAttributes>? csAttributes, PlatformMethodValue info)
+            static SmallDictionary<string, Versions> SetAsCallSiteSupportedAttribute(SmallDictionary<string, Versions>? csAttributes, PlatformMethodValue info)
             {
                 if (csAttributes == null)
                 {
-                    csAttributes = new SmallDictionary<string, PlatformAttributes>();
+                    csAttributes = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
                 }
                 if (csAttributes.TryGetValue(info.PlatformName, out var attributes))
                 {
@@ -537,12 +525,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
                 else
                 {
-                    csAttributes.Add(info.PlatformName, new PlatformAttributes() { SupportedFirst = info.Version });
+                    csAttributes.Add(info.PlatformName, new Versions() { SupportedFirst = info.Version });
                 }
                 return csAttributes;
             }
 
-            static void RemoveUnsupportsOnDifferentPlatforms(SmallDictionary<string, PlatformAttributes> attributes, string platformName)
+            static void RemoveUnsupportsOnDifferentPlatforms(SmallDictionary<string, Versions> attributes, string platformName)
             {
                 foreach (var (name, attribute) in attributes)
                 {
@@ -557,7 +545,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            static void RemoveUnsupportedWithLessVersion(Version supportedVersion, PlatformAttributes attribute)
+            static void RemoveUnsupportedWithLessVersion(Version supportedVersion, Versions attribute)
             {
                 if (attribute.UnsupportedFirst != null &&
                     attribute.UnsupportedFirst <= supportedVersion)
@@ -566,7 +554,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            static void RemoveOtherSupportsOnDifferentPlatforms(SmallDictionary<string, PlatformAttributes> attributes, string platformName)
+            static void RemoveOtherSupportsOnDifferentPlatforms(SmallDictionary<string, Versions> attributes, string platformName)
             {
                 foreach (var (name, attribute) in attributes)
                 {
@@ -581,14 +569,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool IsEmptyVersion(Version version) => version.Major == 0 && version.Minor == 0;
 
-        private static void ReportDiagnostics(KeyValuePair<IOperation, ISymbol> operationToSymbol, SmallDictionary<string, PlatformAttributes> attributes,
-            SmallDictionary<string, PlatformAttributes>? csAttributes, OperationBlockAnalysisContext context,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers)
+        private static void ReportDiagnostics(KeyValuePair<IOperation, ISymbol> operationToSymbol, SmallDictionary<string, Versions> attributes,
+            SmallDictionary<string, Versions>? csAttributes, OperationBlockAnalysisContext context,
+            ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers)
         {
             var symbol = operationToSymbol.Value is IMethodSymbol method && method.IsConstructor() ? operationToSymbol.Value.ContainingType : operationToSymbol.Value;
             var operationName = symbol.ToDisplayString(GetLanguageSpecificFormat(operationToSymbol.Key));
 
-            var originalAttributes = platformSpecificMembers[symbol] ?? attributes;
+            var originalAttributes = platformSpecificMembers[symbol].Platforms ?? attributes;
 
             foreach (var attribute in originalAttributes.Values)
             {
@@ -604,7 +592,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static void ReportSupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string operationName,
-                 SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? callsiteAttributes)
+                 SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? callsiteAttributes)
             {
                 var supportedRule = GetSupportedPlatforms(attributes, callsiteAttributes, out var platformNames);
                 var callSitePlatforms = GetCallsitePlatforms(attributes, callsiteAttributes, out var callsite, supported: supportedRule);
@@ -626,10 +614,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         _ => throw new NotImplementedException()
                     };
 
-                static bool IsDenyList(SmallDictionary<string, PlatformAttributes>? callsiteAttributes) =>
+                static bool IsDenyList(SmallDictionary<string, Versions>? callsiteAttributes) =>
                     callsiteAttributes != null && callsiteAttributes.Any(csa => DenyList(csa.Value));
 
-                static bool GetSupportedPlatforms(SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes, out List<string> platformNames)
+                static bool GetSupportedPlatforms(SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? csAttributes, out List<string> platformNames)
                 {
                     var supportedRule = true;
                     platformNames = new List<string>();
@@ -711,13 +699,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static void ReportUnsupportedDiagnostic(IOperation operation, OperationBlockAnalysisContext context, string operationName,
-                SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? callsiteAttributes)
+                SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? callsiteAttributes)
             {
                 var unsupportedRule = GetPlatformNames(attributes, callsiteAttributes, out var platformNames);
                 var csPlatformNames = JoinNames(GetCallsitePlatforms(attributes, callsiteAttributes, out var callsite, supported: !unsupportedRule));
                 context.ReportDiagnostic(operation.CreateDiagnostic(SwitchRule(callsite, unsupportedRule), operationName, JoinNames(platformNames), csPlatformNames));
 
-                static bool GetPlatformNames(SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes, out List<string> platformNames)
+                static bool GetPlatformNames(SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? csAttributes, out List<string> platformNames)
                 {
                     platformNames = new List<string>();
                     var unsupportedRule = true;
@@ -790,8 +778,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            static List<string> GetCallsitePlatforms(SmallDictionary<string, PlatformAttributes> attributes,
-                SmallDictionary<string, PlatformAttributes>? callsiteAttributes, out Callsite callsite, bool supported)
+            static List<string> GetCallsitePlatforms(SmallDictionary<string, Versions> attributes,
+                SmallDictionary<string, Versions>? callsiteAttributes, out Callsite callsite, bool supported)
             {
                 callsite = Callsite.AllPlatforms;
                 var platformNames = new List<string>();
@@ -887,7 +875,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             static SymbolDisplayFormat GetLanguageSpecificFormat(IOperation operation) =>
                 operation.Language == LanguageNames.CSharp ? SymbolDisplayFormat.CSharpShortErrorMessageFormat : SymbolDisplayFormat.VisualBasicShortErrorMessageFormat;
 
-            static bool HasSameVersionedPlatformSupport(SmallDictionary<string, PlatformAttributes> attributes, string pName, bool checkSupport)
+            static bool HasSameVersionedPlatformSupport(SmallDictionary<string, Versions> attributes, string pName, bool checkSupport)
             {
                 if (attributes.TryGetValue(pName, out var attribute))
                 {
@@ -977,8 +965,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         }
 
         private static void AnalyzeOperation(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>,
-            (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms,
+            (SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? csAttributes)> platformSpecificOperations,
+            ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms,
             ITypeSymbol? notSupportedExceptionType)
         {
             if (operation.Parent is IArgumentOperation argumentOperation && UsedInCreatingNotSupportedException(argumentOperation, notSupportedExceptionType))
@@ -1025,18 +1013,18 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static void CheckTypeArguments(ImmutableArray<ITypeSymbol> typeArguments, IOperation operation, OperationAnalysisContext context,
-                PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, PlatformAttributes> attributes,
-                SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
-                ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms)
+                PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, Versions> attributes,
+                SmallDictionary<string, Versions>? csAttributes)> platformSpecificOperations,
+                ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms)
             {
                 using var workingSet = PooledHashSet<ITypeSymbol>.GetInstance();
                 CheckTypeArgumentsCore(typeArguments, operation, context, platformSpecificOperations, platformSpecificMembers, msBuildPlatforms, workingSet);
             }
 
             static void CheckTypeArgumentsCore(ImmutableArray<ITypeSymbol> typeArguments, IOperation operation, OperationAnalysisContext context,
-                PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, PlatformAttributes> attributes,
-                SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations, ConcurrentDictionary<ISymbol,
-                SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms, PooledHashSet<ITypeSymbol> workingSet)
+                PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>, (SmallDictionary<string, Versions> attributes,
+                SmallDictionary<string, Versions>? csAttributes)> platformSpecificOperations, ConcurrentDictionary<ISymbol,
+                PlatformAttributes> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms, PooledHashSet<ITypeSymbol> workingSet)
             {
                 foreach (var typeArgument in typeArguments)
                 {
@@ -1057,11 +1045,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static void CheckOperationAttributes(IOperation operation, OperationAnalysisContext context, PooledConcurrentDictionary<KeyValuePair<IOperation, ISymbol>,
-                (SmallDictionary<string, PlatformAttributes> attributes, SmallDictionary<string, PlatformAttributes>? csAttributes)> platformSpecificOperations,
-                ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms, ISymbol symbol, bool checkParents)
+                (SmallDictionary<string, Versions> attributes, SmallDictionary<string, Versions>? csAttributes)> platformSpecificOperations,
+                ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers, ImmutableArray<string> msBuildPlatforms, ISymbol symbol, bool checkParents)
             {
-                var callsite = Callsite.AllPlatforms;
-                if (TryGetOrCreatePlatformAttributes(symbol, checkParents, platformSpecificMembers, out var operationAttributes, ref callsite))
+                if (TryGetOrCreatePlatformAttributes(symbol, checkParents, platformSpecificMembers, out var operationAttributes))
                 {
                     var containingSymbol = context.ContainingSymbol;
                     if (containingSymbol is IMethodSymbol method && method.IsAccessorMethod())
@@ -1069,15 +1056,16 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         containingSymbol = method.AssociatedSymbol;
                     }
 
-                    callsite = Callsite.Reachable;
-                    if (TryGetOrCreatePlatformAttributes(containingSymbol, true, platformSpecificMembers, out var callSiteAttributes, ref callsite))
+                    if (TryGetOrCreatePlatformAttributes(containingSymbol, true, platformSpecificMembers, out var callSiteAttributes))
                     {
-                        if (callsite != Callsite.Empty && IsNotSuppressedByCallSite(operationAttributes, callSiteAttributes, msBuildPlatforms, out var notSuppressedAttributes))
+                        if (callSiteAttributes.Callsite != Callsite.Empty &&
+                            IsNotSuppressedByCallSite(operationAttributes.Platforms!, callSiteAttributes.Platforms!, msBuildPlatforms, out var notSuppressedAttributes))
                         {
-                            platformSpecificOperations.TryAdd(new KeyValuePair<IOperation, ISymbol>(operation, symbol), (notSuppressedAttributes, callSiteAttributes));
+                            platformSpecificOperations.TryAdd(new KeyValuePair<IOperation, ISymbol>(operation, symbol), (notSuppressedAttributes, callSiteAttributes.Platforms));
                         }
                     }
-                    else if (callsite != Callsite.Empty && TryCopyAttributesNotSuppressedByMsBuild(operationAttributes, msBuildPlatforms, out var copiedAttributes))
+                    else if (callSiteAttributes.Callsite != Callsite.Empty &&
+                        TryCopyAttributesNotSuppressedByMsBuild(operationAttributes.Platforms!, msBuildPlatforms, out var copiedAttributes))
                     {
                         platformSpecificOperations.TryAdd(new KeyValuePair<IOperation, ISymbol>(operation, symbol), (copiedAttributes, null));
                     }
@@ -1097,27 +1085,40 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return false;
         }
 
-        private static bool TryCopyAttributesNotSuppressedByMsBuild(SmallDictionary<string, PlatformAttributes> operationAttributes,
-            ImmutableArray<string> msBuildPlatforms, out SmallDictionary<string, PlatformAttributes> copiedAttributes)
+        private static bool TryCopyAttributesNotSuppressedByMsBuild(SmallDictionary<string, Versions> operationAttributes,
+            ImmutableArray<string> msBuildPlatforms, out SmallDictionary<string, Versions> copiedAttributes)
         {
-            copiedAttributes = new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
+            copiedAttributes = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
             foreach (var (platformName, attributes) in operationAttributes)
             {
                 if (AllowList(attributes) || msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase))
                 {
-                    copiedAttributes.Add(platformName, CopyAllAttributes(new PlatformAttributes(), attributes));
+                    copiedAttributes.Add(platformName, CopyAllAttributes(new Versions(), attributes));
                 }
             }
 
-            return copiedAttributes.Any();
+            return !copiedAttributes.IsEmpty;
         }
 
-        private static SmallDictionary<string, PlatformAttributes> CopyAttributes(SmallDictionary<string, PlatformAttributes> copyAttributes)
+        private static PlatformAttributes CopyAttributes(PlatformAttributes copyAttributes)
         {
-            var copy = new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
-            foreach (var (platformName, attributes) in copyAttributes)
+            var copy = new PlatformAttributes(copyAttributes.Callsite, new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase));
+
+            foreach (var (platformName, attributes) in copyAttributes.Platforms!)
             {
-                copy.Add(platformName, CopyAllAttributes(new PlatformAttributes(), attributes));
+                copy.Platforms!.Add(platformName, CopyAllAttributes(new Versions(), attributes));
+            }
+
+            return copy;
+        }
+
+        private static SmallDictionary<string, Versions> CopyAttributes(SmallDictionary<string, Versions> copyAttributes)
+        {
+            var copy = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (platformName, attributes) in copyAttributes!)
+            {
+                copy.Add(platformName, CopyAllAttributes(new Versions(), attributes));
             }
 
             return copy;
@@ -1142,16 +1143,16 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// <param name="notSuppressedAttributes"> Out parameter will include all attributes not suppressed by call site</param>
         /// <returns>true if all attributes applied to the operation is suppressed, false otherwise</returns>
 
-        private static bool IsNotSuppressedByCallSite(SmallDictionary<string, PlatformAttributes> operationAttributes,
-            SmallDictionary<string, PlatformAttributes> callSiteAttributes, ImmutableArray<string> msBuildPlatforms,
-            out SmallDictionary<string, PlatformAttributes> notSuppressedAttributes)
+        private static bool IsNotSuppressedByCallSite(SmallDictionary<string, Versions> operationAttributes,
+            SmallDictionary<string, Versions> callSiteAttributes, ImmutableArray<string> msBuildPlatforms,
+            out SmallDictionary<string, Versions> notSuppressedAttributes)
         {
-            notSuppressedAttributes = new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
+            notSuppressedAttributes = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
             bool? mandatorySupportFound = null;
             using var supportedOnlyPlatforms = PooledHashSet<string>.GetInstance(StringComparer.OrdinalIgnoreCase);
             foreach (var (platformName, attribute) in operationAttributes)
             {
-                var diagnosticAttribute = new PlatformAttributes();
+                var diagnosticAttribute = new Versions();
 
                 if (attribute.SupportedFirst != null)
                 {
@@ -1170,12 +1171,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             }
                             else
                             {
-                                diagnosticAttribute.SupportedSecond = (Version)attributeToCheck.Clone();
+                                diagnosticAttribute.SupportedFirst = (Version)attributeToCheck.Clone();
                             }
 
-                            if (attribute.UnsupportedFirst != null &&
+                            if (attribute.UnsupportedFirst != null && (!mandatorySupportFound.Value ||
                                 !(SuppressedByCallSiteSupported(attribute, callSiteAttribute.SupportedFirst) ||
-                                  SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst)))
+                                  SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))))
                             {
                                 diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
                             }
@@ -1203,81 +1204,67 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     diagnosticAttribute.UnsupportedSecond = (Version)attribute.UnsupportedSecond.Clone();
                                 }
                             }
-                            else
+                            else if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase))
                             {
-                                if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase))
+                                if (!SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
                                 {
-                                    if (!SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
-                                    {
-                                        diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
-                                        diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
-                                    }
+                                    diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
+                                    diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
+                                }
 
-                                    if (attribute.UnsupportedSecond != null && !SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedSecond))
-                                    {
-                                        diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
-                                        diagnosticAttribute.UnsupportedSecond = (Version)attribute.UnsupportedSecond.Clone();
-                                    }
+                                if (attribute.UnsupportedSecond != null && !SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedSecond))
+                                {
+                                    diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
+                                    diagnosticAttribute.UnsupportedSecond = (Version)attribute.UnsupportedSecond.Clone();
                                 }
                             }
                         }
-                        else
-                        {
-                            // Call site has no attributes for this platform, check if MsBuild list has it,
-                            // then if call site has deny list, it should support its later support
-                            if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase) &&
+                        // Call site has no attributes for this platform, check if MsBuild list has it,
+                        // then if call site has deny list, it should support its later support
+                        else if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase) &&
                                 callSiteAttributes.Any(ca => DenyList(ca.Value)))
-                            {
-                                diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
-                            }
+                        {
+                            diagnosticAttribute.SupportedFirst = (Version)attribute.SupportedFirst.Clone();
                         }
                     }
                 }
-                else
+                else if (attribute.UnsupportedFirst != null) // Unsupported for this but supported all other
                 {
-                    if (attribute.UnsupportedFirst != null) // Unsupported for this but supported all other
+                    if (callSiteAttributes.TryGetValue(platformName, out var callSiteAttribute))
                     {
-                        if (callSiteAttributes.TryGetValue(platformName, out var callSiteAttribute))
+                        if (callSiteAttribute.SupportedFirst != null)
                         {
-                            if (callSiteAttribute.SupportedFirst != null)
+                            if (callSiteAttribute.UnsupportedFirst != null)
                             {
-                                if (callSiteAttribute.UnsupportedFirst != null)
+                                if (!SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
                                 {
-                                    if (!SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
-                                    {
-                                        diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
-                                    }
-                                    else if (DenyList(callSiteAttribute))
-                                    {
-                                        diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
-                                    }
+                                    diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
                                 }
-                                else
+                                else if (DenyList(callSiteAttribute))
                                 {
                                     diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
                                 }
                             }
                             else
                             {
-                                if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase))
-                                {
-                                    if (!SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
-                                    {
-                                        diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
-                                    }
-                                }
+                                diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
                             }
                         }
                         else if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase) &&
-                            !callSiteAttributes.Values.Any(v => v.SupportedFirst != null))
+                                !SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst))
                         {
-                            // if MsBuild list contain the platform and call site has no any other supported attribute it means global, so need to warn
                             diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
                         }
                     }
+                    else if (msBuildPlatforms.Contains(platformName, StringComparer.OrdinalIgnoreCase) &&
+                        !callSiteAttributes.Values.Any(v => v.SupportedFirst != null))
+                    {
+                        // if MsBuild list contain the platform and call site has no any other supported attribute it means global, so need to warn
+                        diagnosticAttribute.UnsupportedFirst = (Version)attribute.UnsupportedFirst.Clone();
+                    }
                 }
 
-                if (diagnosticAttribute.HasAttribute())
+                if (diagnosticAttribute.IsSet())
                 {
                     notSuppressedAttributes[platformName] = diagnosticAttribute;
                 }
@@ -1289,12 +1276,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     foreach (var (name, attributes) in operationAttributes)
                     {
-                        if (attributes.SupportedFirst != null)
+                        if (attributes.SupportedFirst != null &&
+                            !notSuppressedAttributes.TryGetValue(name, out var diagnosticAttribute))
                         {
-                            if (!notSuppressedAttributes.TryGetValue(name, out var diagnosticAttribute))
-                            {
-                                diagnosticAttribute = new PlatformAttributes();
-                            }
+                            diagnosticAttribute = new Versions();
                             CopyAllAttributes(diagnosticAttribute, attributes);
                             notSuppressedAttributes[name] = diagnosticAttribute;
                         }
@@ -1315,50 +1300,50 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     }
                 }
             }
-            return notSuppressedAttributes.Any();
+            return !notSuppressedAttributes.IsEmpty;
 
-            static void AddOrUpdatedDiagnostic(PlatformAttributes operationAttributes,
-                SmallDictionary<string, PlatformAttributes> notSuppressedAttributes, string name)
+            static void AddOrUpdatedDiagnostic(Versions operationAttributes,
+                SmallDictionary<string, Versions> notSuppressedAttributes, string name)
             {
                 if (operationAttributes.SupportedFirst != null)
                 {
                     if (!notSuppressedAttributes.TryGetValue(name, out var diagnosticAttribute))
                     {
-                        diagnosticAttribute = new PlatformAttributes();
+                        diagnosticAttribute = new Versions();
                     }
                     diagnosticAttribute.SupportedFirst = (Version)operationAttributes.SupportedFirst.Clone();
                     notSuppressedAttributes[name] = diagnosticAttribute;
                 }
             }
 
-            static bool UnsupportedSecondSuppressed(PlatformAttributes attribute, PlatformAttributes callSiteAttribute) =>
+            static bool UnsupportedSecondSuppressed(Versions attribute, Versions callSiteAttribute) =>
                 SuppressedByCallSiteSupported(attribute, callSiteAttribute.SupportedFirst) ||
                 SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedSecond!);
 
-            static bool SuppressedByCallSiteUnsupported(PlatformAttributes callSiteAttribute, Version unsupporteAttribute) =>
+            static bool SuppressedByCallSiteUnsupported(Versions callSiteAttribute, Version unsupporteAttribute) =>
                 DenyList(callSiteAttribute) && callSiteAttribute.SupportedFirst != null ?
                 callSiteAttribute.UnsupportedSecond != null && unsupporteAttribute >= callSiteAttribute.UnsupportedSecond :
                 callSiteAttribute.UnsupportedFirst != null && unsupporteAttribute >= callSiteAttribute.UnsupportedFirst;
 
-            static bool SuppressedByCallSiteSupported(PlatformAttributes attribute, Version? callSiteSupportedFirst) =>
+            static bool SuppressedByCallSiteSupported(Versions attribute, Version? callSiteSupportedFirst) =>
                 callSiteSupportedFirst != null && callSiteSupportedFirst >= attribute.SupportedFirst! &&
                 attribute.SupportedSecond != null && callSiteSupportedFirst >= attribute.SupportedSecond;
 
-            static bool UnsupportedFirstSuppressed(PlatformAttributes attribute, PlatformAttributes callSiteAttribute) =>
+            static bool UnsupportedFirstSuppressed(Versions attribute, Versions callSiteAttribute) =>
                 callSiteAttribute.SupportedFirst != null && callSiteAttribute.SupportedFirst >= attribute.SupportedFirst ||
                 SuppressedByCallSiteUnsupported(callSiteAttribute, attribute.UnsupportedFirst!);
 
             // As optional if call site supports that platform, their versions should match
-            static bool OptionalOsSupportSuppressed(PlatformAttributes callSiteAttribute, PlatformAttributes attribute) =>
+            static bool OptionalOsSupportSuppressed(Versions callSiteAttribute, Versions attribute) =>
                 (callSiteAttribute.SupportedFirst == null || attribute.SupportedFirst <= callSiteAttribute.SupportedFirst) &&
                 (callSiteAttribute.SupportedSecond == null || attribute.SupportedFirst <= callSiteAttribute.SupportedSecond);
 
-            static bool MandatoryOsVersionsSuppressed(PlatformAttributes callSitePlatforms, Version checkingVersion) =>
+            static bool MandatoryOsVersionsSuppressed(Versions callSitePlatforms, Version checkingVersion) =>
                 callSitePlatforms.SupportedFirst != null && checkingVersion <= callSitePlatforms.SupportedFirst ||
                 callSitePlatforms.SupportedSecond != null && checkingVersion <= callSitePlatforms.SupportedSecond;
         }
 
-        private static PlatformAttributes CopyAllAttributes(PlatformAttributes copyTo, PlatformAttributes copyFrom)
+        private static Versions CopyAllAttributes(Versions copyTo, Versions copyFrom)
         {
             copyTo.SupportedFirst = (Version?)copyFrom.SupportedFirst?.Clone();
             copyTo.SupportedSecond = (Version?)copyFrom.SupportedSecond?.Clone();
@@ -1380,8 +1365,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool TryGetOrCreatePlatformAttributes(
             ISymbol symbol, bool checkParents,
-            ConcurrentDictionary<ISymbol, SmallDictionary<string, PlatformAttributes>?> platformSpecificMembers,
-            [NotNullWhen(true)] out SmallDictionary<string, PlatformAttributes>? attributes, ref Callsite callsite)
+            ConcurrentDictionary<ISymbol, PlatformAttributes> platformSpecificMembers,
+            out PlatformAttributes attributes)
         {
             if (!platformSpecificMembers.TryGetValue(symbol, out attributes))
             {
@@ -1396,22 +1381,23 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     }
 
                     if (container != null &&
-                        TryGetOrCreatePlatformAttributes(container, checkParents, platformSpecificMembers, out var containerAttributes, ref callsite))
+                        TryGetOrCreatePlatformAttributes(container, checkParents, platformSpecificMembers, out var containerAttributes))
                     {
                         attributes = CopyAttributes(containerAttributes);
                     }
                 }
 
-                MergePlatformAttributes(symbol.GetAttributes(), ref attributes, ref callsite);
+                attributes ??= new PlatformAttributes();
+                MergePlatformAttributes(symbol.GetAttributes(), ref attributes);
                 attributes = platformSpecificMembers.GetOrAdd(symbol, attributes);
             }
 
-            return attributes != null;
+            return attributes.Platforms != null;
 
             static void MergePlatformAttributes(ImmutableArray<AttributeData> immediateAttributes,
-                ref SmallDictionary<string, PlatformAttributes>? parentAttributes, ref Callsite callsite)
+                ref PlatformAttributes parentAttributes)
             {
-                SmallDictionary<string, PlatformAttributes>? childAttributes = null;
+                SmallDictionary<string, Versions>? childAttributes = null;
                 foreach (AttributeData attribute in immediateAttributes)
                 {
                     if (s_osPlatformAttributes.Contains(attribute.AttributeClass.Name))
@@ -1425,20 +1411,21 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     return;
                 }
 
-                if (parentAttributes != null && parentAttributes.Any())
+                var pAttributes = parentAttributes.Platforms;
+                if (pAttributes != null && !pAttributes.IsEmpty)
                 {
                     var notFoundPlatforms = PooledHashSet<string>.GetInstance();
                     bool supportFound = false;
-                    foreach (var (platform, attributes) in parentAttributes)
+                    foreach (var (platform, attributes) in pAttributes)
                     {
                         if (DenyList(attributes) &&
-                            !parentAttributes.Any(ca => AllowList(ca.Value)))
+                            !pAttributes.Any(ca => AllowList(ca.Value)))
                         {
                             // if all are deny list then we can add the child attributes
                             foreach (var (name, childAttribute) in childAttributes)
                             {
                                 NormalizeAttribute(childAttribute);
-                                if (parentAttributes.TryGetValue(name, out var existing))
+                                if (pAttributes.TryGetValue(name, out var existing))
                                 {
                                     if (childAttribute.UnsupportedFirst != null)
                                     {
@@ -1467,7 +1454,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 }
                                 else
                                 {
-                                    parentAttributes[name] = childAttribute;
+                                    pAttributes[name] = childAttribute;
                                 }
                             }
                             // merged all attributes, no need to continue looping
@@ -1491,10 +1478,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 {
                                     if (childAttribute.UnsupportedFirst <= attributes.SupportedFirst)
                                     {
-                                        if (callsite != Callsite.AllPlatforms)
-                                        {
-                                            callsite = Callsite.Empty;
-                                        }
+                                        parentAttributes.Callsite = Callsite.Empty;
                                         attributes.SupportedFirst = childAttribute.SupportedFirst > attributes.SupportedFirst ? childAttribute.SupportedFirst : null;
                                         attributes.UnsupportedFirst = childAttribute.UnsupportedFirst;
                                     }
@@ -1515,10 +1499,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             }
                             else // not existing parent platforms might need to be removed
                             {
-                                if (callsite != Callsite.AllPlatforms)
-                                {
-                                    callsite = Callsite.Empty;
-                                }
                                 notFoundPlatforms.Add(platform);
                             }
                         }
@@ -1529,56 +1509,54 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     {
                         if (supportFound)
                         {
-                            childAttributes = new SmallDictionary<string, PlatformAttributes>();
-                            foreach (var (platform, attributes) in parentAttributes)
+                            childAttributes = new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
+                            foreach (var (platform, attributes) in pAttributes)
                             {
                                 if (!notFoundPlatforms.Contains(platform))
                                 {
                                     childAttributes.Add(platform, attributes);
                                 }
                             }
-                            parentAttributes = childAttributes;
+                            parentAttributes.Platforms = childAttributes;
                         }
-                        else if (callsite == Callsite.Empty) // child support not found and 
+                        else
                         {
-                            parentAttributes = null;
+                            parentAttributes.Callsite = Callsite.Empty;
                         }
                     }
                 }
                 else
                 {
-                    parentAttributes ??= new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
+                    pAttributes ??= new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
                     foreach (var (platform, attributes) in childAttributes)
                     {
-                        parentAttributes[platform] = NormalizeAttribute(attributes);
+                        pAttributes[platform] = NormalizeAttribute(attributes);
                     }
+                    parentAttributes.Platforms = pAttributes;
                 }
 
                 return;
 
-                static PlatformAttributes NormalizeAttribute(PlatformAttributes attributes)
+                static Versions NormalizeAttribute(Versions attributes)
                 {
                     if (AllowList(attributes))
                     {
                         // For Allow list UnsupportedSecond should not be used.
                         attributes.UnsupportedSecond = null;
                     }
-                    else
-                    {
-                        // For deny list UnsupportedSecond should only set if there is SupportedFirst verison between UnsupportedSecond and UnsupportedFirst  
-                        if (attributes.SupportedFirst == null ||
+                    // For deny list UnsupportedSecond should only set if there is SupportedFirst verison between UnsupportedSecond and UnsupportedFirst 
+                    else if (attributes.SupportedFirst == null ||
                             (attributes.UnsupportedSecond != null &&
                              attributes.SupportedFirst > attributes.UnsupportedSecond))
-                        {
-                            attributes.UnsupportedSecond = null;
-                        }
+                    {
+                        attributes.UnsupportedSecond = null;
                     }
                     return attributes;
                 }
             }
         }
 
-        private static bool TryAddValidAttribute([NotNullWhen(true)] ref SmallDictionary<string, PlatformAttributes>? attributes, AttributeData attribute)
+        private static bool TryAddValidAttribute([NotNullWhen(true)] ref SmallDictionary<string, Versions>? attributes, AttributeData attribute)
         {
             if (!attribute.ConstructorArguments.IsEmpty &&
                                 attribute.ConstructorArguments[0] is { } argument &&
@@ -1588,10 +1566,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 !argument.Value.Equals(string.Empty) &&
                                 TryParsePlatformNameAndVersion(argument.Value.ToString(), out string platformName, out Version? version))
             {
-                attributes ??= new SmallDictionary<string, PlatformAttributes>(StringComparer.OrdinalIgnoreCase);
+                attributes ??= new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
                 if (!attributes.TryGetValue(platformName, out var _))
                 {
-                    attributes[platformName] = new PlatformAttributes();
+                    attributes[platformName] = new Versions();
                 }
 
                 AddAttribute(attribute.AttributeClass.Name, version, attributes[platformName]);
@@ -1625,7 +1603,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             return true;
         }
 
-        private static void AddAttribute(string name, Version version, PlatformAttributes attributes)
+        private static void AddAttribute(string name, Version version, Versions attributes)
         {
             if (name == SupportedOSPlatformAttribute)
             {
@@ -1637,7 +1615,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 AddOrUpdateUnsupportedAttribute(attributes, version);
             }
 
-            static void AddOrUpdateUnsupportedAttribute(PlatformAttributes attributes, Version version)
+            static void AddOrUpdateUnsupportedAttribute(Versions attributes, Version version)
             {
                 if (attributes.UnsupportedFirst != null)
                 {
@@ -1646,13 +1624,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         attributes.UnsupportedSecond = attributes.UnsupportedFirst;
                         attributes.UnsupportedFirst = version;
                     }
-                    else
-                    {
-                        if (attributes.UnsupportedSecond == null ||
+                    else if (attributes.UnsupportedSecond == null ||
                             attributes.UnsupportedSecond > version)
-                        {
-                            attributes.UnsupportedSecond = version;
-                        }
+                    {
+                        attributes.UnsupportedSecond = version;
                     }
                 }
                 else
@@ -1661,7 +1636,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            static void AddOrUpdateSupportedAttribute(PlatformAttributes attributes, Version version)
+            static void AddOrUpdateSupportedAttribute(Versions attributes, Version version)
             {
                 if (attributes.SupportedFirst != null)
                 {
@@ -1683,7 +1658,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// </summary>
         /// <param name="attributes">PlatformAttributes being checked</param>
         /// <returns>true if it is allow list</returns>
-        private static bool AllowList(PlatformAttributes attributes) =>
+        private static bool AllowList(Versions attributes) =>
             attributes.SupportedFirst != null &&
             (attributes.UnsupportedFirst == null || attributes.SupportedFirst <= attributes.UnsupportedFirst);
 
@@ -1692,7 +1667,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         /// </summary>
         /// <param name="attributes">PlatformAttributes being checked</param>
         /// <returns>true if it is deny list</returns>
-        private static bool DenyList(PlatformAttributes attributes) =>
+        private static bool DenyList(Versions attributes) =>
             attributes.UnsupportedFirst != null &&
             (attributes.SupportedFirst == null || attributes.UnsupportedFirst < attributes.SupportedFirst);
     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1499,8 +1499,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     }
                                 }
                             }
-                            else // not existing parent platforms might need to be removed
+                            else
                             {
+                                // not existing parent platforms might need to be removed
                                 notFoundPlatforms.Add(platform);
                             }
                         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -169,34 +169,34 @@ public static class SR
 [UnsupportedOSPlatform(""browser"")]
 public class Test
 {
-    void ThrowWithStringArgument()
+    /*void ThrowWithStringArgument()
     {
-        [|SR.Message|] = ""Warns not reachable on Browser"";
+        SR.Message = ""nOT Warns not reachable on Browser"";
         throw new PlatformNotSupportedException(SR.Message);
     }
 
     void ThrowNotSupportedWithStringArgument()
     {
-        [|SR.Message|] = ""Warns not reachable on Browser"";
+        SR.Message = ""Warns not reachable on Browser"";
         throw new NotSupportedException(SR.Message);
     }
     
     void ThrowWithNoArgument()
     {
-        [|SR.Message|] = ""Warns not reachable on Browser"";
+        SR.Message = ""Warns not reachable on Browser"";
         throw new PlatformNotSupportedException();
     }
     
     void ThrowWithStringAndExceptionConstructor()
     {
-        [|SR.Message|] = ""Warns not reachable on Browser"";
+        SR.Message = ""Warns not reachable on Browser"";
         throw new PlatformNotSupportedException(SR.Message, new Exception());
-    }
+    }*/
     
     void ThrowWithAnotherExceptionUsingResourceString()
     {
-        [|SR.Message|] = ""Warns not reachable on Browser"";
-        throw new PlatformNotSupportedException(SR.Message, new Exception([|SR.Message|]));
+        SR.Message = ""Warns not reachable on Browser"";
+        throw new PlatformNotSupportedException(SR.Message, new Exception(SR.Message));
     }
 }";
             await VerifyAnalyzerAsyncCs(csSource);
@@ -278,14 +278,14 @@ public class Test
     [UnsupportedOSPlatform(""browser"")]
     public static Exception GetNotSupportedWithStringArgument()
     {
-        [|s_message|] = ""Warns not reachable on Browser"";
+        s_message = ""Warns not reachable on Browser"";
         return new NotSupportedException(s_message); 
     }
 
     [UnsupportedOSPlatform(""browser"")]
     public static Exception ThrowPnseWithStringWarnsForInnerException()
     { 
-        return new PlatformNotSupportedException(s_message, new Exception([|s_message|]));
+        return new PlatformNotSupportedException(s_message, new Exception(s_message));
     }
 
     [UnsupportedOSPlatform(""browser"")]
@@ -3196,6 +3196,232 @@ class UnsupportedWindows8_9_12_Ios6_7_14
                     Join(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion, "windows", "10.0", "12.0"), GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion, "ios", "7.0", "11.0"))),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.SupportedCsAllPlatforms).WithLocation(2).WithArguments("UnsupportedWindows8_9_12_Ios6_7_14.UnsupportedWindows6_10_Ios_1_5_11.UnsupportedWindowsIos2_9_10()",
                     Join(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion, "windows", "10.0", "12.0"), GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityFromVersionToVersion, "ios", "9.0", "10.0"))));
+        }
+
+        [Fact]
+        public async Task EmptyCallsiteReferencesLocalFunctionNotWarns()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+[SupportedOSPlatform(""Browser"")]
+public class Test
+{
+    [UnsupportedOSPlatform(""browser"")]
+    public static string CurrentProgram
+    {
+        get
+        {
+            return EnsureInitialized();
+            string EnsureInitialized() { return string.Empty; }
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task NarrowedCallsiteReferencesLocalFunctionNotWarns()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+[SupportedOSPlatform(""Browser"")]
+public class Test
+{
+    [UnsupportedOSPlatform(""browser2.0"")]
+    public static string CurrentProgram
+    {
+        get
+        {
+            return EnsureInitialized();
+            string EnsureInitialized() { return string.Empty; }
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task EmptyCallsiteReferencesApiWithinSameAssemblyAttributeNotWarn()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[assembly:SupportedOSPlatform(""Browser"")] 
+public class Test
+{
+    private string program;
+
+    [UnsupportedOSPlatform(""browser"")] // unsupports the only supported platform of parent producing empty call site, not warning
+    public string CurrentProgram
+    {
+        get
+        {
+            return program; // should not warn
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task EmptyCallsiteReferencesApiWithImmediateAttributeNotWarn()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[assembly:SupportedOSPlatform(""Browser"")]
+public class Test
+{
+    [SupportedOSPlatform(""Browser"")]
+    private static string s_program;
+
+    [UnsupportedOSPlatform(""browser"")]
+    public static string CurrentProgram
+    {
+        get
+        {
+            return s_program; // should not warn
+        }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task EmptyCallsiteReferencesPlatformSpecificLibrariesApisNotWarn()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+[assembly:SupportedOSPlatform(""Browser"")] 
+public class Test
+{
+    [UnsupportedOSPlatform(""browser"")] // Overrides only support parent had, no valid call sites, not warm for anything
+    public void M1()
+    {
+        Console.Beep(); // Unsupported on browser API, should not warn
+        Console.Beep(10, 20); // Windows only API, should not warn
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task Empty_NonCallsiteReferencesVersionedApiWithImmediateAttribute()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""windows7.0"")]
+public class Test
+{
+    [UnsupportedOSPlatform(""windows9.0"")]
+    void StillSupportedOnWindows7and8()
+    {   // This call site is reachable on: 'windows' from version 7.0 to 9.0. 'Test.SupportedOnWindows10()' is only supported on: 'windows' 10.0 and later.
+        [|SupportedOnWindows10()|]; // Warning; calling from Windows 7-8 is still supported but it will fail
+    }
+    [UnsupportedOSPlatform(""windows6.0"")]
+    void NotSupportedAnywhere()
+    {
+        SupportedOnWindows10(); // No warning; no valid call sites
+    }
+    [SupportedOSPlatform(""windows10.0"")]
+    void SupportedOnWindows10() { }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task ChildCanNarrowUpperLevelSupportedPlatforms()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[assembly:SupportedOSPlatform(""windows"")]
+[assembly:SupportedOSPlatform(""ios"")]
+public class Test
+{
+    [SupportedOSPlatform(""windows"")]
+    private void WindowsOnly() { }
+
+    [SupportedOSPlatform(""ios"")]
+    private void IosOnly () { }
+
+    private void NoAttribute () { }
+
+    public void M1 ()
+    {
+        [|WindowsOnly()|];
+        [|IosOnly()|];
+        NoAttribute();
+    }
+    [SupportedOSPlatform(""Windows"")]
+    public void M2 ()
+    {
+       WindowsOnly();
+       [|IosOnly()|];
+        NoAttribute();
+    }
+    [SupportedOSPlatform(""iOS"")]
+    public void M3 ()
+    {
+        [|WindowsOnly()|];
+        IosOnly();
+        NoAttribute();
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task EmptyCallsiteReferencesSupportedUnsupportedApisNotWarns()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""browser"")]
+[SupportedOSPlatform(""windows"")]
+[SupportedOSPlatform(""macos"")]
+class Test
+{
+    [UnsupportedOSPlatform(""browser"")]
+    private static void ApiUnsupportedOnBrowser () { }
+
+    /*[SupportedOSPlatform(""macos"")]
+    class TestMacOs // Inside only mac accessable
+    {
+        [SupportedOSPlatform(""windows"")]
+        void WindowsOnly() // The method attribute causes not valid call sites; no warnings no matter what
+        {
+            Test.ApiUnsupportedOnBrowser();
+            Console.Beep(10, 20); // Windows only API
+        }
+    }*/
+
+    void MethodHasNoAttribute()
+    {
+        [|ApiUnsupportedOnBrowser()|]; // This call site is reachable on: 'macos', 'browser', 'windows'. 'Test.ApiUnsupportedOnBrowser()' is unsupported on: 'browser'.
+        [|Console.Beep(10, 20)|];      // This call site is reachable on: 'macos', 'browser', 'windows'. 'Console.Beep(int, int)' is only supported on: 'windows'.
+    }
+
+    /*[SupportedOSPlatform(""WINDOWS"")]
+    void WindowsOnly() // Nothing should warn
+    {
+        ApiUnsupportedOnBrowser();
+        Console.Beep(10, 20);
+    }
+
+    [SupportedOSPlatform(""Linux"")] // Not valid because Linux is not in parent list of platforms
+    void LinuxOnly() // => not valid call site; no warnings no matter what
+    {
+        ApiUnsupportedOnBrowser();
+        Console.Beep(10, 20);
+    }*/
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
         private string GetFormattedString(string resource, params string[] args) =>

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -171,31 +171,31 @@ public class Test
 {
     void ThrowWithStringArgument()
     {
-        SR.Message = ""nOT Warns not reachable on Browser"";
+        SR.Message = ""Not warn"";
         throw new PlatformNotSupportedException(SR.Message);
     }
 
     void ThrowNotSupportedWithStringArgument()
     {
-        SR.Message = ""Warns not reachable on Browser"";
+        SR.Message = ""Not warn"";
         throw new NotSupportedException(SR.Message);
     }
     
     void ThrowWithNoArgument()
     {
-        SR.Message = ""Warns not reachable on Browser"";
+        SR.Message = ""Not warn"";
         throw new PlatformNotSupportedException();
     }
     
     void ThrowWithStringAndExceptionConstructor()
     {
-        SR.Message = ""Warns not reachable on Browser"";
+        SR.Message = ""Not warn"";
         throw new PlatformNotSupportedException(SR.Message, new Exception());
     }
     
     void ThrowWithAnotherExceptionUsingResourceString()
     {
-        SR.Message = ""Warns not reachable on Browser"";
+        SR.Message = ""Not warn"";
         throw new PlatformNotSupportedException(SR.Message, new Exception(SR.Message));
     }
 }";

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -171,31 +171,31 @@ public class Test
 {
     void ThrowWithStringArgument()
     {
-        SR.Message = ""Not warn"";
+        SR.Message = ""This does not warn because this code is not reachable on any"";
         throw new PlatformNotSupportedException(SR.Message);
     }
 
     void ThrowNotSupportedWithStringArgument()
     {
-        SR.Message = ""Not warn"";
+        SR.Message = ""This does not warn because this code is not reachable on any"";
         throw new NotSupportedException(SR.Message);
     }
     
     void ThrowWithNoArgument()
     {
-        SR.Message = ""Not warn"";
+        SR.Message = ""This does not warn because this code is not reachable on any"";
         throw new PlatformNotSupportedException();
     }
     
     void ThrowWithStringAndExceptionConstructor()
     {
-        SR.Message = ""Not warn"";
+        SR.Message = ""This does not warn because this code is not reachable on any"";
         throw new PlatformNotSupportedException(SR.Message, new Exception());
     }
     
     void ThrowWithAnotherExceptionUsingResourceString()
     {
-        SR.Message = ""Not warn"";
+        SR.Message = ""This does not warn because this code is not reachable on any"";
         throw new PlatformNotSupportedException(SR.Message, new Exception(SR.Message));
     }
 }";

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -169,7 +169,7 @@ public static class SR
 [UnsupportedOSPlatform(""browser"")]
 public class Test
 {
-    /*void ThrowWithStringArgument()
+    void ThrowWithStringArgument()
     {
         SR.Message = ""nOT Warns not reachable on Browser"";
         throw new PlatformNotSupportedException(SR.Message);
@@ -191,7 +191,7 @@ public class Test
     {
         SR.Message = ""Warns not reachable on Browser"";
         throw new PlatformNotSupportedException(SR.Message, new Exception());
-    }*/
+    }
     
     void ThrowWithAnotherExceptionUsingResourceString()
     {
@@ -3390,7 +3390,7 @@ class Test
     [UnsupportedOSPlatform(""browser"")]
     private static void ApiUnsupportedOnBrowser () { }
 
-    /*[SupportedOSPlatform(""macos"")]
+    [SupportedOSPlatform(""macos"")]
     class TestMacOs // Inside only mac accessable
     {
         [SupportedOSPlatform(""windows"")]
@@ -3399,7 +3399,7 @@ class Test
             Test.ApiUnsupportedOnBrowser();
             Console.Beep(10, 20); // Windows only API
         }
-    }*/
+    }
 
     void MethodHasNoAttribute()
     {
@@ -3407,7 +3407,7 @@ class Test
         [|Console.Beep(10, 20)|];      // This call site is reachable on: 'macos', 'browser', 'windows'. 'Console.Beep(int, int)' is only supported on: 'windows'.
     }
 
-    /*[SupportedOSPlatform(""WINDOWS"")]
+    [SupportedOSPlatform(""WINDOWS"")]
     void WindowsOnly() // Nothing should warn
     {
         ApiUnsupportedOnBrowser();
@@ -3419,7 +3419,7 @@ class Test
     {
         ApiUnsupportedOnBrowser();
         Console.Beep(10, 20);
-    }*/
+    }
 }";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }

--- a/src/Utilities/Compiler/SmallDictionary.cs
+++ b/src/Utilities/Compiler/SmallDictionary.cs
@@ -68,6 +68,8 @@ namespace Analyzer.Utilities
             return Comparer.GetHashCode(k);
         }
 
+        public bool IsEmpty => _root == null;
+
         public bool TryGetValue(K key, [MaybeNullWhen(returnValue: false)] out V value)
         {
             if (_root != null)

--- a/src/Utilities/Compiler/SmallDictionary.cs
+++ b/src/Utilities/Compiler/SmallDictionary.cs
@@ -70,6 +70,112 @@ namespace Analyzer.Utilities
 
         public bool IsEmpty => _root == null;
 
+        public void Remove(K key)
+        {
+            _root = Remove(_root, GetHashCode(key));
+        }
+
+        private AvlNode? Remove(AvlNode? currentNode, int hashCode)
+        {
+            if (currentNode == null)
+            {
+                return null;
+            }
+
+            var hc = currentNode.HashCode;
+
+            if (hc > hashCode)
+            {
+                currentNode.Left = Remove(currentNode.Left, hashCode);
+            }
+            else if (hc < hashCode)
+            {
+                currentNode.Right = Remove(currentNode.Right, hashCode);
+            }
+            else
+            {
+                // node with only one child or no child  
+                if ((currentNode.Left == null) || (currentNode.Right == null))
+                {
+                    AvlNode? temp = null;
+                    if (temp == currentNode.Left)
+                        temp = currentNode.Right;
+                    else
+                        temp = currentNode.Left;
+
+                    // No child case  
+                    if (temp == null)
+                    {
+                        currentNode = null;
+                    }
+                    else // One child case  
+                    {
+                        currentNode = temp;
+                    }
+                }
+                else
+                {
+                    // node with two children; get the smallest in the right subtree  
+                    AvlNode temp = MinValueNode(currentNode.Right);
+
+                    // Copy the smallest in the right successor's data to this node  
+                    currentNode.HashCode = temp.HashCode;
+                    currentNode.Value = temp.Value;
+                    currentNode.Key = temp.Key;
+
+                    // Delete the smallest in the right successor  
+                    currentNode.Right = Remove(currentNode.Right, temp.HashCode);
+                }
+            }
+
+            if (currentNode == null)
+                return null;
+
+            currentNode.Balance = (sbyte)(Height(currentNode.Left) - Height(currentNode.Right));
+
+            AvlNode rotated;
+            var balance = currentNode.Balance;
+
+            if (balance == -2)
+            {
+                rotated = currentNode.Right!.Balance < 0 ?
+                    LeftSimple(currentNode) :
+                    LeftComplex(currentNode);
+            }
+            else if (balance == 2)
+            {
+                rotated = currentNode.Left!.Balance > 0 ?
+                    RightSimple(currentNode) :
+                    RightComplex(currentNode);
+            }
+            else
+            {
+                return currentNode;
+            }
+
+            return rotated;
+        }
+
+        private static AvlNode MinValueNode(AvlNode node)
+        {
+            AvlNode current = node;
+
+            while (current.Left != null)
+                current = current.Left;
+
+            return current;
+        }
+
+        private static int Height(AvlNode? node)
+        {
+            if (node == null) return 0;
+
+            int a = Height(node.Left);
+            int b = Height(node.Right);
+
+            return 1 + Math.Max(a, b);
+        }
+
         public bool TryGetValue(K key, [MaybeNullWhen(returnValue: false)] out V value)
         {
             if (_root != null)
@@ -118,7 +224,7 @@ namespace Analyzer.Utilities
 #pragma warning restore CA1822
         private abstract class Node
         {
-            public readonly K Key;
+            public K Key;
             public V Value;
 
             protected Node(K key, V value)
@@ -161,7 +267,7 @@ namespace Analyzer.Utilities
         // Balance is also here for better packing of AvlNode on 64bit
         private abstract class HashedNode : Node
         {
-            public readonly int HashCode;
+            public int HashCode;
             public sbyte Balance;
 
             protected HashedNode(int hashCode, K key, V value)


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/44231

[By design](https://github.com/dotnet/designs/blob/main/accepted/2020/platform-checks/platform-checks.md#platform-context), SDK adds SuuportedOSPlatform attribute with the targeted OS platform from TFMs, which works well for normal condition but for multitargeted env like `runtime` repo it is causing warnings mentioned in  https://github.com/dotnet/runtime/issues/44231 and requiring clear separation of platform-specific APIs which forcing developers to duplicate their code to conform to the strict supported-platform name rules. After evaluating of possible solution and several discussions we have decided to resolve it at the analyzer level. The TFM target attributes are causing inconsistent scenarios in the call site and the real attributes within that assembly are being ignored or malfunctioned which causing the warnings, this shouldn't happen in normal development. By the main rule of "Child API attributes cannot widen parent or containing type attributes" when the inconsistency happens in the call site and call site evaluated to an empty set of support not gonna warn within that empty set context.

cc @jeffhandley @terrajobst  

Examples:
```cs
[SupportedOSPlatform("windows7")]
class Test1
{
    [UnsupportedOSPlatform("windows9")]
    void StillSupportedOnWindows7and8()
    {
        SupportedOnWindows10(); // Warning; calling from Windows 7-8 is still supported but it will fail
    }
    [UnsupportedOSPlatform("windows7")]
    void NotSupportedAnywhere()
    {
        SupportedOnWindows10(); // No warning; no valid call sites
    }
    [SupportedOSPlatform("windows10")]
    void SupportedOnWindows10()
    {
    }
}
[SupportedOSPlatform("windows")]
[SupportedOSPlatform("macos")]
class Test2
{
    [SupportedOSPlatform("macos")]
    class Test2MacOs
    {
        [SupportedOSPlatform("windows")]
        void WindowsOnly()
        {
            // No valid call sites; no warnings no matter what
        }
        [SupportedOSPlatform("linux")]
        void LinuxOnly()
        {
            // No valid call sites; no warnings no matter what
        }
    }
}
```