### PR TITLE
Remove workaround for fixed issue

### DIFF
--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -70,11 +70,6 @@ namespace Test.Utilities
                 var commandLineArguments = CSharpCommandLineParser.Default.Parse(args, baseDirectory: Environment.CurrentDirectory, sdkDirectory: Environment.CurrentDirectory);
                 var nullableWarnings = commandLineArguments.CompilationOptions.SpecificDiagnosticOptions;
 
-                // Workaround for https://github.com/dotnet/roslyn/issues/41610
-                nullableWarnings = nullableWarnings
-                    .SetItem("CS8632", ReportDiagnostic.Error)
-                    .SetItem("CS8669", ReportDiagnostic.Error);
-
                 return nullableWarnings;
             }
 


### PR DESCRIPTION
<!--

Make sure to run `msbuild /t:pack /v:m` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.


-->
