### PR TITLE
Resources pass for code quality analyzers (add single ticks around placeholders)

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
@@ -118,58 +118,58 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AvoidAsyncVoidTitle" xml:space="preserve">
-    <value>Avoid Async Void</value>
+    <value>Avoid 'async void'.</value>
   </data>
   <data name="AvoidAsyncVoidDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="AvoidAsyncVoidMessage" xml:space="preserve">
-    <value>Avoid Async Void</value>
+    <value>Avoid 'async void'.</value>
   </data>
   <data name="AsyncMethodNamesShouldEndInAsyncTitle" xml:space="preserve">
-    <value>Async Method Names Should End in Async</value>
+    <value>Async method names should end in 'Async'</value>
   </data>
   <data name="AsyncMethodNamesShouldEndInAsyncDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="AsyncMethodNamesShouldEndInAsyncMessage" xml:space="preserve">
-    <value>Async Method Names Should End in Async</value>
+    <value>Async method names should end in 'Async'</value>
   </data>
   <data name="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle" xml:space="preserve">
-    <value>Don't Pass Async Lambdas as Void Returning Delegate Types</value>
+    <value>Don't pass async lambdas as void returning delegate types</value>
   </data>
   <data name="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage" xml:space="preserve">
-    <value>Don't Pass Async Lambdas as Void Returning Delegate Types</value>
+    <value>Don't pass async lambdas as void returning delegate types</value>
   </data>
   <data name="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle" xml:space="preserve">
-    <value>Don't Store Async Lambdas as Void Returning Delegate Types</value>
+    <value>Don't store async lambdas as void returning delegate types</value>
   </data>
   <data name="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage" xml:space="preserve">
-    <value>Don't Store Async Lambdas as Void Returning Delegate Types</value>
+    <value>Don't store async lambdas as void returning delegate types</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleTitle" xml:space="preserve">
-    <value>Propagate CancellationTokens When Possible</value>
+    <value>Propagate 'CancellationToken's when possible</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="PropagateCancellationTokensWhenPossibleMessage" xml:space="preserve">
-    <value>Propagate CancellationTokens When Possible</value>
+    <value>Propagate 'CancellationToken's when possible</value>
   </data>
   <data name="DoNotMixBlockingAndAsyncTitle" xml:space="preserve">
-    <value>Don't Mix Blocking and Async</value>
+    <value>Don't mix blocking and async</value>
   </data>
   <data name="DoNotMixBlockingAndAsyncDescription" xml:space="preserve">
     <value>#N/A</value>
   </data>
   <data name="DoNotMixBlockingAndAsyncMessage" xml:space="preserve">
-    <value>Don't Mix Blocking and Async</value>
+    <value>Don't mix blocking and async</value>
   </data>
   <data name="TypesThatOwnDisposableFieldsShouldBeDisposableTitle" xml:space="preserve">
     <value>Types that own disposable fields should be disposable</value>
@@ -208,13 +208,13 @@
     <value>The default value of an uninitialized enumeration, just as other value types, is zero. A nonflags-attributed enumeration should define a member by using the value of zero so that the default value is a valid value of the enumeration. If an enumeration that has the FlagsAttribute attribute applied defines a zero-valued member, its name should be ""None"" to indicate that no values have been set in the enumeration.</value>
   </data>
   <data name="EnumsShouldHaveZeroValueMessageFlagsRename" xml:space="preserve">
-    <value>In enum {0}, change the name of {1} to 'None'</value>
+    <value>In enum '{0}', change the name of '{1}' to 'None'</value>
   </data>
   <data name="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros" xml:space="preserve">
-    <value>Remove all members that have the value zero from {0} except for one member that is named 'None'</value>
+    <value>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</value>
   </data>
   <data name="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue" xml:space="preserve">
-    <value>Add a member to {0} that has a value of zero with a suggested name of 'None'</value>
+    <value>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</value>
   </data>
   <data name="AbstractTypesShouldNotHaveConstructorsTitle" xml:space="preserve">
     <value>Abstract types should not have public constructors</value>
@@ -229,10 +229,10 @@
     <value>Mark assemblies with CLSCompliant</value>
   </data>
   <data name="MarkAssembliesWithClsCompliantDescription" xml:space="preserve">
-    <value>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</value>
+    <value>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</value>
   </data>
   <data name="MarkAssembliesWithClsCompliantMessage" xml:space="preserve">
-    <value>Mark assemblies with CLSCompliant</value>
+    <value>Mark assemblies with 'CLSCompliant'</value>
   </data>
   <data name="MarkAssembliesWithAssemblyVersionTitle" xml:space="preserve">
     <value>Mark assemblies with assembly version</value>
@@ -244,28 +244,28 @@
     <value>Mark assemblies with assembly version</value>
   </data>
   <data name="MarkAssembliesWithComVisibleTitle" xml:space="preserve">
-    <value>Mark assemblies with ComVisible</value>
+    <value>Mark assemblies with 'ComVisible'</value>
   </data>
   <data name="MarkAssembliesWithComVisibleDescription" xml:space="preserve">
     <value>ComVisibleAttribute determines how COM clients access managed code. Good design dictates that assemblies explicitly indicate COM visibility. COM visibility can be set for the whole assembly and then overridden for individual types and type members. If this attribute is not present, the contents of the assembly are visible to COM clients.</value>
   </data>
   <data name="MarkAssembliesWithComVisibleMessageNoAttribute" xml:space="preserve">
-    <value>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</value>
+    <value>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</value>
   </data>
   <data name="MarkAssembliesWithComVisibleMessageAttributeTrue" xml:space="preserve">
     <value>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level.</value>
   </data>
   <data name="MarkAttributesWithAttributeUsageTitle" xml:space="preserve">
-    <value>Mark attributes with AttributeUsageAttribute</value>
+    <value>Mark attributes with 'AttributeUsageAttribute'</value>
   </data>
   <data name="MarkAttributesWithAttributeUsageDescription" xml:space="preserve">
-    <value>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</value>
+    <value>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</value>
   </data>
   <data name="MarkAttributesWithAttributeUsageMessageDefault" xml:space="preserve">
-    <value>Specify AttributeUsage on {0}</value>
+    <value>Specify AttributeUsage on '{0}'</value>
   </data>
   <data name="MarkAttributesWithAttributeUsageMessageInherited" xml:space="preserve">
-    <value>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</value>
+    <value>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</value>
   </data>
   <data name="DefineAccessorsForAttributeArgumentsTitle" xml:space="preserve">
     <value>Define accessors for attribute arguments</value>
@@ -274,31 +274,31 @@
     <value>Attributes can define mandatory arguments that must be specified when you apply the attribute to a target. These are also known as positional arguments because they are supplied to attribute constructors as positional parameters. For every mandatory argument, the attribute should also provide a corresponding read-only property so that the value of the argument can be retrieved at execution time. Attributes can also define optional arguments, which are also known as named arguments. These arguments are supplied to attribute constructors by name and should have a corresponding read/write property.</value>
   </data>
   <data name="DefineAccessorsForAttributeArgumentsMessageDefault" xml:space="preserve">
-    <value>Add a public read-only property accessor for positional argument {0} of Attribute {1}</value>
+    <value>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</value>
   </data>
   <data name="DefineAccessorsForAttributeArgumentsMessageRemoveSetter" xml:space="preserve">
-    <value>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</value>
+    <value>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</value>
   </data>
   <data name="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility" xml:space="preserve">
-    <value>If {0} is the property accessor for positional argument {1}, make it public</value>
+    <value>If '{0}' is the property accessor for positional argument '{1}', make it public</value>
   </data>
   <data name="UsePropertiesWhereAppropriateTitle" xml:space="preserve">
     <value>Use properties where appropriate</value>
   </data>
   <data name="UsePropertiesWhereAppropriateDescription" xml:space="preserve">
-    <value>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</value>
+    <value>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</value>
   </data>
   <data name="UsePropertiesWhereAppropriateMessage" xml:space="preserve">
     <value>Use properties where appropriate</value>
   </data>
   <data name="MarkEnumsWithFlagsTitle" xml:space="preserve">
-    <value>Mark enums with FlagsAttribute</value>
+    <value>Mark enums with 'FlagsAttribute'</value>
   </data>
   <data name="MarkEnumsWithFlagsDescription" xml:space="preserve">
-    <value>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</value>
+    <value>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</value>
   </data>
   <data name="MarkEnumsWithFlagsMessage" xml:space="preserve">
-    <value>Mark enums with FlagsAttribute</value>
+    <value>Mark enums with 'FlagsAttribute'</value>
   </data>
   <data name="InterfaceMethodsShouldBeCallableByChildTypesTitle" xml:space="preserve">
     <value>Interface methods should be callable by child types</value>
@@ -313,13 +313,13 @@
     <value>Override methods on comparable types</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesDescription" xml:space="preserve">
-    <value>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</value>
+    <value>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesMessageEquals" xml:space="preserve">
-    <value>{0} should override Equals since it implements IComparable</value>
+    <value>'{0}' should override 'Equals' since it implements 'IComparable'</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesMessageOperator" xml:space="preserve">
-    <value>{0} should define operator(s) '{1}' since it implements IComparable</value>
+    <value>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</value>
     <comment>1 is a comma-separated list</comment>
   </data>
   <data name="MovePInvokesToNativeMethodsClassTitle" xml:space="preserve">
@@ -344,13 +344,13 @@
     <value>Identifiers should have correct prefix</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectPrefixDescription" xml:space="preserve">
-    <value>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</value>
+    <value>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectPrefixMessageInterface" xml:space="preserve">
-    <value>Prefix interface name {0} with 'I'</value>
+    <value>Prefix interface name '{0}' with 'I'</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter" xml:space="preserve">
-    <value>Prefix generic type parameter name {0} with 'T'</value>
+    <value>Prefix generic type parameter name '{0}' with 'T'</value>
   </data>
   <data name="NonConstantFieldsShouldNotBeVisibleTitle" xml:space="preserve">
     <value>Non-constant fields should not be visible</value>
@@ -362,13 +362,13 @@
     <value>Non-constant fields should not be visible</value>
   </data>
   <data name="DoNotMarkEnumsWithFlagsTitle" xml:space="preserve">
-    <value>Do not mark enums with FlagsAttribute</value>
+    <value>Do not mark enums with 'FlagsAttribute'</value>
   </data>
   <data name="DoNotMarkEnumsWithFlagsDescription" xml:space="preserve">
-    <value>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</value>
+    <value>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</value>
   </data>
   <data name="DoNotMarkEnumsWithFlagsMessage" xml:space="preserve">
-    <value>Do not mark enums with FlagsAttribute</value>
+    <value>Do not mark enums with 'FlagsAttribute'</value>
   </data>
   <data name="OperatorOverloadsHaveNamedAlternatesTitle" xml:space="preserve">
     <value>Operator overloads have named alternates</value>
@@ -377,16 +377,16 @@
     <value>An operator overload was detected, and the expected named alternative method was not found. The named alternative member provides access to the same functionality as the operator and is provided for developers who program in languages that do not support overloaded operators.</value>
   </data>
   <data name="OperatorOverloadsHaveNamedAlternatesMessageDefault" xml:space="preserve">
-    <value>Provide a method named '{0}' as a friendly alternate for operator {1}</value>
+    <value>Provide a method named '{0}' as a friendly alternate for operator '{1}'</value>
   </data>
   <data name="OperatorOverloadsHaveNamedAlternatesMessageProperty" xml:space="preserve">
-    <value>Provide a property named '{0}' as a friendly alternate for operator {1}</value>
+    <value>Provide a property named '{0}' as a friendly alternate for operator '{1}'</value>
   </data>
   <data name="OperatorOverloadsHaveNamedAlternatesMessageMultiple" xml:space="preserve">
-    <value>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</value>
+    <value>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</value>
   </data>
   <data name="OperatorOverloadsHaveNamedAlternatesMessageVisibility" xml:space="preserve">
-    <value>Mark {0} as public because it is a friendly alternate for operator {1}</value>
+    <value>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</value>
   </data>
   <data name="OperatorsShouldHaveSymmetricalOverloadsTitle" xml:space="preserve">
     <value>Operators should have symmetrical overloads</value>
@@ -425,13 +425,13 @@
     <value>Modify '{0}' to call '{1}' instead of '{2}'</value>
   </data>
   <data name="ImplementIEquatableWhenOverridingObjectEqualsMessage" xml:space="preserve">
-    <value>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</value>
+    <value>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</value>
   </data>
   <data name="ImplementIEquatableWhenOverridingObjectEqualsTitle" xml:space="preserve">
-    <value>Implement IEquatable when overriding Object.Equals</value>
+    <value>Implement 'IEquatable' when overriding 'Object.Equals'</value>
   </data>
   <data name="CancellationTokenParametersMustComeLastTitle" xml:space="preserve">
-    <value>CancellationToken parameters must come last</value>
+    <value>'CancellationToken' parameters must come last</value>
   </data>
   <data name="CancellationTokenParametersMustComeLastMessage" xml:space="preserve">
     <value>Method '{0}' should take CancellationToken as the last parameter</value>
@@ -464,25 +464,25 @@
     <value>Make the setter of the property non-public</value>
   </data>
   <data name="AddAssemblyLevelComVisibleFalse" xml:space="preserve">
-    <value>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</value>
+    <value>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</value>
   </data>
   <data name="ChangeAssemblyLevelComVisibleToFalse" xml:space="preserve">
-    <value>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</value>
+    <value>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</value>
   </data>
   <data name="ImplementComparable" xml:space="preserve">
     <value>Implement Equality and Comparison methods and operators</value>
   </data>
   <data name="ImplementEquatable" xml:space="preserve">
-    <value>Implement IEquatable</value>
+    <value>Implement 'IEquatable'</value>
   </data>
   <data name="ImplementIDisposableInterface" xml:space="preserve">
-    <value>Implement IDisposable Interface</value>
+    <value>Implement 'IDisposable' Interface</value>
   </data>
   <data name="DoNotMarkEnumsWithFlagsCodeFix" xml:space="preserve">
-    <value>Remove FlagsAttribute from enum.</value>
+    <value>Remove 'FlagsAttribute' from enum.</value>
   </data>
   <data name="MarkEnumsWithFlagsCodeFix" xml:space="preserve">
-    <value>Apply FlagsAttribute to enum.</value>
+    <value>Apply 'FlagsAttribute' to enum.</value>
   </data>
   <data name="EnumsShouldZeroValueFlagsMultipleZeroCodeFix" xml:space="preserve">
     <value>Remove all members that have the value zero except for one member that is named 'None'.</value>
@@ -515,13 +515,13 @@
     <value>Type '{0}' directly or indirectly inherits '{1}' without implementing '{2}'. Publicly-visible types should implement the generic version to broaden usability.</value>
   </data>
   <data name="EnumStorageShouldBeInt32Title" xml:space="preserve">
-    <value>Enum Storage should be Int32</value>
+    <value>Enum Storage should be 'Int32'</value>
   </data>
   <data name="EnumStorageShouldBeInt32Description" xml:space="preserve">
     <value>An enumeration is a value type that defines a set of related named constants. By default, the System.Int32 data type is used to store the constant value. Although you can change this underlying type, it is not required or recommended for most scenarios.</value>
   </data>
   <data name="EnumStorageShouldBeInt32Message" xml:space="preserve">
-    <value>If possible, make the underlying type of {0} System.Int32 instead of {1}</value>
+    <value>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</value>
   </data>
   <data name="UseEventsWhereAppropriateTitle" xml:space="preserve">
     <value>Use events where appropriate</value>
@@ -539,10 +539,10 @@
     <value>Failure to provide the full set of constructors can make it difficult to correctly handle exceptions.</value>
   </data>
   <data name="ImplementStandardExceptionConstructorsMessageMissingConstructor" xml:space="preserve">
-    <value>Add the following constructor to {0}: {1}</value>
+    <value>Add the following constructor to '{0}': '{1}'</value>
   </data>
   <data name="ImplementStandardExceptionConstructorsMessageAccessibility" xml:space="preserve">
-    <value>Change the accessibility of {0} to {1}.</value>
+    <value>Change the accessibility of '{0}' to '{1}.'</value>
   </data>
   <data name="NestedTypesShouldNotBeVisibleTitle" xml:space="preserve">
     <value>Nested types should not be visible</value>
@@ -551,10 +551,10 @@
     <value>A nested type is a type that is declared in the scope of another type. Nested types are useful to encapsulate private implementation details of the containing type. Used for this purpose, nested types should not be externally visible.</value>
   </data>
   <data name="NestedTypesShouldNotBeVisibleMessageDefault" xml:space="preserve">
-    <value>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</value>
+    <value>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</value>
   </data>
   <data name="NestedTypesShouldNotBeVisibleMessageVisualBasicModule" xml:space="preserve">
-    <value>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</value>
+    <value>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</value>
   </data>
   <data name="AvoidEmptyInterfacesTitle" xml:space="preserve">
     <value>Avoid empty interfaces</value>
@@ -566,13 +566,13 @@
     <value>Avoid empty interfaces</value>
   </data>
   <data name="ProvideObsoleteAttributeMessageTitle" xml:space="preserve">
-    <value>Provide ObsoleteAttribute message</value>
+    <value>Provide 'ObsoleteAttribute' message</value>
   </data>
   <data name="ProvideObsoleteAttributeMessageDescription" xml:space="preserve">
-    <value>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</value>
+    <value>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</value>
   </data>
   <data name="ProvideObsoleteAttributeMessageMessage" xml:space="preserve">
-    <value>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</value>
+    <value>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</value>
   </data>
   <data name="PropertiesShouldNotBeWriteOnlyTitle" xml:space="preserve">
     <value>Properties should not be write only</value>
@@ -581,10 +581,10 @@
     <value>Although it is acceptable and often necessary to have a read-only property, the design guidelines prohibit the use of write-only properties. This is because letting a user set a value, and then preventing the user from viewing that value, does not provide any security. Also, without read access, the state of shared objects cannot be viewed, which limits their usefulness.</value>
   </data>
   <data name="PropertiesShouldNotBeWriteOnlyMessageAddGetter" xml:space="preserve">
-    <value>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</value>
+    <value>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</value>
   </data>
   <data name="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible" xml:space="preserve">
-    <value>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</value>
+    <value>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</value>
   </data>
   <data name="DeclareTypesInNamespacesTitle" xml:space="preserve">
     <value>Declare types in namespaces</value>
@@ -632,19 +632,19 @@
     <value>Change the type of property '{0}' from 'string' to 'System.Uri'</value>
   </data>
   <data name="ImplementIDisposableCorrectlyTitle" xml:space="preserve">
-    <value>Implement IDisposable Correctly</value>
+    <value>Implement 'IDisposable' Correctly</value>
   </data>
   <data name="ImplementIDisposableCorrectlyDescription" xml:space="preserve">
-    <value>All IDisposable types should implement the Dispose pattern correctly.</value>
+    <value>All 'IDisposable' types should implement the Dispose pattern correctly.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageIDisposableReimplementation" xml:space="preserve">
-    <value>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</value>
+    <value>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageFinalizeOverride" xml:space="preserve">
-    <value>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</value>
+    <value>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeOverride" xml:space="preserve">
-    <value>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</value>
+    <value>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeSignature" xml:space="preserve">
     <value>Ensure that '{0}' is declared as public and sealed</value>
@@ -656,19 +656,19 @@
     <value>Ensure that '{0}' is declared as protected, virtual, and unsealed</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageDisposeImplementation" xml:space="preserve">
-    <value>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</value>
+    <value>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageFinalizeImplementation" xml:space="preserve">
-    <value>Modify '{0}' so that it calls Dispose(false) and then returns</value>
+    <value>Modify '{0}' so that it calls 'Dispose(false)' and then returns</value>
   </data>
   <data name="ImplementIDisposableCorrectlyMessageProvideDisposeBool" xml:space="preserve">
-    <value>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</value>
+    <value>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</value>
   </data>
   <data name="ExceptionsShouldBePublicTitle" xml:space="preserve">
     <value>Exceptions should be public</value>
   </data>
   <data name="ExceptionsShouldBePublicDescription" xml:space="preserve">
-    <value>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</value>
+    <value>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</value>
   </data>
   <data name="ExceptionsShouldBePublicMessage" xml:space="preserve">
     <value>Exceptions should be public</value>
@@ -680,43 +680,43 @@
     <value>A method that is not expected to throw exceptions throws an exception.</value>
   </data>
   <data name="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter" xml:space="preserve">
-    <value>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</value>
+    <value>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</value>
   </data>
   <data name="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions" xml:space="preserve">
-    <value>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</value>
+    <value>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</value>
   </data>
   <data name="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions" xml:space="preserve">
-    <value>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</value>
+    <value>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresTitle" xml:space="preserve">
     <value>Identifiers should not contain underscores</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresDescription" xml:space="preserve">
-    <value>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</value>
+    <value>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageAssembly" xml:space="preserve">
-    <value>Remove the underscores from assembly name {0}</value>
+    <value>Remove the underscores from assembly name '{0}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageNamespace" xml:space="preserve">
     <value>Remove the underscores from namespace name '{0}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageType" xml:space="preserve">
-    <value>Remove the underscores from type name {0}</value>
+    <value>Remove the underscores from type name '{0}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageMember" xml:space="preserve">
-    <value>Remove the underscores from member name {0}</value>
+    <value>Remove the underscores from member name '{0}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter" xml:space="preserve">
-    <value>On type {0}, remove the underscores from generic type parameter name {1}</value>
+    <value>On type '{0}', remove the underscores from generic type parameter name '{1}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter" xml:space="preserve">
-    <value>On method {0}, remove the underscores from generic type parameter name {1}</value>
+    <value>On method '{0}', remove the underscores from generic type parameter name '{1}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageMemberParameter" xml:space="preserve">
-    <value>In member {0}, remove the underscores from parameter name {1}</value>
+    <value>In member '{0}', remove the underscores from parameter name '{1}'</value>
   </data>
   <data name="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter" xml:space="preserve">
-    <value>In delegate {0}, remove the underscores from parameter name {1}</value>
+    <value>In delegate '{0}', remove the underscores from parameter name '{1}'</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectSuffixTitle" xml:space="preserve">
     <value>Identifiers should have correct suffix</value>
@@ -725,10 +725,10 @@
     <value>By convention, the names of types that extend certain base types or that implement certain interfaces, or types that are derived from these types, have a suffix that is associated with the base type or interface.</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectSuffixMessageDefault" xml:space="preserve">
-    <value>Rename {0} to end in '{1}'</value>
+    <value>Rename '{0}' to end in '{1}'</value>
   </data>
   <data name="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection" xml:space="preserve">
-    <value>Rename {0} to end in either 'Collection' or '{1}'</value>
+    <value>Rename '{0}' to end in either 'Collection' or '{1}'</value>
   </data>
   <data name="IdentifiersShouldNotHaveIncorrectSuffixTitle" xml:space="preserve">
     <value>Identifiers should not have incorrect suffix</value>
@@ -737,13 +737,13 @@
     <value>By convention, only the names of types that extend certain base types or that implement certain interfaces, or types that are derived from these types, should end with specific reserved suffixes. Other type names should not use these reserved suffixes.</value>
   </data>
   <data name="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate" xml:space="preserve">
-    <value>Rename type name {0} so that it does not end in '{1}'</value>
+    <value>Rename type name '{0}' so that it does not end in '{1}'</value>
   </data>
   <data name="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion" xml:space="preserve">
-    <value>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</value>
+    <value>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</value>
   </data>
   <data name="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion" xml:space="preserve">
-    <value>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</value>
+    <value>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</value>
   </data>
   <data name="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate" xml:space="preserve">
     <value>Either replace the suffix '{0}' in member name '{1}' with the suggested alternate '{2}' or remove the suffix completely</value>
@@ -755,22 +755,22 @@
     <value>A namespace name or a type name matches a reserved keyword in a programming language. Identifiers for namespaces and types should not match keywords that are defined by languages that target the common language runtime.</value>
   </data>
   <data name="IdentifiersShouldNotMatchKeywordsMessageMemberParameter" xml:space="preserve">
-    <value>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</value>
+    <value>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</value>
   </data>
   <data name="IdentifiersShouldNotMatchKeywordsMessageMember" xml:space="preserve">
-    <value>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</value>
+    <value>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</value>
   </data>
   <data name="IdentifiersShouldNotMatchKeywordsMessageType" xml:space="preserve">
-    <value>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</value>
+    <value>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</value>
   </data>
   <data name="IdentifiersShouldNotMatchKeywordsMessageNamespace" xml:space="preserve">
-    <value>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</value>
+    <value>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</value>
   </data>
   <data name="PropertyNamesShouldNotMatchGetMethodsTitle" xml:space="preserve">
     <value>Property names should not match get methods</value>
   </data>
   <data name="PropertyNamesShouldNotMatchGetMethodsDescription" xml:space="preserve">
-    <value>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</value>
+    <value>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</value>
   </data>
   <data name="PropertyNamesShouldNotMatchGetMethodsMessage" xml:space="preserve">
     <value>The property name '{0}' is confusing given the existence of method '{1}'. Rename or remove one of these members.</value>
@@ -782,10 +782,10 @@
     <value>Type names should not match the names of namespaces that are defined in the .NET Framework class library. Violating this rule can reduce the usability of the library.</value>
   </data>
   <data name="TypeNamesShouldNotMatchNamespacesMessageDefault" xml:space="preserve">
-    <value>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</value>
+    <value>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</value>
   </data>
   <data name="TypeNamesShouldNotMatchNamespacesMessageSystem" xml:space="preserve">
-    <value>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</value>
+    <value>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</value>
   </data>
   <data name="ParameterNamesShouldMatchBaseDeclarationTitle" xml:space="preserve">
     <value>Parameter names should match base declaration</value>
@@ -794,7 +794,7 @@
     <value>Consistent naming of parameters in an override hierarchy increases the usability of the method overrides. A parameter name in a derived method that differs from the name in the base declaration can cause confusion about whether the method is an override of the base method or a new overload of the method.</value>
   </data>
   <data name="ParameterNamesShouldMatchBaseDeclarationMessage" xml:space="preserve">
-    <value>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</value>
+    <value>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</value>
   </data>
   <data name="UsePreferredTermsTitle" xml:space="preserve">
     <value>Use preferred terms</value>
@@ -803,52 +803,52 @@
     <value>The name of an externally visible identifier includes a term for which an alternative, preferred term exists. Alternatively, the name includes the term ""Flag"" or ""Flags"".</value>
   </data>
   <data name="UsePreferredTermsMessageAssembly" xml:space="preserve">
-    <value>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</value>
+    <value>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</value>
   </data>
   <data name="UsePreferredTermsMessageNamespace" xml:space="preserve">
     <value>Replace the term '{0}' in namespace name '{1}' with the preferred alternate '{2}'</value>
   </data>
   <data name="UsePreferredTermsMessageMemberParameter" xml:space="preserve">
-    <value>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</value>
+    <value>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</value>
   </data>
   <data name="UsePreferredTermsMessageDelegateParameter" xml:space="preserve">
-    <value>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</value>
+    <value>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</value>
   </data>
   <data name="UsePreferredTermsMessageTypeTypeParameter" xml:space="preserve">
-    <value>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</value>
+    <value>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</value>
   </data>
   <data name="UsePreferredTermsMessageMethodTypeParameter" xml:space="preserve">
-    <value>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</value>
+    <value>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</value>
   </data>
   <data name="UsePreferredTermsMessageType" xml:space="preserve">
-    <value>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</value>
+    <value>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</value>
   </data>
   <data name="UsePreferredTermsMessageMember" xml:space="preserve">
-    <value>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</value>
+    <value>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</value>
   </data>
   <data name="UsePreferredTermsMessageAssemblyNoAlternate" xml:space="preserve">
-    <value>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</value>
+    <value>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageNamespaceNoAlternate" xml:space="preserve">
     <value>Replace the term '{0}' in namespace name '{1}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageMemberParameterNoAlternate" xml:space="preserve">
-    <value>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</value>
+    <value>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageDelegateParameterNoAlternate" xml:space="preserve">
-    <value>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</value>
+    <value>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageTypeTypeParameterNoAlternate" xml:space="preserve">
-    <value>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</value>
+    <value>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageMethodTypeParameterNoAlternate" xml:space="preserve">
-    <value>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</value>
+    <value>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageTypeNoAlternate" xml:space="preserve">
-    <value>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</value>
+    <value>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="UsePreferredTermsMessageMemberNoAlternate" xml:space="preserve">
-    <value>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</value>
+    <value>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</value>
   </data>
   <data name="OverrideEqualsAndOperatorEqualsOnValueTypesTitle" xml:space="preserve">
     <value>Override equals and operator equals on value types</value>
@@ -857,10 +857,10 @@
     <value>For value types, the inherited implementation of Equals uses the Reflection library and compares the contents of all fields. Reflection is computationally expensive, and comparing every field for equality might be unnecessary. If you expect users to compare or sort instances, or to use instances as hash table keys, your value type should implement Equals.</value>
   </data>
   <data name="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals" xml:space="preserve">
-    <value>{0} should override Equals</value>
+    <value>'{0}' should override 'Equals'</value>
   </data>
   <data name="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality" xml:space="preserve">
-    <value>{0} should override the equality (==) and inequality (!=) operators</value>
+    <value>'{0}' should override the equality (==) and inequality (!=) operators</value>
   </data>
   <data name="PropertiesShouldNotReturnArraysTitle" xml:space="preserve">
     <value>Properties should not return arrays</value>
@@ -878,28 +878,28 @@
     <value>The strong name protects clients from unknowingly loading an assembly that has been tampered with. Assemblies without strong names should not be deployed outside very limited scenarios. If you share or distribute assemblies that are not correctly signed, the assembly can be tampered with, the common language runtime might not load the assembly, or the user might have to disable verification on his or her computer.</value>
   </data>
   <data name="AssembliesShouldHaveValidStrongNamesMessageNoStrongName" xml:space="preserve">
-    <value>Sign {0} with a strong name key.</value>
+    <value>Sign '{0}' with a strong name key.</value>
   </data>
   <data name="AssembliesShouldHaveValidStrongNamesMessageNotValid" xml:space="preserve">
-    <value>Verify that {0} has a valid strong name before deploying.</value>
+    <value>Verify that '{0}' has a valid strong name before deploying.</value>
   </data>
   <data name="OverrideGetHashCodeOnOverridingEqualsTitle" xml:space="preserve">
-    <value>Override GetHashCode on overriding Equals</value>
+    <value>Override 'GetHashCode' on overriding 'Equals'</value>
   </data>
   <data name="OverrideGetHashCodeOnOverridingEqualsDescription" xml:space="preserve">
-    <value>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</value>
+    <value>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</value>
   </data>
   <data name="OverrideGetHashCodeOnOverridingEqualsMessage" xml:space="preserve">
-    <value>Override GetHashCode on overriding Equals</value>
+    <value>Override 'GetHashCode' on overriding 'Equals'</value>
   </data>
   <data name="OverrideEqualsOnOverloadingOperatorEqualsTitle" xml:space="preserve">
-    <value>Override Equals on overloading operator equals</value>
+    <value>Override 'Equals' on overloading operator equals</value>
   </data>
   <data name="OverrideEqualsOnOverloadingOperatorEqualsDescription" xml:space="preserve">
-    <value>A public type implements the equality operator but does not override Object.Equals.</value>
+    <value>A public type implements the equality operator but does not override 'Object.Equals'.</value>
   </data>
   <data name="OverrideEqualsOnOverloadingOperatorEqualsMessage" xml:space="preserve">
-    <value>Override Equals on overloading operator equals</value>
+    <value>Override 'Equals' on overloading operator equals</value>
   </data>
   <data name="Since_0_redefines_operator_1_it_should_also_redefine_operator_2" xml:space="preserve">
     <value>Since '{0}' redefines operator '{1}', it should also redefine operator '{2}'</value>
@@ -908,13 +908,13 @@
     <value>Generate missing operators</value>
   </data>
   <data name="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle" xml:space="preserve">
-    <value>Override object.Equals</value>
+    <value>Override 'object.Equals'</value>
   </data>
   <data name="OverrideEqualsOnImplementingIEquatableCodeActionTitle" xml:space="preserve">
-    <value>Override object.Equals</value>
+    <value>Override 'object.Equals'</value>
   </data>
   <data name="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle" xml:space="preserve">
-    <value>Override object.GetHashCode</value>
+    <value>Override 'object.GetHashCode'</value>
   </data>
   <data name="MakeExceptionPublic" xml:space="preserve">
     <value>Make exception public</value>
@@ -935,13 +935,13 @@
     <value>Static holder types should be Static or NotInheritable</value>
   </data>
   <data name="MakeClassStatic" xml:space="preserve">
-    <value>Make Class Static</value>
+    <value>Make class static</value>
   </data>
   <data name="OverrideObjectEqualsMessage" xml:space="preserve">
-    <value>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</value>
+    <value>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</value>
   </data>
   <data name="OverrideObjectEqualsTitle" xml:space="preserve">
-    <value>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</value>
+    <value>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</value>
   </data>
   <data name="UseIntegralOrStringArgumentForIndexersDescription" xml:space="preserve">
     <value>Indexers, that is, indexed properties, should use integer or string types for the index. These types are typically used for indexing data structures and increase the usability of the library. Use of the Object type should be restricted to those cases where the specific integer or string type cannot be specified at design time. If the design requires other types for the index, reconsider whether the type represents a logical data store. If it does not represent a logical data store, use a method.</value>
@@ -953,13 +953,13 @@
     <value>Use Integral Or String Argument For Indexers</value>
   </data>
   <data name="DoNotDirectlyAwaitATaskDescription" xml:space="preserve">
-    <value>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</value>
+    <value>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</value>
   </data>
   <data name="DoNotDirectlyAwaitATaskMessage" xml:space="preserve">
-    <value>Consider calling ConfigureAwait on the awaited task</value>
+    <value>Consider calling 'ConfigureAwait' on the awaited task</value>
   </data>
   <data name="DoNotDirectlyAwaitATaskTitle" xml:space="preserve">
-    <value>Consider calling ConfigureAwait on the awaited task</value>
+    <value>Consider calling 'ConfigureAwait' on the awaited task</value>
   </data>
   <data name="AppendConfigureAwaitFalse" xml:space="preserve">
     <value>Append .ConfigureAwait(false)</value>
@@ -968,7 +968,7 @@
     <value>Append .ConfigureAwait(true)</value>
   </data>
   <data name="ImplementIEquatableWhenOverridingObjectEqualsDescription" xml:space="preserve">
-    <value>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</value>
+    <value>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</value>
   </data>
   <data name="OverrideObjectEqualsDescription" xml:space="preserve">
     <value>When a type T implements the interface IEquatable&lt;T&gt;, it suggests to a user who sees a call to the Equals method in source code that an instance of the type can be equated with an instance of any other type. The user might be confused if their attempt to equate the type with an instance of another type fails to compile. This violates the "principle of least surprise".</value>
@@ -986,7 +986,7 @@
     <value>Do not hide base class methods</value>
   </data>
   <data name="OverrideMethodsOnComparableTypesMessageBoth" xml:space="preserve">
-    <value>{0} should define operator(s) '{1}' and Equals since it implements IComparable</value>
+    <value>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</value>
     <comment>1 is a comma-separated list</comment>
   </data>
   <data name="DoNotCatchGeneralExceptionTypesDescription" xml:space="preserve">
@@ -1014,34 +1014,34 @@
     <value>A member calls a potentially dangerous or problematic method.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemGCCollect" xml:space="preserve">
-    <value>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</value>
+    <value>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume" xml:space="preserve">
-    <value>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</value>
+    <value>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend" xml:space="preserve">
-    <value>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</value>
+    <value>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember" xml:space="preserve">
-    <value>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</value>
+    <value>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageCoInitializeSecurity" xml:space="preserve">
-    <value>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</value>
+    <value>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket" xml:space="preserve">
-    <value>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</value>
+    <value>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle" xml:space="preserve">
-    <value>Remove the call to SafeHandle.DangerousGetHandle from {0}</value>
+    <value>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom" xml:space="preserve">
-    <value>Remove the call to Assembly.LoadFrom from {0}</value>
+    <value>Remove the call to 'Assembly.LoadFile' from '{0}'</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile" xml:space="preserve">
-    <value>Remove the call to Assembly.LoadFile from {0}</value>
+    <value>Remove the call to 'Assembly.LoadFile' from '{0}'</value>
   </data>
   <data name="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName" xml:space="preserve">
-    <value>Remove the call to Assembly.LoadWithPartialName from {0}</value>
+    <value>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</value>
   </data>
   <data name="CategoryReliability" xml:space="preserve">
     <value>Reliability</value>
@@ -1062,10 +1062,10 @@
     <value>An instance method declares a parameter or a local variable whose name matches an instance field of the declaring type, leading to errors.</value>
   </data>
   <data name="VariableNamesShouldNotMatchFieldNamesMessageLocal" xml:space="preserve">
-    <value>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</value>
+    <value>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</value>
   </data>
   <data name="VariableNamesShouldNotMatchFieldNamesMessageParameter" xml:space="preserve">
-    <value>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</value>
+    <value>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</value>
   </data>
   <data name="ReviewUnusedParametersTitle" xml:space="preserve">
     <value>Review unused parameters</value>
@@ -1074,7 +1074,7 @@
     <value>Avoid unused paramereters in your code. If the parameter cannot be removed, then change its name so it starts with an underscore and is optionally followed by an integer, such as '_', '_1', '_2', etc. These are treated as special discard symbol names.</value>
   </data>
   <data name="ReviewUnusedParametersMessage" xml:space="preserve">
-    <value>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</value>
+    <value>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</value>
   </data>
   <data name="RemoveUnusedParameterMessage" xml:space="preserve">
     <value>Remove unused parameter</value>
@@ -1086,16 +1086,16 @@
     <value>A new object is created but never used; or a method that creates and returns a new string is called and the new string is never used; or a COM or P/Invoke method returns an HRESULT or error code that is never used.</value>
   </data>
   <data name="DoNotIgnoreMethodResultsMessageObjectCreation" xml:space="preserve">
-    <value>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</value>
+    <value>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</value>
   </data>
   <data name="DoNotIgnoreMethodResultsMessageStringCreation" xml:space="preserve">
-    <value>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</value>
+    <value>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</value>
   </data>
   <data name="DoNotIgnoreMethodResultsMessageHResultOrErrorCode" xml:space="preserve">
-    <value>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</value>
+    <value>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</value>
   </data>
   <data name="DoNotIgnoreMethodResultsMessageTryParse" xml:space="preserve">
-    <value>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</value>
+    <value>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</value>
   </data>
   <data name="AvoidUninstantiatedInternalClassesTitle" xml:space="preserve">
     <value>Avoid uninstantiated internal classes</value>
@@ -1104,7 +1104,7 @@
     <value>An instance of an assembly-level type is not created by code in the assembly.</value>
   </data>
   <data name="AvoidUninstantiatedInternalClassesMessage" xml:space="preserve">
-    <value>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</value>
+    <value>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</value>
   </data>
   <data name="AvoidUnusedPrivateFieldsTitle" xml:space="preserve">
     <value>Avoid unused private fields</value>
@@ -1116,7 +1116,7 @@
     <value>Unused field '{0}'</value>
   </data>
   <data name="DoNotIgnoreMethodResultsMessagePureMethod" xml:space="preserve">
-    <value>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</value>
+    <value>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</value>
   </data>
   <data name="UseNameOfInPlaceOfStringDescription" xml:space="preserve">
     <value>Using nameof helps keep your code valid when refactoring.</value>
@@ -1212,13 +1212,13 @@
     <value>A jagged array is an array whose elements are arrays. The arrays that make up the elements can be of different sizes, leading to less wasted space for some sets of data.</value>
   </data>
   <data name="PreferJaggedArraysOverMultidimensionalMessageDefault" xml:space="preserve">
-    <value>{0} is a multidimensional array. Replace it with a jagged array if possible.</value>
+    <value>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</value>
   </data>
   <data name="PreferJaggedArraysOverMultidimensionalMessageReturn" xml:space="preserve">
-    <value>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</value>
+    <value>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</value>
   </data>
   <data name="PreferJaggedArraysOverMultidimensionalMessageBody" xml:space="preserve">
-    <value>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</value>
+    <value>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</value>
   </data>
   <data name="MarkMembersAsStaticTitle" xml:space="preserve">
     <value>Mark members as static</value>
@@ -1317,7 +1317,7 @@
     <value>Do not assign a property to itself</value>
   </data>
   <data name="AvoidPropertySelfAssignmentMessage" xml:space="preserve">
-    <value>The property {0} should not be assigned to itself</value>
+    <value>The property '{0}' should not be assigned to itself</value>
   </data>
   <data name="AssigningSymbolAndItsMemberInSameStatementDescription" xml:space="preserve">
     <value>Assigning to a symbol and its member (field/property) in the same statement is not recommended. It is not clear if the member access was intended to use symbol's old value prior to the assignment or new value from the assignment in this statement. For clarity, consider splitting the assignments into separate statements.</value>
@@ -1344,7 +1344,7 @@
     <value>Avoid 'out' parameters as they are not designed for general audience</value>
   </data>
   <data name="AvoidOutParametersTitle" xml:space="preserve">
-    <value>Avoid out parameters</value>
+    <value>Avoid 'out' parameters</value>
   </data>
   <data name="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart" xml:space="preserve">
     <value>The field reference '{0}' is duplicated in this bitwise initialization</value>
@@ -1368,7 +1368,7 @@
     <value>The more type parameters a generic type contains, the more difficult it is to know and remember what each type parameter represents.</value>
   </data>
   <data name="AvoidExcessiveParametersOnGenericTypesMessage" xml:space="preserve">
-    <value>Consider a design where '{0}' has no more than {1} type parameters</value>
+    <value>Consider a design where '{0}' has no more than '{1}' type parameters</value>
   </data>
   <data name="AvoidExcessiveParametersOnGenericTypesTitle" xml:space="preserve">
     <value>Avoid excessive parameters on generic types</value>
@@ -1386,7 +1386,7 @@
     <value>Do not name enum values 'Reserved'</value>
   </data>
   <data name="DoNotExposeGenericListsDescription" xml:space="preserve">
-    <value>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</value>
+    <value>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</value>
   </data>
   <data name="DoNotExposeGenericListsMessage" xml:space="preserve">
     <value>Change '{0}' in '{1}' to use 'Collection&lt;T&gt;', 'ReadOnlyCollection&lt;T&gt;' or 'KeyedCollection&lt;K,V&gt;'</value>
@@ -1419,7 +1419,7 @@
     <value>Do not pass types by reference</value>
   </data>
   <data name="DoNotPassTypesByReferenceDescription" xml:space="preserve">
-    <value>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</value>
+    <value>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</value>
   </data>
   <data name="EventsShouldNotHaveBeforeOrAfterPrefixDescription" xml:space="preserve">
     <value>Event names should describe the action that raises the event. To name related events that are raised in a specific sequence, use the present or past tense to indicate the relative position in the sequence of actions. For example, when naming a pair of events that is raised when closing a resource, you might name it 'Closing' and 'Closed', instead of 'BeforeClose' and 'AfterClose'.</value>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Vyhněte se Async Void.</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Vyhněte se Async Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Vyhněte se Async Void.</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Vyhněte se Async Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Názvy asynchronních metod mají končit na Async.</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Názvy asynchronních metod mají končit na Async.</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Názvy asynchronních metod mají končit na Async.</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Názvy asynchronních metod mají končit na Async.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Zvažte návrh, kde {0} nemá více než tento počet parametrů typu: {1}</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Zvažte návrh, kde {0} nemá více než tento počet parametrů typu: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Vyhněte se výstupním parametrům</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Vyhněte se výstupním parametrům</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; je obecná kolekce navržená pro výkon, nikoli dědičnost. List&lt;T&gt; neobsahuje virtuální členy, které by usnadňovaly změnu chování děděných tříd.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; je obecná kolekce navržená pro výkon, nikoli dědičnost. List&lt;T&gt; neobsahuje virtuální členy, které by usnadňovaly změnu chování děděných tříd.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nepředávejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nepředávejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nepředávejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nepředávejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Předávání typů podle odkazu (jako out nebo ref) vyžaduje zkušenost s ukazateli, porozumění rozdílu mezi hodnotovými a odkazovými typy a obeznámenost s metodami s více návratovými hodnotami. Navíc není široce rozšířeno chápání rozdílu mezi parametry out a ref.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Předávání typů podle odkazu (jako out nebo ref) vyžaduje zkušenost s ukazateli, porozumění rozdílu mezi hodnotovými a odkazovými typy a obeznámenost s metodami s více návratovými hodnotami. Navíc není široce rozšířeno chápání rozdílu mezi parametry out a ref.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Neukládejte asynchronní výrazy lambda jako typy delegátů vracející hodnotu Void.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Odeberte finalizační metodu z typu {0}, přepište Dispose(bool disposing) a vložte finalizační logiku do cesty kódu, kde je disposing hodnoty false. V opačném případě by to mohlo vést k duplicitním voláním Dispose, protože základní typ {1} také poskytuje finalizační metodu.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Odeberte finalizační metodu z typu {0}, přepište Dispose(bool disposing) a vložte finalizační logiku do cesty kódu, kde je disposing hodnoty false. V opačném případě by to mohlo vést k duplicitním voláním Dispose, protože základní typ {1} také poskytuje finalizační metodu.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Když je to možné, rozšiřte objekty CancellationToken.</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Když je to možné, rozšiřte objekty CancellationToken.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Když je to možné, rozšiřte objekty CancellationToken.</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Když je to možné, rozšiřte objekty CancellationToken.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Nekombinujte blokující a asynchronní metody.</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Nekombinujte blokující a asynchronní metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Nekombinujte blokující a asynchronní metody.</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Nekombinujte blokující a asynchronní metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">Ve výčtu {0} změňte název pro {1} na None.</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">Ve výčtu {0} změňte název pro {1} na None.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Odeberte z {0} všechny členy, které mají nulovou hodnotu, s výjimkou jednoho člena s názvem None.</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Odeberte z {0} všechny členy, které mají nulovou hodnotu, s výjimkou jednoho člena s názvem None.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Přidejte do {0} člena, který má nulovou hodnotu, s navrženým názvem None.</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Přidejte do {0} člena, který má nulovou hodnotu, s navrženým názvem None.</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">CLS (Common Language Specification) definuje omezení názvů, datových typů a pravidel, kterým musí sestavení vyhovovat, pokud se budou používat v různých programovacích jazycích. Správný návrh vyžaduje, aby všechna sestavení explicitně označovala vyhovění standardu CSL atributem CLSCompliant. Pokud tento atribut u sestavení neexistuje, není toto sestavení vyhovující.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">CLS (Common Language Specification) definuje omezení názvů, datových typů a pravidel, kterým musí sestavení vyhovovat, pokud se budou používat v různých programovacích jazycích. Správný návrh vyžaduje, aby všechna sestavení explicitně označovala vyhovění standardu CSL atributem CLSCompliant. Pokud tento atribut u sestavení neexistuje, není toto sestavení vyhovující.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Označte sestavení atributem CLSCompliant.</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Označte sestavení atributem CLSCompliant.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Označte sestavení atributem ComVisible.</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Označte sestavení atributem ComVisible.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Protože sestavení {0} zpřístupňuje externě viditelné typy, označte ho pomocí ComVisible(false) na úrovni sestavení a pak označte všechny typy v tomto sestavení, které mají být zpřístupněny klientům modelu COM, pomocí ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Protože sestavení {0} zpřístupňuje externě viditelné typy, označte ho pomocí ComVisible(false) na úrovni sestavení a pak označte všechny typy v tomto sestavení, které mají být zpřístupněny klientům modelu COM, pomocí ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Označte atributy atributem AttributeUsage.</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Označte atributy atributem AttributeUsage.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Když definujete vlastní atribut, označte ho atributem AttributeUsage, který označuje, kde ve zdrojovém kódu se dá tento vlastní atribut použít. Význam a zamýšlené použití atributu určí jeho platné umístění v kódu.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Když definujete vlastní atribut, označte ho atributem AttributeUsage, který označuje, kde ve zdrojovém kódu se dá tento vlastní atribut použít. Význam a zamýšlené použití atributu určí jeho platné umístění v kódu.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Určete AttributeUsage pro {0}.</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Určete AttributeUsage pro {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Přestože atribut {0} dědí AttributeUsage od svého základního typu, měli byste zvážit explicitní určení AttributeUsage u tohoto typu kvůli zlepšení přehlednosti a dokumentace kódu.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Přestože atribut {0} dědí AttributeUsage od svého základního typu, měli byste zvážit explicitní určení AttributeUsage u tohoto typu kvůli zlepšení přehlednosti a dokumentace kódu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Přidejte přístupový objekt veřejné vlastnosti jen pro čtení pro poziční argument {0} atributu {1}.</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Přidejte přístupový objekt veřejné vlastnosti jen pro čtení pro poziční argument {0} atributu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Odeberte z {0} metodu setter nebo omezte její přístupnost, protože odpovídá pozičnímu argumentu {1}.</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Odeberte z {0} metodu setter nebo omezte její přístupnost, protože odpovídá pozičnímu argumentu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Pokud je {0} přístupový objekt vlastnosti pozičního argumentu {1}, nastavte ho jako veřejný.</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Pokud je {0} přístupový objekt vlastnosti pozičního argumentu {1}, nastavte ho jako veřejný.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Veřejná nebo chráněná metoda má název, který začíná na Get, nepřebírá žádné parametry a vrací hodnotu, která není polem. Tato metoda může být vhodným kandidátem na vlastnost.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Veřejná nebo chráněná metoda má název, který začíná na Get, nepřebírá žádné parametry a vrací hodnotu, která není polem. Tato metoda může být vhodným kandidátem na vlastnost.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Označte výčty atributem FlagsAttribute.</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Označte výčty atributem FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Výčet je typ hodnoty, který definuje sadu souvisejících pojmenovaných konstant. Použijte u výčtu atribut FlagsAttribute, pokud se jeho pojmenované konstanty dají smysluplně kombinovat.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Výčet je typ hodnoty, který definuje sadu souvisejících pojmenovaných konstant. Použijte u výčtu atribut FlagsAttribute, pokud se jeho pojmenované konstanty dají smysluplně kombinovat.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Označte výčty atributem FlagsAttribute.</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Označte výčty atributem FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Veřejný nebo chráněný typ implementuje rozhraní System.IComparable. Nepřepisuje Object.Equals ani nepřetěžuje jazykově specifický operátor pro je rovno, není rovno, je menší než, je menší než nebo rovno, je větší než nebo je větší než nebo rovno.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Veřejný nebo chráněný typ implementuje rozhraní System.IComparable. Nepřepisuje Object.Equals ani nepřetěžuje jazykově specifický operátor pro je rovno, není rovno, je menší než, je menší než nebo rovno, je větší než nebo je větší než nebo rovno.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} má přepisovat Je rovno, protože implementuje rozhraní IComparable.</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} má přepisovat Je rovno, protože implementuje rozhraní IComparable.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} má definovat operátory {1}, protože implementuje rozhraní IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} má definovat operátory {1}, protože implementuje rozhraní IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Název externě viditelného rozhraní nezačíná velkým písmenem I. Název parametru obecného typu u externě viditelného typu nebo metody nezačíná velkým písmenem I.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Název externě viditelného rozhraní nezačíná velkým písmenem I. Název parametru obecného typu u externě viditelného typu nebo metody nezačíná velkým písmenem I.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Vložte před název rozhraní {0} předponu I.</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Vložte před název rozhraní {0} předponu I.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Vložte před název parametru obecného typu {0} předponu T.</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Vložte před název parametru obecného typu {0} předponu T.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Neoznačujte výčty atributem FlagsAttribute.</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Neoznačujte výčty atributem FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Externě viditelný výčet je označený atributem FlagsAttribute a obsahuje jednu nebo více hodnot, které nejsou mocninami čísla 2 ani kombinací jiných definovaných hodnot výčtu.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Externě viditelný výčet je označený atributem FlagsAttribute a obsahuje jednu nebo více hodnot, které nejsou mocninami čísla 2 ani kombinací jiných definovaných hodnot výčtu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Neoznačujte výčty atributem FlagsAttribute.</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Neoznačujte výčty atributem FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Zadejte metodu s názvem {0} jako vhodnou alternativu pro operátor {1}.</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Zadejte metodu s názvem {0} jako vhodnou alternativu pro operátor {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Zadejte vlastnost s názvem {0} jako vhodnou alternativu pro operátor {1}.</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Zadejte vlastnost s názvem {0} jako vhodnou alternativu pro operátor {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Zadejte metodu s názvem {0} nebo {1} jako alternativu pro operátor {2}.</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Zadejte metodu s názvem {0} nebo {1} jako alternativu pro operátor {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Označte {0} jako veřejný, protože jde o vhodnou alternativu pro operátor {1}.</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Označte {0} jako veřejný, protože jde o vhodnou alternativu pro operátor {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Při přepisu Object.Equals implementujte IEquatable.</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Při přepisu Object.Equals implementujte IEquatable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Typ {0} by měl implementovat rozhraní IEquatable&lt;T&gt;, protože přepisuje metodu Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Typ {0} by měl implementovat rozhraní IEquatable&lt;T&gt;, protože přepisuje metodu Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Parametry CancellationToken musí být poslední.</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Parametry CancellationToken musí být poslední.</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Protože sestavení {0} zpřístupňuje externě viditelné typy, označte ho pomocí ComVisible(false) na úrovni sestavení a pak označte všechny typy v tomto sestavení, které mají být zpřístupněny klientům modelu COM, pomocí ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Protože sestavení {0} zpřístupňuje externě viditelné typy, označte ho pomocí ComVisible(false) na úrovni sestavení a pak označte všechny typy v tomto sestavení, které mají být zpřístupněny klientům modelu COM, pomocí ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Zvažte změnu atributu ComVisible u sestavení {0} na false a jeho připojení na úrovni typu.</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Zvažte změnu atributu ComVisible u sestavení {0} na false a jeho připojení na úrovni typu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Implementujte rozhraní IEquatable.</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Implementujte rozhraní IEquatable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Implementujte rozhraní IDisposable.</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Implementujte rozhraní IDisposable.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Odeberte z výčtu atribut FlagsAttribute.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Odeberte z výčtu atribut FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Použijte u výčtu atribut FlagsAttribute.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Použijte u výčtu atribut FlagsAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Úložiště výčtu má být typu Int32.</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Úložiště výčtu má být typu Int32.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Pokud je to možné, nastavte podkladový typ {0} na System.Int32 místo na {1}.</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Pokud je to možné, nastavte podkladový typ {0} na System.Int32 místo na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Přidejte k {0} následující konstruktor: {1}.</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Přidejte k {0} následující konstruktor: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Změňte přístupnost {0} na {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Změňte přístupnost {0} na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Nevnořujte typ {0}. Alternativně změňte jeho přístupnost tak, aby nebyl externě viditelný.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Nevnořujte typ {0}. Alternativně změňte jeho přístupnost tak, aby nebyl externě viditelný.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Nevnořujte typ {0}. Alternativně změňte jeho přístupnost tak, aby nebyl externě viditelný. Pokud je tento typ definovaný v nějakém modulu Visual Basicu, budou ho jiné jazyky rozhraní .NET považovat za vnořený. V takovém případě zvažte přesunutí typu mimo tento modul.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Nevnořujte typ {0}. Alternativně změňte jeho přístupnost tak, aby nebyl externě viditelný. Pokud je tento typ definovaný v nějakém modulu Visual Basicu, budou ho jiné jazyky rozhraní .NET považovat za vnořený. V takovém případě zvažte přesunutí typu mimo tento modul.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Zadejte zprávu ObsoleteAttribute.</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Zadejte zprávu ObsoleteAttribute.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Typ nebo člen je označený atributem System.ObsoleteAttribute, u kterého není zadaná vlastnost ObsoleteAttribute.Message. Když se typ nebo člen označený atributem ObsoleteAttribute zkompiluje, zobrazí se vlastnost Message tohoto atributu. Uživatel je tak informován o zastaralém typu nebo členovi.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Typ nebo člen je označený atributem System.ObsoleteAttribute, u kterého není zadaná vlastnost ObsoleteAttribute.Message. Když se typ nebo člen označený atributem ObsoleteAttribute zkompiluje, zobrazí se vlastnost Message tohoto atributu. Uživatel je tak informován o zastaralém typu nebo členovi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Zadejte pro atribut ObsoleteAttribute zprávu, která {0} označí jako zastaralý.</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Zadejte pro atribut ObsoleteAttribute zprávu, která {0} označí jako zastaralý.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Protože vlastnost {0} je jen pro zápis, buď přidejte metodu getter vlastnosti s přístupností, která je větší nebo stejná jako její metoda setter, nebo tuto vlastnost převeďte na metodu.</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Protože vlastnost {0} je jen pro zápis, buď přidejte metodu getter vlastnosti s přístupností, která je větší nebo stejná jako její metoda setter, nebo tuto vlastnost převeďte na metodu.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Protože metoda getter vlastnosti {0} je méně viditelná než její metoda setter, buď zvyšte přístupnost její metody getter, nebo snižte přístupnost její metody setter.</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Protože metoda getter vlastnosti {0} je méně viditelná než její metoda setter, buď zvyšte přístupnost její metody getter, nebo snižte přístupnost její metody setter.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Implementujte IDisposable správně.</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Implementujte IDisposable správně.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Všechny typy IDisposable by měly implementovat vzor Dispose správně.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Všechny typy IDisposable by měly implementovat vzor Dispose správně.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Odebrete IDisposable ze seznamu rozhraní, která implementuje {0}, protože už jej implementuje základní typ {1}.</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Odebrete IDisposable ze seznamu rozhraní, která implementuje {0}, protože už jej implementuje základní typ {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Odeberte {0}, přepište Dispose(bool disposing) a vložte finalizační logiku do cesty kódu, kde je disposing hodnoty true.</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Odeberte {0}, přepište Dispose(bool disposing) a vložte finalizační logiku do cesty kódu, kde je disposing hodnoty true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Upravte {0} tak, že volá Dispose(true), pak volá GC.SupressFinalize na aktuální instanci objektu (this nebo Me ve Visual Basicu) a potom se vrací.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Upravte {0} tak, že volá Dispose(true), pak volá GC.SupressFinalize na aktuální instanci objektu (this nebo Me ve Visual Basicu) a potom se vrací.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Upravte {0} tak, že volá Dispose(false) a potom se vrací.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Upravte {0} tak, že volá Dispose(false) a potom se vrací.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Poskytněte přepisovatelnou implementaci Dispose(bool) na {0} nebo označte typ jako zapečetěný. Volání Dispose(false) by mělo vyčistit jenom nativní prostředky. Volání Dispose(true) by mělo vyčistit prostředky spravované i nativní.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Poskytněte přepisovatelnou implementaci Dispose(bool) na {0} nebo označte typ jako zapečetěný. Volání Dispose(false) by mělo vyčistit jenom nativní prostředky. Volání Dispose(true) by mělo vyčistit prostředky spravované i nativní.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Interní výjimka je viditelná jenom uvnitř svého vlastního interního oboru. Pokud tato výjimka spadá mimo interní obor, dá se k jejímu zachycení použít jenom základní výjimka. Pokud je interní výjimka zděděná od T:System.Exception, T:System.SystemException nebo T:System.ApplicationException, nebude mít externí kód dost informací o tom, co se má s touto výjimkou udělat.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Interní výjimka je viditelná jenom uvnitř svého vlastního interního oboru. Pokud tato výjimka spadá mimo interní obor, dá se k jejímu zachycení použít jenom základní výjimka. Pokud je interní výjimka zděděná od T:System.Exception, T:System.SystemException nebo T:System.ApplicationException, nebude mít externí kód dost informací o tom, co se má s touto výjimkou udělat.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} vytváří výjimku typu {1}, což je typ výjimky, která by neměla být ve vlastnosti vyvolána. Pokud se tato instance výjimky může vyvolat, použijte jiný typ výjimky, převeďte tuto vlastnost na metodu nebo změňte logiku této vlastnosti tak, aby už nevyvolávala výjimku.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} vytváří výjimku typu {1}, což je typ výjimky, která by neměla být ve vlastnosti vyvolána. Pokud se tato instance výjimky může vyvolat, použijte jiný typ výjimky, převeďte tuto vlastnost na metodu nebo změňte logiku této vlastnosti tak, aby už nevyvolávala výjimku.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} vytváří výjimku typu {1}, což je typ výjimky, která by neměla být v tomto typu metody vyvolána. Pokud se tato instance výjimky může vyvolat, buď použijte jiný typ výjimky, nebo změňte logiku této metody tak, aby už nevyvolávala výjimku.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} vytváří výjimku typu {1}, což je typ výjimky, která by neměla být v tomto typu metody vyvolána. Pokud se tato instance výjimky může vyvolat, buď použijte jiný typ výjimky, nebo změňte logiku této metody tak, aby už nevyvolávala výjimku.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} vytváří výjimku typu {1}. V tomto typu metody by se neměly vyvolávat výjimky. Pokud se tato instance výjimky může vyvolat, změňte logiku této metody tak, aby už nevyvolávala výjimku.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} vytváří výjimku typu {1}. V tomto typu metody by se neměly vyvolávat výjimky. Pokud se tato instance výjimky může vyvolat, změňte logiku této metody tak, aby už nevyvolávala výjimku.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Podle dohody nemají názvy identifikátorů obsahovat znaky podtržítka (_). Toto pravidlo kontroluje názvové prostory, typy, členy a parametry.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Podle dohody nemají názvy identifikátorů obsahovat znaky podtržítka (_). Toto pravidlo kontroluje názvové prostory, typy, členy a parametry.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Odeberte podtržítka z názvu sestavení {0}.</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Odeberte podtržítka z názvu sestavení {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Odeberte podtržítka z názvu typu {0}.</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Odeberte podtržítka z názvu typu {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Odeberte podtržítka z názvu člena {0}.</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Odeberte podtržítka z názvu člena {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">U typu {0} odeberte podtržítka z názvu parametru obecného typu {1}.</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">U typu {0} odeberte podtržítka z názvu parametru obecného typu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">U metody {0} odeberte podtržítka z názvu parametru obecného typu {1}.</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">U metody {0} odeberte podtržítka z názvu parametru obecného typu {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">U člena {0} odeberte podtržítka z názvu parametru {1}.</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">U člena {0} odeberte podtržítka z názvu parametru {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">V delegátovi {0} odeberte podtržítka z názvu parametru {1}.</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">V delegátovi {0} odeberte podtržítka z názvu parametru {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Přejmenujte {0} tak, aby název končil na {1}.</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Přejmenujte {0} tak, aby název končil na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Přejmenujte {0} tak, aby název končil buď na Collection, nebo na {1}.</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Přejmenujte {0} tak, aby název končil buď na Collection, nebo na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Přejmenujte název typu {0} tak, aby nekončil na {1}.</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Přejmenujte název typu {0} tak, aby nekončil na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Buď nahraďte příponu {0} v názvu člena {1} navrhovanou číselnou alternativou 2, nebo zadejte výstižnější příponu, která ho odliší od člena, kterého nahrazuje.</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Buď nahraďte příponu {0} v názvu člena {1} navrhovanou číselnou alternativou 2, nebo zadejte výstižnější příponu, která ho odliší od člena, kterého nahrazuje.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Buď nahraďte příponu {0} v názvu typu {1} navrhovanou číselnou alternativou 2, nebo zadejte výstižnější příponu, která ho odliší od typu, kterého nahrazuje.</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Buď nahraďte příponu {0} v názvu typu {1} navrhovanou číselnou alternativou 2, nebo zadejte výstižnější příponu, která ho odliší od typu, kterého nahrazuje.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Přejmenujte parametr {1} ve virtuálním členovi nebo členovi rozhraní {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {2} jazyka. Použití rezervovaného klíčového slova jako názvu parametru u virtuálního člena nebo člena rozhraní znesnadňuje konzumentům v jiných jazycích přepis nebo implementaci tohoto člena.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Přejmenujte parametr {1} ve virtuálním členovi nebo členovi rozhraní {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {2} jazyka. Použití rezervovaného klíčového slova jako názvu parametru u virtuálního člena nebo člena rozhraní znesnadňuje konzumentům v jiných jazycích přepis nebo implementaci tohoto člena.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Přejmenujte virtuálního člena nebo člena rozhraní {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu virtuálního člena nebo člena rozhraní znesnadňuje konzumentům v jiných jazycích přepis nebo implementaci tohoto člena.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Přejmenujte virtuálního člena nebo člena rozhraní {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu virtuálního člena nebo člena rozhraní znesnadňuje konzumentům v jiných jazycích přepis nebo implementaci tohoto člena.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Přejmenujte typ {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu typu znesnadňuje konzumentům v jiných jazycích použití tohoto typu.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Přejmenujte typ {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu typu znesnadňuje konzumentům v jiných jazycích použití tohoto typu.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Přejmenujte názvový prostor {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu názvového prostoru znesnadňuje konzumentům v jiných jazycích použití tohoto názvového prostoru.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Přejmenujte názvový prostor {0} tak, aby už nebyl v konfliktu s rezervovaným klíčovým slovem {1} jazyka. Použití rezervovaného klíčového slova jako názvu názvového prostoru znesnadňuje konzumentům v jiných jazycích použití tohoto názvového prostoru.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Název veřejného nebo chráněného člena začíná na Get a také jinak se shoduje s názvem veřejné nebo chráněné vlastnosti. Metody a vlastnosti Get by měly mít název, který jasně rozlišuje jejich funkci.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Název veřejného nebo chráněného člena začíná na Get a také jinak se shoduje s názvem veřejné nebo chráněné vlastnosti. Metody a vlastnosti Get by měly mít název, který jasně rozlišuje jejich funkci.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Název typu {0} koliduje úplně nebo částečně s názvem názvového prostoru {1}. Změnou některého názvu zabraňte tomuto konfliktu.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Název typu {0} koliduje úplně nebo částečně s názvem názvového prostoru {1}. Změnou některého názvu zabraňte tomuto konfliktu.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Název typu {0} koliduje úplně nebo částečně s názvem názvového prostoru {1} definovaným v rozhraní .NET Framework. Přejmenováním typu zabraňte tomuto konfliktu.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Název typu {0} koliduje úplně nebo částečně s názvem názvového prostoru {1} definovaným v rozhraní .NET Framework. Přejmenováním typu zabraňte tomuto konfliktu.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">V členovi {0} změňte název parametru {1} na {2}, aby se shodoval s identifikátorem deklarovaným v {3}.</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">V členovi {0} změňte název parametru {1} na {2}, aby se shodoval s identifikátorem deklarovaným v {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Nahraďte termín {0} v názvu sestavení {1} preferovanou alternativou {2}.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu sestavení {1} preferovanou alternativou {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">V členovi {0} nahraďte termín {1} v názvu parametru {2} preferovanou alternativou {3}.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">V členovi {0} nahraďte termín {1} v názvu parametru {2} preferovanou alternativou {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">V delegátovi {0} nahraďte termín {1} v názvu parametru {2} preferovanou alternativou {3}.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">V delegátovi {0} nahraďte termín {1} v názvu parametru {2} preferovanou alternativou {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">U typu {0} nahraďte termín {1} v názvu parametru obecného typu {2} preferovanou alternativou {3}.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">U typu {0} nahraďte termín {1} v názvu parametru obecného typu {2} preferovanou alternativou {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">U metody {0} nahraďte termín {1} v názvu parametru obecného typu {2} preferovanou alternativou {3}.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">U metody {0} nahraďte termín {1} v názvu parametru obecného typu {2} preferovanou alternativou {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Nahraďte termín {0} v názvu typu {1} preferovanou alternativou {2}.</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu typu {1} preferovanou alternativou {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Nahraďte termín {0} v názvu člena {1} preferovanou alternativou {2}.</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu člena {1} preferovanou alternativou {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nahraďte termín {0} v názvu sestavení {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu sestavení {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">V členovi {0} nahraďte termín {1} v názvu parametru {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">V členovi {0} nahraďte termín {1} v názvu parametru {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">V delegátovi {0} nahraďte termín {1} v názvu parametru {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">V delegátovi {0} nahraďte termín {1} v názvu parametru {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">U typu {0} nahraďte termín {1} v názvu parametru obecného typu {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">U typu {0} nahraďte termín {1} v názvu parametru obecného typu {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">U metody {0} nahraďte termín {1} v názvu parametru obecného typu {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">U metody {0} nahraďte termín {1} v názvu parametru obecného typu {2} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nahraďte termín {0} v názvu typu {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu typu {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nahraďte termín {0} v názvu člena {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nahraďte termín {0} v názvu člena {1} příslušnou alternativou, nebo ho úplně odeberte.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} má přepsat Equals.</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} má přepsat Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} má přepsat operátory rovnosti (==) a nerovnosti (!=).</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} má přepsat operátory rovnosti (==) a nerovnosti (!=).</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Podepište {0} klíčem se silným názvem.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Podepište {0} klíčem se silným názvem.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Před nasazením ověřte, že má {0} platný silný název.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Před nasazením ověřte, že má {0} platný silný název.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Přepište GetHashCode při přepisu Equals.</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Přepište GetHashCode při přepisu Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode vrací hodnotu na základě aktuální instance, která je vhodná pro algoritmy hash a datové struktury, jako je zatřiďovací tabulka. Dva objekty, které jsou stejného typu a rovnají se, musejí vracet stejný kód hash.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode vrací hodnotu na základě aktuální instance, která je vhodná pro algoritmy hash a datové struktury, jako je zatřiďovací tabulka. Dva objekty, které jsou stejného typu a rovnají se, musejí vracet stejný kód hash.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Přepište GetHashCode při přepisu Equals.</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Přepište GetHashCode při přepisu Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Přepište Equals při přetížení operátorů rovnosti.</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Přepište Equals při přetížení operátorů rovnosti.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Veřejný typ implementuje operátor rovnosti, ale nepřepisuje Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Veřejný typ implementuje operátor rovnosti, ale nepřepisuje Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Přepište Equals při přetížení operátorů rovnosti.</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Přepište Equals při přetížení operátorů rovnosti.</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Přepište object.Equals.</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Přepište object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Přepište object.Equals.</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Přepište object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Přepište object.GetHashCode.</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Přepište object.GetHashCode.</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Nastavte třídu jako statickou.</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Nastavte třídu jako statickou.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Typ {0} by měl přepisovat metodu Equals, protože implementuje IEquatable&lt;T&gt;.</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Typ {0} by měl přepisovat metodu Equals, protože implementuje IEquatable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Při implementaci IEquatable&lt;T&gt; přepište Object.Equals(object)</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Při implementaci IEquatable&lt;T&gt; přepište Object.Equals(object)</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Když asynchronní metoda čeká přímo na Task, bude se pokračovat ve stejném vlákně, v jakém se vytvořila daná úloha. Zvažte možnost zavolat Task.ConfigureAwait(Boolean), čímž dáte najevo, že hodláte pokračovat. Když pro úlohu zavoláte ConfigureAwait(false), můžete ve fondu vláken naplánovat pokračování a vyhnout se tak vzájemnému zablokování ve vláknu uživatelského rozhraní. Pro knihovny, které nejsou závislé na aplikacích, je vhodné předat false. Volání ConfigureAwait(true) pro danou úlohu se chová stejně, jako když se explicitně nezavolá ConfigureAwait. Když tuto metodu explicitně zavoláte, dáváte čtenářům najevo, že se záměrně chystáte pokračovat v původním kontextu synchronizace.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Když asynchronní metoda čeká přímo na Task, bude se pokračovat ve stejném vlákně, v jakém se vytvořila daná úloha. Zvažte možnost zavolat Task.ConfigureAwait(Boolean), čímž dáte najevo, že hodláte pokračovat. Když pro úlohu zavoláte ConfigureAwait(false), můžete ve fondu vláken naplánovat pokračování a vyhnout se tak vzájemnému zablokování ve vláknu uživatelského rozhraní. Pro knihovny, které nejsou závislé na aplikacích, je vhodné předat false. Volání ConfigureAwait(true) pro danou úlohu se chová stejně, jako když se explicitně nezavolá ConfigureAwait. Když tuto metodu explicitně zavoláte, dáváte čtenářům najevo, že se záměrně chystáte pokračovat v původním kontextu synchronizace.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Zvažte možnost zavolat ConfigureAwait pro očekávanou úlohu</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Zvažte možnost zavolat ConfigureAwait pro očekávanou úlohu</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Zvažte možnost zavolat ConfigureAwait pro očekávanou úlohu</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Zvažte možnost zavolat ConfigureAwait pro očekávanou úlohu</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Když typ T přepisuje Object.Equals(object), implementace musí před porovnáním přetypovat argument objektu na správný typ T. Pokud typ implementuje rozhraní IEquatable&lt;T&gt; a tím nabízí metodu T.Equals(T) a pokud je při kompilaci známo, že argument je typu T, kompilátor může zavolat IEquatable&lt;T&gt;.Equals(T) místo Object.Equals(object). Díky tomu není nutné nic přetypovávat, což zvyšuje výkon.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Když typ T přepisuje Object.Equals(object), implementace musí před porovnáním přetypovat argument objektu na správný typ T. Pokud typ implementuje rozhraní IEquatable&lt;T&gt; a tím nabízí metodu T.Equals(T) a pokud je při kompilaci známo, že argument je typu T, kompilátor může zavolat IEquatable&lt;T&gt;.Equals(T) místo Object.Equals(object). Díky tomu není nutné nic přetypovávat, což zvyšuje výkon.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} má definovat operátory {1} a Rovná se, protože implementuje rozhraní IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} má definovat operátory {1} a Rovná se, protože implementuje rozhraní IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Odeberte volání do GC.Collect z {0}. Obvykle není nutné vynucovat uvolňování paměti a pokud to uděláte, může se výkon velmi snížit.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Odeberte volání do GC.Collect z {0}. Obvykle není nutné vynucovat uvolňování paměti a pokud to uděláte, může se výkon velmi snížit.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Odeberte volání do Thread.Resume z {0}. Pozastavení a obnovení vláken může být nebezpečné, pokud systém provádí kritickou operaci, třeba spouští konstruktor třídy důležitého typu systému nebo překládá zabezpečení sdíleného sestavení.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Odeberte volání do Thread.Resume z {0}. Pozastavení a obnovení vláken může být nebezpečné, pokud systém provádí kritickou operaci, třeba spouští konstruktor třídy důležitého typu systému nebo překládá zabezpečení sdíleného sestavení.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Odeberte volání do Thread.Suspend z {0}. Pozastavení a obnovení vláken může být nebezpečné, pokud systém provádí kritickou operaci, třeba spouští konstruktor třídy důležitého typu systému nebo překládá zabezpečení sdíleného sestavení.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Odeberte volání do Thread.Suspend z {0}. Pozastavení a obnovení vláken může být nebezpečné, pokud systém provádí kritickou operaci, třeba spouští konstruktor třídy důležitého typu systému nebo překládá zabezpečení sdíleného sestavení.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Odeberte volání do System.Type.InvokeMember s BindingFlags.NonPublic z {0}. Využití závislosti u privátního členu zvyšuje možnost, že v budoucnu bude nutné provést výraznou změnu.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Odeberte volání do System.Type.InvokeMember s BindingFlags.NonPublic z {0}. Využití závislosti u privátního členu zvyšuje možnost, že v budoucnu bude nutné provést výraznou změnu.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} je deklarace metody P/Invoke do rozhraní API OLE32, kterou nelze spolehlivě volat po inicializaci modulu runtime. Alternativním řešením je vytvořit nespravovaný kód shim, který zavolá rutinu a potom aktivuje a zavolá spravovaný kód. To můžete udělat pomocí exportu z knihovny DDL C++ ve smíšeném režimu, registrací spravované komponenty pro použití modelem COM nebo pomocí rozhraní API, které je hostitelem modulu runtime.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} je deklarace metody P/Invoke do rozhraní API OLE32, kterou nelze spolehlivě volat po inicializaci modulu runtime. Alternativním řešením je vytvořit nespravovaný kód shim, který zavolá rutinu a potom aktivuje a zavolá spravovaný kód. To můžete udělat pomocí exportu z knihovny DDL C++ ve smíšeném režimu, registrací spravované komponenty pro použití modelem COM nebo pomocí rozhraní API, které je hostitelem modulu runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} je deklarace metody P/Invoke do rozhraní API OLE32, kterou nelze spolehlivě volat oproti objektu volatelnému za běhu (spravovaný objekt, který zabaluje objekt modelu COM). Objekty volatelné za běhu dynamicky načítají ukazatele rozhraní, takže nahodile může dojít ke ztrátě efektu volání. Objekty volatelné za běhu pro daný objekt modelu COM se také sdílí napříč doménou, takže volání by mohlo ovlivnit ostatní uživatele. U ukazatele rozhraní, který provádí příslušná volání CoSetProxyBlanket, nahraďte toto volání objektem modelu COM nativní obálky.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} je deklarace metody P/Invoke do rozhraní API OLE32, kterou nelze spolehlivě volat oproti objektu volatelnému za běhu (spravovaný objekt, který zabaluje objekt modelu COM). Objekty volatelné za běhu dynamicky načítají ukazatele rozhraní, takže nahodile může dojít ke ztrátě efektu volání. Objekty volatelné za běhu pro daný objekt modelu COM se také sdílí napříč doménou, takže volání by mohlo ovlivnit ostatní uživatele. U ukazatele rozhraní, který provádí příslušná volání CoSetProxyBlanket, nahraďte toto volání objektem modelu COM nativní obálky.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Odeberte volání do SafeHandle.DangerousGetHandle z {0}.</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Odeberte volání do SafeHandle.DangerousGetHandle z {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Odeberte volání do Assembly.LoadFrom z {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Odeberte volání do Assembly.LoadFrom z {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Odeberte volání do Assembly.LoadFile z {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Odeberte volání do Assembly.LoadFile z {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Odeberte volání do Assembly.LoadWithPartialName z {0}.</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Odeberte volání do Assembly.LoadWithPartialName z {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">Proměnná {0} deklarovaná v {1} má stejný název jako pole instance u tohoto typu. Změňte název jedné z těchto položek.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">Proměnná {0} deklarovaná v {1} má stejný název jako pole instance u tohoto typu. Změňte název jedné z těchto položek.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">Parametr {0} deklarovaný v {1} má stejný název jako pole instance u tohoto typu. Změňte název jedné z těchto položek.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">Parametr {0} deklarovaný v {1} má stejný název jako pole instance u tohoto typu. Změňte název jedné z těchto položek.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Parametr {0} metody {1} se vůbec nepoužívá. Odeberte tento parametr nebo ho použijte v těle metody.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Parametr {0} metody {1} se vůbec nepoužívá. Odeberte tento parametr nebo ho použijte v těle metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} vytváří novou instanci {1}, která se vůbec nepoužívá. Předejte tuto instanci jako argument jiné metodě, přiřaďte tuto instanci proměnné nebo odeberte vytvoření objektu, pokud je nepotřebný.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} vytváří novou instanci {1}, která se vůbec nepoužívá. Předejte tuto instanci jako argument jiné metodě, přiřaďte tuto instanci proměnné nebo odeberte vytvoření objektu, pokud je nepotřebný.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} volá {1}, ale nepoužívá novou instanci řetězce, kterou tato metoda vrací. Předejte tuto instanci jako argument jiné metodě, přiřaďte tuto instanci proměnné nebo odeberte volání, pokud je nepotřebné.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} volá {1}, ale nepoužívá novou instanci řetězce, kterou tato metoda vrací. Předejte tuto instanci jako argument jiné metodě, přiřaďte tuto instanci proměnné nebo odeberte volání, pokud je nepotřebné.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} volá {1}, ale nepoužívá HRESULT ani kód chyby, který tato metoda vrací. To může vést k neočekávanému chování při výskytu chyby nebo nedostatku prostředků. Použijte výsledek v podmíněném příkazu, přiřaďte výsledek proměnné nebo ho předejte jako argument jiné metodě.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} volá {1}, ale nepoužívá HRESULT ani kód chyby, který tato metoda vrací. To může vést k neočekávanému chování při výskytu chyby nebo nedostatku prostředků. Použijte výsledek v podmíněném příkazu, přiřaďte výsledek proměnné nebo ho předejte jako argument jiné metodě.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} volá {1}, ale explicitně nekontroluje, jestli byl převod úspěšný. Buď použijte návratovou hodnotu v podmíněném příkazu, nebo ověřte, jestli volající web očekává, že se výstupní argument nastaví na výchozí hodnotu, když se převod nepodaří.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} volá {1}, ale explicitně nekontroluje, jestli byl převod úspěšný. Buď použijte návratovou hodnotu v podmíněném příkazu, nebo ověřte, jestli volající web očekává, že se výstupní argument nastaví na výchozí hodnotu, když se převod nepodaří.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} je interní třída, jejíž instance není zjevně vůbec vytvořená. V takovém případě odeberte tento kód ze sestavení. Pokud má tato třída obsahovat jenom statické členy, nastavte ji jako statickou (sdílenou ve Visual Basicu).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} je interní třída, jejíž instance není zjevně vůbec vytvořená. V takovém případě odeberte tento kód ze sestavení. Pokud má tato třída obsahovat jenom statické členy, nastavte ji jako statickou (sdílenou ve Visual Basicu).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} volá {1}, ale nepoužívá hodnotu, kterou tato metoda vrací. Protože {1} je označená jako metoda Pure, nemůže mít vedlejší účinky. Použijte výsledek v podmíněném příkazu, přiřaďte výsledek proměnné nebo ho předejte jako argument jiné metodě.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} volá {1}, ale nepoužívá hodnotu, kterou tato metoda vrací. Protože {1} je označená jako metoda Pure, nemůže mít vedlejší účinky. Použijte výsledek v podmíněném příkazu, přiřaďte výsledek proměnné nebo ho předejte jako argument jiné metodě.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">Vlastnost {0} nesmí být přiřazena sama k sobě.</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">Vlastnost {0} nesmí být přiřazena sama k sobě.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} je multidimenzionální pole. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} je multidimenzionální pole. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} vrací multidimenzionální pole {1}. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} vrací multidimenzionální pole {1}. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} používá multidimenzionální pole {1}. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} používá multidimenzionální pole {1}. Pokud je to možné, nahraďte ho vícenásobným polem.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void vermeiden</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void vermeiden</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void vermeiden</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void vermeiden</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Async-Methodennamen müssen auf "Async" enden</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Async-Methodennamen müssen auf "Async" enden</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Async-Methodennamen müssen auf "Async" enden</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Async-Methodennamen müssen auf "Async" enden</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Erwägen Sie einen Entwurf, bei dem "{0}" höchstens {1} Typparameter aufweist.</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Erwägen Sie einen Entwurf, bei dem "{0}" höchstens {1} Typparameter aufweist.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">out-Parameter vermeiden</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">out-Parameter vermeiden</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; ist eine generische Sammlung, die aus Leistungsgründen und nicht zur Vererbung entworfen wurde. List&lt;T&gt; enthält keine virtuellen Member, die das Ändern des Verhaltens einer geerbten Klasse vereinfachen.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; ist eine generische Sammlung, die aus Leistungsgründen und nicht zur Vererbung entworfen wurde. List&lt;T&gt; enthält keine virtuellen Member, die das Ändern des Verhaltens einer geerbten Klasse vereinfachen.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen übergeben</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Async-Lambdas nicht als "Void" zurückgebende Delegattypen übergeben</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen übergeben</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Async-Lambdas nicht als "Void" zurückgebende Delegattypen übergeben</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Das Übergeben von Typen als Verweis (mit "out" oder "ref") erfordert Erfahrung mit Zeigern, den Unterschieden zwischen Werttypen und Verweistypen sowie der Verarbeitung von Methoden mit mehreren Rückgabewerten. Auch der Unterschied zwischen den Parametern "out" und "ref" ist nicht allgemein geläufig.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Das Übergeben von Typen als Verweis (mit "out" oder "ref") erfordert Erfahrung mit Zeigern, den Unterschieden zwischen Werttypen und Verweistypen sowie der Verarbeitung von Methoden mit mehreren Rückgabewerten. Auch der Unterschied zwischen den Parametern "out" und "ref" ist nicht allgemein geläufig.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Async-Lambdas nicht als "Void" zurückgebende Delegattypen speichern</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Entfernen Sie den Finalizer vom Typ "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und platzieren Sie die Finalisierungslogik im Codepfad, wenn "disposing" FALSE lautet. Andernfalls kann es zu doppelten Dispose-Aufrufen kommen, weil der Basistyp "{1}" ebenfalls einen Finalizer bereitstellt.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Entfernen Sie den Finalizer vom Typ "{0}", setzen Sie "Dispose(bool disposing)" außer Kraft, und platzieren Sie die Finalisierungslogik im Codepfad, wenn "disposing" FALSE lautet. Andernfalls kann es zu doppelten Dispose-Aufrufen kommen, weil der Basistyp "{1}" ebenfalls einen Finalizer bereitstellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Nach Möglichkeit CancellationTokens verteilen</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Nach Möglichkeit CancellationTokens verteilen</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Nach Möglichkeit CancellationTokens verteilen</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Nach Möglichkeit CancellationTokens verteilen</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Blockierung und Async nicht kombinieren</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Blockierung und Async nicht kombinieren</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Blockierung und Async nicht kombinieren</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Blockierung und Async nicht kombinieren</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">Ändern Sie in der Enumeration "{0}" den Namen von "{1}" in "None".</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">Ändern Sie in der Enumeration "{0}" den Namen von "{1}" in "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Entfernen Sie alle Member mit dem Wert null aus "{0}", mit Ausnahme des einen Members mit dem Namen "None".</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Entfernen Sie alle Member mit dem Wert null aus "{0}", mit Ausnahme des einen Members mit dem Namen "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Fügen Sie "{0}" einen Member mit einem Wert von null und dem vorgeschlagenen Namen "None" hinzu.</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Fügen Sie "{0}" einen Member mit einem Wert von null und dem vorgeschlagenen Namen "None" hinzu.</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Die Common Language Specification (CLS) definiert Namenseinschränkungen, Datentypen und Regeln, denen Assemblys entsprechen müssen, wenn sie programmiersprachenübergreifend eingesetzt werden sollen. Ein gutes Design gibt vor, dass alle Assemblys über das CLSCompliantAttribute explizit auf ihre CLS-Konformität hinweisen. Wenn dieses Attribut in einer Assembly nicht vorhanden ist, ist die Assembly nicht konform.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Die Common Language Specification (CLS) definiert Namenseinschränkungen, Datentypen und Regeln, denen Assemblys entsprechen müssen, wenn sie programmiersprachenübergreifend eingesetzt werden sollen. Ein gutes Design gibt vor, dass alle Assemblys über das CLSCompliantAttribute explizit auf ihre CLS-Konformität hinweisen. Wenn dieses Attribut in einer Assembly nicht vorhanden ist, ist die Assembly nicht konform.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Assemblys mit CLSCompliant markieren</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Assemblys mit CLSCompliant markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Assemblys mit ComVisible markieren</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Assemblys mit ComVisible markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Da "{0}" extern sichtbare Typen verfügbar macht, setzen Sie auf Assemblyebene eine Markierung mit "ComVisible(false)", und markieren Sie dann alle Typen innerhalb der Assembly, die für COM-Clients verfügbar gemacht werden sollen, mit "ComVisible(true)".</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Da "{0}" extern sichtbare Typen verfügbar macht, setzen Sie auf Assemblyebene eine Markierung mit "ComVisible(false)", und markieren Sie dann alle Typen innerhalb der Assembly, die für COM-Clients verfügbar gemacht werden sollen, mit "ComVisible(true)".</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Attribute mit AttributeUsageAttribute markieren</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Attribute mit AttributeUsageAttribute markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Wenn Sie ein benutzerdefiniertes Attribut definieren, markieren Sie es mit "AttributeUsageAttribute", um darauf hinzuweisen, wo im Quellcode das benutzerdefinierte Attribut angewendet werden kann. Die gültigen Stellen im Code werden durch die Bedeutung und beabsichtigte Verwendung eines Attributs festgelegt.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Wenn Sie ein benutzerdefiniertes Attribut definieren, markieren Sie es mit "AttributeUsageAttribute", um darauf hinzuweisen, wo im Quellcode das benutzerdefinierte Attribut angewendet werden kann. Die gültigen Stellen im Code werden durch die Bedeutung und beabsichtigte Verwendung eines Attributs festgelegt.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Geben Sie "AttributeUsage" für "{0}" an.</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Geben Sie "AttributeUsage" für "{0}" an.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Auch wenn das Attribut "{0}" die AttributeUsage von seinem Basistyp erbt, sollten Sie erwägen, AttributeUsage für den Typ explizit anzugeben, um die Lesbarkeit und Dokumentation des Codes zu verbessern.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Auch wenn das Attribut "{0}" die AttributeUsage von seinem Basistyp erbt, sollten Sie erwägen, AttributeUsage für den Typ explizit anzugeben, um die Lesbarkeit und Dokumentation des Codes zu verbessern.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Fügen Sie eine öffentliche schreibgeschützte Zugriffsmethode für das positionelle Argument "{0}" des Attributs "{1}" hinzu.</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Fügen Sie eine öffentliche schreibgeschützte Zugriffsmethode für das positionelle Argument "{0}" des Attributs "{1}" hinzu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Entfernen Sie den Eigenschaftensetter aus "{0}", oder schränken Sie seine Zugänglichkeit ein, weil er dem positionellen Argument "{1}" entspricht.</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie den Eigenschaftensetter aus "{0}", oder schränken Sie seine Zugänglichkeit ein, weil er dem positionellen Argument "{1}" entspricht.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Wenn "{0}" die Eigenschaftszugriffsmethode für das positionelle Argument "{1}" ist, machen Sie sie öffentlich.</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Wenn "{0}" die Eigenschaftszugriffsmethode für das positionelle Argument "{1}" ist, machen Sie sie öffentlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Eine öffentliche oder geschützte Methode besitzt einen Namen, der mit ""Get"" beginnt, akzeptiert keine Parameter und gibt einen Wert zurück, der kein Array ist. Die Methode ist möglicherweise ein guter Kandidat für eine Eigenschaft.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Eine öffentliche oder geschützte Methode besitzt einen Namen, der mit ""Get"" beginnt, akzeptiert keine Parameter und gibt einen Wert zurück, der kein Array ist. Die Methode ist möglicherweise ein guter Kandidat für eine Eigenschaft.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Enumerationen mit FlagsAttribute markieren</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Enumerationen mit FlagsAttribute markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Eine Enumeration ist ein Werttyp, der eine Menge von verwandten benannten Konstanten definiert. Wenden Sie FlagsAttribute auf eine Enumeration an, wenn die zugehörigen benannten Konstanten sinnvoll zusammengefasst werden können.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Eine Enumeration ist ein Werttyp, der eine Menge von verwandten benannten Konstanten definiert. Wenden Sie FlagsAttribute auf eine Enumeration an, wenn die zugehörigen benannten Konstanten sinnvoll zusammengefasst werden können.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Enumerationen mit FlagsAttribute markieren</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Enumerationen mit FlagsAttribute markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Ein öffentlicher oder geschützter Typ implementiert die System.IComparable-Schnittstelle. Er setzt "Object.Equals" nicht außer Kraft und überlädt nicht den sprachspezifischen Operator für Gleichheit, Ungleichheit, kleiner als, kleiner oder gleich, größer als oder größer oder gleich.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Ein öffentlicher oder geschützter Typ implementiert die System.IComparable-Schnittstelle. Er setzt "Object.Equals" nicht außer Kraft und überlädt nicht den sprachspezifischen Operator für Gleichheit, Ungleichheit, kleiner als, kleiner oder gleich, größer als oder größer oder gleich.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">"{0}" muss "Equals" außer Kraft setzen, weil IComparable implementiert wird.</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">"{0}" muss "Equals" außer Kraft setzen, weil IComparable implementiert wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">"{0}" muss die Operatoren "{1}" definieren, weil IComparable implementiert wird.</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">"{0}" muss die Operatoren "{1}" definieren, weil IComparable implementiert wird.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Der Name einer extern sichtbaren Schnittstelle beginnt nicht mit einem großen ""I"". Der Name eines generischen Typparameters für einen extern sichtbaren Typ oder eine extern sichtbare Methode beginnt nicht mit einem großen ""T"".</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Der Name einer extern sichtbaren Schnittstelle beginnt nicht mit einem großen ""I"". Der Name eines generischen Typparameters für einen extern sichtbaren Typ oder eine extern sichtbare Methode beginnt nicht mit einem großen ""T"".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Stellen Sie dem Schnittstellennamen "{0}" ein "I" voran.</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Stellen Sie dem Schnittstellennamen "{0}" ein "I" voran.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Stellen Sie dem Namen des generischen Typparameters "{0}" ein "T" voran.</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Stellen Sie dem Namen des generischen Typparameters "{0}" ein "T" voran.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Enumerationen nicht mit FlagsAttribute markieren</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Enumerationen nicht mit FlagsAttribute markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Eine extern sichtbare Enumeration wird über das FlagsAttribute markiert und verfügt über mindestens einen Wert, der keine Potenz von zwei oder keine Kombination der anderen definierten Werte für die Enumeration ist.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Eine extern sichtbare Enumeration wird über das FlagsAttribute markiert und verfügt über mindestens einen Wert, der keine Potenz von zwei oder keine Kombination der anderen definierten Werte für die Enumeration ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Enumerationen nicht mit FlagsAttribute markieren</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Enumerationen nicht mit FlagsAttribute markieren</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Geben Sie eine Methode namens "{0}" als Kurzform für den Operator "{1}" an.</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Geben Sie eine Methode namens "{0}" als Kurzform für den Operator "{1}" an.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Geben Sie eine Eigenschaft namens "{0}" als Kurzform für den Operator "{1}" an.</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Geben Sie eine Eigenschaft namens "{0}" als Kurzform für den Operator "{1}" an.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Geben Sie eine Methode namens "{0}" oder "{1}" als Alternative für den Operator "{2}" an.</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Geben Sie eine Methode namens "{0}" oder "{1}" als Alternative für den Operator "{2}" an.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Markieren Sie "{0}" als öffentlich, weil es sich um eine Kurzform des Operators "{1}" handelt.</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Markieren Sie "{0}" als öffentlich, weil es sich um eine Kurzform des Operators "{1}" handelt.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">"IEquatable" beim Außerkraftsetzen von "Object.Equals" implementieren</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">"IEquatable" beim Außerkraftsetzen von "Object.Equals" implementieren</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Typ {0} muss IEquatable&lt;T&gt; implementieren, weil er Equals überschreibt</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Typ {0} muss IEquatable&lt;T&gt; implementieren, weil er Equals überschreibt</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken-Parameter müssen zuletzt aufgeführt werden</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken-Parameter müssen zuletzt aufgeführt werden</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Da "{0}" extern sichtbare Typen verfügbar macht, setzen Sie auf Assemblyebene eine Markierung mit "ComVisible(false)", und markieren Sie dann alle Typen innerhalb der Assembly, die für COM-Clients verfügbar gemacht werden sollen, mit "ComVisible(true)".</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Da "{0}" extern sichtbare Typen verfügbar macht, setzen Sie auf Assemblyebene eine Markierung mit "ComVisible(false)", und markieren Sie dann alle Typen innerhalb der Assembly, die für COM-Clients verfügbar gemacht werden sollen, mit "ComVisible(true)".</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Ziehen Sie in Betracht, das ComVisible-Attribut für "{0}" in FALSE zu ändern und auf Typebene zu aktivieren.</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Ziehen Sie in Betracht, das ComVisible-Attribut für "{0}" in FALSE zu ändern und auf Typebene zu aktivieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">"IEquatable" implementieren</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">"IEquatable" implementieren</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">IDisposable-Schnittstelle implementieren</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">IDisposable-Schnittstelle implementieren</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Entfernen Sie das FlagsAttribute aus der Enumeration.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Entfernen Sie das FlagsAttribute aus der Enumeration.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Wenden Sie das FlagsAttribute auf die Enumeration an.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Wenden Sie das FlagsAttribute auf die Enumeration an.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Enumerationsspeicher muss Int32 sein</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Enumerationsspeicher muss Int32 sein</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Legen Sie nach Möglichkeit den zugrunde liegenden Typ von "{0}" auf "System.Int32" statt auf "{1}" fest.</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Legen Sie nach Möglichkeit den zugrunde liegenden Typ von "{0}" auf "System.Int32" statt auf "{1}" fest.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Fügen Sie "{0}" den folgenden Konstruktor hinzu: {1}.</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Fügen Sie "{0}" den folgenden Konstruktor hinzu: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Ändern Sie die Zugänglichkeit von "{0}" in "{1}".</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Ändern Sie die Zugänglichkeit von "{0}" in "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Schachteln Sie nicht den Typ "{0}". Ändern Sie alternativ dazu seine Zugänglichkeit so, dass er nicht extern sichtbar ist.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Schachteln Sie nicht den Typ "{0}". Ändern Sie alternativ dazu seine Zugänglichkeit so, dass er nicht extern sichtbar ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Schachteln Sie nicht den Typ "{0}". Ändern Sie alternativ dazu seine Zugänglichkeit so, dass er nicht extern sichtbar ist. Wenn dieser Typ in einem Visual Basic-Modul definiert ist, wird er als geschachtelter Typ für andere .NET-Sprachen betrachtet. Ziehen Sie in diesem Fall in Erwägung, den Typ nach außerhalb des Moduls zu verschieben.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Schachteln Sie nicht den Typ "{0}". Ändern Sie alternativ dazu seine Zugänglichkeit so, dass er nicht extern sichtbar ist. Wenn dieser Typ in einem Visual Basic-Modul definiert ist, wird er als geschachtelter Typ für andere .NET-Sprachen betrachtet. Ziehen Sie in diesem Fall in Erwägung, den Typ nach außerhalb des Moduls zu verschieben.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">ObsoleteAttribute-Meldung bereitstellen</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">ObsoleteAttribute-Meldung bereitstellen</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Ein Typ oder ein Member wird anhand eines System.ObsoleteAttribute-Attributs markiert, dessen ObsoleteAttribute.Message-Eigenschaft nicht angegeben ist. Wenn ein mit dem ObsoleteAttribute markierter Typ oder Member kompiliert wird, wird die Message-Eigenschaft des Attributs angezeigt. So erhält der Benutzer Informationen zum veralteten Typ oder Member.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Ein Typ oder ein Member wird anhand eines System.ObsoleteAttribute-Attributs markiert, dessen ObsoleteAttribute.Message-Eigenschaft nicht angegeben ist. Wenn ein mit dem ObsoleteAttribute markierter Typ oder Member kompiliert wird, wird die Message-Eigenschaft des Attributs angezeigt. So erhält der Benutzer Informationen zum veralteten Typ oder Member.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Geben Sie eine Meldung für das ObsoleteAttribute an, das "{0}" als veraltet markiert.</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Geben Sie eine Meldung für das ObsoleteAttribute an, das "{0}" als veraltet markiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Da die Eigenschaft "{0}" lesegeschützt ist, fügen Sie entweder einen Eigenschaftengetter mit einer Zugänglichkeit hinzu, die mindestens der des zugehörigen Setters entspricht, oder konvertieren Sie diese Eigenschaft in eine Methode.</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Da die Eigenschaft "{0}" lesegeschützt ist, fügen Sie entweder einen Eigenschaftengetter mit einer Zugänglichkeit hinzu, die mindestens der des zugehörigen Setters entspricht, oder konvertieren Sie diese Eigenschaft in eine Methode.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Da der Eigenschaftengetter für "{0}" weniger sichtbar ist als der zugehörige Setter, erhöhen Sie entweder die Zugänglichkeit des zugehörigen Getters, oder verringern Sie die Zugänglichkeit des Setters.</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Da der Eigenschaftengetter für "{0}" weniger sichtbar ist als der zugehörige Setter, erhöhen Sie entweder die Zugänglichkeit des zugehörigen Getters, oder verringern Sie die Zugänglichkeit des Setters.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">IDisposable richtig implementieren</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">IDisposable richtig implementieren</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Alle IDisposable-Typen müssen das Dispose-Muster korrekt implementieren.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Alle IDisposable-Typen müssen das Dispose-Muster korrekt implementieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Entfernen Sie "IDisposable" aus der Liste der durch "{0}" implementierten Schnittstellen, weil sie bereits durch den Basistyp "{1}" implementiert wird.</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie "IDisposable" aus der Liste der durch "{0}" implementierten Schnittstellen, weil sie bereits durch den Basistyp "{1}" implementiert wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Entfernen Sie "{0}", überschreiben Sie "Dispose(bool disposing)", und platzieren Sie die Dispose-Logik im Codepfad, wenn "disposing" TRUE lautet.</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Entfernen Sie "{0}", überschreiben Sie "Dispose(bool disposing)", und platzieren Sie die Dispose-Logik im Codepfad, wenn "disposing" TRUE lautet.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Ändern Sie "{0}" so, dass zunächst "Dispose(true)" und dann "GC.SuppressFinalize" für die aktuelle Objektinstanz (in Visual Basic "this" oder "Me") aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Ändern Sie "{0}" so, dass zunächst "Dispose(true)" und dann "GC.SuppressFinalize" für die aktuelle Objektinstanz (in Visual Basic "this" oder "Me") aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Ändern Sie "{0}" so, dass "Dispose(false)" aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Ändern Sie "{0}" so, dass "Dispose(false)" aufgerufen und anschließend ein Wert zurückgegeben wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Stellen Sie eine überschreibbare Implementierung von "Dispose(bool)" auf "{0}" bereit, oder markieren Sie den Typ als versiegelt. Durch einen Aufruf von "Dispose(false)" sollten nur native Ressourcen bereinigt werden. Durch einen Aufruf von "Dispose(true)" sollten sowohl verwaltete als auch native Ressourcen bereinigt werden.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Stellen Sie eine überschreibbare Implementierung von "Dispose(bool)" auf "{0}" bereit, oder markieren Sie den Typ als versiegelt. Durch einen Aufruf von "Dispose(false)" sollten nur native Ressourcen bereinigt werden. Durch einen Aufruf von "Dispose(true)" sollten sowohl verwaltete als auch native Ressourcen bereinigt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Eine interne Ausnahme ist nur innerhalb des eigenen internen Geltungsbereichs sichtbar. Sobald die Ausnahme außerhalb des internen Geltungsbereichs fällt, kann nur die Basisausnahme zum Abfangen der Ausnahme verwendet werden. Wenn die interne Ausnahme von "T:System.Exception", "T:System.SystemException" oder "T:System.ApplicationException" geerbt wird, besitzt der externe Code nicht genügend Informationen für die weitere Verarbeitung der Ausnahme.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Eine interne Ausnahme ist nur innerhalb des eigenen internen Geltungsbereichs sichtbar. Sobald die Ausnahme außerhalb des internen Geltungsbereichs fällt, kann nur die Basisausnahme zum Abfangen der Ausnahme verwendet werden. Wenn die interne Ausnahme von "T:System.Exception", "T:System.SystemException" oder "T:System.ApplicationException" geerbt wird, besitzt der externe Code nicht genügend Informationen für die weitere Verarbeitung der Ausnahme.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">"{0}" erstellt eine Ausnahme vom Typ "{1}". Dies ist ein Ausnahmetyp, der in einer Eigenschaft nicht ausgelöst werden darf. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, verwenden Sie einen anderen Ausnahmetyp, konvertieren Sie diese Eigenschaft in eine Methode, oder ändern Sie die Logik dieser Eigenschaft, sodass sie keine Ausnahme mehr auslöst.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">"{0}" erstellt eine Ausnahme vom Typ "{1}". Dies ist ein Ausnahmetyp, der in einer Eigenschaft nicht ausgelöst werden darf. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, verwenden Sie einen anderen Ausnahmetyp, konvertieren Sie diese Eigenschaft in eine Methode, oder ändern Sie die Logik dieser Eigenschaft, sodass sie keine Ausnahme mehr auslöst.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">"{0}" erstellt eine Ausnahme vom Typ "{1}". Dies ist ein Ausnahmetyp, der in diesem Methodentyp nicht ausgelöst werden darf. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, verwenden Sie entweder einen anderen Ausnahmetyp, oder ändern Sie die Logik dieser Methode, sodass sie keine Ausnahme mehr auslöst.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">"{0}" erstellt eine Ausnahme vom Typ "{1}". Dies ist ein Ausnahmetyp, der in diesem Methodentyp nicht ausgelöst werden darf. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, verwenden Sie entweder einen anderen Ausnahmetyp, oder ändern Sie die Logik dieser Methode, sodass sie keine Ausnahme mehr auslöst.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">"{0}" erstellt eine Ausnahme vom Typ "{1}". Ausnahmen dürfen in diesem Methodentyp nicht ausgelöst werden. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, ändern Sie die Logik dieser Methode, sodass sie keine Ausnahme mehr auslöst.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">"{0}" erstellt eine Ausnahme vom Typ "{1}". Ausnahmen dürfen in diesem Methodentyp nicht ausgelöst werden. Wenn diese Ausnahmeinstanz ausgelöst werden könnte, ändern Sie die Logik dieser Methode, sodass sie keine Ausnahme mehr auslöst.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Laut Konvention enthalten Bezeichnernamen keinen Unterstrich (_). Diese Regel prüft Namespaces, Typen, Member und Parameter.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Laut Konvention enthalten Bezeichnernamen keinen Unterstrich (_). Diese Regel prüft Namespaces, Typen, Member und Parameter.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Entfernen Sie die Unterstriche aus dem Assemblynamen "{0}".</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie die Unterstriche aus dem Assemblynamen "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Entfernen Sie die Unterstriche aus dem Typnamen "{0}".</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie die Unterstriche aus dem Typnamen "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Entfernen Sie die Unterstriche aus dem Membernamen "{0}".</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie die Unterstriche aus dem Membernamen "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Entfernen Sie im Typ "{0}" die Unterstriche aus dem Namen des generischen Typparameters ({1}).</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie im Typ "{0}" die Unterstriche aus dem Namen des generischen Typparameters ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Entfernen Sie in der Methode "{0}" die Unterstriche aus dem Namen des generischen Typparameters ({1}).</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie in der Methode "{0}" die Unterstriche aus dem Namen des generischen Typparameters ({1}).</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Entfernen Sie im Member "{0}" die Unterstriche aus dem Parameternamen "{1}".</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie im Member "{0}" die Unterstriche aus dem Parameternamen "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Entfernen Sie im Delegaten "{0}" die Unterstriche aus dem Parameternamen "{1}".</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Entfernen Sie im Delegaten "{0}" die Unterstriche aus dem Parameternamen "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Benennen Sie "{0}" so um, dass der Name auf "{1}" endet.</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Benennen Sie "{0}" so um, dass der Name auf "{1}" endet.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Benennen Sie "{0}" so um, dass der Name entweder auf "Collection" oder auf "{1}" endet.</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Benennen Sie "{0}" so um, dass der Name entweder auf "Collection" oder auf "{1}" endet.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Benennen Sie den Typnamen "{0}" so um, dass er nicht auf "{1}" endet.</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Benennen Sie den Typnamen "{0}" so um, dass er nicht auf "{1}" endet.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Ersetzen Sie entweder das Suffix "{0}" im Membernamen "{1}" durch die vorgeschlagene numerische Alternative "2", oder geben Sie ein aussagekräftigeres Suffix an, das den Namen von dem des ersetzten Members unterscheidet.</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Ersetzen Sie entweder das Suffix "{0}" im Membernamen "{1}" durch die vorgeschlagene numerische Alternative "2", oder geben Sie ein aussagekräftigeres Suffix an, das den Namen von dem des ersetzten Members unterscheidet.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Ersetzen Sie entweder das Suffix "{0}" im Typnamen "{1}" durch die vorgeschlagene numerische Alternative "2", oder geben Sie ein aussagekräftigeres Suffix an, das den Namen von dem des ersetzten Typs unterscheidet.</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Ersetzen Sie entweder das Suffix "{0}" im Typnamen "{1}" durch die vorgeschlagene numerische Alternative "2", oder geben Sie ein aussagekräftigeres Suffix an, das den Namen von dem des ersetzten Typs unterscheidet.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Benennen Sie im virtuellen/Schnittstellenmember "{0}" den Parameter "{1}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{2}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Parameters für einen virtuellen/Schnittstellenmember ist es für Endverbraucher in anderen Sprachen schwieriger, den Member außer Kraft zu setzen bzw. zu implementieren.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Benennen Sie im virtuellen/Schnittstellenmember "{0}" den Parameter "{1}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{2}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Parameters für einen virtuellen/Schnittstellenmember ist es für Endverbraucher in anderen Sprachen schwieriger, den Member außer Kraft zu setzen bzw. zu implementieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Benennen Sie den virtuellen/Schnittstellenmember "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines virtuellen/Schnittstellenmembers ist es für Endverbraucher in anderen Sprachen schwieriger, den Member außer Kraft zu setzen bzw. zu implementieren.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Benennen Sie den virtuellen/Schnittstellenmember "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines virtuellen/Schnittstellenmembers ist es für Endverbraucher in anderen Sprachen schwieriger, den Member außer Kraft zu setzen bzw. zu implementieren.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Benennen Sie den Typ "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Typs ist es für Endverbraucher in anderen Sprachen schwieriger, den Typ zu verwenden.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Benennen Sie den Typ "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Typs ist es für Endverbraucher in anderen Sprachen schwieriger, den Typ zu verwenden.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Benennen Sie den Namespace "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Namespace ist es für Endverbraucher in anderen Sprachen schwieriger, den Namespace zu verwenden.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Benennen Sie den Namespace "{0}" so um, dass er keinen Konflikt mit dem reservierten Sprachschlüsselwort "{1}" mehr verursacht. Durch die Verwendung eines reservierten Schlüsselworts als Name eines Namespace ist es für Endverbraucher in anderen Sprachen schwieriger, den Namespace zu verwenden.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Der Name eines öffentlichen oder geschützten Members beginnt mit ""Get"" und entspricht ansonsten dem Namen einer öffentlichen oder geschützten Eigenschaft. Get-Methoden und -Eigenschaften müssen Namen aufweisen, die ihre Funktionen klar unterscheiden.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Der Name eines öffentlichen oder geschützten Members beginnt mit ""Get"" und entspricht ansonsten dem Namen einer öffentlichen oder geschützten Eigenschaft. Get-Methoden und -Eigenschaften müssen Namen aufweisen, die ihre Funktionen klar unterscheiden.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Der Typname "{0}" verursacht vollständig oder teilweise einen Konflikt mit dem Namespacenamen "{1}". Ändern Sie einen der Namen, um den Konflikt zu beseitigen.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Der Typname "{0}" verursacht vollständig oder teilweise einen Konflikt mit dem Namespacenamen "{1}". Ändern Sie einen der Namen, um den Konflikt zu beseitigen.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Der Typname "{0}" verursacht vollständig oder teilweise einen Konflikt mit dem im .NET Framework definierten Namespacenamen "{1}". Benennen Sie den Typ um, um den Konflikt zu beseitigen.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Der Typname "{0}" verursacht vollständig oder teilweise einen Konflikt mit dem im .NET Framework definierten Namespacenamen "{1}". Benennen Sie den Typ um, um den Konflikt zu beseitigen.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">Ändern Sie im Member "{0}" den Parameternamen "{1}" in "{2}", damit er der Deklaration des Bezeichners in "{3}" entspricht.</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">Ändern Sie im Member "{0}" den Parameternamen "{1}" in "{2}", damit er der Deklaration des Bezeichners in "{3}" entspricht.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Assemblynamen "{1}" durch die bevorzugte Alternative "{2}".</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Assemblynamen "{1}" durch die bevorzugte Alternative "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Ersetzen Sie im Member "{0}" den Begriff "{1}" im Parameternamen "{2}" durch die bevorzugte Alternative "{3}".</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Ersetzen Sie im Member "{0}" den Begriff "{1}" im Parameternamen "{2}" durch die bevorzugte Alternative "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Ersetzen Sie im Delegaten "{0}" den Begriff "{1}" im Parameternamen "{2}" durch die bevorzugte Alternative "{3}".</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Ersetzen Sie im Delegaten "{0}" den Begriff "{1}" im Parameternamen "{2}" durch die bevorzugte Alternative "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Ersetzen Sie im Typ "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch die bevorzugte Alternative "{3}".</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Ersetzen Sie im Typ "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch die bevorzugte Alternative "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Ersetzen Sie in der Methode "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch die bevorzugte Alternative "{3}".</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Ersetzen Sie in der Methode "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch die bevorzugte Alternative "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Typnamen "{1}" durch die bevorzugte Alternative "{2}".</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Typnamen "{1}" durch die bevorzugte Alternative "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Membernamen "{1}" durch die bevorzugte Alternative "{2}".</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Membernamen "{1}" durch die bevorzugte Alternative "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Assemblynamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Assemblynamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie im Member "{0}" den Begriff "{1}" im Parameternamen "{2}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie im Member "{0}" den Begriff "{1}" im Parameternamen "{2}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie im Delegaten "{0}" den Begriff "{1}" im Parameternamen "{2}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie im Delegaten "{0}" den Begriff "{1}" im Parameternamen "{2}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie im Typ "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie im Typ "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie in der Methode "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie in der Methode "{0}" den Begriff "{1}" im Namen des generischen Typparameters ({2}) durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Typnamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Typnamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Ersetzen Sie den Begriff "{0}" im Membernamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Ersetzen Sie den Begriff "{0}" im Membernamen "{1}" durch eine angemessene Alternative, oder entfernen Sie ihn komplett.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">"{0}" muss "Equals" außer Kraft setzen.</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">"{0}" muss "Equals" außer Kraft setzen.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">"{0}" muss die Operatoren für Gleichheit (==) und Ungleichheit (!=) außer Kraft setzen.</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">"{0}" muss die Operatoren für Gleichheit (==) und Ungleichheit (!=) außer Kraft setzen.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Signieren Sie "{0}" mit einem Schlüssel für einen starken Namen.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Signieren Sie "{0}" mit einem Schlüssel für einen starken Namen.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Stellen Sie vor der Bereitstellung sicher, dass "{0}" einen gültigen starken Namen aufweist.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Stellen Sie vor der Bereitstellung sicher, dass "{0}" einen gültigen starken Namen aufweist.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">GetHashCode beim Außerkraftsetzen von "Equals" außer Kraft setzen</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">GetHashCode beim Außerkraftsetzen von "Equals" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode gibt basierend auf der aktuellen Instanz einen Wert zurück, der für Hashalgorithmen und Datenstrukturen wie eine Hashtabelle geeignet ist. Zwei Objekte, die vom selben Typ und gleich sind, müssen denselben Hashcode zurückgeben.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode gibt basierend auf der aktuellen Instanz einen Wert zurück, der für Hashalgorithmen und Datenstrukturen wie eine Hashtabelle geeignet ist. Zwei Objekte, die vom selben Typ und gleich sind, müssen denselben Hashcode zurückgeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">GetHashCode beim Außerkraftsetzen von "Equals" außer Kraft setzen</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">GetHashCode beim Außerkraftsetzen von "Equals" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">"Equals" beim Überladen von Gleichheitsoperatoren außer Kraft setzen</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">"Equals" beim Überladen von Gleichheitsoperatoren außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Ein öffentlicher Typ implementiert den Gleichheitsoperator, setzt jedoch "Object.Equals" nicht außer Kraft.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Ein öffentlicher Typ implementiert den Gleichheitsoperator, setzt jedoch "Object.Equals" nicht außer Kraft.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">"Equals" beim Überladen von Gleichheitsoperatoren außer Kraft setzen</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">"Equals" beim Überladen von Gleichheitsoperatoren außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">"object.Equals" außer Kraft setzen</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">"object.Equals" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">"object.Equals" außer Kraft setzen</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">"object.Equals" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">"object.GetHashCode" außer Kraft setzen</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">"object.GetHashCode" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Klasse als statisch festlegen</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Klasse als statisch festlegen</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Der Typ {0} muss Equals außer Kraft setzen, weil IEquatable&lt;T&gt; implementiert wird.</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Der Typ {0} muss Equals außer Kraft setzen, weil IEquatable&lt;T&gt; implementiert wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">"Object.Equals(object)" bei Implementierung von "IEquatable&lt;T&gt;" außer Kraft setzen</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">"Object.Equals(object)" bei Implementierung von "IEquatable&lt;T&gt;" außer Kraft setzen</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Wenn eine asynchrone Methode direkt auf einen Task wartet, erfolgt die Fortsetzung in demselben Thread, in dem der Task erstellt wurde. Erwägen Sie den Aufruf von "Task.ConfigureAwait(Boolean)", um Ihre Absicht zur Fortsetzung zu signalisieren. Rufen Sie "ConfigureAwait(false)" auf, um Fortsetzungen für den Threadpool zu planen und so einen Deadlock für den UI-Thread zu vermeiden. Die Übergabe von FALSE ist eine geeignete Option für App-unabhängige Bibliotheken. Der Aufruf von "ConfigureAwait(true)" für den Task führt zum gleichen Verhalten wie der nicht explizite Aufruf von "ConfigureAwait". Wenn Sie diese Methode explizit aufrufen, teilen Sie den Lesern mit, dass Sie die Fortsetzung absichtlich für den ursprünglichen Synchronisierungskontext durchführen möchten.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Wenn eine asynchrone Methode direkt auf einen Task wartet, erfolgt die Fortsetzung in demselben Thread, in dem der Task erstellt wurde. Erwägen Sie den Aufruf von "Task.ConfigureAwait(Boolean)", um Ihre Absicht zur Fortsetzung zu signalisieren. Rufen Sie "ConfigureAwait(false)" auf, um Fortsetzungen für den Threadpool zu planen und so einen Deadlock für den UI-Thread zu vermeiden. Die Übergabe von FALSE ist eine geeignete Option für App-unabhängige Bibliotheken. Der Aufruf von "ConfigureAwait(true)" für den Task führt zum gleichen Verhalten wie der nicht explizite Aufruf von "ConfigureAwait". Wenn Sie diese Methode explizit aufrufen, teilen Sie den Lesern mit, dass Sie die Fortsetzung absichtlich für den ursprünglichen Synchronisierungskontext durchführen möchten.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Aufruf von "ConfigureAwait" für erwarteten Task erwägen</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Aufruf von "ConfigureAwait" für erwarteten Task erwägen</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Aufruf von "ConfigureAwait" für erwarteten Task erwägen</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Aufruf von "ConfigureAwait" für erwarteten Task erwägen</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Wenn ein Object.Equals(object) durch einen Typ T außer Kraft gesetzt wird, muss die Implementierung das Objektargument in den richtigen Typ T umwandeln, bevor der Vergleich durchgeführt wird. Wenn der Typ IEquatable&lt;T&gt; implementiert und daher die T.Equals(T)-Methode anbietet und wenn das Argument zur Kompilierzeit bekanntermaßen dem Typ T entspricht, kann der Compiler IEquatable&lt;T&gt;. Equals(T) anstelle von Object.Equals(object) aufrufen. In diesem Fall ist keine Umwandlung erforderlich, sodass eine bessere Leistung erzielt werden kann.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Wenn ein Object.Equals(object) durch einen Typ T außer Kraft gesetzt wird, muss die Implementierung das Objektargument in den richtigen Typ T umwandeln, bevor der Vergleich durchgeführt wird. Wenn der Typ IEquatable&lt;T&gt; implementiert und daher die T.Equals(T)-Methode anbietet und wenn das Argument zur Kompilierzeit bekanntermaßen dem Typ T entspricht, kann der Compiler IEquatable&lt;T&gt;. Equals(T) anstelle von Object.Equals(object) aufrufen. In diesem Fall ist keine Umwandlung erforderlich, sodass eine bessere Leistung erzielt werden kann.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">"{0}" muss die Operatoren "{1}" und "Equals" definieren, weil IComparable implementiert wird.</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">"{0}" muss die Operatoren "{1}" und "Equals" definieren, weil IComparable implementiert wird.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Entfernen Sie den Aufruf von GC.Collect aus "{0}". Normalerweise ist es nicht nötig, die Garbage Collection zu erzwingen. Dies kann zu erheblichen Leistungseinbußen führen.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von GC.Collect aus "{0}". Normalerweise ist es nicht nötig, die Garbage Collection zu erzwingen. Dies kann zu erheblichen Leistungseinbußen führen.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Entfernen Sie den Aufruf von Thread.Resume aus "{0}". Das Anhalten und Fortsetzen von Threads kann gefährlich sein, wenn das System gerade einen kritischen Vorgang ausführt. Dazu gehört beispielsweise die Ausführung eines Klassenkonstruktors eines wichtigen Systemtyps oder die Auflösung der Sicherheit für eine freigegebene Assembly.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von Thread.Resume aus "{0}". Das Anhalten und Fortsetzen von Threads kann gefährlich sein, wenn das System gerade einen kritischen Vorgang ausführt. Dazu gehört beispielsweise die Ausführung eines Klassenkonstruktors eines wichtigen Systemtyps oder die Auflösung der Sicherheit für eine freigegebene Assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Entfernen Sie den Aufruf von Thread.Suspend aus "{0}". Das Anhalten und Fortsetzen von Threads kann gefährlich sein, wenn das System gerade einen kritischen Vorgang ausführt. Dazu gehört beispielsweise die Ausführung eines Klassenkonstruktors eines wichtigen Systemtyps oder die Auflösung der Sicherheit für eine freigegebene Assembly.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von Thread.Suspend aus "{0}". Das Anhalten und Fortsetzen von Threads kann gefährlich sein, wenn das System gerade einen kritischen Vorgang ausführt. Dazu gehört beispielsweise die Ausführung eines Klassenkonstruktors eines wichtigen Systemtyps oder die Auflösung der Sicherheit für eine freigegebene Assembly.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Entfernen Sie den Aufruf von System.Type.InvokeMember mit BindingFlags.NonPublic aus "{0}". Durch das Übernehmen einer Abhängigkeit von einem privaten Member erhöht sich das Risiko auf eine zukünftige fehlerhafte Änderung.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von System.Type.InvokeMember mit BindingFlags.NonPublic aus "{0}". Durch das Übernehmen einer Abhängigkeit von einem privaten Member erhöht sich das Risiko auf eine zukünftige fehlerhafte Änderung.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">"{0}" ist eine P/Invoke-Deklaration für eine OLE32-API, die nach der Initialisierung der Runtime nicht zuverlässig aufgerufen werden kann. The Problemumgehung besteht darin, einen nicht verwalteten Shim zu schreiben, der die Routine aufruft und aktiviert und anschließend im verwalteten Code aufruft. Hierzu können Sie einen Export aus einer C++-DLL im gemischten Modus verwenden, indem Sie eine verwaltete Komponente für die Verwendung durch COM registrieren oder indem Sie die API für das Hosting der Laufzeit verwenden.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">"{0}" ist eine P/Invoke-Deklaration für eine OLE32-API, die nach der Initialisierung der Runtime nicht zuverlässig aufgerufen werden kann. The Problemumgehung besteht darin, einen nicht verwalteten Shim zu schreiben, der die Routine aufruft und aktiviert und anschließend im verwalteten Code aufruft. Hierzu können Sie einen Export aus einer C++-DLL im gemischten Modus verwenden, indem Sie eine verwaltete Komponente für die Verwendung durch COM registrieren oder indem Sie die API für das Hosting der Laufzeit verwenden.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">"{0}" ist eine P/Invoke-Deklaration für eine OLE32-API, die nicht zuverlässig für einen Runtime Callable Wrapper (ein verwaltetes Objekt, das ein COM-Objekt umschließt) aufgerufen werden kann. Runtime Callable Wrapper rufen Schnittstellenzeiger dynamisch ab, sodass die Wirkung des Aufrufs willkürlich verloren gehen kann. Runtime Callable Wrapper für ein bestimmtes COM-Objekt werden auch in der gesamten Anwendungsdomäne freigegeben, sodass der Aufruf sich auch auf andere Benutzer auswirken kann. Ersetzen Sie diesen Aufruf durch ein COM-Objekt mit einem nativen Wrapper für den Schnittstellenzeiger, der die geeigneten CoSetProxyBlanket-Aufrufe ausführt.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">"{0}" ist eine P/Invoke-Deklaration für eine OLE32-API, die nicht zuverlässig für einen Runtime Callable Wrapper (ein verwaltetes Objekt, das ein COM-Objekt umschließt) aufgerufen werden kann. Runtime Callable Wrapper rufen Schnittstellenzeiger dynamisch ab, sodass die Wirkung des Aufrufs willkürlich verloren gehen kann. Runtime Callable Wrapper für ein bestimmtes COM-Objekt werden auch in der gesamten Anwendungsdomäne freigegeben, sodass der Aufruf sich auch auf andere Benutzer auswirken kann. Ersetzen Sie diesen Aufruf durch ein COM-Objekt mit einem nativen Wrapper für den Schnittstellenzeiger, der die geeigneten CoSetProxyBlanket-Aufrufe ausführt.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Entfernen Sie den Aufruf von "SafeHandle.DangerousGetHandle" aus "{0}".</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von "SafeHandle.DangerousGetHandle" aus "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Entfernen Sie den Aufruf von "Assembly.LoadFrom" aus "{0}".</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von "Assembly.LoadFrom" aus "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Entfernen Sie den Aufruf von "Assembly.LoadFile" aus "{0}".</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von "Assembly.LoadFile" aus "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Entfernen Sie den Aufruf von "Assembly.LoadWithPartialName" aus "{0}".</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Entfernen Sie den Aufruf von "Assembly.LoadWithPartialName" aus "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">"{0}", eine in "{1}" deklarierte Variable, besitzt denselben Namen wie ein Instanzenfeld für den Typ. Ändern Sie den Namen eines der Elemente.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">"{0}", eine in "{1}" deklarierte Variable, besitzt denselben Namen wie ein Instanzenfeld für den Typ. Ändern Sie den Namen eines der Elemente.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">"{0}", ein in "{1}" deklarierter Parameter, besitzt denselben Namen wie ein Instanzenfeld für den Typ. Ändern Sie den Namen eines der Elemente.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">"{0}", ein in "{1}" deklarierter Parameter, besitzt denselben Namen wie ein Instanzenfeld für den Typ. Ändern Sie den Namen eines der Elemente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Der Parameter "{0}" der Methode "{1}" wird niemals verwendet. Entfernen Sie den Parameter, oder verwenden Sie ihn im Methodentext.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Der Parameter "{0}" der Methode "{1}" wird niemals verwendet. Entfernen Sie den Parameter, oder verwenden Sie ihn im Methodentext.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">"{0}" erstellt eine neue Instanz von "{1}", die nicht verwendet wird. Übergeben Sie die Instanz als Argument an eine andere Methode, weisen Sie die Instanz einer Variablen zu, oder entfernen Sie die Objekterstellung, sofern sie unnötig ist.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">"{0}" erstellt eine neue Instanz von "{1}", die nicht verwendet wird. Übergeben Sie die Instanz als Argument an eine andere Methode, weisen Sie die Instanz einer Variablen zu, oder entfernen Sie die Objekterstellung, sofern sie unnötig ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">"{0}" ruft "{1}" auf, verwendet jedoch nicht die neue Zeichenfolgeninstanz, die von der Methode zurückgegeben wird. Übergeben Sie die Instanz als Argument an eine andere Methode, weisen Sie die Instanz einer Variablen zu, oder entfernen Sie den Aufruf, sofern er unnötig ist.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">"{0}" ruft "{1}" auf, verwendet jedoch nicht die neue Zeichenfolgeninstanz, die von der Methode zurückgegeben wird. Übergeben Sie die Instanz als Argument an eine andere Methode, weisen Sie die Instanz einer Variablen zu, oder entfernen Sie den Aufruf, sofern er unnötig ist.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">"{0}" ruft "{1}" auf, verwendet jedoch nicht den HRESULT-Wert oder den Fehlercode, der von der Methode zurückgegeben wird. Dies kann zu unerwartetem Verhalten bei Fehlerbedingungen oder in Situationen mit Ressourcenknappheit führen. Verwenden Sie das Ergebnis in einer Bedingungsanweisung, weisen Sie das Ergebnis einer Variablen zu, oder übergeben Sie es als Argument an eine andere Methode.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">"{0}" ruft "{1}" auf, verwendet jedoch nicht den HRESULT-Wert oder den Fehlercode, der von der Methode zurückgegeben wird. Dies kann zu unerwartetem Verhalten bei Fehlerbedingungen oder in Situationen mit Ressourcenknappheit führen. Verwenden Sie das Ergebnis in einer Bedingungsanweisung, weisen Sie das Ergebnis einer Variablen zu, oder übergeben Sie es als Argument an eine andere Methode.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">"{0}" ruft "{1}" auf, überprüft aber nicht explizit, ob die Konvertierung erfolgreich verlaufen ist. Verwenden Sie entweder den Rückgabewert in einer Bedingungsanweisung, oder prüfen Sie, ob die Aufrufsite erwartet, dass das ausgehende Argument bei einem Konvertierungsfehler auf den Standardwert festgelegt wird.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">"{0}" ruft "{1}" auf, überprüft aber nicht explizit, ob die Konvertierung erfolgreich verlaufen ist. Verwenden Sie entweder den Rückgabewert in einer Bedingungsanweisung, oder prüfen Sie, ob die Aufrufsite erwartet, dass das ausgehende Argument bei einem Konvertierungsfehler auf den Standardwert festgelegt wird.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">"{0}" ist eine interne Klasse, die offenbar niemals instanziiert wird. Entfernen Sie in diesem Fall den Code aus der Assembly. Wenn diese Klasse nur statische Member enthalten soll, legen Sie sie als "static" fest ("Shared" in Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">"{0}" ist eine interne Klasse, die offenbar niemals instanziiert wird. Entfernen Sie in diesem Fall den Code aus der Assembly. Wenn diese Klasse nur statische Member enthalten soll, legen Sie sie als "static" fest ("Shared" in Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">"{0}" ruft "{1}" auf, verwendet jedoch nicht den von der Methode zurückgegebenen Wert. Weil "{1}" als Pure-Methode markiert ist, kann sie keine Nebeneffekte haben. Verwenden Sie das Ergebnis in einer Bedingungsanweisung, weisen Sie das Ergebnis einer Variablen zu, oder übergeben Sie es als Argument an eine andere Methode.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">"{0}" ruft "{1}" auf, verwendet jedoch nicht den von der Methode zurückgegebenen Wert. Weil "{1}" als Pure-Methode markiert ist, kann sie keine Nebeneffekte haben. Verwenden Sie das Ergebnis in einer Bedingungsanweisung, weisen Sie das Ergebnis einer Variablen zu, oder übergeben Sie es als Argument an eine andere Methode.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">Die Eigenschaft "{0}" darf nicht sich selbst zugewiesen werden.</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">Die Eigenschaft "{0}" darf nicht sich selbst zugewiesen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">"{0}" ist ein mehrdimensionales Array. Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">"{0}" ist ein mehrdimensionales Array. Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">"{0}" gibt ein mehrdimensionales Array von "{1}" zurück. Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">"{0}" gibt ein mehrdimensionales Array von "{1}" zurück. Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">"{0}" verwendet ein mehrdimensionales Array von "{1}". Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">"{0}" verwendet ein mehrdimensionales Array von "{1}". Ersetzen Sie es nach Möglichkeit durch ein Jagged Array.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitar async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitar async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitar async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitar async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Los nombres de métodos asincrónicos deben terminar en Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Los nombres de métodos asincrónicos deben terminar en Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Los nombres de métodos asincrónicos deben terminar en Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Los nombres de métodos asincrónicos deben terminar en Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Considere el uso de un diseño donde "{0}" no tenga más de {1} parámetros de tipo.</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Considere el uso de un diseño donde "{0}" no tenga más de {1} parámetros de tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Evitar parámetros out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Evitar parámetros out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; es una colección genérica diseñada para el rendimiento, no para la herencia. La lista&lt;T&gt; no contiene miembros virtuales que faciliten el cambio de comportamiento de una clase heredada.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; es una colección genérica diseñada para el rendimiento, no para la herencia. La lista&lt;T&gt; no contiene miembros virtuales que faciliten el cambio de comportamiento de una clase heredada.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">No pasar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">No pasar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">No pasar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">No pasar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Para pasar tipos por referencia (mediante out o ref) se necesita tener experiencia con punteros, comprender en qué se diferencian los tipos de valor y los tipos de referencia y saber usar métodos que tengan varios valores devueltos. Además, la diferencia entre los parámetros out y ref no se ha entendido del todo.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Para pasar tipos por referencia (mediante out o ref) se necesita tener experiencia con punteros, comprender en qué se diferencian los tipos de valor y los tipos de referencia y saber usar métodos que tengan varios valores devueltos. Además, la diferencia entre los parámetros out y ref no se ha entendido del todo.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">No almacenar expresiones lambda asincrónicas como void que devuelve tipos de delegado</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Elimine el finalizador del tipo "{0}", reemplace el valor de "Dispose(bool disposing)" y coloque la lógica de finalización en la ruta de código de manera que el valor de "disposing" se establezca como falso. De lo contrario, se duplicarían las invocaciones de "Dispose" ya que el tipo Base "{1}" también ofrece un finalizador.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Elimine el finalizador del tipo "{0}", reemplace el valor de "Dispose(bool disposing)" y coloque la lógica de finalización en la ruta de código de manera que el valor de "disposing" se establezca como falso. De lo contrario, se duplicarían las invocaciones de "Dispose" ya que el tipo Base "{1}" también ofrece un finalizador.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar elementos CancellationToken cuando sea posible</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagar elementos CancellationToken cuando sea posible</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar elementos CancellationToken cuando sea posible</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagar elementos CancellationToken cuando sea posible</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">No mezclar código de bloqueo y asincrónico</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">No mezclar código de bloqueo y asincrónico</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">No mezclar código de bloqueo y asincrónico</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">No mezclar código de bloqueo y asincrónico</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">En la enumeración {0}, cambie el nombre de {1} a "None".</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">En la enumeración {0}, cambie el nombre de {1} a "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Quite todos los miembros que tienen valor cero de {0}, excepto uno denominado "None".</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Quite todos los miembros que tienen valor cero de {0}, excepto uno denominado "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Agregue un miembro a {0} que tenga valor cero con el nombre sugerido "None".</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Agregue un miembro a {0} que tenga valor cero con el nombre sugerido "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Common Language Specification (CLS) define las restricciones de nomenclatura, los tipos de datos y las reglas a las que los ensamblados deben ajustarse si se van a usar en los lenguajes de programación. Los procedimientos de diseño recomendados dictan que se use CLSCompliantAttribute para indicar explícitamente el cumplimiento de CLS. Si el atributo no está presente en un ensamblado, este no se considera conforme.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Common Language Specification (CLS) define las restricciones de nomenclatura, los tipos de datos y las reglas a las que los ensamblados deben ajustarse si se van a usar en los lenguajes de programación. Los procedimientos de diseño recomendados dictan que se use CLSCompliantAttribute para indicar explícitamente el cumplimiento de CLS. Si el atributo no está presente en un ensamblado, este no se considera conforme.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Marcar los ensamblados con CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Marcar los ensamblados con CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Marcar los ensamblados con ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Marcar los ensamblados con ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Puesto que {0} expone tipos visibles externamente, márquelo con ComVisible(false) en el nivel de ensamblado y, después, marque todos los tipos del ensamblado que se deben exponer a clientes COM con ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Puesto que {0} expone tipos visibles externamente, márquelo con ComVisible(false) en el nivel de ensamblado y, después, marque todos los tipos del ensamblado que se deben exponer a clientes COM con ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Marcar atributos con AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Marcar atributos con AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Al definir un atributo personalizado, márquelo con AttributeUsageAttribute para indicar dónde se puede aplicar el atributo personalizado en el código fuente. El significado de un atributo y el uso que se le va a dar determinará sus ubicaciones válidas en el código.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Al definir un atributo personalizado, márquelo con AttributeUsageAttribute para indicar dónde se puede aplicar el atributo personalizado en el código fuente. El significado de un atributo y el uso que se le va a dar determinará sus ubicaciones válidas en el código.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Especifique AttributeUsage en {0}.</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Especifique AttributeUsage en {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Aunque el atributo {0} hereda AttributeUsage del tipo base, debe considerar especificar de forma explícita AttributeUsage en el tipo para mejorar la legibilidad del código y la documentación.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Aunque el atributo {0} hereda AttributeUsage del tipo base, debe considerar especificar de forma explícita AttributeUsage en el tipo para mejorar la legibilidad del código y la documentación.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Agregue un descriptor de acceso de propiedades público de solo lectura para el argumento posicional {0} del atributo {1}.</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Agregue un descriptor de acceso de propiedades público de solo lectura para el argumento posicional {0} del atributo {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Quite el establecedor de propiedades de {0} o reduzca su accesibilidad, dado que corresponde al argumento posicional {1}.</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Quite el establecedor de propiedades de {0} o reduzca su accesibilidad, dado que corresponde al argumento posicional {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Si {0} es el descriptor de acceso de propiedades para el argumento posicional {1}, hágalo público.</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Si {0} es el descriptor de acceso de propiedades para el argumento posicional {1}, hágalo público.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Un método público o protegido tiene un nombre que comienza por “Get”, no toma ningún parámetro y devuelve un valor que no es una matriz. El método puede ser un buen candidato para convertirse en propiedad.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Un método público o protegido tiene un nombre que comienza por “Get”, no toma ningún parámetro y devuelve un valor que no es una matriz. El método puede ser un buen candidato para convertirse en propiedad.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marcar las enumeraciones con FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marcar las enumeraciones con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Una enumeración es un tipo de valor que define un conjunto de constantes con nombre relacionadas. Aplique FlagsAttribute a una enumeración cuando sus constantes con nombre se pueden combinar con sentido.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Una enumeración es un tipo de valor que define un conjunto de constantes con nombre relacionadas. Aplique FlagsAttribute a una enumeración cuando sus constantes con nombre se pueden combinar con sentido.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marcar las enumeraciones con FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marcar las enumeraciones con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Un tipo público o protegido implementa la interfaz System.IComparable. No invalida Object.Equals ni sobrecarga el operador específico del lenguaje por un operador de igualdad, desigualdad, menor que, menor o igual que, mayor que o bien mayor o igual que.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Un tipo público o protegido implementa la interfaz System.IComparable. No invalida Object.Equals ni sobrecarga el operador específico del lenguaje por un operador de igualdad, desigualdad, menor que, menor o igual que, mayor que o bien mayor o igual que.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} debe invalidar Equals, porque implementa IComparable.</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} debe invalidar Equals, porque implementa IComparable.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} debe definir los operadores "{1}", porque implementa IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} debe definir los operadores "{1}", porque implementa IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">El nombre de una interfaz visible externamente no empieza por "I" mayúscula. El nombre de un parámetro de tipo genérico en un tipo o método visible externamente no empieza por "T" mayúscula.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">El nombre de una interfaz visible externamente no empieza por "I" mayúscula. El nombre de un parámetro de tipo genérico en un tipo o método visible externamente no empieza por "T" mayúscula.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Agregue el prefijo "I" al nombre de la interfaz {0}.</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Agregue el prefijo "I" al nombre de la interfaz {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Agregue el prefijo "T" al nombre del parámetro de tipo genérico {0}.</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Agregue el prefijo "T" al nombre del parámetro de tipo genérico {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">No marcar las enumeraciones con FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">No marcar las enumeraciones con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Una enumeración visible externamente está marcada con FlagsAttribute y tiene uno o varios valores que no son potencias de dos o una combinación de los otros valores definidos en la enumeración.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Una enumeración visible externamente está marcada con FlagsAttribute y tiene uno o varios valores que no son potencias de dos o una combinación de los otros valores definidos en la enumeración.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">No marcar las enumeraciones con FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">No marcar las enumeraciones con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Proporcione un método con el nombre "{0}" como texto alternativo descriptivo para el operador {1}.</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Proporcione un método con el nombre "{0}" como texto alternativo descriptivo para el operador {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Proporcione una propiedad con el nombre "{0}" como texto alternativo descriptivo para el operador {1}.</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Proporcione una propiedad con el nombre "{0}" como texto alternativo descriptivo para el operador {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Proporcione un método con el nombre "{0}" o "{1}" como texto alternativo para el operador {2}.</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Proporcione un método con el nombre "{0}" o "{1}" como texto alternativo para el operador {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Marque {0} como public porque es un texto alternativo descriptivo para el operador {1}.</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Marque {0} como public porque es un texto alternativo descriptivo para el operador {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Implementar IEquatable al invalidar Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Implementar IEquatable al invalidar Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">El tipo {0} debe implementar IEquatable&lt;T&gt; porque reemplaza a Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">El tipo {0} debe implementar IEquatable&lt;T&gt; porque reemplaza a Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Los parámetros CancellationToken deben aparecer en último lugar</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Los parámetros CancellationToken deben aparecer en último lugar</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Puesto que {0} expone tipos visibles externamente, márquelo con ComVisible(false) en el nivel de ensamblado y, después, marque todos los tipos del ensamblado que se deben exponer a clientes COM con ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Puesto que {0} expone tipos visibles externamente, márquelo con ComVisible(false) en el nivel de ensamblado y, después, marque todos los tipos del ensamblado que se deben exponer a clientes COM con ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Considere cambiar el atributo ComVisible de {0} a false e incluirlo en el nivel de tipo.</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Considere cambiar el atributo ComVisible de {0} a false e incluirlo en el nivel de tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Implementar IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Implementar IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Implementar la interfaz IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Implementar la interfaz IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Quite FlagsAttribute de la enumeración.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Quite FlagsAttribute de la enumeración.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Aplique FlagsAttribute a la enumeración.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Aplique FlagsAttribute a la enumeración.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">El almacenamiento de la enumeración debe ser de tipo Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">El almacenamiento de la enumeración debe ser de tipo Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Si es posible, convierta el tipo subyacente de {0} en System.Int32 en lugar de {1}.</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Si es posible, convierta el tipo subyacente de {0} en System.Int32 en lugar de {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Agregue el constructor siguiente a {0}: {1}.</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Agregue el constructor siguiente a {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Cambie la accesibilidad de {0} a {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Cambie la accesibilidad de {0} a {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">No anide el tipo {0}. Como alternativa, cambie su accesibilidad para que no esté visible externamente.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">No anide el tipo {0}. Como alternativa, cambie su accesibilidad para que no esté visible externamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">No anide el tipo {0}. Como alternativa, cambie su accesibilidad para que no esté visible externamente. Si este tipo está definido en un módulo de Visual Basic, se considerará un tipo anidado en otros lenguajes .NET. En ese caso, considere sacar el tipo del módulo.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">No anide el tipo {0}. Como alternativa, cambie su accesibilidad para que no esté visible externamente. Si este tipo está definido en un módulo de Visual Basic, se considerará un tipo anidado en otros lenguajes .NET. En ese caso, considere sacar el tipo del módulo.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Proporcionar un mensaje ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Proporcionar un mensaje ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Un tipo o miembro se marca mediante un atributo System.ObsoleteAttribute para el que no se ha especificado la propiedad ObsoleteAttribute.Message. Cuando se compila un tipo o un miembro marcado con ObsoleteAttribute, se muestra la propiedad Message del atributo. Esto proporciona información al usuario sobre el miembro o tipo obsoleto.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Un tipo o miembro se marca mediante un atributo System.ObsoleteAttribute para el que no se ha especificado la propiedad ObsoleteAttribute.Message. Cuando se compila un tipo o un miembro marcado con ObsoleteAttribute, se muestra la propiedad Message del atributo. Esto proporciona información al usuario sobre el miembro o tipo obsoleto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Proporcione un mensaje para ObsoleteAttribute que marque {0} como Obsolete.</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Proporcione un mensaje para ObsoleteAttribute que marque {0} como Obsolete.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Puesto que la propiedad {0} es de solo escritura, agregue un captador de propiedad con una accesibilidad que sea mayor o igual que su establecedor o convierta la propiedad en un método.</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Puesto que la propiedad {0} es de solo escritura, agregue un captador de propiedad con una accesibilidad que sea mayor o igual que su establecedor o convierta la propiedad en un método.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Puesto que el captador de propiedad de {0} es menos visible que su establecedor, aumente la accesibilidad de su captador o reduzca la de su establecedor.</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Puesto que el captador de propiedad de {0} es menos visible que su establecedor, aumente la accesibilidad de su captador o reduzca la de su establecedor.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Implementar IDisposable correctamente</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Implementar IDisposable correctamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Todos los tipos IDisposable deben implementar el patrón Dispose correctamente.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Todos los tipos IDisposable deben implementar el patrón Dispose correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Elimine IDisposable de la lista de interfaces implementadas por "{0}" puesto que ya está implementado por el tipo base "{1}".</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Elimine IDisposable de la lista de interfaces implementadas por "{0}" puesto que ya está implementado por el tipo base "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Elimine "{0}", reemplace Dispose(bool disposing) y coloque la lógica de eliminación en la ruta de acceso al código de manera que "disposing" se establezca en verdadero.</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Elimine "{0}", reemplace Dispose(bool disposing) y coloque la lógica de eliminación en la ruta de acceso al código de manera que "disposing" se establezca en verdadero.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Modifique "{0}" de manera que llame a Dispose(true), seguidamente llame a GC.SuppressFinalize en la instancia actual del objeto ("this" o "Me" en Visual Basic) y finalmente devuelva un valor.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Modifique "{0}" de manera que llame a Dispose(true), seguidamente llame a GC.SuppressFinalize en la instancia actual del objeto ("this" o "Me" en Visual Basic) y finalmente devuelva un valor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Modifique "{0}" para que llame a Dispose(false) y luego devuelva un valor.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Modifique "{0}" para que llame a Dispose(false) y luego devuelva un valor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Proporcione una implementación reemplazable de Dispose(bool) en "{0}" o marque el tipo como sellado. Una llamada a Dispose(false) solo debería limpiar recursos nativos. Una llamada a Dispose(true) debería limpiar tanto recursos administrados como nativos.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Proporcione una implementación reemplazable de Dispose(bool) en "{0}" o marque el tipo como sellado. Una llamada a Dispose(false) solo debería limpiar recursos nativos. Una llamada a Dispose(true) debería limpiar tanto recursos administrados como nativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Una excepción interna solo se ve dentro de su propio ámbito interno. Cuando la excepción está fuera del ámbito interno, solo se puede usar la excepción base para capturarla. Si la excepción interna se hereda de T:System.Exception, T:System.SystemException o T:System.ApplicationException, el código externo no tendrá información suficiente para saber qué hacer con ella.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Una excepción interna solo se ve dentro de su propio ámbito interno. Cuando la excepción está fuera del ámbito interno, solo se puede usar la excepción base para capturarla. Si la excepción interna se hereda de T:System.Exception, T:System.SystemException o T:System.ApplicationException, el código externo no tendrá información suficiente para saber qué hacer con ella.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crea una excepción de tipo {1}, que no debe producirse en una propiedad. Si puede producirse esta instancia de excepción, use un tipo de excepción diferente, convierta esta propiedad en un método o cambie la lógica de la propiedad para que deje de producir una excepción.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea una excepción de tipo {1}, que no debe producirse en una propiedad. Si puede producirse esta instancia de excepción, use un tipo de excepción diferente, convierta esta propiedad en un método o cambie la lógica de la propiedad para que deje de producir una excepción.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crea una excepción de tipo {1}, que no debe producirse en este tipo de método. Si puede producirse esta instancia de excepción, use un tipo de excepción diferente o cambie la lógica de este método para que deje de producir una excepción.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea una excepción de tipo {1}, que no debe producirse en este tipo de método. Si puede producirse esta instancia de excepción, use un tipo de excepción diferente o cambie la lógica de este método para que deje de producir una excepción.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} crea una excepción de tipo {1}. No se deben producir excepciones en este tipo de método. Si puede producirse esta instancia de excepción, cambie la lógica de este método para que deje de producir una excepción.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea una excepción de tipo {1}. No se deben producir excepciones en este tipo de método. Si puede producirse esta instancia de excepción, cambie la lógica de este método para que deje de producir una excepción.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Por convención, los nombres de identificador no contienen el carácter de subrayado (_). La regla comprueba espacios de nombres, tipos, miembros y parámetros.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Por convención, los nombres de identificador no contienen el carácter de subrayado (_). La regla comprueba espacios de nombres, tipos, miembros y parámetros.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Quite los caracteres de subrayado del nombre de ensamblado {0}.</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Quite los caracteres de subrayado del nombre de ensamblado {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Quite los caracteres de subrayado del nombre de tipo {0}.</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Quite los caracteres de subrayado del nombre de tipo {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Quite los caracteres de subrayado del nombre de miembro {0}.</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Quite los caracteres de subrayado del nombre de miembro {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">En el tipo {0}, quite los caracteres de subrayado del nombre de parámetro de tipo genérico {1}.</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">En el tipo {0}, quite los caracteres de subrayado del nombre de parámetro de tipo genérico {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">En el método {0}, quite los caracteres de subrayado del nombre de parámetro de tipo genérico {1}.</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">En el método {0}, quite los caracteres de subrayado del nombre de parámetro de tipo genérico {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">En el miembro {0}, quite los caracteres de subrayado del nombre de parámetro {1}.</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">En el miembro {0}, quite los caracteres de subrayado del nombre de parámetro {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">En el delegado {0}, quite los caracteres de subrayado del nombre de parámetro {1}.</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">En el delegado {0}, quite los caracteres de subrayado del nombre de parámetro {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Cambie el nombre de {0} para que termine en "{1}".</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Cambie el nombre de {0} para que termine en "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Cambie el nombre de {0} para que termine en "Collection" o en "{1}".</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Cambie el nombre de {0} para que termine en "Collection" o en "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Cambie el nombre del tipo {0} para que no termine en "{1}".</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Cambie el nombre del tipo {0} para que no termine en "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Reemplace el sufijo "{0}" en el nombre del miembro {1} por la alternativa numérica "2" sugerida o proporcione un sufijo más significativo que lo distinga del miembro al que reemplaza.</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Reemplace el sufijo "{0}" en el nombre del miembro {1} por la alternativa numérica "2" sugerida o proporcione un sufijo más significativo que lo distinga del miembro al que reemplaza.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Reemplace el sufijo "{0}" en el nombre del tipo {1} por la alternativa numérica "2" sugerida o proporcione un sufijo más significativo que lo distinga del tipo al que reemplaza.</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Reemplace el sufijo "{0}" en el nombre del tipo {1} por la alternativa numérica "2" sugerida o proporcione un sufijo más significativo que lo distinga del tipo al que reemplaza.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">En el miembro virtual o de interfaz {0}, cambie el nombre del parámetro {1} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{2}”. El uso de una palabra clave reservada como nombre de un parámetro en un miembro virtual o de interfaz dificulta que consumidores de otros lenguajes invaliden o implementen el miembro.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">En el miembro virtual o de interfaz {0}, cambie el nombre del parámetro {1} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{2}”. El uso de una palabra clave reservada como nombre de un parámetro en un miembro virtual o de interfaz dificulta que consumidores de otros lenguajes invaliden o implementen el miembro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Cambie el nombre del miembro virtual o de interfaz {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un miembro virtual o de interfaz dificulta que usuarios de otros lenguajes invaliden o implementen el miembro.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Cambie el nombre del miembro virtual o de interfaz {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un miembro virtual o de interfaz dificulta que usuarios de otros lenguajes invaliden o implementen el miembro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Cambie el nombre del tipo {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un tipo dificulta que los consumidores de otros lenguajes usen el tipo.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Cambie el nombre del tipo {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un tipo dificulta que los consumidores de otros lenguajes usen el tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Cambie el nombre del espacio de nombres {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un espacio de nombres dificulta que los consumidores de otros lenguajes usen el espacio de nombres.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Cambie el nombre del espacio de nombres {0} para que deje de estar en conflicto con la palabra clave reservada del lenguaje “{1}”. El uso de una palabra clave reservada como nombre de un espacio de nombres dificulta que los consumidores de otros lenguajes usen el espacio de nombres.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">El nombre de un miembro público o protegido comienza con "Get" y en cualquier otro caso coincide con el nombre de una propiedad pública o protegida. Las propiedades y métodos “Get” deben tener nombres que distingan claramente su función.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">El nombre de un miembro público o protegido comienza con "Get" y en cualquier otro caso coincide con el nombre de una propiedad pública o protegida. Las propiedades y métodos “Get” deben tener nombres que distingan claramente su función.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">El nombre de tipo {0} está en conflicto total o parcialmente con el nombre del espacio de nombres “{1}”. Cambie uno de los nombres para eliminar el conflicto.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">El nombre de tipo {0} está en conflicto total o parcialmente con el nombre del espacio de nombres “{1}”. Cambie uno de los nombres para eliminar el conflicto.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">El nombre de tipo {0} está en conflicto total o parcialmente con el nombre del espacio de nombres “{1}” definido en .NET Framework. Cambie el nombre del tipo para eliminar el conflicto.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">El nombre de tipo {0} está en conflicto total o parcialmente con el nombre del espacio de nombres “{1}” definido en .NET Framework. Cambie el nombre del tipo para eliminar el conflicto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">En el miembro {0}, cambie el nombre del parámetro {1} a {2} para que coincida con el identificador tal como se ha declarado en {3}.</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">En el miembro {0}, cambie el nombre del parámetro {1} a {2} para que coincida con el identificador tal como se ha declarado en {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del ensamblado {1} por la alternativa "{2}" preferida.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del ensamblado {1} por la alternativa "{2}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">En el miembro {0}, reemplace el término "{1}" en el nombre del parámetro {2} por la alternativa "{3}" preferida.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">En el miembro {0}, reemplace el término "{1}" en el nombre del parámetro {2} por la alternativa "{3}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">En el delegado {0}, reemplace el término "{1}" en el nombre del parámetro {2} por la alternativa "{3}" preferida.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">En el delegado {0}, reemplace el término "{1}" en el nombre del parámetro {2} por la alternativa "{3}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">En el tipo {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por la alternativa "{3}" preferida.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">En el tipo {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por la alternativa "{3}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">En el método {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por la alternativa "{3}" preferida.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">En el método {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por la alternativa "{3}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del tipo {1} por la alternativa "{2}".</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del tipo {1} por la alternativa "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del miembro {1} por la alternativa "{2}" preferida.</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del miembro {1} por la alternativa "{2}" preferida.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del ensamblado {1} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del ensamblado {1} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">En el miembro {0}, reemplace el término "{1}" en el nombre del parámetro {2} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">En el miembro {0}, reemplace el término "{1}" en el nombre del parámetro {2} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">En el delegado {0}, reemplace el término "{1}" en el nombre del parámetro {2} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">En el delegado {0}, reemplace el término "{1}" en el nombre del parámetro {2} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">En el tipo {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">En el tipo {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">En el método {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">En el método {0}, reemplace el término "{1}" en el nombre del parámetro de tipo genérico {2} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del tipo {1} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del tipo {1} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Reemplace el término "{0}" en el nombre del miembro {1} por una alternativa adecuada o quítelo totalmente.</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Reemplace el término "{0}" en el nombre del miembro {1} por una alternativa adecuada o quítelo totalmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} debe reemplazar Equals.</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} debe reemplazar Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} debe reemplazar los operadores de igualdad (==) y desigualdad (!=).</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} debe reemplazar los operadores de igualdad (==) y desigualdad (!=).</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Firme {0} con una clave de nombre seguro.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Firme {0} con una clave de nombre seguro.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Compruebe que {0} tiene un nombre seguro válido antes de implementar.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Compruebe que {0} tiene un nombre seguro válido antes de implementar.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Reemplazar GetHashCode al reemplazar Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Reemplazar GetHashCode al reemplazar Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode devuelve un valor basado en la instancia actual que se adapta a las estructuras de datos y los algoritmos hash, como una tabla hash. Dos objetos iguales del mismo tipo deben devolver el mismo código hash.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode devuelve un valor basado en la instancia actual que se adapta a las estructuras de datos y los algoritmos hash, como una tabla hash. Dos objetos iguales del mismo tipo deben devolver el mismo código hash.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Reemplazar GetHashCode al reemplazar Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Reemplazar GetHashCode al reemplazar Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Reemplazar Equals al sobrecargar operadores de igualdad</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Reemplazar Equals al sobrecargar operadores de igualdad</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Un tipo público implementa el operador de igualdad, pero no reemplaza Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Un tipo público implementa el operador de igualdad, pero no reemplaza Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Reemplazar Equals al sobrecargar operadores de igualdad</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Reemplazar Equals al sobrecargar operadores de igualdad</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Reemplazar object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Reemplazar object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Reemplazar object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Reemplazar object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Reemplazar object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Reemplazar object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Convertir la clase en estática</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Convertir la clase en estática</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">El tipo {0} debe reemplazar a Equals porque implementa IEquatable&lt;T&gt;.</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">El tipo {0} debe reemplazar a Equals porque implementa IEquatable&lt;T&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Reemplazar Object.Equals(object) al implementar IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Reemplazar Object.Equals(object) al implementar IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Cuando un método asincrónico espera una tarea directamente, la continuación se produce en el mismo subproceso que creó la tarea. Puede llamar a Task.ConfigureAwait(Boolean) para indicar su intención de continuación. Llame a ConfigureAwait(false) en la tarea para programar las continuaciones en el grupo de subprocesos, lo que evita un interbloqueo en el subproceso de IU. Pasar el valor false es una opción adecuada para bibliotecas independientes de aplicación. El comportamiento obtenido al llamar a ConfigureAwait(true) en la tarea coincide con no llamar explícitamente a ConfigureAwait. Al llamar a este método de forma explícita, se informa a los lectores de que quiere realizar la continuación en el contexto de sincronización original.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Cuando un método asincrónico espera una tarea directamente, la continuación se produce en el mismo subproceso que creó la tarea. Puede llamar a Task.ConfigureAwait(Boolean) para indicar su intención de continuación. Llame a ConfigureAwait(false) en la tarea para programar las continuaciones en el grupo de subprocesos, lo que evita un interbloqueo en el subproceso de IU. Pasar el valor false es una opción adecuada para bibliotecas independientes de aplicación. El comportamiento obtenido al llamar a ConfigureAwait(true) en la tarea coincide con no llamar explícitamente a ConfigureAwait. Al llamar a este método de forma explícita, se informa a los lectores de que quiere realizar la continuación en el contexto de sincronización original.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Puede llamar a ConfigureAwait en la tarea esperada</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Puede llamar a ConfigureAwait en la tarea esperada</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Puede llamar a ConfigureAwait en la tarea esperada</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Puede llamar a ConfigureAwait en la tarea esperada</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Cuando un tipo T reemplaza a Object.Equals(object), la implementación debe convertir el argumento de objeto al tipo T correcto antes de realizar la comparación. Si el tipo implementa IEquatable&lt;T&gt; y, por tanto, ofrece el método T.Equals(T) y si se sabe que el argumento es de tipo T en tiempo de compilación, el compilador puede llamar a IEquatable&lt;T&gt;. Equals(T) en lugar de a Object.Equals(object) y no es necesaria ninguna conversión, lo que mejora el rendimiento.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Cuando un tipo T reemplaza a Object.Equals(object), la implementación debe convertir el argumento de objeto al tipo T correcto antes de realizar la comparación. Si el tipo implementa IEquatable&lt;T&gt; y, por tanto, ofrece el método T.Equals(T) y si se sabe que el argumento es de tipo T en tiempo de compilación, el compilador puede llamar a IEquatable&lt;T&gt;. Equals(T) en lugar de a Object.Equals(object) y no es necesaria ninguna conversión, lo que mejora el rendimiento.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} debe definir los operadores "{1}" y también Equals, porque implementa IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} debe definir los operadores "{1}" y también Equals, porque implementa IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Quite la llamada a GC.Collect de {0}. Normalmente no es necesario forzar la recolección de elementos no utilizados y, si lo hace, puede degradar considerablemente el rendimiento.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Quite la llamada a GC.Collect de {0}. Normalmente no es necesario forzar la recolección de elementos no utilizados y, si lo hace, puede degradar considerablemente el rendimiento.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Quite la llamada a Thread.Resume de {0}. Suspender y reanudar subprocesos puede ser peligroso si el sistema está en medio de una operación crítica como, por ejemplo, ejecutar un constructor de clases de un tipo de sistema importante o resolver la seguridad de un ensamblado compartido.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Quite la llamada a Thread.Resume de {0}. Suspender y reanudar subprocesos puede ser peligroso si el sistema está en medio de una operación crítica como, por ejemplo, ejecutar un constructor de clases de un tipo de sistema importante o resolver la seguridad de un ensamblado compartido.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Quite la llamada a Thread.Suspend de {0}. Suspender y reanudar subprocesos puede ser peligroso si el sistema está en medio de una operación crítica como, por ejemplo, ejecutar un constructor de clases de un tipo de sistema importante o resolver la seguridad de un ensamblado compartido.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Quite la llamada a Thread.Suspend de {0}. Suspender y reanudar subprocesos puede ser peligroso si el sistema está en medio de una operación crítica como, por ejemplo, ejecutar un constructor de clases de un tipo de sistema importante o resolver la seguridad de un ensamblado compartido.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Quite la llamada a System.Type.InvokeMember con BindingFlags.NonPublic de {0}. Tomar una dependencia en un miembro privado aumenta la posibilidad de que se produzca un cambio drástico en el futuro.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Quite la llamada a System.Type.InvokeMember con BindingFlags.NonPublic de {0}. Tomar una dependencia en un miembro privado aumenta la posibilidad de que se produzca un cambio drástico en el futuro.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} es una declaración P/Invoke a una API OLE32 a la que no se puede llamar de forma confiable una vez inicializado el entorno de ejecución. La solución es escribir correcciones de compatibilidad (shim) no administradas que llamen a la rutina y, después, activen y llamen a código administrado. Para ello, use una exportación de una DLL de C++ en modo mixto, registre un componente administrado para que lo use COM o utilice la API de hospedaje del entorno de ejecución.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} es una declaración P/Invoke a una API OLE32 a la que no se puede llamar de forma confiable una vez inicializado el entorno de ejecución. La solución es escribir correcciones de compatibilidad (shim) no administradas que llamen a la rutina y, después, activen y llamen a código administrado. Para ello, use una exportación de una DLL de C++ en modo mixto, registre un componente administrado para que lo use COM o utilice la API de hospedaje del entorno de ejecución.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} es una declaración P/Invoke a una API OLE32 a la que no se puede llamar de forma confiable respecto a un contenedor RCW (objeto administrado que contiene un objeto COM). Los contenedores RCW capturan punteros de interfaz de forma dinámica; por tanto, el efecto de la llamada se puede perder de forma arbitraria. Los contenedores RCW de un objeto COM dado se comparten también en el dominio de una aplicación, de forma que la llamada podría afectar a otros usuarios. Reemplace esta llamada por un objeto COM contenedor nativo para el puntero de interfaz que realiza las llamadas a CoSetProxyBlanket correspondientes.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} es una declaración P/Invoke a una API OLE32 a la que no se puede llamar de forma confiable respecto a un contenedor RCW (objeto administrado que contiene un objeto COM). Los contenedores RCW capturan punteros de interfaz de forma dinámica; por tanto, el efecto de la llamada se puede perder de forma arbitraria. Los contenedores RCW de un objeto COM dado se comparten también en el dominio de una aplicación, de forma que la llamada podría afectar a otros usuarios. Reemplace esta llamada por un objeto COM contenedor nativo para el puntero de interfaz que realiza las llamadas a CoSetProxyBlanket correspondientes.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Quite la llamada a SafeHandle.DangerousGetHandle de {0}.</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Quite la llamada a SafeHandle.DangerousGetHandle de {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Quite la llamada a Assembly.LoadFrom de {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Quite la llamada a Assembly.LoadFrom de {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Quite la llamada a Assembly.LoadFile de {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Quite la llamada a Assembly.LoadFile de {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Quite la llamada a Assembly.LoadWithPartialName de {0}.</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Quite la llamada a Assembly.LoadWithPartialName de {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, una variable declarada en {1}, tiene el mismo nombre que un campo de instancia en el tipo. Cambie el nombre de uno de estos elementos.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, una variable declarada en {1}, tiene el mismo nombre que un campo de instancia en el tipo. Cambie el nombre de uno de estos elementos.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, un parámetro declarado en {1}, tiene el mismo nombre que un campo de instancia en el tipo. Cambie el nombre de uno de estos elementos.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, un parámetro declarado en {1}, tiene el mismo nombre que un campo de instancia en el tipo. Cambie el nombre de uno de estos elementos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">El parámetro {0} del método {1} no se usa nunca. Quite el parámetro o úselo en el cuerpo del método.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">El parámetro {0} del método {1} no se usa nunca. Quite el parámetro o úselo en el cuerpo del método.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} crea una instancia de {1} que no se usa nunca. Pase la instancia como argumento a otro método, asigne la instancia a una variable o quite la creación del objeto si no es necesaria.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} crea una instancia de {1} que no se usa nunca. Pase la instancia como argumento a otro método, asigne la instancia a una variable o quite la creación del objeto si no es necesaria.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} llama a {1} pero no usa la nueva instancia de cadena que devuelve el método. Pase la instancia como argumento a otro método, asigne la instancia a una variable o quite la llamada si no es necesaria.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} llama a {1} pero no usa la nueva instancia de cadena que devuelve el método. Pase la instancia como argumento a otro método, asigne la instancia a una variable o quite la llamada si no es necesaria.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} llama a {1} pero no usa el código de error o HRESULT que devuelve el método. Esto puede dar lugar a un comportamiento inesperado en condiciones de error o situaciones de pocos recursos. Use el resultado en una instrucción condicional, asigne el resultado a una variable o páselo como argumento a otro método.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} llama a {1} pero no usa el código de error o HRESULT que devuelve el método. Esto puede dar lugar a un comportamiento inesperado en condiciones de error o situaciones de pocos recursos. Use el resultado en una instrucción condicional, asigne el resultado a una variable o páselo como argumento a otro método.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} llama a {1} pero no comprueba de forma explícita si la conversión se realizó correctamente. Use el valor devuelto en una instrucción condicional o compruebe que el sitio de la llamada espera que el argumento de salida se establezca en el valor predeterminado cuando la conversión no es correcta.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} llama a {1} pero no comprueba de forma explícita si la conversión se realizó correctamente. Use el valor devuelto en una instrucción condicional o compruebe que el sitio de la llamada espera que el argumento de salida se establezca en el valor predeterminado cuando la conversión no es correcta.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} es una clase interna de la que aparentemente nunca se crea una instancia. Si es así, quite el código del ensamblado. Si esta clase está destinada a contener solo miembros estáticos, conviértala en static (Shared en Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} es una clase interna de la que aparentemente nunca se crea una instancia. Si es así, quite el código del ensamblado. Si esta clase está destinada a contener solo miembros estáticos, conviértala en static (Shared en Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} llama a {1} pero no usa el valor que el método devuelve. {1} se ha marcado como método Pure, por lo que no puede tener efectos secundarios. Use el resultado en una instrucción condicional, asigne el resultado a una variable o páselo como argumento a otro método.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} llama a {1} pero no usa el valor que el método devuelve. {1} se ha marcado como método Pure, por lo que no puede tener efectos secundarios. Use el resultado en una instrucción condicional, asigne el resultado a una variable o páselo como argumento a otro método.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">La propiedad {0} no debe asignarse a sí misma.</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">La propiedad {0} no debe asignarse a sí misma.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} es una matriz multidimensional. Sustitúyala por una matriz escalonada si fuera posible.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} es una matriz multidimensional. Sustitúyala por una matriz escalonada si fuera posible.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} devuelve una matriz multidimensional de {1}. Sustitúyala por una matriz escalonada si fuera posible.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} devuelve una matriz multidimensional de {1}. Sustitúyala por una matriz escalonada si fuera posible.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} utiliza una matriz multidimensional de {1}. Sustitúyala por una matriz escalonada si fuera posible.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} utiliza una matriz multidimensional de {1}. Sustitúyala por una matriz escalonada si fuera posible.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Éviter Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Éviter Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Éviter Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Éviter Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Les noms de méthodes Async doivent finir par Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Les noms de méthodes Async doivent finir par Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Les noms de méthodes Async doivent finir par Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Les noms de méthodes Async doivent finir par Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Utilisez une conception où '{0}' n'a pas plus de {1} paramètres de type</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Utilisez une conception où '{0}' n'a pas plus de {1} paramètres de type</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Éviter les paramètres out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Éviter les paramètres out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; est une collection générique conçue pour les performances et non pour l'héritage. List&lt;T&gt; ne contient pas de membres virtuels qui facilitent le changement de comportement d'une classe héritée.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; est une collection générique conçue pour les performances et non pour l'héritage. List&lt;T&gt; ne contient pas de membres virtuels qui facilitent le changement de comportement d'une classe héritée.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Ne pas passer de lambdas asynchrones en tant que types délégués retournant void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Ne pas passer de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Ne pas passer de lambdas asynchrones en tant que types délégués retournant void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Ne pas passer de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Le passage de types par référence (via out ou ref) nécessite une bonne connaissance des pointeurs, une bonne compréhension des différences entre les types valeur et les types référence ainsi qu'une certaine expérience de la gestion des méthodes ayant plusieurs valeurs de retour. En effet, la différence entre les paramètres out et ref n'est pas comprise par tout le monde.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Le passage de types par référence (via out ou ref) nécessite une bonne connaissance des pointeurs, une bonne compréhension des différences entre les types valeur et les types référence ainsi qu'une certaine expérience de la gestion des méthodes ayant plusieurs valeurs de retour. En effet, la différence entre les paramètres out et ref n'est pas comprise par tout le monde.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Ne pas stocker de lambdas asynchrones en tant que types délégués retournant void</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Supprimez le finaliseur du type '{0}', remplacez Dispose(bool disposing) et placez la logique de finalisation dans le chemin de code où 'disposing' est false. Sinon, vous risquez d'avoir des invocations de Dispose en double, car le type de base '{1}' fournit aussi un finaliseur.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Supprimez le finaliseur du type '{0}', remplacez Dispose(bool disposing) et placez la logique de finalisation dans le chemin de code où 'disposing' est false. Sinon, vous risquez d'avoir des invocations de Dispose en double, car le type de base '{1}' fournit aussi un finaliseur.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propager CancellationTokens quand cela est possible</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propager CancellationTokens quand cela est possible</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propager CancellationTokens quand cela est possible</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propager CancellationTokens quand cela est possible</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Ne pas mélanger bloquant et asynchrone</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Ne pas mélanger bloquant et asynchrone</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Ne pas mélanger bloquant et asynchrone</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Ne pas mélanger bloquant et asynchrone</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">Dans l'enum {0}, changez le nom de {1} en 'None'</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">Dans l'enum {0}, changez le nom de {1} en 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Supprimez de {0} tous les membres ayant la valeur zéro, à l'exception d'un membre nommé 'None'</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Supprimez de {0} tous les membres ayant la valeur zéro, à l'exception d'un membre nommé 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Ajoutez un membre à {0} ayant la valeur zéro et le nom suggéré 'None'</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Ajoutez un membre à {0} ayant la valeur zéro et le nom suggéré 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">La spécification CLS (Common Language Specification) définit des restrictions de nommage, des types de données, ainsi que des règles auxquelles les assemblys doivent se conformer pour pouvoir être utilisés avec les langages de programmation. Un design est correct quand tous les assemblys indiquent explicitement la conformité CLS avec CLSCompliantAttribute. Si cet attribut n'est pas présent sur un assembly, l'assembly n'est pas conforme.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">La spécification CLS (Common Language Specification) définit des restrictions de nommage, des types de données, ainsi que des règles auxquelles les assemblys doivent se conformer pour pouvoir être utilisés avec les langages de programmation. Un design est correct quand tous les assemblys indiquent explicitement la conformité CLS avec CLSCompliantAttribute. Si cet attribut n'est pas présent sur un assembly, l'assembly n'est pas conforme.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Marquer les assemblys avec CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Marquer les assemblys avec CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Marquer les assemblys avec ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Marquer les assemblys avec ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Dans la mesure où {0} expose les types visibles de manière externe, marquez-le avec ComVisible(false) au niveau de l'assembly, puis marquez tous les types dans l'assembly qui doivent être exposés aux clients COM avec ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Dans la mesure où {0} expose les types visibles de manière externe, marquez-le avec ComVisible(false) au niveau de l'assembly, puis marquez tous les types dans l'assembly qui doivent être exposés aux clients COM avec ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Marquer les attributs avec AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Marquer les attributs avec AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Quand vous définissez un attribut personnalisé, marquez-le avec AttributeUsageAttribute pour indiquer où l'attribut personnalisé peut être appliqué dans le code source. La signification et l'utilisation prévue d'un attribut déterminent ses emplacements valides dans le code.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Quand vous définissez un attribut personnalisé, marquez-le avec AttributeUsageAttribute pour indiquer où l'attribut personnalisé peut être appliqué dans le code source. La signification et l'utilisation prévue d'un attribut déterminent ses emplacements valides dans le code.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Spécifiez AttributeUsage sur {0}</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Spécifiez AttributeUsage sur {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Même si l'attribut {0} hérite de AttributeUsage à partir de son type de base, vous devez spécifier explicitement AttributeUsage sur le type pour améliorer la documentation et la lisibilité du code.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Même si l'attribut {0} hérite de AttributeUsage à partir de son type de base, vous devez spécifier explicitement AttributeUsage sur le type pour améliorer la documentation et la lisibilité du code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Ajoutez un accesseur de propriété en lecture seule pour l'argument positionnel {0} de l'attribut {1}</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Ajoutez un accesseur de propriété en lecture seule pour l'argument positionnel {0} de l'attribut {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Supprimez la méthode setter de propriété de {0}, ou réduisez son accessibilité, car il correspond à l'argument positionnel {1}</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Supprimez la méthode setter de propriété de {0}, ou réduisez son accessibilité, car il correspond à l'argument positionnel {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Si {0} est l'accesseur de propriété pour l'argument positionnel {1}, déclarez-le public</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Si {0} est l'accesseur de propriété pour l'argument positionnel {1}, déclarez-le public</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Le nom d'une méthode publique ou protégée commence par ""Get"", n'accepte aucun paramètre et retourne une valeur qui n'est pas un tableau. La méthode est susceptible de devenir une propriété.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Le nom d'une méthode publique ou protégée commence par ""Get"", n'accepte aucun paramètre et retourne une valeur qui n'est pas un tableau. La méthode est susceptible de devenir une propriété.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marquer les enums avec FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marquer les enums avec FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Une énumération est un type valeur qui définit un ensemble de constantes nommées associées. Appliquez FlagsAttribute à une énumération quand ses constantes nommées peuvent être combinées de manière pertinente.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Une énumération est un type valeur qui définit un ensemble de constantes nommées associées. Appliquez FlagsAttribute à une énumération quand ses constantes nommées peuvent être combinées de manière pertinente.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marquer les enums avec FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marquer les enums avec FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Un type public ou protégé implémente l'interface System.IComparable. Il ne remplace pas Object.Equals. De même, il ne surcharge pas l'opérateur égal à, différent de, inférieur à, inférieur ou égal à, supérieur à, supérieur ou égal à propre au langage.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Un type public ou protégé implémente l'interface System.IComparable. Il ne remplace pas Object.Equals. De même, il ne surcharge pas l'opérateur égal à, différent de, inférieur à, inférieur ou égal à, supérieur à, supérieur ou égal à propre au langage.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} doit remplacer Égal, car il implémente IComparable</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} doit remplacer Égal, car il implémente IComparable</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} doit définir le ou les opérateurs '{1}', car il implémente IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} doit définir le ou les opérateurs '{1}', car il implémente IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Le nom d'une interface visible de manière externe ne commence pas par un ""I"" majuscule. Le nom d'un paramètre de type générique sur un type ou une méthode visible de manière externe ne commence pas par un ""T"" majuscule.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Le nom d'une interface visible de manière externe ne commence pas par un ""I"" majuscule. Le nom d'un paramètre de type générique sur un type ou une méthode visible de manière externe ne commence pas par un ""T"" majuscule.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Faites précéder de la lettre 'I' le nom d'interface {0}</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Faites précéder de la lettre 'I' le nom d'interface {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Faites précéder de la lettre 'T' le nom de paramètre de type générique {0}</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Faites précéder de la lettre 'T' le nom de paramètre de type générique {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Ne pas marquer les enums avec l'attribut FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Ne pas marquer les enums avec l'attribut FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Une énumération visible de manière externe est marquée par FlagsAttribute. Elle a une ou plusieurs valeurs qui ne sont pas des puissances de deux ou une combinaison des autres valeurs définies dans l'énumération.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Une énumération visible de manière externe est marquée par FlagsAttribute. Elle a une ou plusieurs valeurs qui ne sont pas des puissances de deux ou une combinaison des autres valeurs définies dans l'énumération.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Ne pas marquer les enums avec l'attribut FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Ne pas marquer les enums avec l'attribut FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Fournissez une méthode nommée '{0}' comme solution de remplacement conviviale de l'opérateur {1}</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Fournissez une méthode nommée '{0}' comme solution de remplacement conviviale de l'opérateur {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Fournissez une propriété nommée '{0}' comme solution de remplacement conviviale de l'opérateur {1}</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Fournissez une propriété nommée '{0}' comme solution de remplacement conviviale de l'opérateur {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Fournissez une méthode nommée '{0}' ou '{1}' comme solution de remplacement de l'opérateur {2}</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Fournissez une méthode nommée '{0}' ou '{1}' comme solution de remplacement de l'opérateur {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Marquez {0} comme étant public, car il s'agit d'une solution de remplacement conviviale de l'opérateur {1}</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Marquez {0} comme étant public, car il s'agit d'une solution de remplacement conviviale de l'opérateur {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Implémenter IEquatable au moment de remplacer Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Implémenter IEquatable au moment de remplacer Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Le type {0} doit implémenter IEquatable&lt;T&gt;, car il remplace Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Le type {0} doit implémenter IEquatable&lt;T&gt;, car il remplace Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Les paramètres CancellationToken doivent venir en dernier</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Les paramètres CancellationToken doivent venir en dernier</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Dans la mesure où {0} expose les types visibles de manière externe, marquez-le avec ComVisible(false) au niveau de l'assembly, puis marquez tous les types dans l'assembly qui doivent être exposés aux clients COM avec ComVisible(true)</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Dans la mesure où {0} expose les types visibles de manière externe, marquez-le avec ComVisible(false) au niveau de l'assembly, puis marquez tous les types dans l'assembly qui doivent être exposés aux clients COM avec ComVisible(true)</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Changez éventuellement l'attribut ComVisible sur {0} en lui affectant la valeur false, puis intervenez au niveau du type</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Changez éventuellement l'attribut ComVisible sur {0} en lui affectant la valeur false, puis intervenez au niveau du type</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Implémenter IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Implémenter IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Implémenter l'interface IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Implémenter l'interface IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Supprimez FlagsAttribute de l'enum.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Supprimez FlagsAttribute de l'enum.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Appliquez FlagsAttribute à l'enum.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Appliquez FlagsAttribute à l'enum.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Le stockage d'enum doit être de type Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Le stockage d'enum doit être de type Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Si possible, faites en sorte que le type sous-jacent de {0} soit System.Int32 au lieu de {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Si possible, faites en sorte que le type sous-jacent de {0} soit System.Int32 au lieu de {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Ajoutez le constructeur suivant à {0} : {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Ajoutez le constructeur suivant à {0} : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Changez l'accessibilité de {0} en {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Changez l'accessibilité de {0} en {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">N'imbriquez pas le type {0}. Vous pouvez aussi changer son accessibilité pour qu'il ne soit pas visible de manière externe.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">N'imbriquez pas le type {0}. Vous pouvez aussi changer son accessibilité pour qu'il ne soit pas visible de manière externe.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">N'imbriquez pas le type {0}. Vous pouvez aussi changer son accessibilité pour qu'il ne soit pas visible de manière externe. Si ce type est défini dans un module Visual Basic, il est considéré comme un type imbriqué dans d'autres langages .NET. Dans ce cas, déplacez le type en dehors du module.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">N'imbriquez pas le type {0}. Vous pouvez aussi changer son accessibilité pour qu'il ne soit pas visible de manière externe. Si ce type est défini dans un module Visual Basic, il est considéré comme un type imbriqué dans d'autres langages .NET. Dans ce cas, déplacez le type en dehors du module.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Fournir un message ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Fournir un message ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Un type ou un membre est marqué à l'aide d'un attribut System.ObsoleteAttribute dont la propriété ObsoleteAttribute.Message n'est pas spécifiée. Quand un type ou un membre marqué à l'aide de ObsoleteAttribute est compilé, la propriété Message de l'attribut s'affiche. Cela fournit à l'utilisateur des informations sur le type ou le membre obsolète.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Un type ou un membre est marqué à l'aide d'un attribut System.ObsoleteAttribute dont la propriété ObsoleteAttribute.Message n'est pas spécifiée. Quand un type ou un membre marqué à l'aide de ObsoleteAttribute est compilé, la propriété Message de l'attribut s'affiche. Cela fournit à l'utilisateur des informations sur le type ou le membre obsolète.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Fournir un message pour l'attribut ObsoleteAttribute qui marque {0} comme étant obsolète</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Fournir un message pour l'attribut ObsoleteAttribute qui marque {0} comme étant obsolète</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Dans la mesure où la propriété {0} est en écriture seule, ajoutez une méthode getter de propriété avec une accessibilité supérieure ou égale à celle de sa méthode setter, ou convertissez cette propriété en méthode</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Dans la mesure où la propriété {0} est en écriture seule, ajoutez une méthode getter de propriété avec une accessibilité supérieure ou égale à celle de sa méthode setter, ou convertissez cette propriété en méthode</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Dans la mesure où la méthode getter de propriété pour {0} est moins visible que sa méthode setter, augmentez l'accessibilité de sa méthode getter ou diminuez celle de sa méthode setter</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Dans la mesure où la méthode getter de propriété pour {0} est moins visible que sa méthode setter, augmentez l'accessibilité de sa méthode getter ou diminuez celle de sa méthode setter</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Implémenter IDisposable correctement</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Implémenter IDisposable correctement</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Tous les types IDisposable doivent implémenter le modèle Dispose correctement.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Tous les types IDisposable doivent implémenter le modèle Dispose correctement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Supprimez IDisposable de la liste des interfaces implémentées par '{0}', car elle est déjà implémentée par le type de base '{1}'</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Supprimez IDisposable de la liste des interfaces implémentées par '{0}', car elle est déjà implémentée par le type de base '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Supprimez '{0}', remplacez Dispose(bool disposing) et placez la logique dispose dans le chemin de code où 'disposing' est true</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Supprimez '{0}', remplacez Dispose(bool disposing) et placez la logique dispose dans le chemin de code où 'disposing' est true</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Modifez '{0}' pour qu'il appelle Dispose(true), puis GC.SuppressFinalize sur l'instance d'objet actuelle ('this' ou 'Me' en Visual Basic), puis retourne un résultat</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Modifez '{0}' pour qu'il appelle Dispose(true), puis GC.SuppressFinalize sur l'instance d'objet actuelle ('this' ou 'Me' en Visual Basic), puis retourne un résultat</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Modifiez '{0}' pour qu'il appelle Dispose(false), puis retourne un résultat</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Modifiez '{0}' pour qu'il appelle Dispose(false), puis retourne un résultat</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Fournissez une implémentation remplaçable de Dispose(bool) sur '{0}' ou marquez le type comme sealed. Un appel à Dispose(false) doit uniquement nettoyer les ressources natives. Un appel à Dispose(true) doit nettoyer les ressources natives et managées.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Fournissez une implémentation remplaçable de Dispose(bool) sur '{0}' ou marquez le type comme sealed. Un appel à Dispose(false) doit uniquement nettoyer les ressources natives. Un appel à Dispose(true) doit nettoyer les ressources natives et managées.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Une exception interne est visible uniquement à l'intérieur de sa propre portée interne. Quand l'exception est en dehors de la portée interne, seule l'exception de base peut être utilisée pour intercepter l'exception. Si l'exception interne est héritée de T:System.Exception, T:System.SystemException ou T:System.ApplicationException, le code externe n'a pas suffisamment d'informations pour savoir comment traiter l'exception.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Une exception interne est visible uniquement à l'intérieur de sa propre portée interne. Quand l'exception est en dehors de la portée interne, seule l'exception de base peut être utilisée pour intercepter l'exception. Si l'exception interne est héritée de T:System.Exception, T:System.SystemException ou T:System.ApplicationException, le code externe n'a pas suffisamment d'informations pour savoir comment traiter l'exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crée une exception de type {1}, un type d'exception qui ne doit pas être levé dans une propriété. Si cette instance d'exception est susceptible d'être levée, utilisez un autre type d'exception, convertissez cette propriété en méthode ou changez la logique de cette propriété pour qu'elle ne lève plus d'exception.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crée une exception de type {1}, un type d'exception qui ne doit pas être levé dans une propriété. Si cette instance d'exception est susceptible d'être levée, utilisez un autre type d'exception, convertissez cette propriété en méthode ou changez la logique de cette propriété pour qu'elle ne lève plus d'exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crée une exception de type {1}, un type d'exception qui ne doit pas être levé dans ce type de méthode. Si cette instance d'exception est susceptible d'être levée, utilisez un autre type d'exception ou changez la logique de cette méthode pour qu'elle ne lève plus d'exception.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crée une exception de type {1}, un type d'exception qui ne doit pas être levé dans ce type de méthode. Si cette instance d'exception est susceptible d'être levée, utilisez un autre type d'exception ou changez la logique de cette méthode pour qu'elle ne lève plus d'exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} crée une exception de type {1}. Les exceptions ne doivent pas être levées dans ce type de méthode. Si cette instance d'exception est susceptible d'être levée, changez la logique de cette méthode pour qu'elle ne lève plus d'exception.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crée une exception de type {1}. Les exceptions ne doivent pas être levées dans ce type de méthode. Si cette instance d'exception est susceptible d'être levée, changez la logique de cette méthode pour qu'elle ne lève plus d'exception.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Par convention, les noms d'identificateurs ne contiennent pas le caractère de soulignement (_). Cette règle vérifie les espaces de noms, les types, les membres et les paramètres.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Par convention, les noms d'identificateurs ne contiennent pas le caractère de soulignement (_). Cette règle vérifie les espaces de noms, les types, les membres et les paramètres.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Supprimez les traits de soulignement du nom d'assembly {0}</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Supprimez les traits de soulignement du nom d'assembly {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Supprimez les traits de soulignement du nom de type {0}</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Supprimez les traits de soulignement du nom de type {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Supprimez les traits de soulignement du nom de membre {0}</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Supprimez les traits de soulignement du nom de membre {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Dans le type {0}, supprimez les traits de soulignement du nom de paramètre de type générique {1}</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Dans le type {0}, supprimez les traits de soulignement du nom de paramètre de type générique {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Dans la méthode {0}, supprimez les traits de soulignement du nom de paramètre de type générique {1}</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Dans la méthode {0}, supprimez les traits de soulignement du nom de paramètre de type générique {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Dans le membre {0}, supprimez les traits de soulignement du nom de paramètre {1}</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Dans le membre {0}, supprimez les traits de soulignement du nom de paramètre {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Dans le délégué {0}, supprimez les traits de soulignement du nom de paramètre {1}</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Dans le délégué {0}, supprimez les traits de soulignement du nom de paramètre {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Renommez {0} pour qu'il finisse par '{1}'</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Renommez {0} pour qu'il finisse par '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Renommez {0} pour qu'il finisse par 'Collection' ou par '{1}'</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Renommez {0} pour qu'il finisse par 'Collection' ou par '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Renommez le nom de type {0} pour qu'il ne finisse pas par '{1}'</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Renommez le nom de type {0} pour qu'il ne finisse pas par '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Remplacez le suffixe '{0}' dans le nom de membre {1} par le substitut numérique suggéré '2', ou fournissez un suffixe plus significatif qui le distingue du membre qu'il remplace</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Remplacez le suffixe '{0}' dans le nom de membre {1} par le substitut numérique suggéré '2', ou fournissez un suffixe plus significatif qui le distingue du membre qu'il remplace</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Remplacez le suffixe '{0}' dans le nom de type {1} par le substitut numérique suggéré '2', ou fournissez un suffixe plus significatif qui le distingue du type qu'il remplace</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Remplacez le suffixe '{0}' dans le nom de type {1} par le substitut numérique suggéré '2', ou fournissez un suffixe plus significatif qui le distingue du type qu'il remplace</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Dans le membre virtuel/membre d'interface {0}, renommez le paramètre {1} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{2}'. L'utilisation d'un mot clé réservé comme nom de paramètre pour un membre virtuel/membre d'interface rend plus difficile le remplacement/l'implémentation du membre par les contrôles serveur consommateurs dans d'autres langages.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Dans le membre virtuel/membre d'interface {0}, renommez le paramètre {1} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{2}'. L'utilisation d'un mot clé réservé comme nom de paramètre pour un membre virtuel/membre d'interface rend plus difficile le remplacement/l'implémentation du membre par les contrôles serveur consommateurs dans d'autres langages.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Renommez le membre virtuel/membre d'interface {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom de membre virtuel/membre d'interface rend plus difficile le remplacement/l'implémentation du membre par les contrôles serveur consommateurs dans d'autres langages.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Renommez le membre virtuel/membre d'interface {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom de membre virtuel/membre d'interface rend plus difficile le remplacement/l'implémentation du membre par les contrôles serveur consommateurs dans d'autres langages.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Renommez le type {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom de type rend plus difficile l'utilisation du type par les contrôles serveur consommateurs dans d'autres langages.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Renommez le type {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom de type rend plus difficile l'utilisation du type par les contrôles serveur consommateurs dans d'autres langages.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Renommez l'espace de noms {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom d'espace de noms rend plus difficile l'utilisation de l'espace de noms par les contrôles serveur consommateurs dans d'autres langages.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Renommez l'espace de noms {0} pour qu'il ne soit plus en conflit avec le mot clé de langage réservé '{1}'. L'utilisation d'un mot clé réservé comme nom d'espace de noms rend plus difficile l'utilisation de l'espace de noms par les contrôles serveur consommateurs dans d'autres langages.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Le nom d'un membre public ou protégé commence par ""Get"". Sinon, il correspond au nom d'une propriété publique ou protégée. Les méthodes et propriétés ""Get"" doivent porter des noms qui distinguent clairement leur fonction.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Le nom d'un membre public ou protégé commence par ""Get"". Sinon, il correspond au nom d'une propriété publique ou protégée. Les méthodes et propriétés ""Get"" doivent porter des noms qui distinguent clairement leur fonction.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Le nom de type {0} est en conflit partiellement ou totalement avec le nom d'espace de noms '{1}'. Changez l'un de ces deux noms pour éliminer le conflit.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Le nom de type {0} est en conflit partiellement ou totalement avec le nom d'espace de noms '{1}'. Changez l'un de ces deux noms pour éliminer le conflit.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Le nom de type {0} est en conflit partiellement ou totalement avec le nom d'espace de noms '{1}' défini dans le .NET Framework. Renommez le type pour éliminer le conflit.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Le nom de type {0} est en conflit partiellement ou totalement avec le nom d'espace de noms '{1}' défini dans le .NET Framework. Renommez le type pour éliminer le conflit.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">Dans le membre {0}, changez le nom de paramètre {1} en {2} pour faire correspondre l'identificateur tel qu'il a été déclaré dans {3}</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">Dans le membre {0}, changez le nom de paramètre {1} en {2} pour faire correspondre l'identificateur tel qu'il a été déclaré dans {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom d'assembly {1} par le terme de remplacement par défaut '{2}'</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom d'assembly {1} par le terme de remplacement par défaut '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Dans le membre {0}, remplacez le terme '{1}' du nom de paramètre {2} par le terme de remplacement par défaut '{3}'</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Dans le membre {0}, remplacez le terme '{1}' du nom de paramètre {2} par le terme de remplacement par défaut '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Dans le délégué {0}, remplacez le terme '{1}' du nom de paramètre {2} par le terme de remplacement par défaut '{3}'</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Dans le délégué {0}, remplacez le terme '{1}' du nom de paramètre {2} par le terme de remplacement par défaut '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Pour le type {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par le terme de remplacement par défaut '{3}'</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Pour le type {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par le terme de remplacement par défaut '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Pour la méthode {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par le terme de remplacement par défaut '{3}'</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Pour la méthode {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par le terme de remplacement par défaut '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom de type {1} par le terme de remplacement par défaut '{2}'</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom de type {1} par le terme de remplacement par défaut '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom de membre {1} par le terme de remplacement par défaut '{2}'</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom de membre {1} par le terme de remplacement par défaut '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom d'assembly {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom d'assembly {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Dans le membre {0}, remplacez le terme '{1}' du nom de paramètre {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Dans le membre {0}, remplacez le terme '{1}' du nom de paramètre {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Dans le délégué {0}, remplacez le terme '{1}' du nom de paramètre {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Dans le délégué {0}, remplacez le terme '{1}' du nom de paramètre {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Pour le type {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Pour le type {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Pour la méthode {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Pour la méthode {0}, remplacez le terme '{1}' du nom de paramètre de type générique {2} par un terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom de type {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom de type {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Remplacez le terme '{0}' dans le nom de membre {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Remplacez le terme '{0}' dans le nom de membre {1} par le terme de remplacement approprié, ou supprimez-le entièrement</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} doit remplacer Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} doit remplacer Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} doit remplacer les opérateurs d'égalité (==) et d'inégalité (!=)</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} doit remplacer les opérateurs d'égalité (==) et d'inégalité (!=)</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Signez {0} avec une clé de nom fort.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Signez {0} avec une clé de nom fort.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Vérifiez que {0} a un nom fort valide avant d'effectuer le déploiement.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Vérifiez que {0} a un nom fort valide avant d'effectuer le déploiement.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Remplacer GetHashCode au moment de remplacer Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Remplacer GetHashCode au moment de remplacer Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode retourne une valeur, en fonction de l'instance actuelle, qui est adaptée aux algorithmes de hachage et aux structures de données telles qu'une table de hachage. Deux objets de même type et égaux doivent retourner le même code de hachage.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode retourne une valeur, en fonction de l'instance actuelle, qui est adaptée aux algorithmes de hachage et aux structures de données telles qu'une table de hachage. Deux objets de même type et égaux doivent retourner le même code de hachage.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Remplacer GetHashCode au moment de remplacer Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Remplacer GetHashCode au moment de remplacer Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Remplacer Equals au moment de surcharger l'opérateur égal</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Remplacer Equals au moment de surcharger l'opérateur égal</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Un type public implémente l'opérateur d'égalité, mais ne remplace pas Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Un type public implémente l'opérateur d'égalité, mais ne remplace pas Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Remplacer Equals au moment de surcharger l'opérateur égal</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Remplacer Equals au moment de surcharger l'opérateur égal</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Remplacer object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Remplacer object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Remplacer object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Remplacer object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Remplacer object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Remplacer object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Rendre la classe static</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Rendre la classe static</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Le type {0} doit remplacer Equals, car il implémente IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Le type {0} doit remplacer Equals, car il implémente IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Remplacer Object.Equals(object) au moment d'implémenter IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Remplacer Object.Equals(object) au moment d'implémenter IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Quand une méthode asynchrone attend directement une tâche, la continuation se produit dans le même thread qui a créé la tâche. Appelez Task.ConfigureAwait(Boolean) pour signaler votre intention de continuer. Appelez ConfigureAwait(false) sur la tâche pour planifier les continuations sur le pool de threads, afin d'éviter un blocage sur le thread d'interface utilisateur. Vous pouvez passer false pour les bibliothèques indépendantes des applications. L'appel de ConfigureAwait(true) sur la tâche a le même comportement qu'un appel non explicite de ConfigureAwait. En appelant explicitement cette méthode, vous indiquez aux lecteurs que vous voulez volontairement effectuer la continuation sur le contexte de synchronisation d'origine.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Quand une méthode asynchrone attend directement une tâche, la continuation se produit dans le même thread qui a créé la tâche. Appelez Task.ConfigureAwait(Boolean) pour signaler votre intention de continuer. Appelez ConfigureAwait(false) sur la tâche pour planifier les continuations sur le pool de threads, afin d'éviter un blocage sur le thread d'interface utilisateur. Vous pouvez passer false pour les bibliothèques indépendantes des applications. L'appel de ConfigureAwait(true) sur la tâche a le même comportement qu'un appel non explicite de ConfigureAwait. En appelant explicitement cette méthode, vous indiquez aux lecteurs que vous voulez volontairement effectuer la continuation sur le contexte de synchronisation d'origine.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Appeler ConfigureAwait sur la tâche attendue</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Appeler ConfigureAwait sur la tâche attendue</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Appeler ConfigureAwait sur la tâche attendue</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Appeler ConfigureAwait sur la tâche attendue</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Quand un type T remplace Object.Equals(object), l'implémentation doit caster l'argument d'objet vers le type T approprié avant d'effectuer la comparaison. Si le type implémente IEquatable&lt;T&gt;, et offre donc la méthode T.Equals(T), et si l'argument est connu au moment de la compilation pour être de type T, le compilateur peut appeler IEquatable&lt;T&gt;.Equals(T) à la place de Object.Equals(object). Aucun cast n'est nécessaire, ce qui se traduit par une amélioration des performances.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Quand un type T remplace Object.Equals(object), l'implémentation doit caster l'argument d'objet vers le type T approprié avant d'effectuer la comparaison. Si le type implémente IEquatable&lt;T&gt;, et offre donc la méthode T.Equals(T), et si l'argument est connu au moment de la compilation pour être de type T, le compilateur peut appeler IEquatable&lt;T&gt;.Equals(T) à la place de Object.Equals(object). Aucun cast n'est nécessaire, ce qui se traduit par une amélioration des performances.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} doit définir le ou les opérateurs '{1}' et Égal, car il implémente IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} doit définir le ou les opérateurs '{1}' et Égal, car il implémente IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Supprimez l'appel à GC.Collect dans {0}. En règle générale, il n'est pas nécessaire d'imposer un garbage collection. En effet, cela peut sérieusement dégrader les performances.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Supprimez l'appel à GC.Collect dans {0}. En règle générale, il n'est pas nécessaire d'imposer un garbage collection. En effet, cela peut sérieusement dégrader les performances.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Supprimez l'appel à Thread.Resume dans {0}. L'interruption et la reprise de threads peuvent être dangereuses si le système est en train d'effectuer une opération critique, par exemple l'exécution d'un constructeur de classe d'un type système important ou la résolution de la sécurité pour un assembly partagé.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Supprimez l'appel à Thread.Resume dans {0}. L'interruption et la reprise de threads peuvent être dangereuses si le système est en train d'effectuer une opération critique, par exemple l'exécution d'un constructeur de classe d'un type système important ou la résolution de la sécurité pour un assembly partagé.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Supprimez l'appel à Thread.Suspend dans {0}. L'interruption et la reprise de threads peuvent être dangereuses si le système est en train d'effectuer une opération critique, par exemple l'exécution d'un constructeur de classe d'un type système important ou la résolution de la sécurité pour un assembly partagé.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Supprimez l'appel à Thread.Suspend dans {0}. L'interruption et la reprise de threads peuvent être dangereuses si le système est en train d'effectuer une opération critique, par exemple l'exécution d'un constructeur de classe d'un type système important ou la résolution de la sécurité pour un assembly partagé.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Supprimez l'appel à System.Type.InvokeMember avec BindingFlags.NonPublic dans {0}. L'acceptation d'une dépendance pour un membre privé augmente les chances de rupture dans le futur.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Supprimez l'appel à System.Type.InvokeMember avec BindingFlags.NonPublic dans {0}. L'acceptation d'une dépendance pour un membre privé augmente les chances de rupture dans le futur.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} est une déclaration P/Invoke à une API OLE32 qui ne peut pas être appelée de manière fiable après l'initialisation du runtime. La solution consiste à écrire un shim non managé qui appelle la routine, puis l'active et l'appelle dans du code managé. Vous pouvez y parvenir en utilisant une exportation d'une DLL C++ en mode mixte, en inscrivant un composant managé à utiliser par COM ou en utilisant l'API d'hébergement du runtime.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} est une déclaration P/Invoke à une API OLE32 qui ne peut pas être appelée de manière fiable après l'initialisation du runtime. La solution consiste à écrire un shim non managé qui appelle la routine, puis l'active et l'appelle dans du code managé. Vous pouvez y parvenir en utilisant une exportation d'une DLL C++ en mode mixte, en inscrivant un composant managé à utiliser par COM ou en utilisant l'API d'hébergement du runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} est une déclaration P/Invoke à une API OLE32 qui ne peut pas être appelée de manière fiable sur un wrapper RCW (objet managé incluant un objet COM dans un wrapper). Dans la mesure où les wrappers RCW récupèrent (fetch) dynamiquement les pointeurs d'interface, l'effet de l'appel peut être arbitrairement perdu. Dans la mesure où les wrappers RCW d'un objet COM donné sont également partagés dans un domaine d'application, l'appel peut affecter d'autres utilisateurs. Remplacez cet appel par un objet COM de wrapper natif pour le pointeur d'interface qui effectue les appels CoSetProxyBlanket appropriés.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} est une déclaration P/Invoke à une API OLE32 qui ne peut pas être appelée de manière fiable sur un wrapper RCW (objet managé incluant un objet COM dans un wrapper). Dans la mesure où les wrappers RCW récupèrent (fetch) dynamiquement les pointeurs d'interface, l'effet de l'appel peut être arbitrairement perdu. Dans la mesure où les wrappers RCW d'un objet COM donné sont également partagés dans un domaine d'application, l'appel peut affecter d'autres utilisateurs. Remplacez cet appel par un objet COM de wrapper natif pour le pointeur d'interface qui effectue les appels CoSetProxyBlanket appropriés.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Supprimez l'appel à SafeHandle.DangerousGetHandle dans {0}</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Supprimez l'appel à SafeHandle.DangerousGetHandle dans {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Supprimez l'appel à Assembly.LoadFrom dans {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Supprimez l'appel à Assembly.LoadFrom dans {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Supprimez l'appel à Assembly.LoadFile dans {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Supprimez l'appel à Assembly.LoadFile dans {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Supprimez l'appel à Assembly.LoadWithPartialName dans {0}</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Supprimez l'appel à Assembly.LoadWithPartialName dans {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, une variable déclarée dans {1}, a le même nom qu'un champ d'instance sur le type. Changez le nom de l'un de ces éléments.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, une variable déclarée dans {1}, a le même nom qu'un champ d'instance sur le type. Changez le nom de l'un de ces éléments.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, un paramètre déclaré dans {1}, a le même nom qu'un champ d'instance sur le type. Changez le nom de l'un de ces éléments.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, un paramètre déclaré dans {1}, a le même nom qu'un champ d'instance sur le type. Changez le nom de l'un de ces éléments.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Le paramètre {0} de la méthode {1} n'est jamais utilisé. Supprimez le paramètre ou utilisez-le dans le corps de la méthode.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Le paramètre {0} de la méthode {1} n'est jamais utilisé. Supprimez le paramètre ou utilisez-le dans le corps de la méthode.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} crée une instance de {1} qui n'est jamais utilisée. Passez l'instance en tant qu'argument à une autre méthode, assignez l'instance à une variable ou supprimez la création d'objet si elle n'est pas nécessaire.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} crée une instance de {1} qui n'est jamais utilisée. Passez l'instance en tant qu'argument à une autre méthode, assignez l'instance à une variable ou supprimez la création d'objet si elle n'est pas nécessaire.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} appelle {1} mais n'utilise pas la nouvelle instance de chaîne retournée par la méthode. Passez l'instance en tant qu'argument à une autre méthode, assignez l'instance à une variable ou supprimez l'appel s'il n'est pas nécessaire.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} appelle {1} mais n'utilise pas la nouvelle instance de chaîne retournée par la méthode. Passez l'instance en tant qu'argument à une autre méthode, assignez l'instance à une variable ou supprimez l'appel s'il n'est pas nécessaire.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} appelle {1} mais n'utilise pas la valeur HRESULT ou le code d'erreur retourné par la méthode. Cela peut entraîner un comportement inattendu dans les conditions d'erreurs ou dans les situations où les ressources sont limitées. Utilisez le résultat dans une instruction conditionnelle, assignez-le à une variable ou passez-le en tant qu'argument à une autre méthode.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} appelle {1} mais n'utilise pas la valeur HRESULT ou le code d'erreur retourné par la méthode. Cela peut entraîner un comportement inattendu dans les conditions d'erreurs ou dans les situations où les ressources sont limitées. Utilisez le résultat dans une instruction conditionnelle, assignez-le à une variable ou passez-le en tant qu'argument à une autre méthode.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} appelle {1} mais ne vérifie pas explicitement si la conversion a réussi. Utilisez la valeur de retour dans une instruction conditionnelle, ou vérifiez que le site d'appel s'attend à ce que l'argument out accepte la valeur par défaut en cas d'échec de la conversion.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} appelle {1} mais ne vérifie pas explicitement si la conversion a réussi. Utilisez la valeur de retour dans une instruction conditionnelle, ou vérifiez que le site d'appel s'attend à ce que l'argument out accepte la valeur par défaut en cas d'échec de la conversion.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} est une classe interne qui n'est apparemment jamais instanciée. Si tel est le cas, supprimez le code de l'assembly. Si cette classe est destinée à contenir uniquement des membres statiques, rendez-la static (Shared en Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} est une classe interne qui n'est apparemment jamais instanciée. Si tel est le cas, supprimez le code de l'assembly. Si cette classe est destinée à contenir uniquement des membres statiques, rendez-la static (Shared en Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} appelle {1} mais n'utilise pas la valeur retournée par la méthode. Dans la mesure où {1} est marqué en tant que méthode Pure, il ne peut pas avoir d'effets secondaires. Utilisez le résultat dans une instruction conditionnelle, assignez-le à une variable ou passez-le en tant qu'argument à une autre méthode.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} appelle {1} mais n'utilise pas la valeur retournée par la méthode. Dans la mesure où {1} est marqué en tant que méthode Pure, il ne peut pas avoir d'effets secondaires. Utilisez le résultat dans une instruction conditionnelle, assignez-le à une variable ou passez-le en tant qu'argument à une autre méthode.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">La propriété {0} ne doit pas être assignée à elle-même</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">La propriété {0} ne doit pas être assignée à elle-même</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} est un tableau multidimensionnel. Remplacez-le, si possible, par un tableau en escalier.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} est un tableau multidimensionnel. Remplacez-le, si possible, par un tableau en escalier.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} retourne un tableau multidimensionnel de {1}. Remplacez-le, si possible, par un tableau en escalier.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} retourne un tableau multidimensionnel de {1}. Remplacez-le, si possible, par un tableau en escalier.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} utilise un tableau multidimensionnel de {1}. Remplacez-le, si possible, par un tableau en escalier.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} utilise un tableau multidimensionnel de {1}. Remplacez-le, si possible, par un tableau en escalier.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitare metodi asincroni void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitare metodi asincroni void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitare metodi asincroni void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitare metodi asincroni void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">I nomi di metodi asincroni devono terminare con Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">I nomi di metodi asincroni devono terminare con Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">I nomi di metodi asincroni devono terminare con Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">I nomi di metodi asincroni devono terminare con Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Provare a usare una progettazione in cui '{0}' contiene più di {1} parametri di tipo</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Provare a usare una progettazione in cui '{0}' contiene più di {1} parametri di tipo</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Evitare parametri out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Evitare parametri out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; è una raccolta generica progettata per le prestazioni e non per l'ereditarietà. List&lt;T&gt; non contiene membri virtuali che semplificano la modifica del comportamento di una classe ereditata.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; è una raccolta generica progettata per le prestazioni e non per l'ereditarietà. List&lt;T&gt; non contiene membri virtuali che semplificano la modifica del comportamento di una classe ereditata.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Non passare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Non passare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Non passare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Non passare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Oltre all'esperienza con i puntatori, per passare tipi per riferimento (con out o ref), è necessario comprendere le differenze tra tipi valore e tipi riferimento e gestire i metodi con più valori restituiti. Anche la differenza tra parametri out e ref non è del tutto compresa.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Oltre all'esperienza con i puntatori, per passare tipi per riferimento (con out o ref), è necessario comprendere le differenze tra tipi valore e tipi riferimento e gestire i metodi con più valori restituiti. Anche la differenza tra parametri out e ref non è del tutto compresa.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Non archiviare espressioni lambda asincrone come tipi delegati che restituiscono void</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Rimuovere il finalizzatore dal tipo '{0}', eseguire l'override di Dispose(bool disposing) e inserire la logica di finalizzazione nel percorso del codice in cui 'disposing' è false. In caso contrario, potrebbero verificarsi chiamate duplicate a Dispose perché il tipo di base '{1}' fornisce anche un finalizzatore.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Rimuovere il finalizzatore dal tipo '{0}', eseguire l'override di Dispose(bool disposing) e inserire la logica di finalizzazione nel percorso del codice in cui 'disposing' è false. In caso contrario, potrebbero verificarsi chiamate duplicate a Dispose perché il tipo di base '{1}' fornisce anche un finalizzatore.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagare parametri CancellationToken quando possibile</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagare parametri CancellationToken quando possibile</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagare parametri CancellationToken quando possibile</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagare parametri CancellationToken quando possibile</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Non combinare codice di blocco e asincrono</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Non combinare codice di blocco e asincrono</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Non combinare codice di blocco e asincrono</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Non combinare codice di blocco e asincrono</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">Nell'enumerazione {0} modificare il nome di {1} in 'None'</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">Nell'enumerazione {0} modificare il nome di {1} in 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Rimuovere da {0} tutti i membri con valore zero ad eccezione dell'unico membro denominato 'None'</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Rimuovere da {0} tutti i membri con valore zero ad eccezione dell'unico membro denominato 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Aggiungere a {0} un membro con valore zero e assegnargli il nome suggerito 'None'</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Aggiungere a {0} un membro con valore zero e assegnargli il nome suggerito 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Le specifiche CLS definiscono restrizioni per l'assegnazione dei nomi, tipi di dati e regole che gli assembly devono rispettare per poter essere usati nei diversi linguaggi di programmazione. In una progettazione corretta tutti gli assembly devono indicare in modo esplicito la conformità CLS con l'attributo CLSCompliantAttribute. Se questo attributo non è presente su un assembly, l'assembly non è conforme.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Le specifiche CLS definiscono restrizioni per l'assegnazione dei nomi, tipi di dati e regole che gli assembly devono rispettare per poter essere usati nei diversi linguaggi di programmazione. In una progettazione corretta tutti gli assembly devono indicare in modo esplicito la conformità CLS con l'attributo CLSCompliantAttribute. Se questo attributo non è presente su un assembly, l'assembly non è conforme.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Contrassegnare gli assembly con CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Contrassegnare gli assembly con CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Contrassegnare gli assembly con ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Contrassegnare gli assembly con ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Dal momento che {0} espone tipi visibili esternamente, contrassegnarlo con ComVisible(false) a livello di assembly e quindi contrassegnare con ComVisible(true) tutti i tipi all'interno dell'assembly che devono essere esposti ai client COM.</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Dal momento che {0} espone tipi visibili esternamente, contrassegnarlo con ComVisible(false) a livello di assembly e quindi contrassegnare con ComVisible(true) tutti i tipi all'interno dell'assembly che devono essere esposti ai client COM.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Contrassegnare gli attributi con AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Contrassegnare gli attributi con AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Quando si definisce un attributo personalizzato, contrassegnarlo usando AttributeUsageAttribute per indicare la posizione in cui applicare l'attributo personalizzato nel codice sorgente. Il significato e l'utilizzo previsto di un attributo ne determinano le posizioni valide nel codice.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Quando si definisce un attributo personalizzato, contrassegnarlo usando AttributeUsageAttribute per indicare la posizione in cui applicare l'attributo personalizzato nel codice sorgente. Il significato e l'utilizzo previsto di un attributo ne determinano le posizioni valide nel codice.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Specificare AttributeUsage su {0}</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Specificare AttributeUsage su {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Anche se l'attributo {0} eredita AttributeUsage dal relativo tipo di base, è consigliabile provare a specificare esplicitamente AttributeUsage sul tipo per migliorare la documentazione e la leggibilità del codice.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Anche se l'attributo {0} eredita AttributeUsage dal relativo tipo di base, è consigliabile provare a specificare esplicitamente AttributeUsage sul tipo per migliorare la documentazione e la leggibilità del codice.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Aggiungere una funzione di accesso alla proprietà di sola lettura public per l'argomento posizionale {0} dell'attributo {1}</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Aggiungere una funzione di accesso alla proprietà di sola lettura public per l'argomento posizionale {0} dell'attributo {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Rimuovere il setter di proprietà da {0} o ridurne l'accessibilità perché corrisponde all'argomento posizionale {1}</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Rimuovere il setter di proprietà da {0} o ridurne l'accessibilità perché corrisponde all'argomento posizionale {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Impostare {0} come public se è la funzione di accesso alla proprietà per l'argomento posizionale {1}</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Impostare {0} come public se è la funzione di accesso alla proprietà per l'argomento posizionale {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Un metodo public o protected è contraddistinto da un nome che inizia con ""Get"", non accetta parametri e restituisce un valore diverso da una matrice. Il metodo potrebbe essere un candidato ideale per diventare una proprietà.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Un metodo public o protected è contraddistinto da un nome che inizia con ""Get"", non accetta parametri e restituisce un valore diverso da una matrice. Il metodo potrebbe essere un candidato ideale per diventare una proprietà.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Contrassegnare le enumerazioni con FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Contrassegnare le enumerazioni con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Un'enumerazione è un tipo valore che definisce un set di costanti denominate correlate. Applicare FlagsAttribute a un'enumerazione quando le relative costanti denominate possono essere combinate in modo significativo.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Un'enumerazione è un tipo valore che definisce un set di costanti denominate correlate. Applicare FlagsAttribute a un'enumerazione quando le relative costanti denominate possono essere combinate in modo significativo.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Contrassegnare le enumerazioni con FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Contrassegnare le enumerazioni con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Un tipo public o protected implementa l'interfaccia System.IComparable. Non esegue l'override di Object.Equals né l'overload dell'operatore specifico del linguaggio per uguaglianza, disuguaglianza, minore di, minore o uguale a, maggiore di o maggiore o uguale a.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Un tipo public o protected implementa l'interfaccia System.IComparable. Non esegue l'override di Object.Equals né l'overload dell'operatore specifico del linguaggio per uguaglianza, disuguaglianza, minore di, minore o uguale a, maggiore di o maggiore o uguale a.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} deve eseguire l'override di Equals perché implementa IComparable</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve eseguire l'override di Equals perché implementa IComparable</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} deve definire l'operatore o gli operatori '{1}' perché implementa IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve definire l'operatore o gli operatori '{1}' perché implementa IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Il nome di un'interfaccia visibile esternamente non inizia con una ""I"" maiuscola. Il nome di un parametro di tipo generico su un tipo o un metodo visibile esternamente non inizia con una ""T"" maiuscola.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Il nome di un'interfaccia visibile esternamente non inizia con una ""I"" maiuscola. Il nome di un parametro di tipo generico su un tipo o un metodo visibile esternamente non inizia con una ""T"" maiuscola.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Anteporre il prefisso 'I' al nome di interfaccia {0}</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Anteporre il prefisso 'I' al nome di interfaccia {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Anteporre il prefisso 'T' al nome di parametro di tipo generico {0}</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Anteporre il prefisso 'T' al nome di parametro di tipo generico {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Non contrassegnare le enumerazioni con FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Non contrassegnare le enumerazioni con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Un'enumerazione visibile esternamente è contrassegnata tramite FlagsAttribute e contiene uno o più valori che non sono potenze di due o una combinazione degli altri valori definiti nell'enumerazione.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Un'enumerazione visibile esternamente è contrassegnata tramite FlagsAttribute e contiene uno o più valori che non sono potenze di due o una combinazione degli altri valori definiti nell'enumerazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Non contrassegnare le enumerazioni con FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Non contrassegnare le enumerazioni con FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Fornire un metodo denominato '{0}' come alternativa descrittiva per l'operatore {1}</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Fornire un metodo denominato '{0}' come alternativa descrittiva per l'operatore {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Fornire una proprietà denominata '{0}' come alternativa descrittiva per l'operatore {1}</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Fornire una proprietà denominata '{0}' come alternativa descrittiva per l'operatore {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Fornire un metodo denominato '{0}' o '{1}' come alternativa per l'operatore {2}</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Fornire un metodo denominato '{0}' o '{1}' come alternativa per l'operatore {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Contrassegnare {0} come public perché è un'alternativa descrittiva per l'operatore {1}</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Contrassegnare {0} come public perché è un'alternativa descrittiva per l'operatore {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Implementare IEquatable quando si esegue l'override di Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Implementare IEquatable quando si esegue l'override di Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Il tipo {0} deve implementare IEquatable&lt;T&gt; perché esegue l'override di Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Il tipo {0} deve implementare IEquatable&lt;T&gt; perché esegue l'override di Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">I parametri CancellationToken devono essere indicati per ultimi</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">I parametri CancellationToken devono essere indicati per ultimi</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Dal momento che {0} espone tipi visibili esternamente, contrassegnarlo con ComVisible(false) a livello di assembly e quindi contrassegnare con ComVisible(true) tutti i tipi all'interno dell'assembly che devono essere esposti ai client COM</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Dal momento che {0} espone tipi visibili esternamente, contrassegnarlo con ComVisible(false) a livello di assembly e quindi contrassegnare con ComVisible(true) tutti i tipi all'interno dell'assembly che devono essere esposti ai client COM</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Provare a impostare su false l'attributo ComVisible su {0} e ad acconsentire in modo esplicito a livello di tipo</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Provare a impostare su false l'attributo ComVisible su {0} e ad acconsentire in modo esplicito a livello di tipo</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Implementare IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Implementare IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Implementare l'interfaccia IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Implementare l'interfaccia IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Rimuovere FlagsAttribute dall'enumerazione.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Rimuovere FlagsAttribute dall'enumerazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Applicare FlagsAttribute all'enumerazione.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Applicare FlagsAttribute all'enumerazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Le risorse di archiviazione dell'enumerazione devono essere Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Le risorse di archiviazione dell'enumerazione devono essere Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Se possibile, impostare System.Int32 come tipo sottostante di {0} invece di {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Se possibile, impostare System.Int32 come tipo sottostante di {0} invece di {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Aggiungere il costruttore seguente a {0}: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Aggiungere il costruttore seguente a {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Modificare l'accessibilità di {0} in {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Modificare l'accessibilità di {0} in {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Non annidare il tipo {0}. In alternativa, modificarne l'accessibilità in modo che non sia visibile esternamente.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Non annidare il tipo {0}. In alternativa, modificarne l'accessibilità in modo che non sia visibile esternamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Non annidare il tipo {0}. In alternativa, modificarne l'accessibilità in modo che non sia visibile esternamente. Se questo tipo è definito in un modulo Visual Basic, verrà considerato come un tipo nidificato in altri linguaggi .NET. In tal caso, provare a spostare il tipo all'esterno del modulo.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Non annidare il tipo {0}. In alternativa, modificarne l'accessibilità in modo che non sia visibile esternamente. Se questo tipo è definito in un modulo Visual Basic, verrà considerato come un tipo nidificato in altri linguaggi .NET. In tal caso, provare a spostare il tipo all'esterno del modulo.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Fornire il messaggio per ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Fornire il messaggio per ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Un tipo o un membro viene contrassegnato con un attributo System.ObsoleteAttribute per il quale non è stata specificata la proprietà ObsoleteAttribute.Message. Quando si compila un membro o un tipo contrassegnato usando ObsoleteAttribute, viene visualizzata la proprietà Message dell'attributo. In questo modo vengono fornite le informazioni utente sul tipo o sul membro obsoleto.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Un tipo o un membro viene contrassegnato con un attributo System.ObsoleteAttribute per il quale non è stata specificata la proprietà ObsoleteAttribute.Message. Quando si compila un membro o un tipo contrassegnato usando ObsoleteAttribute, viene visualizzata la proprietà Message dell'attributo. In questo modo vengono fornite le informazioni utente sul tipo o sul membro obsoleto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Fornire un messaggio per ObsoleteAttribute che contrassegna {0} come obsoleto</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Fornire un messaggio per ObsoleteAttribute che contrassegna {0} come obsoleto</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Dal momento che la proprietà {0} è di sola scrittura, aggiungere un getter di proprietà con un'accessibilità maggiore o uguale al rispettivo setter oppure convertire questa proprietà in un metodo</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Dal momento che la proprietà {0} è di sola scrittura, aggiungere un getter di proprietà con un'accessibilità maggiore o uguale al rispettivo setter oppure convertire questa proprietà in un metodo</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Dal momento che il getter di proprietà per {0} è meno visibile del rispettivo setter, aumentare l'accessibilità del getter o diminuire l'accessibilità del relativo setter</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Dal momento che il getter di proprietà per {0} è meno visibile del rispettivo setter, aumentare l'accessibilità del getter o diminuire l'accessibilità del relativo setter</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Implementare correttamente IDisposable</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Implementare correttamente IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Tutti i tipi IDisposable devono implementare correttamente il criterio Dispose.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Tutti i tipi IDisposable devono implementare correttamente il criterio Dispose.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Rimuovere IDisposable dall'elenco delle interfacce implementate da '{0}' perché è già implementato dal tipo di base '{1}'</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Rimuovere IDisposable dall'elenco delle interfacce implementate da '{0}' perché è già implementato dal tipo di base '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Rimuovere '{0}', eseguire l'override di Dispose(bool disposing) e inserire la logica di Dispose nel percorso del codice in cui 'disposing' è true</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Rimuovere '{0}', eseguire l'override di Dispose(bool disposing) e inserire la logica di Dispose nel percorso del codice in cui 'disposing' è true</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Modificare '{0}' in modo che chiami Dispose(true), quindi GC.SuppressFinalize nell'istanza dell'oggetto corrente ('this' o 'Me' in Visual Basic) e quindi esca dalla funzione</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Modificare '{0}' in modo che chiami Dispose(true), quindi GC.SuppressFinalize nell'istanza dell'oggetto corrente ('this' o 'Me' in Visual Basic) e quindi esca dalla funzione</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Modificare '{0}' in modo che chiami Dispose(false) e quindi esca dalla funzione</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Modificare '{0}' in modo che chiami Dispose(false) e quindi esca dalla funzione</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Fornire un'implementazione sottoponibile a override di Dispose(bool) su '{0}' o contrassegnare il tipo come sealed. Una chiamata a Dispose(false) pulisce solo le risorse native. Una chiamata a Dispose(true) pulisce le risorse native e quelle gestite.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Fornire un'implementazione sottoponibile a override di Dispose(bool) su '{0}' o contrassegnare il tipo come sealed. Una chiamata a Dispose(false) pulisce solo le risorse native. Una chiamata a Dispose(true) pulisce le risorse native e quelle gestite.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Un'eccezione interna è visibile solo nel relativo ambito interno. Se l'eccezione si verifica al di fuori dell'ambito interno, può essere rilevata solo tramite l'eccezione di base. Se l'eccezione interna è ereditata da T:System.Exception, T:System.SystemException o T:System.ApplicationException, il codice esterno non avrà di informazioni sufficienti per la corretta gestione dell'eccezione.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Un'eccezione interna è visibile solo nel relativo ambito interno. Se l'eccezione si verifica al di fuori dell'ambito interno, può essere rilevata solo tramite l'eccezione di base. Se l'eccezione interna è ereditata da T:System.Exception, T:System.SystemException o T:System.ApplicationException, il codice esterno non avrà di informazioni sufficienti per la corretta gestione dell'eccezione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crea un'eccezione di tipo {1} e tale tipo di eccezione non dovrebbe essere generato in una proprietà. Se questa istanza di eccezione può essere generata, usare un altro tipo di eccezione, convertire questa proprietà in un metodo o modificare la logica della proprietà in modo che non generi più un'eccezione.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea un'eccezione di tipo {1} e tale tipo di eccezione non dovrebbe essere generato in una proprietà. Se questa istanza di eccezione può essere generata, usare un altro tipo di eccezione, convertire questa proprietà in un metodo o modificare la logica della proprietà in modo che non generi più un'eccezione.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} crea un'eccezione di tipo {1} e tale tipo di eccezione non dovrebbe essere generato in questo tipo di metodo. Se questa istanza di eccezione può essere generata, usare un altro tipo di eccezione o modificare la logica di questo metodo in modo che non generi più un'eccezione.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea un'eccezione di tipo {1} e tale tipo di eccezione non dovrebbe essere generato in questo tipo di metodo. Se questa istanza di eccezione può essere generata, usare un altro tipo di eccezione o modificare la logica di questo metodo in modo che non generi più un'eccezione.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} crea un'eccezione di tipo {1}. Le eccezioni non dovrebbe essere generate in questo tipo di metodo. Se questa istanza di eccezione può essere generata, modificare la logica di questo metodo in modo che non generi più un'eccezione.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} crea un'eccezione di tipo {1}. Le eccezioni non dovrebbe essere generate in questo tipo di metodo. Se questa istanza di eccezione può essere generata, modificare la logica di questo metodo in modo che non generi più un'eccezione.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Per convenzione i nomi degli identificatori non contengono il carattere di sottolineatura (_). Questa regola controlla spazi dei nomi, tipi, membri e parametri.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Per convenzione i nomi degli identificatori non contengono il carattere di sottolineatura (_). Questa regola controlla spazi dei nomi, tipi, membri e parametri.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Rimuovere i caratteri di sottolineatura dal nome di assembly {0}</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Rimuovere i caratteri di sottolineatura dal nome di assembly {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Rimuovere i caratteri di sottolineatura dal nome di tipo {0}</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Rimuovere i caratteri di sottolineatura dal nome di tipo {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Rimuovere i caratteri di sottolineatura dal nome di membro {0}</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Rimuovere i caratteri di sottolineatura dal nome di membro {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Nel tipo {0} rimuovere i caratteri di sottolineatura dal nome di parametro di tipo generico {1}</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Nel tipo {0} rimuovere i caratteri di sottolineatura dal nome di parametro di tipo generico {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">Nel metodo {0} rimuovere i caratteri di sottolineatura dal nome di parametro di tipo generico {1}</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">Nel metodo {0} rimuovere i caratteri di sottolineatura dal nome di parametro di tipo generico {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Nel membro {0} rimuovere i caratteri di sottolineatura dal nome di parametro {1}</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Nel membro {0} rimuovere i caratteri di sottolineatura dal nome di parametro {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">Nel delegato {0} rimuovere i caratteri di sottolineatura dal nome di parametro {1}</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">Nel delegato {0} rimuovere i caratteri di sottolineatura dal nome di parametro {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Rinominare {0} in modo che termini con '{1}'</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Rinominare {0} in modo che termini con '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Rinominare {0} in modo che termini con 'Collection' o '{1}'</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Rinominare {0} in modo che termini con 'Collection' o '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Rinominare il nome di tipo {0} in modo che non termini con '{1}'</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Rinominare il nome di tipo {0} in modo che non termini con '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Sostituire il suffisso '{0}' nel nome di membro {1} con l'alternativa numerica suggerita '2' o fornire un suffisso più significativo che lo distingua dal membro che sostituisce</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Sostituire il suffisso '{0}' nel nome di membro {1} con l'alternativa numerica suggerita '2' o fornire un suffisso più significativo che lo distingua dal membro che sostituisce</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Sostituire il suffisso '{0}' nel nome di tipo {1} con l'alternativa numerica suggerita '2' o fornire un suffisso più significativo che lo distingua dal tipo che sostituisce</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Sostituire il suffisso '{0}' nel nome di tipo {1} con l'alternativa numerica suggerita '2' o fornire un suffisso più significativo che lo distingua dal tipo che sostituisce</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Nel membro di interfaccia/virtuale {0}, rinominare il parametro {1} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{2}'. L'uso di una parola chiave riservata come nome di un parametro di un membro di interfaccia/virtuale può causare complicazioni quando consumer in altri linguaggi eseguono l'override o l'implementazione del membro.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Nel membro di interfaccia/virtuale {0}, rinominare il parametro {1} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{2}'. L'uso di una parola chiave riservata come nome di un parametro di un membro di interfaccia/virtuale può causare complicazioni quando consumer in altri linguaggi eseguono l'override o l'implementazione del membro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Rinominare il membro di interfaccia/virtuale {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di un membro di interfaccia/virtuale può causare complicazioni quando consumer in altri linguaggi eseguono l'override o l'implementazione del membro.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Rinominare il membro di interfaccia/virtuale {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di un membro di interfaccia/virtuale può causare complicazioni quando consumer in altri linguaggi eseguono l'override o l'implementazione del membro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Rinominare il tipo {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di un tipo può causare complicazioni quando consumer in altri linguaggi usano il tipo.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Rinominare il tipo {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di un tipo può causare complicazioni quando consumer in altri linguaggi usano il tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Rinominare lo spazio dei nomi {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di uno spazio dei nomi può causare complicazioni quando consumer in altri linguaggi usano lo spazio dei nomi.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Rinominare lo spazio dei nomi {0} in modo che non sia più in conflitto con la parola chiave del linguaggio riservata '{1}'. L'uso di una parola chiave riservata come nome di uno spazio dei nomi può causare complicazioni quando consumer in altri linguaggi usano lo spazio dei nomi.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Il nome di un membro public o protected inizia con ""Get"" o diversamente corrisponde al nome di una proprietà public o protected. Ai metodi e alle proprietà ""Get"" devono essere assegnati nomi che consentano di distinguere chiaramente la loro funzione.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Il nome di un membro public o protected inizia con ""Get"" o diversamente corrisponde al nome di una proprietà public o protected. Ai metodi e alle proprietà ""Get"" devono essere assegnati nomi che consentano di distinguere chiaramente la loro funzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Il nome di tipo {0} è completamente o parzialmente in conflitto con il nome di spazio dei nomi '{1}'. Modificare uno dei due nomi per eliminare il conflitto.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Il nome di tipo {0} è completamente o parzialmente in conflitto con il nome di spazio dei nomi '{1}'. Modificare uno dei due nomi per eliminare il conflitto.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Il nome di tipo {0} è completamente o parzialmente in conflitto con il nome di spazio dei nomi '{1}' definito in .NET Framework. Rinominare il tipo per eliminare il conflitto.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Il nome di tipo {0} è completamente o parzialmente in conflitto con il nome di spazio dei nomi '{1}' definito in .NET Framework. Rinominare il tipo per eliminare il conflitto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">Nel membro {0} modificare il nome di parametro {1} in {2} in modo che corrisponda all'identificatore come è stato dichiarato in {3}</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">Nel membro {0} modificare il nome di parametro {1} in {2} in modo che corrisponda all'identificatore come è stato dichiarato in {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di assembly {1} con l'alternativa preferita '{2}'</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di assembly {1} con l'alternativa preferita '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Nel membro {0} sostituire il termine '{1}' nel nome di parametro '{2}' con l'alternativa preferita '{3}'</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Nel membro {0} sostituire il termine '{1}' nel nome di parametro '{2}' con l'alternativa preferita '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Nel delegato {0} sostituire il termine '{1}' nel nome di parametro '{2}' con l'alternativa preferita '{3}'</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Nel delegato {0} sostituire il termine '{1}' nel nome di parametro '{2}' con l'alternativa preferita '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Nel tipo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con l'alternativa preferita '{3}'</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Nel tipo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con l'alternativa preferita '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">Nel metodo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con l'alternativa preferita '{3}'</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">Nel metodo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con l'alternativa preferita '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di tipo {1} con l'alternativa preferita '{2}'</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di tipo {1} con l'alternativa preferita '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di membro {1} con l'alternativa preferita '{2}'</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di membro {1} con l'alternativa preferita '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di assembly {1} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di assembly {1} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nel membro {0} sostituire il termine '{1}' nel nome di parametro {2} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nel membro {0} sostituire il termine '{1}' nel nome di parametro {2} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nel delegato {0} sostituire il termine '{1}' nel nome di parametro {2} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nel delegato {0} sostituire il termine '{1}' nel nome di parametro {2} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nel tipo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nel tipo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Nel metodo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Nel metodo {0} sostituire il termine '{1}' nel nome di parametro di tipo generico {2} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di tipo {1} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di tipo {1} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Sostituire il termine '{0}' nel nome di membro {1} con un'alternativa appropriata o rimuoverlo completamente</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Sostituire il termine '{0}' nel nome di membro {1} con un'alternativa appropriata o rimuoverlo completamente</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} deve eseguire l'override di Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} deve eseguire l'override di Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} deve eseguire l'override degli operatori di uguaglianza (==) e disuguaglianza (!=)</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} deve eseguire l'override degli operatori di uguaglianza (==) e disuguaglianza (!=)</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Firmare {0} con una chiave con nome sicuro.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Firmare {0} con una chiave con nome sicuro.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Prima della distribuzione verificare che a {0} sia assegnato un nome sicuro valido.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Prima della distribuzione verificare che a {0} sia assegnato un nome sicuro valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Eseguire l'override di GetHashCode durante l'override di Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Eseguire l'override di GetHashCode durante l'override di Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode restituisce un valore, basato sull'istanza corrente, che è appropriato per algoritmi hash e strutture dei dati come una tabella hash. Due oggetti uguali e dello stesso tipo devono restituire lo stesso codice hash.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode restituisce un valore, basato sull'istanza corrente, che è appropriato per algoritmi hash e strutture dei dati come una tabella hash. Due oggetti uguali e dello stesso tipo devono restituire lo stesso codice hash.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Eseguire l'override di GetHashCode durante l'override di Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Eseguire l'override di GetHashCode durante l'override di Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Eseguire l'override di Equals durante l'overload dell'operatore di uguaglianza</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Eseguire l'override di Equals durante l'overload dell'operatore di uguaglianza</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Un tipo public implementa l'operatore di uguaglianza, ma non esegue l'override di Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Un tipo public implementa l'operatore di uguaglianza, ma non esegue l'override di Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Eseguire l'override di Equals durante l'overload dell'operatore di uguaglianza</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Eseguire l'override di Equals durante l'overload dell'operatore di uguaglianza</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Eseguire l'override di object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Eseguire l'override di object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Eseguire l'override di object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Eseguire l'override di object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Eseguire l'override di object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Eseguire l'override di object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Impostare la classe come static</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Impostare la classe come static</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Il tipo {0} deve eseguire l'override di Equals perché implementa IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Il tipo {0} deve eseguire l'override di Equals perché implementa IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Eseguire l'override di Object.Equals(object) durante l'implementazione di IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Eseguire l'override di Object.Equals(object) durante l'implementazione di IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Quando un metodo asincrono attende direttamente un elemento Task, la continuazione avviene nello stesso thread che ha creato l'attività. Provare a chiamare Task.ConfigureAwait(Boolean) per segnalare l'intenzione di continuare. Chiamare ConfigureAwait(false) sull'attività per pianificare le continuazioni nel pool di thread, evitando così un deadlock nel thread dell'interfaccia utente. È consigliabile passare false per le librerie indipendenti dall'app. Chiamare ConfigureAwait(true) sull'attività per ottenere lo stesso comportamento di quando ConfigureAwait non viene chiamato in modo esplicito. Se si chiama questo metodo in modo esplicito, si consente ai lettori di sapere che si intende intenzionalmente eseguire la continuazione nel contesto di sincronizzazione originale.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Quando un metodo asincrono attende direttamente un elemento Task, la continuazione avviene nello stesso thread che ha creato l'attività. Provare a chiamare Task.ConfigureAwait(Boolean) per segnalare l'intenzione di continuare. Chiamare ConfigureAwait(false) sull'attività per pianificare le continuazioni nel pool di thread, evitando così un deadlock nel thread dell'interfaccia utente. È consigliabile passare false per le librerie indipendenti dall'app. Chiamare ConfigureAwait(true) sull'attività per ottenere lo stesso comportamento di quando ConfigureAwait non viene chiamato in modo esplicito. Se si chiama questo metodo in modo esplicito, si consente ai lettori di sapere che si intende intenzionalmente eseguire la continuazione nel contesto di sincronizzazione originale.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Provare a chiamare ConfigureAwait sull'attività attesa</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Provare a chiamare ConfigureAwait sull'attività attesa</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Provare a chiamare ConfigureAwait sull'attività attesa</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Provare a chiamare ConfigureAwait sull'attività attesa</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Quando un tipo T esegue l'override di Object.Equals(object), prima del confronto l'implementazione deve eseguire il cast dell'argomento dell'oggetto al tipo T corretto. Se il tipo implementa IEquatable&lt;T&gt; e quindi offre il metodo T.Equals(T) e si sa che in fase di compilazione l'argomento è di tipo T, il compilatore può chiamare IEquatable&lt;T&gt;.Equals(T) invece di Object.Equals(object) senza eseguire alcun cast, migliorando in tal modo le prestazioni.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Quando un tipo T esegue l'override di Object.Equals(object), prima del confronto l'implementazione deve eseguire il cast dell'argomento dell'oggetto al tipo T corretto. Se il tipo implementa IEquatable&lt;T&gt; e quindi offre il metodo T.Equals(T) e si sa che in fase di compilazione l'argomento è di tipo T, il compilatore può chiamare IEquatable&lt;T&gt;.Equals(T) invece di Object.Equals(object) senza eseguire alcun cast, migliorando in tal modo le prestazioni.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} deve definire l'operatore o gli operatori '{1}' e Equals perché implementa IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve definire l'operatore o gli operatori '{1}' e Equals perché implementa IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Rimuovere la chiamata a GC.Collect da {0}. Non è necessario forzare la Garbage Collection perché tale operazione può influire molto negativamente sulle prestazioni.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a GC.Collect da {0}. Non è necessario forzare la Garbage Collection perché tale operazione può influire molto negativamente sulle prestazioni.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Rimuovere la chiamata a Thread.Resume da {0}. Può essere pericoloso sospendere e riprendere i thread se il sistema sta eseguendo un'operazione critica, ad esempio durante l'esecuzione di un costruttore di classe di un importante tipo di sistema o la risoluzione della sicurezza per un assembly condiviso.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a Thread.Resume da {0}. Può essere pericoloso sospendere e riprendere i thread se il sistema sta eseguendo un'operazione critica, ad esempio durante l'esecuzione di un costruttore di classe di un importante tipo di sistema o la risoluzione della sicurezza per un assembly condiviso.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Rimuovere la chiamata a Thread.Suspend da {0}. Può essere pericoloso sospendere e riprendere i thread se il sistema sta eseguendo un'operazione critica, ad esempio durante l'esecuzione di un costruttore di classe di un importante tipo di sistema o la risoluzione della sicurezza per un assembly condiviso.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a Thread.Suspend da {0}. Può essere pericoloso sospendere e riprendere i thread se il sistema sta eseguendo un'operazione critica, ad esempio durante l'esecuzione di un costruttore di classe di un importante tipo di sistema o la risoluzione della sicurezza per un assembly condiviso.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Rimuovere la chiamata a System.Type.InvokeMember con BindingFlags.NonPublic da {0}. L'uso di una dipendenza su un membro privato aumenta la possibilità di una modifica importante in futuro.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a System.Type.InvokeMember con BindingFlags.NonPublic da {0}. L'uso di una dipendenza su un membro privato aumenta la possibilità di una modifica importante in futuro.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} è una dichiarazione P/Invoke per un'API OLE32 che non può essere chiamata in modo affidabile dopo l'inizializzazione del runtime. Come soluzione alternativa è possibile scrivere uno shim non gestito che chiamerà la routine e quindi la attiverà e la chiamerà nel codice gestito. A questo scopo, è possibile usare un'esportazione da una DLL C++ in modalità mista, registrando un componente gestito per COM o usando l'API di hosting del runtime.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} è una dichiarazione P/Invoke per un'API OLE32 che non può essere chiamata in modo affidabile dopo l'inizializzazione del runtime. Come soluzione alternativa è possibile scrivere uno shim non gestito che chiamerà la routine e quindi la attiverà e la chiamerà nel codice gestito. A questo scopo, è possibile usare un'esportazione da una DLL C++ in modalità mista, registrando un componente gestito per COM o usando l'API di hosting del runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} è una dichiarazione P/Invoke per un'API OLE32 che non può essere chiamata in modo affidabile su un oggetto Runtime Callable Wrapper, ovvero un oggetto gestito che esegue il wrapping di un oggetto COM. Gli oggetti Runtime Callable Wrapper recuperano dinamicamente i puntatori a interfaccia, quindi l'effetto della chiamata potrebbe andare arbitrariamente perso. Gli oggetti Runtime Callable Wrapper relativi a un determinato oggetto COM sono inoltre condivisi in un dominio dell'applicazione, quindi la chiamata potrebbe interessare altri utenti. Sostituire questa chiamata con un oggetto COM wrapper nativo per il puntatore a interfaccia che effettua le chiamate appropriate a CoSetProxyBlanket.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} è una dichiarazione P/Invoke per un'API OLE32 che non può essere chiamata in modo affidabile su un oggetto Runtime Callable Wrapper, ovvero un oggetto gestito che esegue il wrapping di un oggetto COM. Gli oggetti Runtime Callable Wrapper recuperano dinamicamente i puntatori a interfaccia, quindi l'effetto della chiamata potrebbe andare arbitrariamente perso. Gli oggetti Runtime Callable Wrapper relativi a un determinato oggetto COM sono inoltre condivisi in un dominio dell'applicazione, quindi la chiamata potrebbe interessare altri utenti. Sostituire questa chiamata con un oggetto COM wrapper nativo per il puntatore a interfaccia che effettua le chiamate appropriate a CoSetProxyBlanket.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Rimuovere la chiamata a SafeHandle.DangerousGetHandle da {0}</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a SafeHandle.DangerousGetHandle da {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Rimuovere la chiamata a Assembly.LoadFrom da {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a Assembly.LoadFrom da {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Rimuovere la chiamata a Assembly.LoadFile da {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a Assembly.LoadFile da {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Rimuovere la chiamata a Assembly.LoadWithPartialName da {0}</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Rimuovere la chiamata a Assembly.LoadWithPartialName da {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">La variabile {0} dichiarata in {1} ha lo stesso nome di un campo di istanza sul tipo. Modificare il nome di uno di questi elementi.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">La variabile {0} dichiarata in {1} ha lo stesso nome di un campo di istanza sul tipo. Modificare il nome di uno di questi elementi.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">Il parametro {0} dichiarato in {1} ha lo stesso nome di un campo di istanza sul tipo. Modificare il nome di uno di questi elementi.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">Il parametro {0} dichiarato in {1} ha lo stesso nome di un campo di istanza sul tipo. Modificare il nome di uno di questi elementi.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Il parametro {0} del metodo {1} non viene mai usato. Rimuovere il parametro o usarlo nel corpo del metodo.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Il parametro {0} del metodo {1} non viene mai usato. Rimuovere il parametro o usarlo nel corpo del metodo.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} crea una nuova istanza di {1} che non viene mai usata. Passare l'istanza come argomento di un altro metodo, assegnare l'istanza a una variabile oppure rimuovere la creazione dell'oggetto se non è necessaria.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} crea una nuova istanza di {1} che non viene mai usata. Passare l'istanza come argomento di un altro metodo, assegnare l'istanza a una variabile oppure rimuovere la creazione dell'oggetto se non è necessaria.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} chiama {1} ma non usa la nuova istanza di stringa restituita dal metodo. Passare l'istanza come argomento di un altro metodo, assegnare l'istanza a una variabile oppure rimuovere la chiamata se non è necessaria.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} chiama {1} ma non usa la nuova istanza di stringa restituita dal metodo. Passare l'istanza come argomento di un altro metodo, assegnare l'istanza a una variabile oppure rimuovere la chiamata se non è necessaria.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} chiama {1} ma non usa l'HRESULT o il codice errore restituito dal metodo. Questo potrebbe causare un comportamento imprevisto in condizioni di errore o in situazioni di risorse insufficienti. Usare il risultato in un'istruzione condizionale, assegnare il risultato a una variabile o passarlo come argomento a un altro metodo.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} chiama {1} ma non usa l'HRESULT o il codice errore restituito dal metodo. Questo potrebbe causare un comportamento imprevisto in condizioni di errore o in situazioni di risorse insufficienti. Usare il risultato in un'istruzione condizionale, assegnare il risultato a una variabile o passarlo come argomento a un altro metodo.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} chiama {1} ma non verifica in modo esplicito se la conversione è riuscita. Usare il valore restituito in un'istruzione condizionale o verificare che il sito di chiamata preveda l'impostazione dell'argomento out sul valore predefinito in caso di conversione non riuscita.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} chiama {1} ma non verifica in modo esplicito se la conversione è riuscita. Usare il valore restituito in un'istruzione condizionale o verificare che il sito di chiamata preveda l'impostazione dell'argomento out sul valore predefinito in caso di conversione non riuscita.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} è una classe internal per la quale sembra che non sia stata mai creata un'istanza. In tal caso, rimuovere il codice dall'assembly. Se questa classe deve contenere solo membri static, impostarla come static (Shared in Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} è una classe internal per la quale sembra che non sia stata mai creata un'istanza. In tal caso, rimuovere il codice dall'assembly. Se questa classe deve contenere solo membri static, impostarla come static (Shared in Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} chiama {1} ma non usa il valore restituito dal metodo. Dal momento che {1} è contrassegnato come metodo Pure, non può avere effetti collaterali. Usare il risultato in un'istruzione condizionale, assegnare il risultato a una variabile o passarlo come argomento a un altro metodo.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} chiama {1} ma non usa il valore restituito dal metodo. Dal momento che {1} è contrassegnato come metodo Pure, non può avere effetti collaterali. Usare il risultato in un'istruzione condizionale, assegnare il risultato a una variabile o passarlo come argomento a un altro metodo.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">La proprietà {0} non deve essere assegnata a se stessa</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">La proprietà {0} non deve essere assegnata a se stessa</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} è una matrice multidimensionale. Se possibile, sostituirla con una matrice di matrici.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} è una matrice multidimensionale. Se possibile, sostituirla con una matrice di matrici.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} restituisce una matrice multidimensionale di {1}. Se possibile, sostituirla con una matrice di matrici.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} restituisce una matrice multidimensionale di {1}. Se possibile, sostituirla con una matrice di matrici.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} usa una matrice multidimensionale di {1}. Se possibile, sostituirla con una matrice di matrici.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} usa una matrice multidimensionale di {1}. Se possibile, sostituirla con una matrice di matrici.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void を使用しないでください</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void を使用しないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void を使用しないでください</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void を使用しないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">非同期メソッド名は Async で終わる必要があります</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">非同期メソッド名は Async で終わる必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">非同期メソッド名は Async で終わる必要があります</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">非同期メソッド名は Async で終わる必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">'{0}' が {1} 個を超える型パラメーターを伴わない設計を検討してください</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">'{0}' が {1} 個を超える型パラメーターを伴わない設計を検討してください</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">out パラメーターを使用しません</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">out パラメーターを使用しません</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; は、継承のためではなく、パフォーマンスのためのジェネリック コレクションです。List&lt;T&gt; には、継承されたクラスの動作の変更を容易にする仮想メンバーが含まれていません。</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; は、継承のためではなく、パフォーマンスのためのジェネリック コレクションです。List&lt;T&gt; には、継承されたクラスの動作の変更を容易にする仮想メンバーが含まれていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">デリゲート型を返す Void として非同期ラムダを渡さないでください</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">デリゲート型を返す Void として非同期ラムダを渡さないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">デリゲート型を返す Void として非同期ラムダを渡さないでください</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">デリゲート型を返す Void として非同期ラムダを渡さないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">(out または ref を使用して) 型を参照によって渡すには、ポインターの使用経験、値型と参照型の違いの理解、および複数の戻り値を持つメソッドの処理が必要です。また、out および ref パラメーターの違いはあまり理解されていません。</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">(out または ref を使用して) 型を参照によって渡すには、ポインターの使用経験、値型と参照型の違いの理解、および複数の戻り値を持つメソッドの処理が必要です。また、out および ref パラメーターの違いはあまり理解されていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">デリゲート型を返す Void として非同期ラムダを格納しないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">型 '{0}' からファイナライザーを削除し、Dispose(bool disposing) をオーバーライドします。その後、'disposing' が false のコード パスに finalization 論理を配置します。その他の場合、基本型 '{1}' でもファイナライザーが提供されるため、Dispose 呼び出しが重複する可能性があります。</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">型 '{0}' からファイナライザーを削除し、Dispose(bool disposing) をオーバーライドします。その後、'disposing' が false のコード パスに finalization 論理を配置します。その他の場合、基本型 '{1}' でもファイナライザーが提供されるため、Dispose 呼び出しが重複する可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">可能な場合は CancellationToken を伝達してください</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">可能な場合は CancellationToken を伝達してください</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">可能な場合は CancellationToken を伝達してください</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">可能な場合は CancellationToken を伝達してください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">ブロッキングと非同期を組み合わせないでください</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">ブロッキングと非同期を組み合わせないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">ブロッキングと非同期を組み合わせないでください</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">ブロッキングと非同期を組み合わせないでください</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">列挙型 {0} では、{1} の名前を 'None' に変更してください</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">列挙型 {0} では、{1} の名前を 'None' に変更してください</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">'None' という名前の 1 つのメンバーを除き、値 0 を含むすべてのメンバーを {0} から削除します</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">'None' という名前の 1 つのメンバーを除き、値 0 を含むすべてのメンバーを {0} から削除します</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">提案された名前 'None' を伴う、値 0 を含む {0} にメンバーを追加します</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">提案された名前 'None' を伴う、値 0 を含む {0} にメンバーを追加します</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">共通言語仕様 (CLS) では、名前付け制限、データ型、規則が定義されています。アセンブリは、複数のプログラミング言語で使用する場合、これらに準拠する必要があります。すべてのアセンブリに CLSCompliantAttribute を使用して CLS への準拠を明示することをお勧めします。この属性がアセンブリに存在しない場合、そのアセンブリは CLS に準拠しません。</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">共通言語仕様 (CLS) では、名前付け制限、データ型、規則が定義されています。アセンブリは、複数のプログラミング言語で使用する場合、これらに準拠する必要があります。すべてのアセンブリに CLSCompliantAttribute を使用して CLS への準拠を明示することをお勧めします。この属性がアセンブリに存在しない場合、そのアセンブリは CLS に準拠しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">アセンブリに CLSCompliant を設定します</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">アセンブリに CLSCompliant を設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">アセンブリに ComVisible を設定します</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">アセンブリに ComVisible を設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">{0} は外部から参照可能な型を公開するため、アセンブリ レベルで ComVisible(false) に設定し、COM クライアントに公開する必要があるアセンブリ内のすべての型を ComVisible(true) に設定します。</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">{0} は外部から参照可能な型を公開するため、アセンブリ レベルで ComVisible(false) に設定し、COM クライアントに公開する必要があるアセンブリ内のすべての型を ComVisible(true) に設定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">属性を AttributeUsageAttribute に設定します</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">属性を AttributeUsageAttribute に設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">カスタム属性を定義する場合、AttributeUsageAttribute を使用して、ソース コード内でカスタム属性を適用できる位置を示すように設定します。属性の意味と用途により、コード内での有効な位置が決まります。</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">カスタム属性を定義する場合、AttributeUsageAttribute を使用して、ソース コード内でカスタム属性を適用できる位置を示すように設定します。属性の意味と用途により、コード内での有効な位置が決まります。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">AttributeUsage を {0} で指定してください</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">AttributeUsage を {0} で指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">属性 {0} がその基本データ型から AttributeUsage を継承した場合でも、コードの読みやすさ、ドキュメントを改善するために、AttributeUsage をその型で明示的に指定することを検討してください。</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">属性 {0} がその基本データ型から AttributeUsage を継承した場合でも、コードの読みやすさ、ドキュメントを改善するために、AttributeUsage をその型で明示的に指定することを検討してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">属性 {1} の位置引数 {0} 用にパブリックな読み取り専用プロパティ アクセサーを追加します</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">属性 {1} の位置引数 {0} 用にパブリックな読み取り専用プロパティ アクセサーを追加します</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">プロパティ セッターが位置引数 {1} に対応しているため、これを {0} から削除するか、アクセシビリティを下げてください</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">プロパティ セッターが位置引数 {1} に対応しているため、これを {0} から削除するか、アクセシビリティを下げてください</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">{0} が位置引数 {1} のプロパティ アクセサーである場合は、パブリックにしてください</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">{0} が位置引数 {1} のプロパティ アクセサーである場合は、パブリックにしてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">パブリック メソッドまたは保護されたメソッドは、""Get"" で始まる名前を持ち、パラメーターを受け取らず、配列ではない値を返します。このメソッドは、プロパティに変更できる可能性があります。</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">パブリック メソッドまたは保護されたメソッドは、""Get"" で始まる名前を持ち、パラメーターを受け取らず、配列ではない値を返します。このメソッドは、プロパティに変更できる可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">列挙型を FlagsAttribute に設定します</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">列挙型を FlagsAttribute に設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">列挙型は、関連する一連の名前付き定数を定義する値型です。名前付き定数を意味を持つように組み合わせることができる場合は、列挙型に FlagsAttribute を適用します。</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">列挙型は、関連する一連の名前付き定数を定義する値型です。名前付き定数を意味を持つように組み合わせることができる場合は、列挙型に FlagsAttribute を適用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">列挙型を FlagsAttribute に設定します</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">列挙型を FlagsAttribute に設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">パブリック型または保護された型で System.IComparable インターフェイスを実装します。これにより、Object.Equals はオーバーライドされません。また、"等しい"、"等しくない"、"未満"、"以下"、"より大きい"、または "以上" を示す言語固有の演算子はオーバーロードされません。</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">パブリック型または保護された型で System.IComparable インターフェイスを実装します。これにより、Object.Equals はオーバーライドされません。また、"等しい"、"等しくない"、"未満"、"以下"、"より大きい"、または "以上" を示す言語固有の演算子はオーバーロードされません。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} は IComparable を実装しているため、Equals をオーバーライドする必要があります</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} は IComparable を実装しているため、Equals をオーバーライドする必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} は IComparable を実装しているため、演算子 '{1}' を定義する必要があります</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} は IComparable を実装しているため、演算子 '{1}' を定義する必要があります</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">外部から参照可能なインターフェイスの名前は大文字の ""I"" で始まりません。外部から参照可能な型またはメソッドのジェネリック型パラメーターの名前は大文字の ""T"" で始まりません。</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">外部から参照可能なインターフェイスの名前は大文字の ""I"" で始まりません。外部から参照可能な型またはメソッドのジェネリック型パラメーターの名前は大文字の ""T"" で始まりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">インターフェイス名 {0} にプレフィックスとして 'I' を指定してください</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">インターフェイス名 {0} にプレフィックスとして 'I' を指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">ジェネリック型パラメーター名 {0} にプレフィックスとして 'T' を指定してください</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">ジェネリック型パラメーター名 {0} にプレフィックスとして 'T' を指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">列挙型を FlagsAttribute に設定しません</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">列挙型を FlagsAttribute に設定しません</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">外部から参照可能な列挙型が FlagsAttribute を使用してマークされ、その列挙型に、2 の累乗でもその列挙型で定義されている他の値の組み合わせでもない値が 1 つ以上含まれています。</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">外部から参照可能な列挙型が FlagsAttribute を使用してマークされ、その列挙型に、2 の累乗でもその列挙型で定義されている他の値の組み合わせでもない値が 1 つ以上含まれています。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">列挙型を FlagsAttribute に設定しません</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">列挙型を FlagsAttribute に設定しません</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">'{0}' という名前のメソッドを演算子 {1} の代替として指定してください</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">'{0}' という名前のメソッドを演算子 {1} の代替として指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">'{0}' という名前のプロパティを演算子 {1} の代替として指定してください</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">'{0}' という名前のプロパティを演算子 {1} の代替として指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">'{0}' または '{1}' という名前のメソッドを演算子 {2} の代替として指定してください</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">'{0}' または '{1}' という名前のメソッドを演算子 {2} の代替として指定してください</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">演算子 {1} の代替であるため、{0} をパブリックとしてマークしてください</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">演算子 {1} の代替であるため、{0} をパブリックとしてマークしてください</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Object.Equals をオーバーライドする際に IEquatable を実装します</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Object.Equals をオーバーライドする際に IEquatable を実装します</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">型 {0} は Equals をオーバーライドするため、IEquatable&lt;T&gt; を実装する必要があります</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">型 {0} は Equals をオーバーライドするため、IEquatable&lt;T&gt; を実装する必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken パラメーターは最後に指定する必要があります</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken パラメーターは最後に指定する必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">{0} は外部から参照可能な型を公開するため、アセンブリ レベルで ComVisible(false) に設定し、COM クライアントに公開する必要があるアセンブリ内のすべての型を ComVisible(true) に設定します</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">{0} は外部から参照可能な型を公開するため、アセンブリ レベルで ComVisible(false) に設定し、COM クライアントに公開する必要があるアセンブリ内のすべての型を ComVisible(true) に設定します</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">{0} の ComVisible 属性を false に変更してから、型レベルでオプトインすることを検討してください</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">{0} の ComVisible 属性を false に変更してから、型レベルでオプトインすることを検討してください</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">IEquatable を実装します</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">IEquatable を実装します</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">IDisposable インターフェイスを実装します</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">IDisposable インターフェイスを実装します</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">FlagsAttribute を列挙型から削除します。</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">FlagsAttribute を列挙型から削除します。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">FlagsAttribute を列挙型に適用します。</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">FlagsAttribute を列挙型に適用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">列挙ストレージは Int32 でなければなりません</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">列挙ストレージは Int32 でなければなりません</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">可能な場合は、基になる型 {0} を {1} ではなく System.Int32 にしてください</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">可能な場合は、基になる型 {0} を {1} ではなく System.Int32 にしてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">次のコンストラクターを {0} に追加してください。{1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">次のコンストラクターを {0} に追加してください。{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">{0} のアクセシビリティを {1} に変更します。</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">{0} のアクセシビリティを {1} に変更します。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">型 {0} を入れ子にしないでください。外部から参照できなくするために、そのアクセシビリティを変更することもできます。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">型 {0} を入れ子にしないでください。外部から参照できなくするために、そのアクセシビリティを変更することもできます。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">型 {0} を入れ子にしないでください。外部から参照できなくするために、そのアクセシビリティを変更することもできます。この型は、Visual Basic モジュールで定義されている場合、他の .NET 言語への入れ子にされた型と見なされます。その場合、その型をモジュールの外部へ移動することを検討してください。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">型 {0} を入れ子にしないでください。外部から参照できなくするために、そのアクセシビリティを変更することもできます。この型は、Visual Basic モジュールで定義されている場合、他の .NET 言語への入れ子にされた型と見なされます。その場合、その型をモジュールの外部へ移動することを検討してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">ObsoleteAttribute メッセージを指定します</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">ObsoleteAttribute メッセージを指定します</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">型またはメンバーが System.ObsoleteAttribute 属性でマークされていますが、この属性では ObsoleteAttribute.Message プロパティが指定されていません。ObsoleteAttribute でマークされている型またはメンバーをコンパイルすると、属性の Message プロパティが表示されます。これにより、古いの型またはメンバーに関する情報がユーザーに表示されます。</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">型またはメンバーが System.ObsoleteAttribute 属性でマークされていますが、この属性では ObsoleteAttribute.Message プロパティが指定されていません。ObsoleteAttribute でマークされている型またはメンバーをコンパイルすると、属性の Message プロパティが表示されます。これにより、古いの型またはメンバーに関する情報がユーザーに表示されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">{0} を Obsolete に設定する ObsoleteAttribute のメッセージを指定します。</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">{0} を Obsolete に設定する ObsoleteAttribute のメッセージを指定します。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">プロパティ {0} は書き込み専用であるため、アクセシビリティがプロパティ セッター以上のプロパティ ゲッターを追加するか、このプロパティをメソッドに変換してください</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">プロパティ {0} は書き込み専用であるため、アクセシビリティがプロパティ セッター以上のプロパティ ゲッターを追加するか、このプロパティをメソッドに変換してください</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">{0} のプロパティ ゲッターがプロパティ セッターよりも参照範囲が小さいため、ゲッターのアクセシビリティを上げるか、セッターのアクセシビリティを下げてください</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">{0} のプロパティ ゲッターがプロパティ セッターよりも参照範囲が小さいため、ゲッターのアクセシビリティを上げるか、セッターのアクセシビリティを下げてください</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">IDisposable を正しく実装します</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">IDisposable を正しく実装します</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">すべての IDisposable 型は、Dispose パターンを正しく実装しなければなりません。</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">すべての IDisposable 型は、Dispose パターンを正しく実装しなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">'{0}' によって実装されたインターフェイスの一覧から IDisposable を削除してください。基本型 '{1}' によって既に実装されているためです</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">'{0}' によって実装されたインターフェイスの一覧から IDisposable を削除してください。基本型 '{1}' によって既に実装されているためです</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">'{0}' を削除し、Dispose(bool disposing) をオーバーライドしてください。その後、'disposing' が true であるコード パスに dispose 論理を配置します</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">'{0}' を削除し、Dispose(bool disposing) をオーバーライドしてください。その後、'disposing' が true であるコード パスに dispose 論理を配置します</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">'{0}' を変更し、Dispose(true) を呼び出したのちに現在のオブジェクト インスタンスで GC.SuppressFinalize (Visual Basic の 'this' または 'Me') を呼び出してから戻るようにしてください</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">'{0}' を変更し、Dispose(true) を呼び出したのちに現在のオブジェクト インスタンスで GC.SuppressFinalize (Visual Basic の 'this' または 'Me') を呼び出してから戻るようにしてください</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">'{0}' を変更し、Dispose(false) を呼び出してから戻るようにしてください</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">'{0}' を変更し、Dispose(false) を呼び出してから戻るようにしてください</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">'{0}' で Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">'{0}' で Dispose(bool) のオーバーライド可能な実装を提供するか、型を sealed としてマークします。Dispose(false) を呼び出す場合は、ネイティブ リソースのみがクリーンアップされます。Dispose(true) を呼び出す場合には、マネージド リソースとネイティブ リソースの両方がクリーンアップされます。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">内部例外を参照できるのは、それ独自の内部スコープ内でのみです。例外が内部スコープ外にあると、基本例外を使用しなければキャッチできません。内部例外が System.Exception、System.SystemException、または System.ApplicationException から継承されている場合、外部コードはその例外の処理に関する十分な情報を取得できません。</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">内部例外を参照できるのは、それ独自の内部スコープ内でのみです。例外が内部スコープ外にあると、基本例外を使用しなければキャッチできません。内部例外が System.Exception、System.SystemException、または System.ApplicationException から継承されている場合、外部コードはその例外の処理に関する十分な情報を取得できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} は型 {1} の例外を作成します。これは、プロパティで発生させることができない例外の種類です。この例外インスタンスが発生する可能性がある場合は、別の例外の種類を使用するか、このプロパティをメソッドに変換するか、例外が発生しないようにこのプロパティのロジックを変更します。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} は型 {1} の例外を作成します。これは、プロパティで発生させることができない例外の種類です。この例外インスタンスが発生する可能性がある場合は、別の例外の種類を使用するか、このプロパティをメソッドに変換するか、例外が発生しないようにこのプロパティのロジックを変更します。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} は型 {1} の例外を作成します。これは、この型のメソッドで発生させることができない例外の種類です。この例外インスタンスが発生する可能性がある場合は、別の例外の種類を使用するか、例外が発生しないようにこのメソッドのロジックを変更します。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} は型 {1} の例外を作成します。これは、この型のメソッドで発生させることができない例外の種類です。この例外インスタンスが発生する可能性がある場合は、別の例外の種類を使用するか、例外が発生しないようにこのメソッドのロジックを変更します。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} は型 {1} の例外を作成します。この型のメソッドでは例外を発生させることはできません。この例外インスタンスが発生する可能性がある場合は、例外が発生しないようにこのメソッドのロジックを変更します。</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} は型 {1} の例外を作成します。この型のメソッドでは例外を発生させることはできません。この例外インスタンスが発生する可能性がある場合は、例外が発生しないようにこのメソッドのロジックを変更します。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">規則により、識別子名にアンダースコア (_) 文字を含めることができません。この規則では名前空間、型、メンバー、およびパラメーターをチェックします。</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">規則により、識別子名にアンダースコア (_) 文字を含めることができません。この規則では名前空間、型、メンバー、およびパラメーターをチェックします。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">アンダースコアをアセンブリ名 {0} から削除してください</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">アンダースコアをアセンブリ名 {0} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">アンダースコアを型名 {0} から削除してください</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">アンダースコアを型名 {0} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">アンダースコアをメンバー名 {0} から削除してください</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">アンダースコアをメンバー名 {0} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">型 {0} で、アンダースコアをジェネリック型パラメーター名 {1} から削除してください</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">型 {0} で、アンダースコアをジェネリック型パラメーター名 {1} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">メソッド {0} で、アンダースコアをジェネリック型パラメーター名 {1} から削除してください</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">メソッド {0} で、アンダースコアをジェネリック型パラメーター名 {1} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">メンバー {0} で、アンダースコアをパラメーター名 {1} から削除してください</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">メンバー {0} で、アンダースコアをパラメーター名 {1} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">デリゲート {0} で、アンダースコアをパラメーター名 {1} から削除してください</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">デリゲート {0} で、アンダースコアをパラメーター名 {1} から削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">{0} の名前が '{1}' で終わるように変更してください</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">{0} の名前が '{1}' で終わるように変更してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">{0} の名前が 'Collection' または '{1}' で終わるように変更してください</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">{0} の名前が 'Collection' または '{1}' で終わるように変更してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">型名 {0} が '{1}' で終わらないように変更してください</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">型名 {0} が '{1}' で終わらないように変更してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">メンバー名 {1} のサフィックス '{0}' を推奨される数値 '2' で置き換えるか、もっと意味のあるサフィックスを指定して置き換えるメンバーと区別してください</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">メンバー名 {1} のサフィックス '{0}' を推奨される数値 '2' で置き換えるか、もっと意味のあるサフィックスを指定して置き換えるメンバーと区別してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">型名 {1} のサフィックス '{0}' を推奨される数値 '2' で置き換えるか、もっと意味のあるサフィックスを指定して置き換える型と区別してください</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">型名 {1} のサフィックス '{0}' を推奨される数値 '2' で置き換えるか、もっと意味のあるサフィックスを指定して置き換える型と区別してください</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">仮想メンバーまたはインターフェイス メンバー {0} のパラメーター {1} の名前を変更して、予約されている言語キーワード '{2}' と競合しないようにしてください。仮想メンバーまたはインターフェイス メンバーのパラメーター名として、予約されているキーワードを使用すると、他の言語を使用するユーザーがそのメンバーをオーバーライドまたは実装することが困難になります。</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">仮想メンバーまたはインターフェイス メンバー {0} のパラメーター {1} の名前を変更して、予約されている言語キーワード '{2}' と競合しないようにしてください。仮想メンバーまたはインターフェイス メンバーのパラメーター名として、予約されているキーワードを使用すると、他の言語を使用するユーザーがそのメンバーをオーバーライドまたは実装することが困難になります。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">仮想メンバーまたはインターフェイス メンバー {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。仮想メンバーまたはインターフェイス メンバーの名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがそのメンバーをオーバーライドまたは実装することが困難になります。</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">仮想メンバーまたはインターフェイス メンバー {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。仮想メンバーまたはインターフェイス メンバーの名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがそのメンバーをオーバーライドまたは実装することが困難になります。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">型 {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。型の名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがその型を使用することが困難になります。</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">型 {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。型の名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがその型を使用することが困難になります。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">名前空間 {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。名前空間の名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがその名前空間を使用することが困難になります。</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">名前空間 {0} の名前を変更して、予約されている言語キーワード '{1}' と競合しないようにしてください。名前空間の名前として、予約されているキーワードを使用すると、他の言語を使用するユーザーがその名前空間を使用することが困難になります。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">パブリック メンバーまたは保護されたメンバーの名前が、""Get"" から始まっているか、パブリック プロパティまたは保護されたプロパティの名前と一致します。""Get"" メソッドおよびプロパティには、その機能を明確に区別する名前が必要です。</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">パブリック メンバーまたは保護されたメンバーの名前が、""Get"" から始まっているか、パブリック プロパティまたは保護されたプロパティの名前と一致します。""Get"" メソッドおよびプロパティには、その機能を明確に区別する名前が必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">型名 {0} は、名前空間の名前 '{1}' と全体または部分的に競合します。競合を解消するには、どちらかの名前を変更してください。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">型名 {0} は、名前空間の名前 '{1}' と全体または部分的に競合します。競合を解消するには、どちらかの名前を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">型名 {0} は、.NET Framework で定義されている名前空間の名前 '{1}' と全体または部分的に競合します。競合を解消するには、型名を変更してください。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">型名 {0} は、.NET Framework で定義されている名前空間の名前 '{1}' と全体または部分的に競合します。競合を解消するには、型名を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">{3} で宣言されている識別子と一致するように、メンバー {0} のパラメーター名 {1} を {2} に変更してください</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">{3} で宣言されている識別子と一致するように、メンバー {0} のパラメーター名 {1} を {2} に変更してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">アセンブリ名 {1} の用語 '{0}' を適切なもの '{2}' に置き換えてください</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">アセンブリ名 {1} の用語 '{0}' を適切なもの '{2}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">メンバー {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">メンバー {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">デリゲート {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">デリゲート {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">型 {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">型 {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">メソッド {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">メソッド {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語 '{3}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">型名 {1} の用語 '{0}' を適切な用語 '{2}' に置き換えてください</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">型名 {1} の用語 '{0}' を適切な用語 '{2}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">メンバー名 {1} の用語 '{0}' を適切な用語 '{2}' に置き換えてください</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">メンバー名 {1} の用語 '{0}' を適切な用語 '{2}' に置き換えてください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">アセンブリ名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">アセンブリ名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">メンバー {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">メンバー {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">デリゲート {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">デリゲート {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">型 {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">型 {0} で、ジェネリック型パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">メソッド {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">メソッド {0} で、パラメーター名 {2} の用語 '{1}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">型名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">型名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">メンバー名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">メンバー名 {1} の用語 '{0}' を適切な用語に置き換えるか、全体を削除してください</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} は Equals をオーバーライドする必要があります</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} は Equals をオーバーライドする必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} は、等値演算子 (==) および非等値演算子 (!=) をオーバーライドする必要があります</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} は、等値演算子 (==) および非等値演算子 (!=) をオーバーライドする必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">{0} を厳密な名前キーで署名します。</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">{0} を厳密な名前キーで署名します。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">配置する前に、{0} に有効な厳密な名前が指定されていることを確認してください。</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">配置する前に、{0} に有効な厳密な名前が指定されていることを確認してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">オーバーライドする Equals で GetHashCode をオーバーライドします</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">オーバーライドする Equals で GetHashCode をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode は、現在のインスタンスに基づいて、ハッシュ アルゴリズムとデータ構造 (ハッシュ テーブルなど) に適した値を返します。同じ型で等しい 2 つのオブジェクトは、同じハッシュ コードを返す必要があります。</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode は、現在のインスタンスに基づいて、ハッシュ アルゴリズムとデータ構造 (ハッシュ テーブルなど) に適した値を返します。同じ型で等しい 2 つのオブジェクトは、同じハッシュ コードを返す必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">オーバーライドする Equals で GetHashCode をオーバーライドします</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">オーバーライドする Equals で GetHashCode をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">オーバーロードする演算子 equals で Equals をオーバーライドします</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">オーバーロードする演算子 equals で Equals をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">パブリック型では等値演算子が実装されますが、Object.Equals はオーバーライドされていません。</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">パブリック型では等値演算子が実装されますが、Object.Equals はオーバーライドされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">オーバーロードする演算子 equals で Equals をオーバーライドします</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">オーバーロードする演算子 equals で Equals をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals をオーバーライドします</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals をオーバーライドします</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">object.GetHashCode をオーバーライドします</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">object.GetHashCode をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">クラスを静的にします</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">クラスを静的にします</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">型 {0} は IEquatable&lt;T&gt; を実装するため、Equals をオーバーライドする必要があります</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">型 {0} は IEquatable&lt;T&gt; を実装するため、Equals をオーバーライドする必要があります</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">IEquatable&lt;T&gt; を実装するときに Object.Equals(object) をオーバーライドします</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">IEquatable&lt;T&gt; を実装するときに Object.Equals(object) をオーバーライドします</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">非同期メソッドがタスクを直接待機すると、タスクを作成したのと同じスレッドで継続が発生します。継続の意図を示すには、Task.ConfigureAwait(Boolean) の呼び出しを検討してください。タスクで ConfigureAwait(false) を呼び出して、スレッド プールへの継続をスケジュールします。その結果、UI スレッドのデッドロックを回避できます。アプリに依存しないライブラリでは、false を渡すことが適切なオプションです。タスクで ConfigureAwait(true) を呼び出すと、ConfigureAwait を明示的に呼び出さない場合と動作が同じになります。このメソッドを明示的に呼び出すことにより、元の同期コンテキストで意図的に継続を実行していることを閲覧者に示します。</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">非同期メソッドがタスクを直接待機すると、タスクを作成したのと同じスレッドで継続が発生します。継続の意図を示すには、Task.ConfigureAwait(Boolean) の呼び出しを検討してください。タスクで ConfigureAwait(false) を呼び出して、スレッド プールへの継続をスケジュールします。その結果、UI スレッドのデッドロックを回避できます。アプリに依存しないライブラリでは、false を渡すことが適切なオプションです。タスクで ConfigureAwait(true) を呼び出すと、ConfigureAwait を明示的に呼び出さない場合と動作が同じになります。このメソッドを明示的に呼び出すことにより、元の同期コンテキストで意図的に継続を実行していることを閲覧者に示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">待機中のタスクでの ConfigureAwait の呼び出しを検討してください</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">待機中のタスクでの ConfigureAwait の呼び出しを検討してください</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">待機中のタスクでの ConfigureAwait の呼び出しを検討してください</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">待機中のタスクでの ConfigureAwait の呼び出しを検討してください</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">型 T が Object.Equals(object) をオーバーライドする場合、この実装は、比較を行う前にオブジェクトの引数を正しい型 T にキャストする必要があります。型が IEquatable&lt;T&gt; を実装してメソッド T.Equals(T) を提供する場合、およびコンパイル時に引数が型 T であることがわかっている場合、コンパイラは Object.Equals(object) の代わりに IEquatable&lt;T&gt;.Equals(T) を呼び出すことができ、キャストは必要ではなくなるため、パフォーマンスが向上します。</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">型 T が Object.Equals(object) をオーバーライドする場合、この実装は、比較を行う前にオブジェクトの引数を正しい型 T にキャストする必要があります。型が IEquatable&lt;T&gt; を実装してメソッド T.Equals(T) を提供する場合、およびコンパイル時に引数が型 T であることがわかっている場合、コンパイラは Object.Equals(object) の代わりに IEquatable&lt;T&gt;.Equals(T) を呼び出すことができ、キャストは必要ではなくなるため、パフォーマンスが向上します。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} は IComparable を実装しているため、演算子 '{1}' と Equals を定義する必要があります</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} は IComparable を実装しているため、演算子 '{1}' と Equals を定義する必要があります</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">GC.Collect への呼び出しを {0} から削除します。通常、ガベージ コレクションを強制する必要はありません。ガベージ コレクションを行うと、パフォーマンスが大幅に低下する可能性があります。</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">GC.Collect への呼び出しを {0} から削除します。通常、ガベージ コレクションを強制する必要はありません。ガベージ コレクションを行うと、パフォーマンスが大幅に低下する可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Thread.Resume への呼び出しを {0} から削除します。重要なシステム型のクラス コンストラクターを実行中である、または共有アセンブリのセキュリティを解決中であるなどの重大な操作をシステムが実行している場合、スレッドの中断および再開には危険性が伴います。</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Thread.Resume への呼び出しを {0} から削除します。重要なシステム型のクラス コンストラクターを実行中である、または共有アセンブリのセキュリティを解決中であるなどの重大な操作をシステムが実行している場合、スレッドの中断および再開には危険性が伴います。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Thread.Suspend への呼び出しを {0} から削除します。重要なシステム型のクラス コンストラクターを実行中である、または共有アセンブリのセキュリティを解決中であるなどの重大な操作をシステムが実行している場合、スレッドの中断および再開には危険性が伴います。</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Thread.Suspend への呼び出しを {0} から削除します。重要なシステム型のクラス コンストラクターを実行中である、または共有アセンブリのセキュリティを解決中であるなどの重大な操作をシステムが実行している場合、スレッドの中断および再開には危険性が伴います。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">BindingFlags.NonPublic を伴う System.Type.InvokeMember への呼び出しを {0} から削除します。プライベート メンバーの依存関係を取得すると、今後のコードに対する重大な変更が発生する可能性を高めます。</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">BindingFlags.NonPublic を伴う System.Type.InvokeMember への呼び出しを {0} から削除します。プライベート メンバーの依存関係を取得すると、今後のコードに対する重大な変更が発生する可能性を高めます。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} は、ランタイムが初期化された後に正しく呼び出すことができない OLE32 API への P/Invoke 宣言です。次善策としては、そのルーチンを呼び出してからマネージ コードをアクティブ化し、そのマネージ コードに呼び出しを行うアンマネージ shim を書き込むことです。COM によって使用するためにマネージ コンポーネントを登録することによって、またはランタイムをホストする API を使用することによって、混合モードの C++ DLL からのエクスポートを使用してこの動作を行うことができます。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} は、ランタイムが初期化された後に正しく呼び出すことができない OLE32 API への P/Invoke 宣言です。次善策としては、そのルーチンを呼び出してからマネージ コードをアクティブ化し、そのマネージ コードに呼び出しを行うアンマネージ shim を書き込むことです。COM によって使用するためにマネージ コンポーネントを登録することによって、またはランタイムをホストする API を使用することによって、混合モードの C++ DLL からのエクスポートを使用してこの動作を行うことができます。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} は、ランタイム呼び出しラッパー (COM オブジェクトをラップするマネージ オブジェクト) に対して正しく呼び出すことができない OLE32 API への P/Invoke 宣言です。ランタイム呼び出しラッパーはインターフェイス ポインターを動的に取得するため、呼び出しの結果は任意に失われます。特定の COM オブジェクトの呼び出しラッパーがアプリケーション ドメインで共有されることもあるため、呼び出しが他のユーザーに影響する可能性もあります。この呼び出しを、適切な CoSetProxyBlanket 呼び出しを行う、インターフェイス ポインターのネイティブ ラッパー COM オブジェクトで置き換えてください。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} は、ランタイム呼び出しラッパー (COM オブジェクトをラップするマネージ オブジェクト) に対して正しく呼び出すことができない OLE32 API への P/Invoke 宣言です。ランタイム呼び出しラッパーはインターフェイス ポインターを動的に取得するため、呼び出しの結果は任意に失われます。特定の COM オブジェクトの呼び出しラッパーがアプリケーション ドメインで共有されることもあるため、呼び出しが他のユーザーに影響する可能性もあります。この呼び出しを、適切な CoSetProxyBlanket 呼び出しを行う、インターフェイス ポインターのネイティブ ラッパー COM オブジェクトで置き換えてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">SafeHandle.DangerousGetHandle への呼び出しを {0} から削除します</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">SafeHandle.DangerousGetHandle への呼び出しを {0} から削除します</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Assembly.LoadFrom への呼び出しを {0} から削除します</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Assembly.LoadFrom への呼び出しを {0} から削除します</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Assembly.LoadFile への呼び出しを {0} から削除します</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Assembly.LoadFile への呼び出しを {0} から削除します</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Assembly.LoadWithPartialName への呼び出しを {0} から削除します</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Assembly.LoadWithPartialName への呼び出しを {0} から削除します</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{1} で宣言された変数 {0} には、型のインスタンス フィールドと同じ名前が指定されています。これらの項目のうちの 1 つの名前を変更してください。</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{1} で宣言された変数 {0} には、型のインスタンス フィールドと同じ名前が指定されています。これらの項目のうちの 1 つの名前を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{1} で宣言されたパラメーター {0} には、型のインスタンス フィールドと同じ名前が指定されています。これらの項目のうちの 1 つの名前を変更してください。</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{1} で宣言されたパラメーター {0} には、型のインスタンス フィールドと同じ名前が指定されています。これらの項目のうちの 1 つの名前を変更してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">{1} のパラメーター {0} は使用されていません。パラメーターを削除するか、メソッド本体で使用してください。</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">{1} のパラメーター {0} は使用されていません。パラメーターを削除するか、メソッド本体で使用してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} では使用されない {1} の新しいインスタンスが作成されます。インスタンスを引数として他のメソッドに渡すか、インスタンスを変数に割り当てるか、不要な場合はオブジェクト作成を削除してください。</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} では使用されない {1} の新しいインスタンスが作成されます。インスタンスを引数として他のメソッドに渡すか、インスタンスを変数に割り当てるか、不要な場合はオブジェクト作成を削除してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} は {1} を呼び出しますが、メソッドから返される新しい文字列インスタンスは使用されません。インスタンスを引数として他のメソッドに渡すか、インスタンスを変数に割り当てるか、不要な場合は呼び出しを削除してください。</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} は {1} を呼び出しますが、メソッドから返される新しい文字列インスタンスは使用されません。インスタンスを引数として他のメソッドに渡すか、インスタンスを変数に割り当てるか、不要な場合は呼び出しを削除してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} は {1} を呼び出しますが、メソッドから返される HRESULT またはエラー コードは使用されません。このため、エラー条件での予期しない動作やリソース不足が発生する可能性があります。条件ステートメントで結果を使用するか、結果を変数に割り当てるか、引数として他のメソッドに渡してください。</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} は {1} を呼び出しますが、メソッドから返される HRESULT またはエラー コードは使用されません。このため、エラー条件での予期しない動作やリソース不足が発生する可能性があります。条件ステートメントで結果を使用するか、結果を変数に割り当てるか、引数として他のメソッドに渡してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} は {1} を呼び出しますが、変換が成功したかどうかを明示的に確認しません。戻り値を条件ステートメントで使用するか、または、変換が失敗した場合に out 引数が既定値に設定されることを呼び出しサイトで想定するようにしてください。</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} は {1} を呼び出しますが、変換が成功したかどうかを明示的に確認しません。戻り値を条件ステートメントで使用するか、または、変換が失敗した場合に out 引数が既定値に設定されることを呼び出しサイトで想定するようにしてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} は、インスタンス化されていない内部クラスです。その場合、コードをアセンブリから削除してください。このクラスが静的メンバーのみを含むことを意図している場合は、このクラスを static (Visual Basic の場合は Shared) にしてください。</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} は、インスタンス化されていない内部クラスです。その場合、コードをアセンブリから削除してください。このクラスが静的メンバーのみを含むことを意図している場合は、このクラスを static (Visual Basic の場合は Shared) にしてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} は {1} を呼び出しますが、メソッドから返される値は使用されません。{1} は Pure メソッドとしてマークされているため、副作用は発生しません。条件ステートメントで結果を使用するか、結果を変数に割り当てるか、引数として他のメソッドに渡してください。</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} は {1} を呼び出しますが、メソッドから返される値は使用されません。{1} は Pure メソッドとしてマークされているため、副作用は発生しません。条件ステートメントで結果を使用するか、結果を変数に割り当てるか、引数として他のメソッドに渡してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">プロパティ {0} をそれ自体に割り当てることはできません</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">プロパティ {0} をそれ自体に割り当てることはできません</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} は多次元配列です。可能である場合、ジャグ配列で置き換えてください。</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} は多次元配列です。可能である場合、ジャグ配列で置き換えてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} は {1} の多次元配列を返します。可能である場合、ジャグ配列で置き換えてください。</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} は {1} の多次元配列を返します。可能である場合、ジャグ配列で置き換えてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} は {1} の多次元配列を使用します。可能である場合、ジャグ配列で置き換えてください。</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} は {1} の多次元配列を使用します。可能である場合、ジャグ配列で置き換えてください。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void를 사용하지 마세요.</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void를 사용하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void를 사용하지 마세요.</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void를 사용하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">비동기 메서드 이름은 Async로 끝나야 합니다.</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">비동기 메서드 이름은 Async로 끝나야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">비동기 메서드 이름은 Async로 끝나야 합니다.</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">비동기 메서드 이름은 Async로 끝나야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">'{0}'의 형식 매개 변수가 {1}개를 넘지 않는 디자인이 좋습니다.</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">'{0}'의 형식 매개 변수가 {1}개를 넘지 않는 디자인이 좋습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">out 매개 변수를 사용하지 마십시오.</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">out 매개 변수를 사용하지 마십시오.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt;는 상속이 아닌 성능을 위해 설계된 제네릭 컬렉션입니다. List&lt;T&gt;는 상속된 클래스의 동작을 더 쉽게 변경할 수 있도록 만들어 주는 가상 멤버를 포함하지 않습니다.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt;는 상속이 아닌 성능을 위해 설계된 제네릭 컬렉션입니다. List&lt;T&gt;는 상속된 클래스의 동작을 더 쉽게 변경할 수 있도록 만들어 주는 가상 멤버를 포함하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 전달하지 마세요.</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">비동기 람다를 Void 반환 대리자 형식으로 전달하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 전달하지 마세요.</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">비동기 람다를 Void 반환 대리자 형식으로 전달하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">out 또는 ref를 사용하여 참조로 형식을 전달하려면 포인터 사용 경험이 있고, 값 형식과 참조 형식의 차이점을 알고 있으며, 반환 값이 여러 개인 메서드를 처리해야 합니다. 또한 out 매개 변수와 ref 매개 변수의 차이점은 널리 알려져 있지 않습니다.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">out 또는 ref를 사용하여 참조로 형식을 전달하려면 포인터 사용 경험이 있고, 값 형식과 참조 형식의 차이점을 알고 있으며, 반환 값이 여러 개인 메서드를 처리해야 합니다. 또한 out 매개 변수와 ref 매개 변수의 차이점은 널리 알려져 있지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">비동기 람다를 Void 반환 대리자 형식으로 저장하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">'{0}' 형식에서 종료자를 제거하고 Dispose(bool disposing)를 재정의한 후 종료 논리를 'disposing'이 false인 코드 경로에 추가하세요. 그렇지 않으면, 기본 형식 '{1}'도 종료자를 제공할 때 중복된 Dispose 호출이 발생할 수 있습니다.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">'{0}' 형식에서 종료자를 제거하고 Dispose(bool disposing)를 재정의한 후 종료 논리를 'disposing'이 false인 코드 경로에 추가하세요. 그렇지 않으면, 기본 형식 '{1}'도 종료자를 제공할 때 중복된 Dispose 호출이 발생할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">가능한 경우 취소 토큰을 전파하세요.</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">가능한 경우 취소 토큰을 전파하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">가능한 경우 취소 토큰을 전파하세요.</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">가능한 경우 취소 토큰을 전파하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">차단과 비동기를 조합하지 않습니다.</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">차단과 비동기를 조합하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">차단과 비동기를 조합하지 않습니다.</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">차단과 비동기를 조합하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">{0} 열거형에서 {1}의 이름을 'None'으로 변경하세요.</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">{0} 열거형에서 {1}의 이름을 'None'으로 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">{0}에서 'None'으로 명명된 하나의 멤버를 제외하고 0 값이 있는 모든 멤버를 제거하세요.</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">{0}에서 'None'으로 명명된 하나의 멤버를 제외하고 0 값이 있는 모든 멤버를 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">제안된 이름 'None'과 0 값이 있는 멤버를 {0}에 추가하세요.</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">제안된 이름 'None'과 0 값이 있는 멤버를 {0}에 추가하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">CLS(공용 언어 사양)는 명명 제한, 데이터 형식 및 어셈블리가 프로그래밍 언어에 사용될 경우 준수해야 할 규칙을 정의합니다. 설계 시 CLSCompliantAttribute를 사용하여 모든 어셈블리가 명시적으로 CLS를 준수함을 나타내는 것이 좋습니다. 이 특성이 어셈블리에 표시되지 않는 경우는 어셈블리가 비규격 상태입니다.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">CLS(공용 언어 사양)는 명명 제한, 데이터 형식 및 어셈블리가 프로그래밍 언어에 사용될 경우 준수해야 할 규칙을 정의합니다. 설계 시 CLSCompliantAttribute를 사용하여 모든 어셈블리가 명시적으로 CLS를 준수함을 나타내는 것이 좋습니다. 이 특성이 어셈블리에 표시되지 않는 경우는 어셈블리가 비규격 상태입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">CLSCompliant로 어셈블리를 표시하세요.</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">CLSCompliant로 어셈블리를 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">ComVisible로 어셈블리를 표시하세요.</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">ComVisible로 어셈블리를 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">{0}이(가) 외부에 표시되는 형식을 노출하므로 어셈블리 수준에서 ComVisible(false)로 표시한 다음 COM 클라이언트에서 ComVisible(true)로 노출되어야 하는 어셈블리 내에서 모든 형식을 표시하세요.</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">{0}이(가) 외부에 표시되는 형식을 노출하므로 어셈블리 수준에서 ComVisible(false)로 표시한 다음 COM 클라이언트에서 ComVisible(true)로 노출되어야 하는 어셈블리 내에서 모든 형식을 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">AttributeUsageAttribute로 특성을 표시하세요.</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">AttributeUsageAttribute로 특성을 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">사용자 지정 특성을 정의하는 경우 AttributeUsageAttribute를 사용하여 표시하고 사용자 지정 특성이 적용될 수 있는 소스 코드 위치를 나타내세요. 특성의 의미와 용도가 해당 특성의 유효한 코드 위치를 결정합니다.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">사용자 지정 특성을 정의하는 경우 AttributeUsageAttribute를 사용하여 표시하고 사용자 지정 특성이 적용될 수 있는 소스 코드 위치를 나타내세요. 특성의 의미와 용도가 해당 특성의 유효한 코드 위치를 결정합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">{0}에서 AttributeUsage를 지정하세요.</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">{0}에서 AttributeUsage를 지정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">{0} 특성이 해당 특성의 기본 형식에서 AttributeUsage를 상속해도 형식에서 AttributeUsage를 명시적으로 지정하여 코드 가독성과 문서 품질을 향상시켜야 합니다.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">{0} 특성이 해당 특성의 기본 형식에서 AttributeUsage를 상속해도 형식에서 AttributeUsage를 명시적으로 지정하여 코드 가독성과 문서 품질을 향상시켜야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">{1} 특성의 위치 인수 {0}에 대한 공개 읽기 전용 속성 접근자를 추가하세요.</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">{1} 특성의 위치 인수 {0}에 대한 공개 읽기 전용 속성 접근자를 추가하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">속성 setter가 위치 인수 {1}에 해당하므로 이 속성 setter를 {0}에서 제거하거나 해당 접근성을 낮추세요.</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">속성 setter가 위치 인수 {1}에 해당하므로 이 속성 setter를 {0}에서 제거하거나 해당 접근성을 낮추세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">{0}이(가) 위치 인수 {1}에 대한 속성 접근자인 경우 공개로 설정하세요.</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">{0}이(가) 위치 인수 {1}에 대한 속성 접근자인 경우 공개로 설정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">public 또는 protected 메서드는 ""Get""으로 시작하는 이름을 가지며 매개 변수를 사용하지 않고 배열이 아닌 값을 반환합니다. 이 메서드는 속성에 사용하기 적합할 수 있습니다.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">public 또는 protected 메서드는 ""Get""으로 시작하는 이름을 가지며 매개 변수를 사용하지 않고 배열이 아닌 값을 반환합니다. 이 메서드는 속성에 사용하기 적합할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">FlagsAttribute로 열거형을 표시하세요.</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">FlagsAttribute로 열거형을 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">열거형은 관련된 명명된 상수의 집합을 정의하는 값 형식입니다. 명명된 상수가 의미 있게 결합될 수 있을 때 FlagsAttribute를 열거형에 적용하세요.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">열거형은 관련된 명명된 상수의 집합을 정의하는 값 형식입니다. 명명된 상수가 의미 있게 결합될 수 있을 때 FlagsAttribute를 열거형에 적용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">FlagsAttribute로 열거형을 표시하세요.</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">FlagsAttribute로 열거형을 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">public 또는 protected 형식은 System.IComparable 인터페이스를 구현합니다. Object.Equals를 재정의하지도 않고 같음, 같지 않음, 작음, 작거나 같음, 큼, 크거나 같음에 대한 언어 특정 연산자를 오버로드하지도 않습니다.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">public 또는 protected 형식은 System.IComparable 인터페이스를 구현합니다. Object.Equals를 재정의하지도 않고 같음, 같지 않음, 작음, 작거나 같음, 큼, 크거나 같음에 대한 언어 특정 연산자를 오버로드하지도 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0}은(는) IComparable을 구현하므로 Equals를 재정의해야 합니다.</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}은(는) IComparable을 구현하므로 Equals를 재정의해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0}은(는) IComparable을 구현하므로 '{1}' 연산자를 정의해야 합니다.</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}은(는) IComparable을 구현하므로 '{1}' 연산자를 정의해야 합니다.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">외부에 표시되는 인터페이스의 이름은 대문자 ""I""로 시작하지 않습니다. 외부에 표시되는 형식의 제네릭 형식 매개 변수 또는 메서드의 이름은 대문자 ""T""로 시작하지 않습니다.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">외부에 표시되는 인터페이스의 이름은 대문자 ""I""로 시작하지 않습니다. 외부에 표시되는 형식의 제네릭 형식 매개 변수 또는 메서드의 이름은 대문자 ""T""로 시작하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">인터페이스 이름 {0}에 'I'를 접두사로 사용하세요.</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">인터페이스 이름 {0}에 'I'를 접두사로 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">제네릭 형식 매개 변수 이름 {0}에 'T'를 접두사로 사용하세요.</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">제네릭 형식 매개 변수 이름 {0}에 'T'를 접두사로 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">FlagsAttribute로 열거형을 표시하지 마세요.</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">FlagsAttribute로 열거형을 표시하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">외부에 표시되는 열거형은 FlagsAttribute를 사용하여 표시되며 2의 거듭제곱 또는 열거형에서 정의된 다른 값의 조합이 아닌 하나 이상의 값을 가집니다.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">외부에 표시되는 열거형은 FlagsAttribute를 사용하여 표시되며 2의 거듭제곱 또는 열거형에서 정의된 다른 값의 조합이 아닌 하나 이상의 값을 가집니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">FlagsAttribute로 열거형을 표시하지 마세요.</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">FlagsAttribute로 열거형을 표시하지 마세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">{1} 연산자의 적절한 대체 메서드로 이름이 '{0}'인 메서드를 제공하세요.</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{1} 연산자의 적절한 대체 메서드로 이름이 '{0}'인 메서드를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">{1} 연산자의 적절한 대체 속성으로 이름이 '{0}'인 속성을 제공하세요.</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{1} 연산자의 적절한 대체 속성으로 이름이 '{0}'인 속성을 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">{2} 연산자의 대체 메서드로 이름이 '{0}' 또는 '{1}'인 메서드를 제공하세요.</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">{2} 연산자의 대체 메서드로 이름이 '{0}' 또는 '{1}'인 메서드를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">{0}은(는) {1} 연산자의 적절한 대체 항목이므로 공개로 표시하세요.</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{0}은(는) {1} 연산자의 적절한 대체 항목이므로 공개로 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Object.Equals를 재정의할 때 IEquatable을 구현하세요.</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Object.Equals를 재정의할 때 IEquatable을 구현하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">{0} 형식은 Equals를 재정의하므로 IEquatable&lt;T&gt;를 구현해야 합니다.</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">{0} 형식은 Equals를 재정의하므로 IEquatable&lt;T&gt;를 구현해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken 매개 변수는 마지막에 위치해야 합니다.</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken 매개 변수는 마지막에 위치해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">{0}이(가) 외부에 표시되는 형식을 노출하므로 어셈블리 수준에서 ComVisible(false)로 표시한 다음, COM 클라이언트에 노출되어야 하는 어셈블리 내의 모든 형식을 ComVisible(true)로 표시하세요.</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">{0}이(가) 외부에 표시되는 형식을 노출하므로 어셈블리 수준에서 ComVisible(false)로 표시한 다음, COM 클라이언트에 노출되어야 하는 어셈블리 내의 모든 형식을 ComVisible(true)로 표시하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">{0}에서 ComVisible 특성을 false로 변경하고 형식 수준에서 선택하는 것이 좋습니다.</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">{0}에서 ComVisible 특성을 false로 변경하고 형식 수준에서 선택하는 것이 좋습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">IEquatable을 구현하세요.</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">IEquatable을 구현하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">IDisposable 인터페이스를 구현하세요.</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">IDisposable 인터페이스를 구현하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">열거형에서 FlagsAttribute를 제거하세요.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">열거형에서 FlagsAttribute를 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">열거형에 FlagsAttribute를 적용하세요.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">열거형에 FlagsAttribute를 적용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">열거형 스토리지는 Int32여야 합니다</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">열거형 스토리지는 Int32여야 합니다</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">가능한 경우 {1} 대신 {0} System.Int32의 기본 형식을 만드세요.</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">가능한 경우 {1} 대신 {0} System.Int32의 기본 형식을 만드세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">{1} 생성자를 {0}에 추가하세요.</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">{1} 생성자를 {0}에 추가하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">{0}의 접근성을 {1}(으)로 변경하세요.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">{0}의 접근성을 {1}(으)로 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">{0} 형식을 중첩하지 마세요. 대신 형식이 외부에 표시되지 않도록 접근성을 변경하세요.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">{0} 형식을 중첩하지 마세요. 대신 형식이 외부에 표시되지 않도록 접근성을 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">{0} 형식을 중첩하지 마세요. 대신 형식이 외부에 표시되지 않도록 접근성을 변경하세요. 이 형식이 Visual Basic 모듈에 정의된 경우 다른 .NET 언어에 대해 중첩 형식으로 간주됩니다. 이 경우 형식을 모듈 외부로 이동하세요.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">{0} 형식을 중첩하지 마세요. 대신 형식이 외부에 표시되지 않도록 접근성을 변경하세요. 이 형식이 Visual Basic 모듈에 정의된 경우 다른 .NET 언어에 대해 중첩 형식으로 간주됩니다. 이 경우 형식을 모듈 외부로 이동하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">ObsoleteAttribute 메시지를 제공하세요.</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">ObsoleteAttribute 메시지를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">형식 또는 멤버가 지정된 ObsoleteAttribute.Message 속성이 없는 System.ObsoleteAttribute 특성을 사용하여 표시됩니다. ObsoleteAttribute를 사용하여 표시된 형식 또는 멤버가 컴파일되면 해당 특성의 메시지 속성이 표시됩니다. 이를 통해 사용되지 않는 형식 또는 멤버에 대한 사용자 정보를 얻을 수 있습니다.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">형식 또는 멤버가 지정된 ObsoleteAttribute.Message 속성이 없는 System.ObsoleteAttribute 특성을 사용하여 표시됩니다. ObsoleteAttribute를 사용하여 표시된 형식 또는 멤버가 컴파일되면 해당 특성의 메시지 속성이 표시됩니다. 이를 통해 사용되지 않는 형식 또는 멤버에 대한 사용자 정보를 얻을 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">{0}을(를) 사용되지 않는 것으로 표시하는 ObsoleteAttribute에 대한 메시지를 제공하세요.</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">{0}을(를) 사용되지 않는 것으로 표시하는 ObsoleteAttribute에 대한 메시지를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">{0} 속성이 쓰기 전용이므로 해당 setter보다 크거나 같은 접근성이 있는 속성 getter를 추가하거나 이 속성을 메서드로 변환하세요.</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">{0} 속성이 쓰기 전용이므로 해당 setter보다 크거나 같은 접근성이 있는 속성 getter를 추가하거나 이 속성을 메서드로 변환하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">{0}의 속성 getter가 setter보다 표시 수준이 낮으므로 getter의 접근성을 높이거나 해당 setter의 접근성을 낮추세요.</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">{0}의 속성 getter가 setter보다 표시 수준이 낮으므로 getter의 접근성을 높이거나 해당 setter의 접근성을 낮추세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">IDisposable 인터페이스를 올바르게 구현하세요.</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">IDisposable 인터페이스를 올바르게 구현하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">모든 IDisposable 형식은 Dispose 패턴을 올바르게 구현해야 합니다.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">모든 IDisposable 형식은 Dispose 패턴을 올바르게 구현해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">기본 형식 '{1}'에서 이미 구현되었으므로 '{0}'에서 구현된 인터페이스의 목록에서 IDisposable을 제거하세요.</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">기본 형식 '{1}'에서 이미 구현되었으므로 '{0}'에서 구현된 인터페이스의 목록에서 IDisposable을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">'{0}'을(를) 제거하고 Dispose(bool disposing)를 재정의한 후 삭제 논리를 'disposing'이 true인 코드 경로에 추가하세요.</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">'{0}'을(를) 제거하고 Dispose(bool disposing)를 재정의한 후 삭제 논리를 'disposing'이 true인 코드 경로에 추가하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">'{0}'을(를) 수정하여 Dispose(true)를 호출한 다음에 현재 개체 인스턴스(Visual Basic의 경우 'this' 또는 'Me')에서 GC.SuppressFinalize를 호출한 후 반환하도록 하세요.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">'{0}'을(를) 수정하여 Dispose(true)를 호출한 다음에 현재 개체 인스턴스(Visual Basic의 경우 'this' 또는 'Me')에서 GC.SuppressFinalize를 호출한 후 반환하도록 하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">'{0}'을(를) 수정하여 Dispose(false)를 호출한 후 반환하도록 하세요.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">'{0}'을(를) 수정하여 Dispose(false)를 호출한 후 반환하도록 하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">'{0}'에 Dispose(bool)의 재정의 가능한 구현을 제공하거나 형식을 sealed로 표시합니다. Dispose(false)에 대한 호출은 네이티브 리소스만 정리해야 하지만 Dispose(true)에 대한 호출은 관리되는 리소스와 네이티브 리소스 모두를 정리해야 합니다.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">'{0}'에 Dispose(bool)의 재정의 가능한 구현을 제공하거나 형식을 sealed로 표시합니다. Dispose(false)에 대한 호출은 네이티브 리소스만 정리해야 하지만 Dispose(true)에 대한 호출은 관리되는 리소스와 네이티브 리소스 모두를 정리해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">내부 예외는 내부 범위에서만 표시됩니다. 이 예외가 내부 범위를 벗어난 후 예외를 catch하려면 기본 예외만 사용할 수 있습니다. 내부 예외가 T:System.Exception, T:System.SystemException 또는 T:System.ApplicationException에서 상속되는 경우 외부 코드에는 예외를 사용하여 수행해야 하는 작업에 대한 충분한 정보가 제공되지 않습니다.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">내부 예외는 내부 범위에서만 표시됩니다. 이 예외가 내부 범위를 벗어난 후 예외를 catch하려면 기본 예외만 사용할 수 있습니다. 내부 예외가 T:System.Exception, T:System.SystemException 또는 T:System.ApplicationException에서 상속되는 경우 외부 코드에는 예외를 사용하여 수행해야 하는 작업에 대한 충분한 정보가 제공되지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0}이(가) 속성에서 발생하지 않아야 하는 예외 형식인 {1} 형식의 예외를 만듭니다. 이 예외 인스턴스가 발생하는 경우 예외가 더 이상 발생하지 않도록 다른 예외 형식을 사용하고 이 속성을 메서드로 변환하거나 이 속성의 논리를 변경하세요.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}이(가) 속성에서 발생하지 않아야 하는 예외 형식인 {1} 형식의 예외를 만듭니다. 이 예외 인스턴스가 발생하는 경우 예외가 더 이상 발생하지 않도록 다른 예외 형식을 사용하고 이 속성을 메서드로 변환하거나 이 속성의 논리를 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0}이(가) 이 메서드의 형식에서 발생하지 않아야 하는 예외 형식인 {1} 형식의 예외를 만듭니다. 이 예외 인스턴스가 발생하는 경우 더 이상 예외가 발생하지 않도록 다른 예외 형식을 사용하거나 이 메서드의 논리를 변경하세요.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}이(가) 이 메서드의 형식에서 발생하지 않아야 하는 예외 형식인 {1} 형식의 예외를 만듭니다. 이 예외 인스턴스가 발생하는 경우 더 이상 예외가 발생하지 않도록 다른 예외 형식을 사용하거나 이 메서드의 논리를 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0}이(가) {1} 형식의 예외를 만듭니다. 예외는 이 메서드의 형식에서 발생하지 않아야 합니다. 이 예외 인스턴스가 발생하는 경우 더 이상 예외가 발생하지 않도록 이 메서드의 논리를 변경하세요.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}이(가) {1} 형식의 예외를 만듭니다. 예외는 이 메서드의 형식에서 발생하지 않아야 합니다. 이 예외 인스턴스가 발생하는 경우 더 이상 예외가 발생하지 않도록 이 메서드의 논리를 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">규칙에 따라 식별자 이름은 밑줄(_) 문자를 포함하지 않습니다. 이 규칙은 네임스페이스, 형식, 멤버 및 매개 변수를 검사합니다.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">규칙에 따라 식별자 이름은 밑줄(_) 문자를 포함하지 않습니다. 이 규칙은 네임스페이스, 형식, 멤버 및 매개 변수를 검사합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">어셈블리 이름 {0}에서 밑줄을 제거하세요.</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">어셈블리 이름 {0}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">형식 이름 {0}에서 밑줄을 제거하세요.</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">형식 이름 {0}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">멤버 이름 {0}에서 밑줄을 제거하세요.</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">멤버 이름 {0}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">{0} 형식의 제네릭 형식 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} 형식의 제네릭 형식 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">{0} 메서드의 제네릭 형식 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} 메서드의 제네릭 형식 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">{0} 멤버의 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} 멤버의 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">{0} 대리자의 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} 대리자의 매개 변수 이름 {1}에서 밑줄을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">{0}이(가) '{1}'(으)로 끝나도록 이름을 바꾸세요.</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">{0}이(가) '{1}'(으)로 끝나도록 이름을 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">{0}이(가) 'Collection' 또는 '{1}'(으)로 끝나도록 이름을 바꾸세요.</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">{0}이(가) 'Collection' 또는 '{1}'(으)로 끝나도록 이름을 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">'{1}'(으)로 끝나지 않도록 형식 이름 {0}을(를) 바꾸세요.</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">'{1}'(으)로 끝나지 않도록 형식 이름 {0}을(를) 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">멤버 이름 {1}의 '{0}' 접미사를 제안된 대체 숫자 '2'로 바꾸거나 대체될 멤버와 구별되는 더 의미 있는 접미사를 제공하세요.</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">멤버 이름 {1}의 '{0}' 접미사를 제안된 대체 숫자 '2'로 바꾸거나 대체될 멤버와 구별되는 더 의미 있는 접미사를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">형식 이름 {1}의 '{0}' 접미사를 제안된 대체 숫자 '2'로 바꾸거나 대체될 형식과 구별되는 더 의미 있는 접미사를 제공하세요.</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">형식 이름 {1}의 '{0}' 접미사를 제안된 대체 숫자 '2'로 바꾸거나 대체될 형식과 구별되는 더 의미 있는 접미사를 제공하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">가상/인터페이스 멤버 {0}에서 예약된 언어 키워드 '{2}'과(와) 더 이상 충돌하지 않도록 매개 변수 {1}의 이름을 바꾸세요. 가상/인터페이스 멤버에서 예약된 키워드를 매개 변수의 이름으로 사용하면 다른 언어 소비자가 해당 멤버를 재정의/구현하기 어렵습니다.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">가상/인터페이스 멤버 {0}에서 예약된 언어 키워드 '{2}'과(와) 더 이상 충돌하지 않도록 매개 변수 {1}의 이름을 바꾸세요. 가상/인터페이스 멤버에서 예약된 키워드를 매개 변수의 이름으로 사용하면 다른 언어 소비자가 해당 멤버를 재정의/구현하기 어렵습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않도록 가상/인터페이스 멤버 {0}의 이름을 바꾸세요. 예약된 키워드를 가상/인터페이스 멤버의 이름으로 사용하면 다른 언어 소비자가 해당 멤버를 재정의/구현하기 어렵습니다.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않도록 가상/인터페이스 멤버 {0}의 이름을 바꾸세요. 예약된 키워드를 가상/인터페이스 멤버의 이름으로 사용하면 다른 언어 소비자가 해당 멤버를 재정의/구현하기 어렵습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않도록 형식{0}의 이름을 바꾸세요. 예약된 키워드를 형식의 이름으로 사용하면 다른 언어 소비자가 형식을 사용하기 어렵습니다.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않도록 형식{0}의 이름을 바꾸세요. 예약된 키워드를 형식의 이름으로 사용하면 다른 언어 소비자가 형식을 사용하기 어렵습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않으려면 네임스페이스 {0}의 이름을 바꾸세요. 예약된 키워드를 네임스페이스의 이름으로 사용하면 다른 언어 소비자가 네임스페이스를 사용하기 어렵습니다.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">예약된 언어 키워드 '{1}'과(와) 더 이상 충돌하지 않으려면 네임스페이스 {0}의 이름을 바꾸세요. 예약된 키워드를 네임스페이스의 이름으로 사용하면 다른 언어 소비자가 네임스페이스를 사용하기 어렵습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Public 또는 protected 멤버의 이름이 ""Get""으로 시작하고 나머지 부분이 public 또는 protected 속성의 이름과 일치합니다. ""Get"" 메서드 및 속성은 기능과 완전히 다른 이름을 사용해야 합니다.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Public 또는 protected 멤버의 이름이 ""Get""으로 시작하고 나머지 부분이 public 또는 protected 속성의 이름과 일치합니다. ""Get"" 메서드 및 속성은 기능과 완전히 다른 이름을 사용해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">형식 이름 {0}이(가) 네임스페이스 이름 '{1}'과(와) 전부 또는 부분적으로 충돌합니다. 충돌이 발생하지 않도록 둘 중 하나의 이름을 변경하세요.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">형식 이름 {0}이(가) 네임스페이스 이름 '{1}'과(와) 전부 또는 부분적으로 충돌합니다. 충돌이 발생하지 않도록 둘 중 하나의 이름을 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">형식 이름 {0}이(가) .NET Framework에서 정의된 네임스페이스 이름 '{1}'과(와) 전부 또는 부분적으로 충돌합니다. 충돌이 발생하지 않도록 형식의 이름을 바꾸세요.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">형식 이름 {0}이(가) .NET Framework에서 정의된 네임스페이스 이름 '{1}'과(와) 전부 또는 부분적으로 충돌합니다. 충돌이 발생하지 않도록 형식의 이름을 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">{3}에 선언된 식별자와 일치하도록 {0} 멤버의 매개 변수 이름 {1}을(를) {2}(으)로 변경하세요.</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">{3}에 선언된 식별자와 일치하도록 {0} 멤버의 매개 변수 이름 {1}을(를) {2}(으)로 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">어셈블리 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">어셈블리 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} 멤버에서 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} 멤버에서 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} 대리자에서 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} 대리자에서 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} 형식에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} 형식에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} 메서드에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} 메서드에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 기본 대체 용어 '{3}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">형식 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">형식 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">멤버 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">멤버 이름 {1}의 '{0}' 용어를 기본 대체 용어 '{2}'(으)로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">어셈블리 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">어셈블리 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} 멤버에서 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} 멤버에서 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} 대리자에서 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} 대리자에서 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} 형식에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} 형식에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} 메서드에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} 메서드에서 제네릭 형식 매개 변수 이름 {2}의 '{1}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">형식 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">형식 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">멤버 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">멤버 이름 {1}의 '{0}' 용어를 적절한 대체 용어로 바꾸거나 완전히 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0}은(는) Equals를 재정의해야 합니다.</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0}은(는) Equals를 재정의해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0}은(는) 같음(==) 및 같지 않음(!=) 연산자를 재정의해야 합니다.</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0}은(는) 같음(==) 및 같지 않음(!=) 연산자를 재정의해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">강력한 이름의 키로 {0}을(를) 서명하세요.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">강력한 이름의 키로 {0}을(를) 서명하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">{0}을(를) 배포하기 전에 유효하고 강력한 이름이 사용되었는지 확인하세요.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">{0}을(를) 배포하기 전에 유효하고 강력한 이름이 사용되었는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Equals를 재정의할 때 GetHashCode를 재정의하세요.</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Equals를 재정의할 때 GetHashCode를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode는 현재 인스턴스를 기반으로 값을 반환하며 이 값은 해시 알고리즘과 해시 테이블과 같은 데이터 구조에 적합합니다. 형식이 같은 동일한 개체 2개는 동일한 해시 코드를 반환해야 합니다.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode는 현재 인스턴스를 기반으로 값을 반환하며 이 값은 해시 알고리즘과 해시 테이블과 같은 데이터 구조에 적합합니다. 형식이 같은 동일한 개체 2개는 동일한 해시 코드를 반환해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Equals를 재정의할 때 GetHashCode를 재정의하세요.</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Equals를 재정의할 때 GetHashCode를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">같음 연산자를 오버로드할 때 Equals를 재정의하세요.</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">같음 연산자를 오버로드할 때 Equals를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">public 형식이 같음 연산자를 구현하지만 Object.Equals를 재정의하지 않습니다.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">public 형식이 같음 연산자를 구현하지만 Object.Equals를 재정의하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">같음 연산자를 오버로드할 때 Equals를 재정의하세요.</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">같음 연산자를 오버로드할 때 Equals를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals를 재정의하세요.</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals를 재정의하세요.</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">object.GetHashCode를 재정의하세요.</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">object.GetHashCode를 재정의하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">클래스를 Static으로 설정</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">클래스를 Static으로 설정</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">{0} 형식은 IEquatable&lt;T&gt;를 구현하므로 Equals를 재정의해야 합니다.</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">{0} 형식은 IEquatable&lt;T&gt;를 구현하므로 Equals를 재정의해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">IEquatable&lt;T&gt;를 구현할 때 Object.Equals(개체)를 재정의합니다.</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">IEquatable&lt;T&gt;를 구현할 때 Object.Equals(개체)를 재정의합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">비동기 메서드가 작업을 바로 대기하는 경우 작업을 만든 스레드와 같은 스레드에서 연속이 발생합니다. 연속에 대한 의도를 알리려면 Task.ConfigureAwait(Boolean) 호출을 고려합니다. 작업에 대해 ConfigureAwait(false)를 호출하여 스레드 풀에 대한 연속을 예약함으로써 UI 스레드에서의 교착 상태를 방지합니다. 앱과 관계없는 라이브러리의 경우 false를 전달하는 것이 좋은 옵션이 됩니다. 작업에 대해 ConfigureAwait(true)를 호출하는 것은 명시적으로 ConfigureAwait를 호출하지 않는 것과 동작이 같습니다. 이 메서드를 명시적으로 호출하여 판독기에 원래 동기화 컨텍스트에서 의도적으로 연속을 수행하려는 것임을 알립니다.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">비동기 메서드가 작업을 바로 대기하는 경우 작업을 만든 스레드와 같은 스레드에서 연속이 발생합니다. 연속에 대한 의도를 알리려면 Task.ConfigureAwait(Boolean) 호출을 고려합니다. 작업에 대해 ConfigureAwait(false)를 호출하여 스레드 풀에 대한 연속을 예약함으로써 UI 스레드에서의 교착 상태를 방지합니다. 앱과 관계없는 라이브러리의 경우 false를 전달하는 것이 좋은 옵션이 됩니다. 작업에 대해 ConfigureAwait(true)를 호출하는 것은 명시적으로 ConfigureAwait를 호출하지 않는 것과 동작이 같습니다. 이 메서드를 명시적으로 호출하여 판독기에 원래 동기화 컨텍스트에서 의도적으로 연속을 수행하려는 것임을 알립니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">대기된 작업에 대해 ConfigureAwait 호출을 고려하세요.</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">대기된 작업에 대해 ConfigureAwait 호출을 고려하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">대기된 작업에 대해 ConfigureAwait 호출 고려</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">대기된 작업에 대해 ConfigureAwait 호출 고려</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">형식 T가 Object.Equals(object)를 재정의하면 해당 구현은 비교를 수행하기 전에 개체 인수를 올바른 형식 T로 캐스트해야 합니다. 해당 형식이 IEquatable&lt;T&gt;를 구현하므로 T.Equals(T) 메서드를 제공하는 경우 및 인수가 컴파일 시간에 형식 T로 알려지는 경우 컴파일러는 Object.Equals(object) 대신 IEquatable&lt;T&gt;.Equals(T)를 호출할 수 있고, 캐스트가 필요하지 않으므로 성능이 향상됩니다.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">형식 T가 Object.Equals(object)를 재정의하면 해당 구현은 비교를 수행하기 전에 개체 인수를 올바른 형식 T로 캐스트해야 합니다. 해당 형식이 IEquatable&lt;T&gt;를 구현하므로 T.Equals(T) 메서드를 제공하는 경우 및 인수가 컴파일 시간에 형식 T로 알려지는 경우 컴파일러는 Object.Equals(object) 대신 IEquatable&lt;T&gt;.Equals(T)를 호출할 수 있고, 캐스트가 필요하지 않으므로 성능이 향상됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0}은(는) IComparable을 구현하므로 '{1}' 및 같음 연산자를 정의해야 합니다.</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}은(는) IComparable을 구현하므로 '{1}' 및 같음 연산자를 정의해야 합니다.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">{0}에서 GC.Collect에 대한 호출을 제거하세요. 이러한 호출은 일반적으로 불필요한 가비지를 수집하므로 성능을 크게 떨어뜨릴 수 있습니다.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">{0}에서 GC.Collect에 대한 호출을 제거하세요. 이러한 호출은 일반적으로 불필요한 가비지를 수집하므로 성능을 크게 떨어뜨릴 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">{0}에서 Thread.Resume에 대한 호출을 제거하세요. 시스템에서 중요한 시스템 형식의 클래스 생성자를 실행하고 있거나 공유 어셈블리의 보안을 확인하고 있는 경우처럼 중요한 작업을 수행하는 동안 스레드를 일시 중단하고 다시 시작하면 위험할 수 있습니다.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">{0}에서 Thread.Resume에 대한 호출을 제거하세요. 시스템에서 중요한 시스템 형식의 클래스 생성자를 실행하고 있거나 공유 어셈블리의 보안을 확인하고 있는 경우처럼 중요한 작업을 수행하는 동안 스레드를 일시 중단하고 다시 시작하면 위험할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">{0}에서 Thread.Suspend에 대한 호출을 제거하세요. 시스템에서 중요한 시스템 형식의 클래스 생성자를 실행하고 있거나 공유 어셈블리의 보안을 확인하고 있는 경우처럼 중요한 작업을 수행하는 동안 스레드를 일시 중단하고 다시 시작하면 위험할 수 있습니다.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">{0}에서 Thread.Suspend에 대한 호출을 제거하세요. 시스템에서 중요한 시스템 형식의 클래스 생성자를 실행하고 있거나 공유 어셈블리의 보안을 확인하고 있는 경우처럼 중요한 작업을 수행하는 동안 스레드를 일시 중단하고 다시 시작하면 위험할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">{0}에서 BindingFlags.NonPublic을 사용하는 System.Type.InvokeMember에 대한 호출을 제거하세요. private 멤버에서 종속성을 사용하면 나중에 크게 바뀔 가능성이 큽니다.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">{0}에서 BindingFlags.NonPublic을 사용하는 System.Type.InvokeMember에 대한 호출을 제거하세요. private 멤버에서 종속성을 사용하면 나중에 크게 바뀔 가능성이 큽니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0}은(는) OLE32 API에 대한 P/Invoke 선언으로, 런타임이 초기화된 후에는 안정적으로 호출할 수 없습니다. 이 문제를 해결하려면 루틴을 호출하는 관리되지 않는 shim을 작성한 후 관리 코드를 활성화하여 호출해야 합니다. COM에서 사용할 수 있도록 관리되는 구성 요소를 등록하거나 런타임 호스팅 API를 사용하면 혼합 모드 C++ DLL의 내보내기를 통해 이를 수행할 수 있습니다.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0}은(는) OLE32 API에 대한 P/Invoke 선언으로, 런타임이 초기화된 후에는 안정적으로 호출할 수 없습니다. 이 문제를 해결하려면 루틴을 호출하는 관리되지 않는 shim을 작성한 후 관리 코드를 활성화하여 호출해야 합니다. COM에서 사용할 수 있도록 관리되는 구성 요소를 등록하거나 런타임 호스팅 API를 사용하면 혼합 모드 C++ DLL의 내보내기를 통해 이를 수행할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0}는 런타임 호출 가능 래퍼 (COM 개체를 래핑하는 관리 되는 개체)에 대 한 안정적으로 호출 될 수 없습니다 OLE32 API에는 P/Invoke 선언 이다. 런타임 호출 가능 래퍼는 동적으로 호출의 효과 임의로 손실 될 수 있습니다 그래서 인터페이스 포인터를 가져옵니다. 통화 가능 하 게 다른 사용자에 영향을 미칠 수 있도록 지정된 된 COM 개체에 대 한 런타임 호출 가능 래퍼 또한 응용 프로그램 도메인에 걸쳐 공유 됩니다. 이 호출을 적절 한 CoSetProxyBlanket 호출을 수행 하는 인터페이스 포인터에 대 한 네이티브 래퍼 COM 개체를 바꿉니다.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0}는 런타임 호출 가능 래퍼 (COM 개체를 래핑하는 관리 되는 개체)에 대 한 안정적으로 호출 될 수 없습니다 OLE32 API에는 P/Invoke 선언 이다. 런타임 호출 가능 래퍼는 동적으로 호출의 효과 임의로 손실 될 수 있습니다 그래서 인터페이스 포인터를 가져옵니다. 통화 가능 하 게 다른 사용자에 영향을 미칠 수 있도록 지정된 된 COM 개체에 대 한 런타임 호출 가능 래퍼 또한 응용 프로그램 도메인에 걸쳐 공유 됩니다. 이 호출을 적절 한 CoSetProxyBlanket 호출을 수행 하는 인터페이스 포인터에 대 한 네이티브 래퍼 COM 개체를 바꿉니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">{0}에서 SafeHandle.DangerousGetHandle 호출을 제거하세요.</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">{0}에서 SafeHandle.DangerousGetHandle 호출을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">{0}에서 Assembly.LoadFrom 호출을 제거하세요.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">{0}에서 Assembly.LoadFrom 호출을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">{0}에서 Assembly.LoadFile 호출을 제거하세요.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">{0}에서 Assembly.LoadFile 호출을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">{0}에서 Assembly.LoadWithPartialName 호출을 제거하세요.</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">{0}에서 Assembly.LoadWithPartialName 호출을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{1}에서 선언된 변수 {0}의 이름이 이 형식의 인스턴스 필드와 일치합니다. 이 항목 중 하나의 이름을 변경하세요.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{1}에서 선언된 변수 {0}의 이름이 이 형식의 인스턴스 필드와 일치합니다. 이 항목 중 하나의 이름을 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{1}에서 선언된 매개 변수 {0}의 이름이 이 형식의 인스턴스 필드와 일치합니다. 이 항목 중 하나의 이름을 변경하세요.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{1}에서 선언된 매개 변수 {0}의 이름이 이 형식의 인스턴스 필드와 일치합니다. 이 항목 중 하나의 이름을 변경하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">{1} 메서드의 {0} 매개 변수가 사용되지 않았습니다. 매개 변수를 제거하거나 메서드 본문에 사용하세요.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">{1} 메서드의 {0} 매개 변수가 사용되지 않았습니다. 매개 변수를 제거하거나 메서드 본문에 사용하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0}이(가) 사용되지 않는 {1}의 새 인스턴스를 만듭니다. 인스턴스를 다른 메서드에 인수로 전달하고 변수에 할당하거나 불필요한 경우 개체 만들기를 제거하세요.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0}이(가) 사용되지 않는 {1}의 새 인스턴스를 만듭니다. 인스턴스를 다른 메서드에 인수로 전달하고 변수에 할당하거나 불필요한 경우 개체 만들기를 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 새 문자열 인스턴스를 사용하지 않습니다. 인스턴스를 다른 메서드에 인수로 전달하고 변수에 할당하거나 불필요한 경우 호출을 제거하세요.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 새 문자열 인스턴스를 사용하지 않습니다. 인스턴스를 다른 메서드에 인수로 전달하고 변수에 할당하거나 불필요한 경우 호출을 제거하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 HRESULT 또는 오류 코드를 사용하지 않습니다. 이로 인해 오류 상태의 예기치 않은 동작이 발생하거나 리소스가 부족해질 수 있습니다. 결과를 조건문에 사용하거나 변수에 할당하거나 다른 메서드에 인수로 전달하세요.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 HRESULT 또는 오류 코드를 사용하지 않습니다. 이로 인해 오류 상태의 예기치 않은 동작이 발생하거나 리소스가 부족해질 수 있습니다. 결과를 조건문에 사용하거나 변수에 할당하거나 다른 메서드에 인수로 전달하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0}이(가) {1}을(를) 호출하지만 변환 성공 여부를 명시적으로 검사하지 않습니다. 반환 값을 조건문에 사용하거나, 변환에 실패하면 out 인수가 기본값으로 설정되도록 호출 사이트가 지정되어 있는지 확인하세요.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0}이(가) {1}을(를) 호출하지만 변환 성공 여부를 명시적으로 검사하지 않습니다. 반환 값을 조건문에 사용하거나, 변환에 실패하면 out 인수가 기본값으로 설정되도록 호출 사이트가 지정되어 있는지 확인하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0}은(는) 인스턴스화되지 않는 내부 클래스입니다. 어셈블리에서 해당 코드를 제거하세요. 이 클래스가 정적 멤버만 포함하는 경우 static(Visual Basic의 경우 Shared)으로 설정하세요.</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0}은(는) 인스턴스화되지 않는 내부 클래스입니다. 어셈블리에서 해당 코드를 제거하세요. 이 클래스가 정적 멤버만 포함하는 경우 static(Visual Basic의 경우 Shared)으로 설정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 값을 사용하지 않습니다. {1}이(가) 순수 메서드로 표시되어 있으므로 의도하지 않은 결과가 발생하지 않습니다. 결과를 조건문에 사용하거나 변수에 할당하거나 다른 메서드에 인수로 전달하세요.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0}이(가) {1}을(를) 호출하지만 메서드가 반환하는 값을 사용하지 않습니다. {1}이(가) 순수 메서드로 표시되어 있으므로 의도하지 않은 결과가 발생하지 않습니다. 결과를 조건문에 사용하거나 변수에 할당하거나 다른 메서드에 인수로 전달하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">{0} 속성을 자체에 할당하면 안 됩니다.</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">{0} 속성을 자체에 할당하면 안 됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}은(는) 다차원 배열입니다. 가능한 경우 가변 배열로 바꾸세요.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}은(는) 다차원 배열입니다. 가능한 경우 가변 배열로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}이(가) {1}의 다차원 배열을 반환합니다. 가능한 경우 가변 배열로 바꾸세요.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}이(가) {1}의 다차원 배열을 반환합니다. 가능한 경우 가변 배열로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}이(가) {1}의 다차원 배열을 사용합니다. 가능한 경우 가변 배열로 바꾸세요.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}이(가) {1}의 다차원 배열을 사용합니다. 가능한 경우 가변 배열로 바꾸세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Unikaj metod async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Unikaj metod async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Unikaj metod async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Unikaj metod async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Nazwy metod asynchronicznych powinny kończyć się ciągiem Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Nazwy metod asynchronicznych powinny kończyć się ciągiem Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Nazwy metod asynchronicznych powinny kończyć się ciągiem Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Nazwy metod asynchronicznych powinny kończyć się ciągiem Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Rozważ użycie projektu, w którym element „{0}” ma nie więcej niż następująca liczba parametrów typu: {1}</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Rozważ użycie projektu, w którym element „{0}” ma nie więcej niż następująca liczba parametrów typu: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Unikaj parametrów out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Unikaj parametrów out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; to ogólna kolekcja zaprojektowana pod kątem wydajności, a nie dziedziczenia. Element List&lt;T&gt; nie zawiera wirtualnych składowych, które ułatwiają zmianę zachowania dziedziczonej klasy.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; to ogólna kolekcja zaprojektowana pod kątem wydajności, a nie dziedziczenia. Element List&lt;T&gt; nie zawiera wirtualnych składowych, które ułatwiają zmianę zachowania dziedziczonej klasy.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nie przekazuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nie przekazuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nie przekazuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nie przekazuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Przekazywanie typów przez odwołanie (zastosowanie parametrów „out” lub „ref”) wymaga doświadczenia w pracy ze wskaźnikami, rozumienia różnic między typami wartości i typami odwołań oraz umiejętności stosowania metod z wieloma wartościami zwracanymi. Ponadto różnice między parametrami „out” i „ref” nie są powszechnie zrozumiałe.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Przekazywanie typów przez odwołanie (zastosowanie parametrów „out” lub „ref”) wymaga doświadczenia w pracy ze wskaźnikami, rozumienia różnic między typami wartości i typami odwołań oraz umiejętności stosowania metod z wieloma wartościami zwracanymi. Ponadto różnice między parametrami „out” i „ref” nie są powszechnie zrozumiałe.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Nie przechowuj asynchronicznych wyrażeń lambda jako typów delegatów zwracających typ void</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Usuń finalizator z typu „{0}”, przesłoń funkcję Dispose(bool disposing) i umieść logikę finalizacji w ścieżce kodu, gdzie element „disposing” ma wartość false. W przeciwnym razie mogą pojawić się zduplikowane wywołania funkcji Dispose, ponieważ typ bazowy „{1}” także udostępnia finalizator.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Usuń finalizator z typu „{0}”, przesłoń funkcję Dispose(bool disposing) i umieść logikę finalizacji w ścieżce kodu, gdzie element „disposing” ma wartość false. W przeciwnym razie mogą pojawić się zduplikowane wywołania funkcji Dispose, ponieważ typ bazowy „{1}” także udostępnia finalizator.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propaguj elementy CancellationToken, jeśli to możliwe</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propaguj elementy CancellationToken, jeśli to możliwe</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propaguj elementy CancellationToken, jeśli to możliwe</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propaguj elementy CancellationToken, jeśli to możliwe</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Nie mieszaj kodu blokującego i asynchronicznego</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Nie mieszaj kodu blokującego i asynchronicznego</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Nie mieszaj kodu blokującego i asynchronicznego</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Nie mieszaj kodu blokującego i asynchronicznego</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">W wyliczeniu {0} zmień nazwę elementu {1} na „None”</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">W wyliczeniu {0} zmień nazwę elementu {1} na „None”</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Usuń wszystkie składowe o wartości zero z wyliczenia {0}, z wyjątkiem jednej składowej o nazwie „None”</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Usuń wszystkie składowe o wartości zero z wyliczenia {0}, z wyjątkiem jednej składowej o nazwie „None”</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Dodaj składową o wartości zero do wyliczenia {0} z sugerowaną nazwą „None”</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Dodaj składową o wartości zero do wyliczenia {0} z sugerowaną nazwą „None”</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Specyfikacja CLS (Common Language Specification) definiuje ograniczenia nazewnictwa, typy danych i reguły, z którymi muszą być zgodne zestawy, jeśli będą używane z różnymi językami programowania. Reguły poprawnego projektowania nakazują, aby wszystkie zestawy jawnie deklarowały zgodność ze specyfikacją CLS za pomocą atrybutu CLSCompliantAttribute. Jeśli zestaw nie ma tego atrybutu, nie jest zgodny.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Specyfikacja CLS (Common Language Specification) definiuje ograniczenia nazewnictwa, typy danych i reguły, z którymi muszą być zgodne zestawy, jeśli będą używane z różnymi językami programowania. Reguły poprawnego projektowania nakazują, aby wszystkie zestawy jawnie deklarowały zgodność ze specyfikacją CLS za pomocą atrybutu CLSCompliantAttribute. Jeśli zestaw nie ma tego atrybutu, nie jest zgodny.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Oznacz zestawy atrybutem CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Oznacz zestawy atrybutem CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Oznacz zestawy atrybutem ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Oznacz zestawy atrybutem ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Ponieważ zestaw {0} udostępnia typy widoczne zewnętrznie, oznacz go atrybutem ComVisible(false) na poziomie zestawu, a następnie oznacz atrybutem ComVisible(true) wszystkie typy w zestawie, które powinny być dostępne dla klientów modelu COM.</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Ponieważ zestaw {0} udostępnia typy widoczne zewnętrznie, oznacz go atrybutem ComVisible(false) na poziomie zestawu, a następnie oznacz atrybutem ComVisible(true) wszystkie typy w zestawie, które powinny być dostępne dla klientów modelu COM.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Oznacz atrybuty za pomocą atrybutu AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Oznacz atrybuty za pomocą atrybutu AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Przy definiowaniu atrybutu niestandardowego oznacz go za pomocą atrybutu AttributeUsageAttribute, aby wskazać, gdzie można stosować ten atrybut niestandardowy w kodzie źródłowym. Znaczenie i zamierzone użycie atrybutu określi jego prawidłowe lokalizacje w kodzie.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Przy definiowaniu atrybutu niestandardowego oznacz go za pomocą atrybutu AttributeUsageAttribute, aby wskazać, gdzie można stosować ten atrybut niestandardowy w kodzie źródłowym. Znaczenie i zamierzone użycie atrybutu określi jego prawidłowe lokalizacje w kodzie.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Określ atrybut AttributeUsage dla elementu {0}</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Określ atrybut AttributeUsage dla elementu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Mimo że atrybut {0} dziedziczy atrybut AttributeUsage ze swojego typu podstawowego, rozważ jawne określenie atrybutu AttributeUsage dla typu w celu ulepszenia czytelności kodu i dokumentacji.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Mimo że atrybut {0} dziedziczy atrybut AttributeUsage ze swojego typu podstawowego, rozważ jawne określenie atrybutu AttributeUsage dla typu w celu ulepszenia czytelności kodu i dokumentacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Dodaj publiczną metodę dostępu do właściwości tylko do odczytu dla argumentu pozycyjnego {0} atrybutu {1}</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Dodaj publiczną metodę dostępu do właściwości tylko do odczytu dla argumentu pozycyjnego {0} atrybutu {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Usuń metodę ustawiającą właściwość z argumentu {0} lub ogranicz jej dostępność, ponieważ odpowiada ona argumentowi pozycyjnemu {1}</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Usuń metodę ustawiającą właściwość z argumentu {0} lub ogranicz jej dostępność, ponieważ odpowiada ona argumentowi pozycyjnemu {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Jeśli {0} to metoda dostępu do właściwości dla argumentu pozycyjnego {1}, zadeklaruj ją jako publiczną</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Jeśli {0} to metoda dostępu do właściwości dla argumentu pozycyjnego {1}, zadeklaruj ją jako publiczną</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Metoda publiczna lub chroniona ma nazwę zaczynającą się od „Get”, nie pobiera parametrów i zwraca wartość, która nie jest tablicą. Ta metoda może być dobrym kandydatem na właściwość.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Metoda publiczna lub chroniona ma nazwę zaczynającą się od „Get”, nie pobiera parametrów i zwraca wartość, która nie jest tablicą. Ta metoda może być dobrym kandydatem na właściwość.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Oznacz wyliczenia atrybutem FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Oznacz wyliczenia atrybutem FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Wyliczenie to typ wartości, który definiuje zestaw powiązanych stałych nazwanych. Zastosuj atrybut FlagsAttribute do wyliczenia, jeśli jego stałe nazwane można połączyć w znaczący sposób.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Wyliczenie to typ wartości, który definiuje zestaw powiązanych stałych nazwanych. Zastosuj atrybut FlagsAttribute do wyliczenia, jeśli jego stałe nazwane można połączyć w znaczący sposób.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Oznacz wyliczenia atrybutem FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Oznacz wyliczenia atrybutem FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Typ publiczny lub chroniony implementuje interfejs System.IComparable. Nie przesłania on metody Object.Equals ani nie przeciąża specyficznego dla języka operatora równości, nierówności, mniejszości, mniejszości lub równości, większości ani większości lub równości.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Typ publiczny lub chroniony implementuje interfejs System.IComparable. Nie przesłania on metody Object.Equals ani nie przeciąża specyficznego dla języka operatora równości, nierówności, mniejszości, mniejszości lub równości, większości ani większości lub równości.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">Typ {0} powinien przesłaniać metodę Equals, ponieważ implementuje interfejs IComparable</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">Typ {0} powinien przesłaniać metodę Equals, ponieważ implementuje interfejs IComparable</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">Typ {0} powinien definiować operatory „{1}”, ponieważ implementuje interfejs IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">Typ {0} powinien definiować operatory „{1}”, ponieważ implementuje interfejs IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Nazwa interfejsu widocznego zewnętrznie nie zaczyna się wielką literą „I”. Nazwa parametru typu ogólnego dla typu lub metody widocznych zewnętrznie nie zaczyna się wielką literą „T”.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Nazwa interfejsu widocznego zewnętrznie nie zaczyna się wielką literą „I”. Nazwa parametru typu ogólnego dla typu lub metody widocznych zewnętrznie nie zaczyna się wielką literą „T”.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Dodaj do nazwy interfejsu {0} prefiks „I”</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Dodaj do nazwy interfejsu {0} prefiks „I”</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Dodaj do nazwy parametru typu ogólnego {0} prefiks „T”</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Dodaj do nazwy parametru typu ogólnego {0} prefiks „T”</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Nie oznaczaj wyliczeń atrybutem FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Nie oznaczaj wyliczeń atrybutem FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Wyliczenie widoczne zewnętrznie jest oznaczone atrybutem FlagsAttribute i ma co najmniej jedną wartość, która nie jest potęgą dwójki ani kombinacją innych wartości zdefiniowanych dla wyliczenia.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Wyliczenie widoczne zewnętrznie jest oznaczone atrybutem FlagsAttribute i ma co najmniej jedną wartość, która nie jest potęgą dwójki ani kombinacją innych wartości zdefiniowanych dla wyliczenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Nie oznaczaj wyliczeń atrybutem FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Nie oznaczaj wyliczeń atrybutem FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Określ metodę o nazwie „{0}” jako metodę alternatywną operatora {1} o przyjaznej nazwie</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Określ metodę o nazwie „{0}” jako metodę alternatywną operatora {1} o przyjaznej nazwie</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Określ właściwość o nazwie „{0}” jako właściwość alternatywną operatora {1} o przyjaznej nazwie</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Określ właściwość o nazwie „{0}” jako właściwość alternatywną operatora {1} o przyjaznej nazwie</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Określ metodę o nazwie „{0}” lub „{1}” jako metodę alternatywną operatora {2}</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Określ metodę o nazwie „{0}” lub „{1}” jako metodę alternatywną operatora {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Oznacz metodę {0} jako publiczną, ponieważ jest ona metodą alternatywną operatora {1} o przyjaznej nazwie</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Oznacz metodę {0} jako publiczną, ponieważ jest ona metodą alternatywną operatora {1} o przyjaznej nazwie</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Zaimplementuj interfejs IEquatable przy przesłanianiu metody Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Zaimplementuj interfejs IEquatable przy przesłanianiu metody Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Typ {0} powinien implementować interfejs IEquatable&lt;T&gt;, ponieważ przesłania metodę Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Typ {0} powinien implementować interfejs IEquatable&lt;T&gt;, ponieważ przesłania metodę Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Parametry CancellationToken muszą występować na końcu</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Parametry CancellationToken muszą występować na końcu</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Ponieważ zestaw {0} udostępnia typy widoczne zewnętrznie, oznacz go atrybutem ComVisible(false) na poziomie zestawu, a następnie oznacz atrybutem ComVisible(true) wszystkie typy w zestawie, które powinny być dostępne dla klientów modelu COM</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Ponieważ zestaw {0} udostępnia typy widoczne zewnętrznie, oznacz go atrybutem ComVisible(false) na poziomie zestawu, a następnie oznacz atrybutem ComVisible(true) wszystkie typy w zestawie, które powinny być dostępne dla klientów modelu COM</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Rozważ zmianę atrybutu ComVisible dla zestawu {0} na wartość false i użycie wartości true na poziomie typów</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Rozważ zmianę atrybutu ComVisible dla zestawu {0} na wartość false i użycie wartości true na poziomie typów</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Zaimplementuj interfejs IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Zaimplementuj interfejs IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Zaimplementuj interfejs IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Zaimplementuj interfejs IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Usuń atrybut FlagsAttribute z wyliczenia.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Usuń atrybut FlagsAttribute z wyliczenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Zastosuj atrybut FlagsAttribute do wyliczenia.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Zastosuj atrybut FlagsAttribute do wyliczenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Wyliczenia powinny być przechowywane jako typ Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Wyliczenia powinny być przechowywane jako typ Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Jeśli to możliwe, zmień typ bazowy wyliczenia {0} na System.Int32 zamiast {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Jeśli to możliwe, zmień typ bazowy wyliczenia {0} na System.Int32 zamiast {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Dodaj następujący konstruktor do elementu {0}: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Dodaj następujący konstruktor do elementu {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Zmień dostępność elementu {0} na {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Zmień dostępność elementu {0} na {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Nie zagnieżdżaj typu {0}. Możesz też zmienić jego dostępność tak, aby nie był widoczny zewnętrznie.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Nie zagnieżdżaj typu {0}. Możesz też zmienić jego dostępność tak, aby nie był widoczny zewnętrznie.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Nie zagnieżdżaj typu {0}. Możesz też zmienić jego dostępność tak, aby nie był widoczny zewnętrznie. Jeśli ten typ jest zdefiniowany w module języka Visual Basic, będzie uznawany za typ zagnieżdżony przez inne języki .NET. W takim przypadku rozważ przeniesienie typu poza moduł.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Nie zagnieżdżaj typu {0}. Możesz też zmienić jego dostępność tak, aby nie był widoczny zewnętrznie. Jeśli ten typ jest zdefiniowany w module języka Visual Basic, będzie uznawany za typ zagnieżdżony przez inne języki .NET. W takim przypadku rozważ przeniesienie typu poza moduł.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Określ komunikat dla atrybutu ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Określ komunikat dla atrybutu ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Typ lub element członkowski jest oznaczony atrybutem System.ObsoleteAttribute, dla którego nie określono właściwości ObsoleteAttribute.Message. Gdy jest kompilowany typ lub element członkowski oznaczony atrybutem ObsoleteAttribute, wyświetlana jest właściwość Message atrybutu. Zapewnia to użytkownikowi informację o przestarzałym typie lub elemencie członkowskim.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Typ lub element członkowski jest oznaczony atrybutem System.ObsoleteAttribute, dla którego nie określono właściwości ObsoleteAttribute.Message. Gdy jest kompilowany typ lub element członkowski oznaczony atrybutem ObsoleteAttribute, wyświetlana jest właściwość Message atrybutu. Zapewnia to użytkownikowi informację o przestarzałym typie lub elemencie członkowskim.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Określ komunikat dla atrybutu ObsoleteAttribute, który oznacza element {0} jako przestarzały</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Określ komunikat dla atrybutu ObsoleteAttribute, który oznacza element {0} jako przestarzały</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Ponieważ właściwość {0} jest właściwością tylko do zapisu, dodaj metodę pobierającą właściwość z dostępnością co najmniej taką samą lub większą niż jej metoda ustawiająca albo przekonwertuj tę właściwość na metodę</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Ponieważ właściwość {0} jest właściwością tylko do zapisu, dodaj metodę pobierającą właściwość z dostępnością co najmniej taką samą lub większą niż jej metoda ustawiająca albo przekonwertuj tę właściwość na metodę</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Ponieważ metoda pobierająca właściwość {0} ma mniejszą widoczność niż jej metoda ustawiająca, zwiększ dostępność metody pobierającej lub zmniejsz dostępność metody ustawiającej</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Ponieważ metoda pobierająca właściwość {0} ma mniejszą widoczność niż jej metoda ustawiająca, zwiększ dostępność metody pobierającej lub zmniejsz dostępność metody ustawiającej</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Zaimplementuj poprawnie interfejs IDisposable</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Zaimplementuj poprawnie interfejs IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Wszystkie typy IDisposable powinny poprawnie implementować wzorzec Dispose.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Wszystkie typy IDisposable powinny poprawnie implementować wzorzec Dispose.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Usuń interfejs IDisposable z listy interfejsów implementowanych przez element „{0}”, ponieważ jest on już implementowany przez typ bazowy „{1}”</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Usuń interfejs IDisposable z listy interfejsów implementowanych przez element „{0}”, ponieważ jest on już implementowany przez typ bazowy „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Usuń funkcję „{0}”, przesłoń funkcję Dispose(bool disposing) i umieść logikę usuwania w ścieżce kodu, gdzie element „disposing” ma wartość true</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Usuń funkcję „{0}”, przesłoń funkcję Dispose(bool disposing) i umieść logikę usuwania w ścieżce kodu, gdzie element „disposing” ma wartość true</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Zmodyfikuj element „{0}” tak, aby wywoływał funkcję Dispose(true), a następnie wywoływał funkcję GC.SuppressFinalize dla bieżącego wystąpienia obiektu („this” lub „Me” w języku Visual Basic), po czym wykonywał instrukcję return</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Zmodyfikuj element „{0}” tak, aby wywoływał funkcję Dispose(true), a następnie wywoływał funkcję GC.SuppressFinalize dla bieżącego wystąpienia obiektu („this” lub „Me” w języku Visual Basic), po czym wykonywał instrukcję return</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Zmodyfikuj element „{0}” tak, aby wywoływał funkcję Dispose(false), a następnie wykonywał instrukcję return</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Zmodyfikuj element „{0}” tak, aby wywoływał funkcję Dispose(false), a następnie wykonywał instrukcję return</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Zapewnij możliwą do zastąpienia implementację funkcji Dispose(bool) dla elementu „{0}” lub oznacz typ jako sealed. Wywołanie funkcji Dispose(false) powinno czyścić tylko zasoby natywne. Wywołanie funkcji Dispose(true) powinno czyścić zasoby zarządzane i natywne.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Zapewnij możliwą do zastąpienia implementację funkcji Dispose(bool) dla elementu „{0}” lub oznacz typ jako sealed. Wywołanie funkcji Dispose(false) powinno czyścić tylko zasoby natywne. Wywołanie funkcji Dispose(true) powinno czyścić zasoby zarządzane i natywne.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Wyjątek wewnętrzny jest widoczny tylko wewnątrz własnego zakresu wewnętrznego. Gdy wyjątek zostanie przekazany poza zakres wewnętrzny, do przechwycenia tego wyjątku można użyć tylko wyjątku podstawowego. Jeśli wyjątek wewnętrzny jest dziedziczony z wyjątku T:System.Exception, T:System.SystemException lub T:System.ApplicationException, kod zewnętrzny nie będzie miał wystarczających informacji do określenia, co zrobić z wyjątkiem.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Wyjątek wewnętrzny jest widoczny tylko wewnątrz własnego zakresu wewnętrznego. Gdy wyjątek zostanie przekazany poza zakres wewnętrzny, do przechwycenia tego wyjątku można użyć tylko wyjątku podstawowego. Jeśli wyjątek wewnętrzny jest dziedziczony z wyjątku T:System.Exception, T:System.SystemException lub T:System.ApplicationException, kod zewnętrzny nie będzie miał wystarczających informacji do określenia, co zrobić z wyjątkiem.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">Właściwość {0} tworzy wyjątek typu {1}, który nie powinien być zgłaszany przez właściwość. Jeśli to wystąpienie wyjątku może zostać zgłoszone, użyj innego typu wyjątku, przekonwertuj tę właściwość na metodę lub zmień logikę tej właściwości tak, aby nie zgłaszała wyjątku.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">Właściwość {0} tworzy wyjątek typu {1}, który nie powinien być zgłaszany przez właściwość. Jeśli to wystąpienie wyjątku może zostać zgłoszone, użyj innego typu wyjątku, przekonwertuj tę właściwość na metodę lub zmień logikę tej właściwości tak, aby nie zgłaszała wyjątku.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">Metoda {0} tworzy wyjątek typu {1}, który nie powinien być zgłaszany przez metodę tego typu. Jeśli to wystąpienie wyjątku może zostać zgłoszone, użyj innego typu wyjątku lub zmień logikę tej metody tak, aby nie zgłaszała wyjątku.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">Metoda {0} tworzy wyjątek typu {1}, który nie powinien być zgłaszany przez metodę tego typu. Jeśli to wystąpienie wyjątku może zostać zgłoszone, użyj innego typu wyjątku lub zmień logikę tej metody tak, aby nie zgłaszała wyjątku.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">Metoda {0} tworzy wyjątek typu {1}. Ten typ metody nie powinien zgłaszać wyjątków. Jeśli to wystąpienie wyjątku może zostać zgłoszone, zmień logikę tej metody tak, aby nie zgłaszała wyjątku.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">Metoda {0} tworzy wyjątek typu {1}. Ten typ metody nie powinien zgłaszać wyjątków. Jeśli to wystąpienie wyjątku może zostać zgłoszone, zmień logikę tej metody tak, aby nie zgłaszała wyjątku.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Według konwencji nazwy identyfikatorów nie powinny zawierać znaku podkreślenia (_). Ta reguła sprawdza przestrzenie nazw, typy, elementy członkowskie i parametry.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Według konwencji nazwy identyfikatorów nie powinny zawierać znaku podkreślenia (_). Ta reguła sprawdza przestrzenie nazw, typy, elementy członkowskie i parametry.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Usuń znaki podkreślenia z nazwy zestawu {0}</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Usuń znaki podkreślenia z nazwy zestawu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Usuń znaki podkreślenia z nazwy typu {0}</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Usuń znaki podkreślenia z nazwy typu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Usuń znaki podkreślenia z nazwy składowej {0}</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Usuń znaki podkreślenia z nazwy składowej {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">W typie {0} usuń znaki podkreślenia z nazwy parametru typu ogólnego {1}</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">W typie {0} usuń znaki podkreślenia z nazwy parametru typu ogólnego {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">W metodzie {0} usuń znaki podkreślenia z nazwy parametru typu ogólnego {1}</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">W metodzie {0} usuń znaki podkreślenia z nazwy parametru typu ogólnego {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">W składowej {0} usuń znaki podkreślenia z nazwy parametru {1}</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">W składowej {0} usuń znaki podkreślenia z nazwy parametru {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">W delegacie {0} usuń znaki podkreślenia z nazwy parametru {1}</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">W delegacie {0} usuń znaki podkreślenia z nazwy parametru {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Zmień nazwę elementu {0} tak, aby kończyła się sufiksem „{1}”</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Zmień nazwę elementu {0} tak, aby kończyła się sufiksem „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Zmień nazwę elementu {0} tak, aby kończyła się sufiksem „Collection” lub „{1}”</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Zmień nazwę elementu {0} tak, aby kończyła się sufiksem „Collection” lub „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Zmień nazwę typu {0} tak, aby nie kończyła się sufiksem „{1}”</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Zmień nazwę typu {0} tak, aby nie kończyła się sufiksem „{1}”</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Zamień sufiks „{0}” w nazwie składowej {1} na zalecany alternatywny sufiks liczbowy „2” lub określ bardziej opisowy sufiks, który umożliwi odróżnienie go od zamienianej składowej</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Zamień sufiks „{0}” w nazwie składowej {1} na zalecany alternatywny sufiks liczbowy „2” lub określ bardziej opisowy sufiks, który umożliwi odróżnienie go od zamienianej składowej</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Zamień sufiks „{0}” w nazwie typu {1} na zalecany alternatywny sufiks liczbowy „2” lub określ bardziej opisowy sufiks, który umożliwi odróżnienie go od zamienianego typu</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Zamień sufiks „{0}” w nazwie typu {1} na zalecany alternatywny sufiks liczbowy „2” lub określ bardziej opisowy sufiks, który umożliwi odróżnienie go od zamienianego typu</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">W elemencie członkowskim interfejsu lub wirtualnym elemencie członkowskim {0} zmień nazwę parametru {1} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{2}”. Użycie zastrzeżonego słowa kluczowego jako nazwy parametru w elemencie członkowskim interfejsu lub wirtualnym elemencie członkowskim utrudnia klientom w innych językach przesłonięcie/zaimplementowanie tego elementu członkowskiego.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">W elemencie członkowskim interfejsu lub wirtualnym elemencie członkowskim {0} zmień nazwę parametru {1} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{2}”. Użycie zastrzeżonego słowa kluczowego jako nazwy parametru w elemencie członkowskim interfejsu lub wirtualnym elemencie członkowskim utrudnia klientom w innych językach przesłonięcie/zaimplementowanie tego elementu członkowskiego.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Zmień nazwę elementu członkowskiego interfejsu lub wirtualnego elementu członkowskiego {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy elementu członkowskiego interfejsu lub wirtualnego elementu członkowskiego utrudnia klientom w innych językach przesłonięcie/zaimplementowanie tego elementu członkowskiego.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Zmień nazwę elementu członkowskiego interfejsu lub wirtualnego elementu członkowskiego {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy elementu członkowskiego interfejsu lub wirtualnego elementu członkowskiego utrudnia klientom w innych językach przesłonięcie/zaimplementowanie tego elementu członkowskiego.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Zmień nazwę typu {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy typu utrudnia klientom użycie tego typu w innych językach.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Zmień nazwę typu {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy typu utrudnia klientom użycie tego typu w innych językach.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Zmień nazwę przestrzeni nazw {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy przestrzeni nazw utrudnia klientom użycie tej przestrzeni nazw w innych językach.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Zmień nazwę przestrzeni nazw {0} tak, aby nie powodowała konfliktu z zastrzeżonym słowem kluczowym języka „{1}”. Użycie zastrzeżonego słowa kluczowego jako nazwy przestrzeni nazw utrudnia klientom użycie tej przestrzeni nazw w innych językach.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Nazwa publicznego lub chronionego elementu członkowskiego zaczyna się od „Get” i jest taka sama jak nazwa właściwości publicznej lub chronionej. Metody i właściwości „Get” powinny mieć nazwy jasno określające ich funkcję.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Nazwa publicznego lub chronionego elementu członkowskiego zaczyna się od „Get” i jest taka sama jak nazwa właściwości publicznej lub chronionej. Metody i właściwości „Get” powinny mieć nazwy jasno określające ich funkcję.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Nazwa typu {0} powoduje konflikt w całości lub częściowo z nazwą przestrzeni nazw „{1}”. Zmień jedną z tych nazw, aby wyeliminować konflikt.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Nazwa typu {0} powoduje konflikt w całości lub częściowo z nazwą przestrzeni nazw „{1}”. Zmień jedną z tych nazw, aby wyeliminować konflikt.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Nazwa typu {0} powoduje konflikt w całości lub częściowo z nazwą przestrzeni nazw „{1}” zdefiniowaną w programie .NET Framework. Zmień nazwę typu, aby wyeliminować konflikt.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Nazwa typu {0} powoduje konflikt w całości lub częściowo z nazwą przestrzeni nazw „{1}” zdefiniowaną w programie .NET Framework. Zmień nazwę typu, aby wyeliminować konflikt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">W składowej {0} zmień nazwę parametru {1} na {2}, aby zapewnić zgodność z identyfikatorem zadeklarowanym w elemencie {3}</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">W składowej {0} zmień nazwę parametru {1} na {2}, aby zapewnić zgodność z identyfikatorem zadeklarowanym w elemencie {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Zamień termin „{0}” w nazwie zestawu {1} na preferowany termin alternatywny „{2}”</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie zestawu {1} na preferowany termin alternatywny „{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">W składowej {0} zamień termin „{1}” w nazwie parametru {2} na preferowany termin alternatywny „{3}”</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">W składowej {0} zamień termin „{1}” w nazwie parametru {2} na preferowany termin alternatywny „{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">W delegacie {0} zamień termin „{1}” w nazwie parametru {2} na preferowany termin alternatywny „{3}”</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">W delegacie {0} zamień termin „{1}” w nazwie parametru {2} na preferowany termin alternatywny „{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">W typie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na preferowany termin alternatywny „{3}”</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">W typie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na preferowany termin alternatywny „{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">W metodzie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na preferowany termin alternatywny „{3}”</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">W metodzie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na preferowany termin alternatywny „{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Zamień termin „{0}” w nazwie typu {1} na preferowany termin alternatywny „{2}”</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie typu {1} na preferowany termin alternatywny „{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Zamień termin „{0}” w nazwie składowej {1} na preferowany termin alternatywny „{2}”</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie składowej {1} na preferowany termin alternatywny „{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Zamień termin „{0}” w nazwie zestawu {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie zestawu {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">W składowej {0} zamień termin „{1}” w nazwie parametru {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">W składowej {0} zamień termin „{1}” w nazwie parametru {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">W delegacie {0} zamień termin „{1}” w nazwie parametru {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">W delegacie {0} zamień termin „{1}” w nazwie parametru {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">W typie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">W typie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">W metodzie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">W metodzie {0} zamień termin „{1}” w nazwie parametru typu ogólnego {2} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Zamień termin „{0}” w nazwie typu {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie typu {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Zamień termin „{0}” w nazwie składowej {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Zamień termin „{0}” w nazwie składowej {1} na odpowiedni termin alternatywny lub usuń go całkowicie</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">Typ {0} powinien przesłaniać metodę Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">Typ {0} powinien przesłaniać metodę Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">Typ {0} powinien przesłaniać operatory równości (==) i nierówności (!=)</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">Typ {0} powinien przesłaniać operatory równości (==) i nierówności (!=)</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Podpisz zestaw {0} kluczem o silnej nazwie.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Podpisz zestaw {0} kluczem o silnej nazwie.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Zweryfikuj przed wdrożeniem, czy zestaw {0} ma prawidłową silną nazwę.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Zweryfikuj przed wdrożeniem, czy zestaw {0} ma prawidłową silną nazwę.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Przesłoń metodę GetHashCode przy przesłanianiu metody Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Przesłoń metodę GetHashCode przy przesłanianiu metody Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">Metoda GetHashCode zwraca wartość na podstawie bieżącego wystąpienia, co jest przydatne na potrzeby algorytmów skrótu i struktur danych takich jak tablica skrótów. Dwa obiekty, które są tego samego typu i są równe, muszą zwracać ten sam kod skrótu.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">Metoda GetHashCode zwraca wartość na podstawie bieżącego wystąpienia, co jest przydatne na potrzeby algorytmów skrótu i struktur danych takich jak tablica skrótów. Dwa obiekty, które są tego samego typu i są równe, muszą zwracać ten sam kod skrótu.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Przesłoń metodę GetHashCode przy przesłanianiu metody Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Przesłoń metodę GetHashCode przy przesłanianiu metody Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Przesłoń metodę Equals przy przeciążaniu operatora równości</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Przesłoń metodę Equals przy przeciążaniu operatora równości</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Typ publiczny implementuje operator równości, lecz nie przesłania metody Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Typ publiczny implementuje operator równości, lecz nie przesłania metody Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Przesłoń metodę Equals przy przeciążaniu operatora równości</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Przesłoń metodę Equals przy przeciążaniu operatora równości</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Przesłoń metodę object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Przesłoń metodę object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Przesłoń metodę object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Przesłoń metodę object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Przesłoń metodę object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Przesłoń metodę object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Zadeklaruj klasę jako statyczną</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Zadeklaruj klasę jako statyczną</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Typ {0} powinien przesłaniać metodę Equals, ponieważ implementuje interfejs IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Typ {0} powinien przesłaniać metodę Equals, ponieważ implementuje interfejs IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Przesłoń metodę Object.Equals(object) przy implementowaniu interfejsu IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Przesłoń metodę Object.Equals(object) przy implementowaniu interfejsu IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Gdy metoda asynchroniczna oczekuje na zadanie bezpośrednio, kontynuowanie następuje w tym samym wątku, w którym utworzono zadanie. Rozważ wywołanie metody Task.ConfigureAwait(wartość logiczna), aby zasygnalizować zamiar kontynuowania. Wywołaj metodę ConfigureAwait(false) w zadaniu, aby zaplanować kontynuacje do puli wątków, co pozwoli uniknąć zakleszczenia wątku interfejsu użytkownika. Przekazywanie wartości false to dobra opcja dla bibliotek niezależnych od aplikacji. Wywoływanie metody ConfigureAwait(true) w zadaniu działa tak samo jak brak jawnego wywołania metody ConfigureAwait. Wywołując jawnie tę metodę, informujesz czytelników, że celowo zamierzasz kontynuować w pierwotnym kontekście synchronizacji.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Gdy metoda asynchroniczna oczekuje na zadanie bezpośrednio, kontynuowanie następuje w tym samym wątku, w którym utworzono zadanie. Rozważ wywołanie metody Task.ConfigureAwait(wartość logiczna), aby zasygnalizować zamiar kontynuowania. Wywołaj metodę ConfigureAwait(false) w zadaniu, aby zaplanować kontynuacje do puli wątków, co pozwoli uniknąć zakleszczenia wątku interfejsu użytkownika. Przekazywanie wartości false to dobra opcja dla bibliotek niezależnych od aplikacji. Wywoływanie metody ConfigureAwait(true) w zadaniu działa tak samo jak brak jawnego wywołania metody ConfigureAwait. Wywołując jawnie tę metodę, informujesz czytelników, że celowo zamierzasz kontynuować w pierwotnym kontekście synchronizacji.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Rozważ wywołanie metody ConfigureAwait w zadaniu, na które się oczekuje</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Rozważ wywołanie metody ConfigureAwait w zadaniu, na które się oczekuje</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Rozważ wywołanie metody ConfigureAwait w zadaniu, na które się oczekuje</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Rozważ wywołanie metody ConfigureAwait w zadaniu, na które się oczekuje</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Gdy typ T przesłania metodę Object.Equals(object), implementacja musi rzutować obiekt będący argumentem na poprawny typ T przed wykonaniem porównania. Jeśli typ implementuje interfejs IEquatable&lt;T&gt;, a więc oferuje metodę T.Equals(T), i jeśli o argumencie wiadomo w chwili kompilacji, że jest typu T, kompilator może wywołać metodę IEquatable&lt;T&gt;.Equals(T) zamiast metody Object.Equals(object) bez konieczności wykonywania rzutowania, co poprawia wydajność.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Gdy typ T przesłania metodę Object.Equals(object), implementacja musi rzutować obiekt będący argumentem na poprawny typ T przed wykonaniem porównania. Jeśli typ implementuje interfejs IEquatable&lt;T&gt;, a więc oferuje metodę T.Equals(T), i jeśli o argumencie wiadomo w chwili kompilacji, że jest typu T, kompilator może wywołać metodę IEquatable&lt;T&gt;.Equals(T) zamiast metody Object.Equals(object) bez konieczności wykonywania rzutowania, co poprawia wydajność.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">Typ {0} powinien definiować operatory „{1}” i metodę Equals, ponieważ implementuje interfejs IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">Typ {0} powinien definiować operatory „{1}” i metodę Equals, ponieważ implementuje interfejs IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Usuń wywołanie GC.Collect z elementu {0}. Zazwyczaj nie jest konieczne wymuszanie odzyskiwania pamięci i robienie tego może znacznie pogorszyć wydajność.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Usuń wywołanie GC.Collect z elementu {0}. Zazwyczaj nie jest konieczne wymuszanie odzyskiwania pamięci i robienie tego może znacznie pogorszyć wydajność.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Usuń wywołanie Thread.Resume z elementu {0}. Zawieszanie i wznawianie wątków może być niebezpieczne, jeśli system jest w trakcie krytycznej operacji, takiej jak wykonywanie konstruktora klasy ważnego typu systemu lub rozwiązywanie zabezpieczeń dla udostępnionego zestawu.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Usuń wywołanie Thread.Resume z elementu {0}. Zawieszanie i wznawianie wątków może być niebezpieczne, jeśli system jest w trakcie krytycznej operacji, takiej jak wykonywanie konstruktora klasy ważnego typu systemu lub rozwiązywanie zabezpieczeń dla udostępnionego zestawu.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Usuń wywołanie Thread.Suspend z elementu {0}. Zawieszanie i wznawianie wątków może być niebezpieczne, jeśli system jest w trakcie krytycznej operacji, takiej jak wykonywanie konstruktora klasy ważnego typu systemu lub rozwiązywanie zabezpieczeń dla udostępnionego zestawu.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Usuń wywołanie Thread.Suspend z elementu {0}. Zawieszanie i wznawianie wątków może być niebezpieczne, jeśli system jest w trakcie krytycznej operacji, takiej jak wykonywanie konstruktora klasy ważnego typu systemu lub rozwiązywanie zabezpieczeń dla udostępnionego zestawu.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Usuń wywołanie System.Type.InvokeMember razem z BindingFlags.NonPublic z elementu {0}. Przyjęcie zależności dla prywatnego członka zwiększa szansę istotnej zmiany w przyszłości.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Usuń wywołanie System.Type.InvokeMember razem z BindingFlags.NonPublic z elementu {0}. Przyjęcie zależności dla prywatnego członka zwiększa szansę istotnej zmiany w przyszłości.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">Element {0} jest deklaracją P/Invoke dla interfejsu API OLE32, która nie może być niezawodnie wywołana po zainicjowaniu środowiska uruchomieniowego. Obejściem jest napisanie niezarządzanej poprawki, która będzie wywoływać procedurę, a następnie uaktywniać i wywoływać zarządzany kod. Możesz to zrobić za pomocą eksportu z biblioteki DLL języka C++ trybu mieszanego, rejestrując zarządzany składnik do używania przez model COM lub używając interfejsu API hostingu środowiska uruchomieniowego.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">Element {0} jest deklaracją P/Invoke dla interfejsu API OLE32, która nie może być niezawodnie wywołana po zainicjowaniu środowiska uruchomieniowego. Obejściem jest napisanie niezarządzanej poprawki, która będzie wywoływać procedurę, a następnie uaktywniać i wywoływać zarządzany kod. Możesz to zrobić za pomocą eksportu z biblioteki DLL języka C++ trybu mieszanego, rejestrując zarządzany składnik do używania przez model COM lub używając interfejsu API hostingu środowiska uruchomieniowego.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">Element {0} jest deklaracją P/Invoke dla interfejsu API OLE32, który nie może być niezawodnie wywoływany dla wywoływalnego programu owijania środowiska uruchomieniowego (obiekt zarządzany owija obiekt COM). Wywoływalne programy owijania środowiska uruchomieniowego dynamicznie pobierają wskaźniki interfejsu, więc efekt wywołania może zostać arbitralnie utracony. Wywoływalne programy owijania środowiska uruchomieniowego dla danego obiektu COM są również udostępniane w domenie aplikacji, więc wywołanie może ewentualnie mieć wpływ na innych użytkowników. Zastąp to wywołanie natywnym programem owijania obiektu COM dla wskaźnika interfejsu, który wykonuje odpowiednie wywołania CoSetProxyBlanket.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">Element {0} jest deklaracją P/Invoke dla interfejsu API OLE32, który nie może być niezawodnie wywoływany dla wywoływalnego programu owijania środowiska uruchomieniowego (obiekt zarządzany owija obiekt COM). Wywoływalne programy owijania środowiska uruchomieniowego dynamicznie pobierają wskaźniki interfejsu, więc efekt wywołania może zostać arbitralnie utracony. Wywoływalne programy owijania środowiska uruchomieniowego dla danego obiektu COM są również udostępniane w domenie aplikacji, więc wywołanie może ewentualnie mieć wpływ na innych użytkowników. Zastąp to wywołanie natywnym programem owijania obiektu COM dla wskaźnika interfejsu, który wykonuje odpowiednie wywołania CoSetProxyBlanket.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Usuń wywołanie SafeHandlemetody SafeHandle.DangerousGetHandle z elementu {0}</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Usuń wywołanie SafeHandlemetody SafeHandle.DangerousGetHandle z elementu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Usuń wywołanie metody Assembly.LoadFrom z elementu {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Usuń wywołanie metody Assembly.LoadFrom z elementu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Usuń wywołanie metody Assembly.LoadFile z elementu {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Usuń wywołanie metody Assembly.LoadFile z elementu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Usuń wywołanie metody Assembly.LoadWithPartialName z elementu {0}</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Usuń wywołanie metody Assembly.LoadWithPartialName z elementu {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, zmienna zadeklarowana w elemencie {1}, ma taką samą nazwę jak pole wystąpienia dla typu. Zmień nazwę jednego z tych elementów.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, zmienna zadeklarowana w elemencie {1}, ma taką samą nazwę jak pole wystąpienia dla typu. Zmień nazwę jednego z tych elementów.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, parametr zadeklarowany w elemencie {1}, ma taką samą nazwę jak pole wystąpienia dla typu. Zmień nazwę jednego z tych elementów.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, parametr zadeklarowany w elemencie {1}, ma taką samą nazwę jak pole wystąpienia dla typu. Zmień nazwę jednego z tych elementów.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Parametr {0} metody {1} nie jest nigdy używany. Usuń parametr lub użyj go w treści metody.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Parametr {0} metody {1} nie jest nigdy używany. Usuń parametr lub użyj go w treści metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">Element {0} tworzy nowe wystąpienie elementu {1}, które nigdy nie zostało użyte. Przekaż wystąpienie jako argument do innej metody, przypisz wystąpienie do zmiennej lub usuń tworzenie obiektu, jeśli jest zbędne.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">Element {0} tworzy nowe wystąpienie elementu {1}, które nigdy nie zostało użyte. Przekaż wystąpienie jako argument do innej metody, przypisz wystąpienie do zmiennej lub usuń tworzenie obiektu, jeśli jest zbędne.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">Element {0} wywołuje element {1}, ale nie używa wystąpienia nowego ciągu zwracanego przez metodę. Przekaż wystąpienie jako argument do innej metody, przypisz wystąpienie do zmiennej lub usuń wywołanie, jeśli jest zbędne.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">Element {0} wywołuje element {1}, ale nie używa wystąpienia nowego ciągu zwracanego przez metodę. Przekaż wystąpienie jako argument do innej metody, przypisz wystąpienie do zmiennej lub usuń wywołanie, jeśli jest zbędne.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">Element {0} wywołuje element {1}, ale nie używa wartości HRESULT ani kodu błędu zwracanego przez metodę. Może to doprowadzić do nieoczekiwanego zachowania w warunkach błędu lub sytuacjach małej ilości zasobów. Użyj wyniku w instrukcji warunkowej, przypisz wynik do zmiennej lub przekaż go jako argument do innej metody.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">Element {0} wywołuje element {1}, ale nie używa wartości HRESULT ani kodu błędu zwracanego przez metodę. Może to doprowadzić do nieoczekiwanego zachowania w warunkach błędu lub sytuacjach małej ilości zasobów. Użyj wyniku w instrukcji warunkowej, przypisz wynik do zmiennej lub przekaż go jako argument do innej metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">Element {0} wywołuje element {1}, ale nie sprawdza jawnie, czy konwersja się udała. Użyj wartości zwracanej w instrukcji warunkowej lub zweryfikuj, czy lokacja wywołania oczekuje, że argument wychodzący zostanie ustawiony na wartość domyślną w razie niepowodzenia konwersji.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">Element {0} wywołuje element {1}, ale nie sprawdza jawnie, czy konwersja się udała. Użyj wartości zwracanej w instrukcji warunkowej lub zweryfikuj, czy lokacja wywołania oczekuje, że argument wychodzący zostanie ustawiony na wartość domyślną w razie niepowodzenia konwersji.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">Element {0} jest klasą wewnętrzną, która najwyraźniej nigdy nie miała wystąpień. Jeśli tak, usuń kod z zestawu. Jeśli ta klasa w założeniu ma zawierać tylko statyczne składowe, zmień ją na statyczną (udostępnianą w języku Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">Element {0} jest klasą wewnętrzną, która najwyraźniej nigdy nie miała wystąpień. Jeśli tak, usuń kod z zestawu. Jeśli ta klasa w założeniu ma zawierać tylko statyczne składowe, zmień ją na statyczną (udostępnianą w języku Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">Element {0} wywołuje element {1}, ale nie używa wartości zwracanej przez metodę. Ponieważ metoda {1} jest oznaczona jako metoda Pure, nie może ona mieć efektów ubocznych. Użyj wyniku w instrukcji warunkowej, przypisz wynik do zmiennej lub przekaż go jako argument do innej metody.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">Element {0} wywołuje element {1}, ale nie używa wartości zwracanej przez metodę. Ponieważ metoda {1} jest oznaczona jako metoda Pure, nie może ona mieć efektów ubocznych. Użyj wyniku w instrukcji warunkowej, przypisz wynik do zmiennej lub przekaż go jako argument do innej metody.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">Właściwość {0} nie powinna być przypisana do samej siebie</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">Właściwość {0} nie powinna być przypisana do samej siebie</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} jest tablicą wielowymiarową. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} jest tablicą wielowymiarową. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} zwraca tablicę wielowymiarową {1}. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} zwraca tablicę wielowymiarową {1}. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} powoduje użycie tablicy wielowymiarowej {1}. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} powoduje użycie tablicy wielowymiarowej {1}. Należy ją zastąpić tablicą nieregularną, jeśli to możliwe.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitar async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitar async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Evitar async void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Evitar async void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Os nomes de método assíncrono devem terminar em Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Os nomes de método assíncrono devem terminar em Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Os nomes de método assíncrono devem terminar em Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Os nomes de método assíncrono devem terminar em Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Considere um design no qual '{0}' não tenha mais de {1} parâmetros de tipo</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Considere um design no qual '{0}' não tenha mais de {1} parâmetros de tipo</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Evitar parâmetros out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Evitar parâmetros out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; é uma coleção genérica projetada para desempenho e não para herança. A lista&lt;T&gt; não contém membros virtuais que tornam mais fácil alterar o comportamento de uma classe herdada.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; é uma coleção genérica projetada para desempenho e não para herança. A lista&lt;T&gt; não contém membros virtuais que tornam mais fácil alterar o comportamento de uma classe herdada.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Não passar lambdas assíncronas como tipos delegados que retornam void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Não passar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Não passar lambdas assíncronas como tipos delegados que retornam void</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Não passar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">A passagem de tipos por referência (usando 'out' ou 'ref') exige experiência com ponteiros, o entendimento da diferença entre os tipos de valor e de referência e a manipulação de métodos com vários valores retornados. Além disso, não há um amplo entendimento sobre a diferença entre os parâmetros out e ref.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">A passagem de tipos por referência (usando 'out' ou 'ref') exige experiência com ponteiros, o entendimento da diferença entre os tipos de valor e de referência e a manipulação de métodos com vários valores retornados. Além disso, não há um amplo entendimento sobre a diferença entre os parâmetros out e ref.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Não armazenar lambdas assíncronas como tipos delegados que retornam void</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Remova o finalizador do tipo '{0}', substitua Dispose(bool disposing) e coloque a lógica de finalização no caminho do código em que 'disposing' é false. Caso contrário, ele poderá duplicar invocações Dispose, já que o tipo Base '{1}' também fornece um finalizador.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Remova o finalizador do tipo '{0}', substitua Dispose(bool disposing) e coloque a lógica de finalização no caminho do código em que 'disposing' é false. Caso contrário, ele poderá duplicar invocações Dispose, já que o tipo Base '{1}' também fornece um finalizador.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar CancellationTokens quando possível</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagar CancellationTokens quando possível</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Propagar CancellationTokens quando possível</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Propagar CancellationTokens quando possível</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Não combinar bloqueio e assíncrono</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Não combinar bloqueio e assíncrono</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Não combinar bloqueio e assíncrono</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Não combinar bloqueio e assíncrono</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">Na enumeração {0}, altere o nome de {1} para 'None'</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">Na enumeração {0}, altere o nome de {1} para 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Remova todos os membros que têm valor zero de {0}, exceto o membro chamado 'None'</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Remova todos os membros que têm valor zero de {0}, exceto o membro chamado 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Adicione um membro a {0} que tenha um valor zero com um nome sugerido 'None'</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Adicione um membro a {0} que tenha um valor zero com um nome sugerido 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">A CLS (Common Language Specification) define restrições de nomenclatura, tipos de dados e regras com as quais os assemblies deverão estar em conformidade se forem usados em linguagens de programação. O bom design dita que todos os assemblies indicam explicitamente a conformidade com a CLS usando CLSCompliantAttribute. Se este atributo não estiver presente em um assembly, o assembly não estará em conformidade.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">A CLS (Common Language Specification) define restrições de nomenclatura, tipos de dados e regras com as quais os assemblies deverão estar em conformidade se forem usados em linguagens de programação. O bom design dita que todos os assemblies indicam explicitamente a conformidade com a CLS usando CLSCompliantAttribute. Se este atributo não estiver presente em um assembly, o assembly não estará em conformidade.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Marcar assemblies com CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Marcar assemblies com CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Marcar assemblies com ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Marcar assemblies com ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Já que {0} expõe os tipos visíveis externamente, marque-o com ComVisible(false) no nível de assembly e marque todos os tipos dentro do assembly que devem ser expostos a clientes COM com ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Já que {0} expõe os tipos visíveis externamente, marque-o com ComVisible(false) no nível de assembly e marque todos os tipos dentro do assembly que devem ser expostos a clientes COM com ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Marcar atributos com AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Marcar atributos com AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Quando você definir um atributo personalizado, marque-o usando AttributeUsageAttribute para indicar o local no código-fonte em que o atributo personalizado poderá ser aplicado. O significado e o uso pretendido de um atributo determinará seus locais válidos no código.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Quando você definir um atributo personalizado, marque-o usando AttributeUsageAttribute para indicar o local no código-fonte em que o atributo personalizado poderá ser aplicado. O significado e o uso pretendido de um atributo determinará seus locais válidos no código.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Especifique AttributeUsage em {0}</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Especifique AttributeUsage em {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Mesmo que o atributo {0} herde AttributeUsage de seu tipo base, você deve considerar especificar explicitamente AttributeUsage no tipo para melhorar a documentação e a legibilidade do código.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Mesmo que o atributo {0} herde AttributeUsage de seu tipo base, você deve considerar especificar explicitamente AttributeUsage no tipo para melhorar a documentação e a legibilidade do código.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Adicione um acessador de propriedade pública somente leitura para o argumento posicional {0} do atributo {1}</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Adicione um acessador de propriedade pública somente leitura para o argumento posicional {0} do atributo {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Remova o setter da propriedade de {0} ou reduza a acessibilidade dele porque ele corresponde ao argumento posicional {1}</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Remova o setter da propriedade de {0} ou reduza a acessibilidade dele porque ele corresponde ao argumento posicional {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Se {0} for o acessador de propriedade para o argumento posicional {1}, torne-o público</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Se {0} for o acessador de propriedade para o argumento posicional {1}, torne-o público</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Um método público ou protegido tem um nome que começa com ""Get"", não aceita nenhum parâmetro e retorna um valor que não é uma matriz. O método pode ser um bom candidato para se tornar uma propriedade.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Um método público ou protegido tem um nome que começa com ""Get"", não aceita nenhum parâmetro e retorna um valor que não é uma matriz. O método pode ser um bom candidato para se tornar uma propriedade.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marcar enums com FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marcar enums com FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Uma enumeração é um tipo de valor que define um conjunto de constantes nomeadas relacionadas. Aplique FlagsAttribute a uma enumeração quando suas constantes nomeadas puderem ser combinadas de forma significativa.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Uma enumeração é um tipo de valor que define um conjunto de constantes nomeadas relacionadas. Aplique FlagsAttribute a uma enumeração quando suas constantes nomeadas puderem ser combinadas de forma significativa.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Marcar enums com FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Marcar enums com FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Um tipo público ou protegido implementa a interface System.IComparable. Ele não substitui Object.Equals nem sobrecarrega o operador específico a um idioma para igualdade, desigualdade, menor que, menor ou igual a, maior que ou maior ou igual a.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Um tipo público ou protegido implementa a interface System.IComparable. Ele não substitui Object.Equals nem sobrecarrega o operador específico a um idioma para igualdade, desigualdade, menor que, menor ou igual a, maior que ou maior ou igual a.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} deve substituir Equals, pois implementa IComparable</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve substituir Equals, pois implementa IComparable</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} deve definir os operadores '{1}', pois ele implementa IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve definir os operadores '{1}', pois ele implementa IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">O nome de uma interface visível externamente não começa com um ""I"" maiúsculo. O nome de um parâmetro de tipo genérico em um tipo ou método visível externamente não começa com um ""T"" maiúsculo.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">O nome de uma interface visível externamente não começa com um ""I"" maiúsculo. O nome de um parâmetro de tipo genérico em um tipo ou método visível externamente não começa com um ""T"" maiúsculo.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Prefixe o nome da interface {0} com 'I'</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Prefixe o nome da interface {0} com 'I'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Prefixe o nome de parâmetro de tipo genérico {0} com 'T'</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Prefixe o nome de parâmetro de tipo genérico {0} com 'T'</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Não marcar enums com FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Não marcar enums com FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Uma enumeração visível externamente é marcada usado FlagsAttribute e ela tem um ou mais valores que não são potências de dois nem uma combinação dos outros valores definidos na enumeração.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Uma enumeração visível externamente é marcada usado FlagsAttribute e ela tem um ou mais valores que não são potências de dois nem uma combinação dos outros valores definidos na enumeração.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Não marcar enums com FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Não marcar enums com FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Forneça um método chamado '{0}' como alternativa amigável ao operador {1}</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Forneça um método chamado '{0}' como alternativa amigável ao operador {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Forneça uma propriedade chamada '{0}' como alternativa amigável ao operador {1}</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Forneça uma propriedade chamada '{0}' como alternativa amigável ao operador {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Forneça um método chamado '{0}' ou '{1}' como alternativa ao operador {2}</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Forneça um método chamado '{0}' ou '{1}' como alternativa ao operador {2}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Marque {0} como público, porque é uma alternativa amigável ao operador {1}</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Marque {0} como público, porque é uma alternativa amigável ao operador {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Implementar IEquatable ao substituir Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Implementar IEquatable ao substituir Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">O tipo {0} deve implementar IEquatable&lt;T&gt; porque ele substitui Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">O tipo {0} deve implementar IEquatable&lt;T&gt; porque ele substitui Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Os parâmetros CancellationToken devem vir por último</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Os parâmetros CancellationToken devem vir por último</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Já que {0} expõe os tipos visíveis externamente, marque-o com ComVisible(false) no nível de assembly e marque todos os tipos no assembly que devem ser expostos a clientes COM que têm ComVisible(true)</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Já que {0} expõe os tipos visíveis externamente, marque-o com ComVisible(false) no nível de assembly e marque todos os tipos no assembly que devem ser expostos a clientes COM que têm ComVisible(true)</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Considere alterar o atributo ComVisible em {0} para false e aceitá-lo no nível de tipo</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Considere alterar o atributo ComVisible em {0} para false e aceitá-lo no nível de tipo</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Implementar IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Implementar IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Implementar interface IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Implementar interface IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Remova FlagsAttribute da enum.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Remova FlagsAttribute da enum.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Aplique FlagsAttribute ao enum.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Aplique FlagsAttribute ao enum.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Enum Storage deve ser Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Enum Storage deve ser Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Se possível, crie o tipo subjacente de {0} System.Int32 em vez de {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Se possível, crie o tipo subjacente de {0} System.Int32 em vez de {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Adicione o construtor a seguir para {0}: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Adicione o construtor a seguir para {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Altere a acessibilidade de {0} para {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Altere a acessibilidade de {0} para {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Não aninhe o tipo {0}. Alternativamente, altere a acessibilidade dele para que não seja visível externamente.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Não aninhe o tipo {0}. Alternativamente, altere a acessibilidade dele para que não seja visível externamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Não aninhe o tipo {0}. Alternativamente, altere a acessibilidade dele para que não seja visível externamente. Se este tipo for definido em um Módulo do Visual Basic, ele será considerado um tipo aninhado para outras linguagens .NET. Nesse caso, considere mover o tipo para fora do Módulo.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Não aninhe o tipo {0}. Alternativamente, altere a acessibilidade dele para que não seja visível externamente. Se este tipo for definido em um Módulo do Visual Basic, ele será considerado um tipo aninhado para outras linguagens .NET. Nesse caso, considere mover o tipo para fora do Módulo.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Fornecer a mensagem ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Fornecer a mensagem ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Um tipo ou membro marcado usando um atributo System.ObsoleteAttribute que não tem a respectiva propriedade ObsoleteAttribute.Message especificada. Quando um tipo ou membro marcado usando ObsoleteAttribute é compilado, a propriedade Message do atributo é exibida. Isso dá ao usuário informações sobre o tipo ou o membro obsoleto.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Um tipo ou membro marcado usando um atributo System.ObsoleteAttribute que não tem a respectiva propriedade ObsoleteAttribute.Message especificada. Quando um tipo ou membro marcado usando ObsoleteAttribute é compilado, a propriedade Message do atributo é exibida. Isso dá ao usuário informações sobre o tipo ou o membro obsoleto.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Fornecer uma mensagem para o ObsoleteAttribute que marca {0} como Obsoleto</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Fornecer uma mensagem para o ObsoleteAttribute que marca {0} como Obsoleto</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Como a propriedade {0} é somente gravação, adicione uma propriedade getter com uma acessibilidade maior ou igual ao setter ou converta essa propriedade em um método</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Como a propriedade {0} é somente gravação, adicione uma propriedade getter com uma acessibilidade maior ou igual ao setter ou converta essa propriedade em um método</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Como a propriedade getter para {0} é menos visível do que o setter dela, aumente a acessibilidade do getter ou diminua a acessibilidade do setter</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Como a propriedade getter para {0} é menos visível do que o setter dela, aumente a acessibilidade do getter ou diminua a acessibilidade do setter</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Implementar IDisposable corretamente</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Implementar IDisposable corretamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Todos os tipos IDisposable devem implementar o padrão Dispose corretamente.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Todos os tipos IDisposable devem implementar o padrão Dispose corretamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Remova IDisposable da lista de interfaces implementadas por '{0}', uma vez que ela já foi implementada pelo tipo base '{1}'</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Remova IDisposable da lista de interfaces implementadas por '{0}', uma vez que ela já foi implementada pelo tipo base '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Remova '{0}', substitua Dispose(bool disposing) e coloque a lógica de descarte no caminho do código em que 'disposing' é true</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Remova '{0}', substitua Dispose(bool disposing) e coloque a lógica de descarte no caminho do código em que 'disposing' é true</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Modifique '{0}' para chamar Dispose(true), depois chamar GC.SuppressFinalize na instância do objeto atual ('this' ou 'Me' no Visual Basic) e retornar</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Modifique '{0}' para chamar Dispose(true), depois chamar GC.SuppressFinalize na instância do objeto atual ('this' ou 'Me' no Visual Basic) e retornar</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Modifique '{0}' para que ele chame Dispose(false) e retorne</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Modifique '{0}' para que ele chame Dispose(false) e retorne</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Forneça uma implementação substituível de Dispose(bool) em '{0}' ou marque o tipo como selado. Uma chamada para Dispose(false) deve limpar somente os recursos nativos. Uma chamada para Dispose(true) deve limpar os recursos gerenciados e nativos.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Forneça uma implementação substituível de Dispose(bool) em '{0}' ou marque o tipo como selado. Uma chamada para Dispose(false) deve limpar somente os recursos nativos. Uma chamada para Dispose(true) deve limpar os recursos gerenciados e nativos.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Uma exceção interna é visível apenas dentro do seu escopo interno. Depois que a exceção estiver fora do escopo interno, apenas a exceção base poderá ser usada capturar a exceção. Se a exceção interna for herdada de T:System.Exception, T:System.SystemException ou T:System.ApplicationException, o código externo não terá informações suficientes para saber o que fazer com a exceção.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Uma exceção interna é visível apenas dentro do seu escopo interno. Depois que a exceção estiver fora do escopo interno, apenas a exceção base poderá ser usada capturar a exceção. Se a exceção interna for herdada de T:System.Exception, T:System.SystemException ou T:System.ApplicationException, o código externo não terá informações suficientes para saber o que fazer com a exceção.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} cria uma exceção do tipo {1}, um tipo de exceção que não deve ser gerado em uma propriedade. Se essa instância de exceção puder ser gerada, use um tipo de exceção diferente, converta essa propriedade em um método ou altere a lógica dessa propriedade para que ela deixe de gerar uma exceção.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} cria uma exceção do tipo {1}, um tipo de exceção que não deve ser gerado em uma propriedade. Se essa instância de exceção puder ser gerada, use um tipo de exceção diferente, converta essa propriedade em um método ou altere a lógica dessa propriedade para que ela deixe de gerar uma exceção.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} cria uma exceção do tipo {1}, um tipo de exceção que não deve ser gerado nesse tipo de método. Se essa instância de exceção puder ser gerada, use um tipo de exceção diferente ou altere a lógica desse método para que ele deixe de gerar uma exceção.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} cria uma exceção do tipo {1}, um tipo de exceção que não deve ser gerado nesse tipo de método. Se essa instância de exceção puder ser gerada, use um tipo de exceção diferente ou altere a lógica desse método para que ele deixe de gerar uma exceção.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} cria uma exceção do tipo {1}. Exceções não devem ser geradas nesse tipo de método. Se essa instância de exceção puder ser gerada, altere a lógica desse método para que ele deixe de gerar uma exceção.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} cria uma exceção do tipo {1}. Exceções não devem ser geradas nesse tipo de método. Se essa instância de exceção puder ser gerada, altere a lógica desse método para que ele deixe de gerar uma exceção.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Por convenção, os nomes de identificadores não contêm o caractere sublinhado (_). Essa regra verifica namespaces, tipos, membros e parâmetros.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Por convenção, os nomes de identificadores não contêm o caractere sublinhado (_). Essa regra verifica namespaces, tipos, membros e parâmetros.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Remova os sublinhados do nome do assembly {0}</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Remova os sublinhados do nome do assembly {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Remova os sublinhados do nome de tipo {0}</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Remova os sublinhados do nome de tipo {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Remova os sublinhados do nome do membro {0}</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Remova os sublinhados do nome do membro {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">No tipo {0}, remova os sublinhados do nome de parâmetro de tipo genérico {1}</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">No tipo {0}, remova os sublinhados do nome de parâmetro de tipo genérico {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">No método {0}, remova os sublinhados do nome de parâmetro de tipo genérico {1}</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">No método {0}, remova os sublinhados do nome de parâmetro de tipo genérico {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">No membro {0}, remova os sublinhados do nome de parâmetro {1}</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">No membro {0}, remova os sublinhados do nome de parâmetro {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">No delegado {0}, remova os sublinhados do nome de parâmetro {1}</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">No delegado {0}, remova os sublinhados do nome de parâmetro {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Renomeie {0} para terminar em '{1}'</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Renomeie {0} para terminar em '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Renomeie {0} para terminar em 'Collection' ou em '{1}'</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Renomeie {0} para terminar em 'Collection' ou em '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Renomeie o nome de tipo {0} para que ele não termine em '{1}'</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Renomeie o nome de tipo {0} para que ele não termine em '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Substitua o sufixo '{0}' no nome de membro {1} pela alternativa numérica sugerida '2' ou forneça um sufixo mais significativo que o distinga do membro que ele substitui</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Substitua o sufixo '{0}' no nome de membro {1} pela alternativa numérica sugerida '2' ou forneça um sufixo mais significativo que o distinga do membro que ele substitui</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Substitua o sufixo '{0}' no nome de tipo {1} pela alternativa numérica sugerida '2' ou forneça um sufixo mais significativo que o diferencie do tipo que ele substitui</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Substitua o sufixo '{0}' no nome de tipo {1} pela alternativa numérica sugerida '2' ou forneça um sufixo mais significativo que o diferencie do tipo que ele substitui</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">No membro virtual/de interface {0}, renomeie o parâmetro {1} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{2}'. Se você usar uma palavra-chave reservada como o nome de um parâmetro em um membro virtual/de interface, ficará mais difícil para os consumidores de outras linguagens substituírem/implementarem o membro.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">No membro virtual/de interface {0}, renomeie o parâmetro {1} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{2}'. Se você usar uma palavra-chave reservada como o nome de um parâmetro em um membro virtual/de interface, ficará mais difícil para os consumidores de outras linguagens substituírem/implementarem o membro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Renomeie o membro virtual/de interface {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um membro virtual/de interface, ficará mais difícil para os consumidores de outras linguagens substituírem/implementarem o membro.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Renomeie o membro virtual/de interface {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um membro virtual/de interface, ficará mais difícil para os consumidores de outras linguagens substituírem/implementarem o membro.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Renomeie o tipo {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um tipo, ficará mais difícil para os consumidores de outras linguagens utilizarem o tipo.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Renomeie o tipo {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um tipo, ficará mais difícil para os consumidores de outras linguagens utilizarem o tipo.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Renomeie o namespace {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um namespace, ficará mais difícil para os consumidores de outras linguagens utilizarem o namespace.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Renomeie o namespace {0} de forma que ele não fique mais em conflito com a palavra-chave reservada de linguagem '{1}'. Se você usar uma palavra-chave reservada como o nome de um namespace, ficará mais difícil para os consumidores de outras linguagens utilizarem o namespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">O nome de um membro público ou protegido começa com ""Get"" e, caso contrário, corresponde ao nome de uma propriedade pública ou protegida. Métodos e propriedades ""Get"" devem ter nomes que distinguem claramente sua função.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">O nome de um membro público ou protegido começa com ""Get"" e, caso contrário, corresponde ao nome de uma propriedade pública ou protegida. Métodos e propriedades ""Get"" devem ter nomes que distinguem claramente sua função.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">O nome de tipo {0} está em conflito, no todo ou em parte, com o nome de namespace '{1}'. Altere um desses nomes para eliminar o conflito.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">O nome de tipo {0} está em conflito, no todo ou em parte, com o nome de namespace '{1}'. Altere um desses nomes para eliminar o conflito.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">O nome de tipo {0} está em conflito, no todo ou em parte, com o nome de namespace '{1}' definido no .NET Framework. Renomeie o tipo para eliminar o conflito.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">O nome de tipo {0} está em conflito, no todo ou em parte, com o nome de namespace '{1}' definido no .NET Framework. Renomeie o tipo para eliminar o conflito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">No membro {0}, altere o nome de parâmetro {1} para {2} a fim de corresponder ao identificador conforme declarado em {3}</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">No membro {0}, altere o nome de parâmetro {1} para {2} a fim de corresponder ao identificador conforme declarado em {3}</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Substitua o termo '{0}' no nome de assembly {1} pela alternativa preferencial '{2}'</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de assembly {1} pela alternativa preferencial '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">No membro {0}, substitua o termo '{1}' no nome de parâmetro {2} pela alternativa preferencial '{3}'</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">No membro {0}, substitua o termo '{1}' no nome de parâmetro {2} pela alternativa preferencial '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">No delegado {0}, substitua o termo '{1}' no nome de parâmetro {2} pela alternativa preferencial '{3}'</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">No delegado {0}, substitua o termo '{1}' no nome de parâmetro {2} pela alternativa preferencial '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">No tipo {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} pela alternativa preferencial '{3}'</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">No tipo {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} pela alternativa preferencial '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">No método {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} pela alternativa preferencial '{3}'</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">No método {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} pela alternativa preferencial '{3}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Substitua o termo '{0}' no nome de tipo '{1}' pela alternativa preferencial '{2}'</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de tipo '{1}' pela alternativa preferencial '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Substitua o termo '{0}' no nome de membro {1} pela alternativa preferencial '{2}'</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de membro {1} pela alternativa preferencial '{2}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Substitua o termo '{0}' no nome de assembly {1} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de assembly {1} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">No membro {0}, substitua o termo '{1}' no nome de parâmetro {2} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">No membro {0}, substitua o termo '{1}' no nome de parâmetro {2} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">No delegado {0}, substitua o termo '{1}' no nome de parâmetro {2} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">No delegado {0}, substitua o termo '{1}' no nome de parâmetro {2} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">No tipo {0}, substitua o termo '{1}' no nome do parâmetro de tipo genérico {2} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">No tipo {0}, substitua o termo '{1}' no nome do parâmetro de tipo genérico {2} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">No método {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">No método {0}, substitua o termo '{1}' no nome de parâmetro de tipo genérico {2} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Substitua o termo '{0}' no nome de tipo {1} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de tipo {1} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Substitua o termo '{0}' no nome de membro {1} por uma alternativa apropriada ou remova-o inteiramente</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Substitua o termo '{0}' no nome de membro {1} por uma alternativa apropriada ou remova-o inteiramente</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} deve substituir Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} deve substituir Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} deve substituir os operadores de igualdade (==) e de desigualdade (!=)</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} deve substituir os operadores de igualdade (==) e de desigualdade (!=)</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Assine {0} com uma chave de nome forte.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Assine {0} com uma chave de nome forte.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Verifique se {0} tem um nome forte válido antes de implantar.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Verifique se {0} tem um nome forte válido antes de implantar.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Substituir GetHashCode ao substituir Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Substituir GetHashCode ao substituir Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode retorna um valor, com base na instância atual, que é adequado para algoritmos de hash e estruturas de dados como uma tabela de hash. Dois objetos do mesmo tipo e iguais devem retornar o mesmo código hash.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode retorna um valor, com base na instância atual, que é adequado para algoritmos de hash e estruturas de dados como uma tabela de hash. Dois objetos do mesmo tipo e iguais devem retornar o mesmo código hash.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Substituir GetHashCode ao substituir Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Substituir GetHashCode ao substituir Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Substituir Equals ao sobrecarregar o operador Equals</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Substituir Equals ao sobrecarregar o operador Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Um tipo público implementa o operador de igualdade, mas não substitui Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Um tipo público implementa o operador de igualdade, mas não substitui Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Substituir Equals ao sobrecarregar o operador Equals</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Substituir Equals ao sobrecarregar o operador Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Substituir object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Substituir object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Substituir object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Substituir object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Substituir object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Substituir object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Tornar a classe estática</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Tornar a classe estática</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">O tipo {0} deve substituir Equals porque ele implementa IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">O tipo {0} deve substituir Equals porque ele implementa IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Substitua Object.Equals(object) ao implementar IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Substitua Object.Equals(object) ao implementar IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Quando um método assíncrono aguarda uma Tarefa diretamente, a continuação ocorre no mesmo thread que criou a tarefa. Considere chamar Task.ConfigureAwait(Boolean) para sinalizar sua intenção de continuação. Chame ConfigureAwait(false) na tarefa para agendar continuações para o pool de threads, evitando assim um deadlock no thread da interface do usuário. Passar false é uma boa opção para bibliotecas independentes de aplicativo. Chamar ConfigureAwait(true) na tarefa tem o mesmo comportamento que não chamar ConfigureAwait explicitamente. Ao chamar esse método explicitamente, você está permitindo que os leitores saibam que você deseja intencionalmente executar a continuação no contexto de sincronização original.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Quando um método assíncrono aguarda uma Tarefa diretamente, a continuação ocorre no mesmo thread que criou a tarefa. Considere chamar Task.ConfigureAwait(Boolean) para sinalizar sua intenção de continuação. Chame ConfigureAwait(false) na tarefa para agendar continuações para o pool de threads, evitando assim um deadlock no thread da interface do usuário. Passar false é uma boa opção para bibliotecas independentes de aplicativo. Chamar ConfigureAwait(true) na tarefa tem o mesmo comportamento que não chamar ConfigureAwait explicitamente. Ao chamar esse método explicitamente, você está permitindo que os leitores saibam que você deseja intencionalmente executar a continuação no contexto de sincronização original.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Considere chamar ConfigureAwait na tarefa esperada</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Considere chamar ConfigureAwait na tarefa esperada</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Considere chamar ConfigureAwait na tarefa esperada</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Considere chamar ConfigureAwait na tarefa esperada</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Quando um tipo T substitui Object.Equals(object), a implementação precisa converter o argumento de objeto no tipo T correto antes de executar a comparação. Se o tipo implementa IEquatable&lt;T&gt; e, portanto, oferece o método T.Equals(T) e se, no tempo de compilação, o argumento é reconhecido como do tipo T, o compilador pode chamar IEquatable&lt;T&gt;.Equals(T) em vez de Object.Equals(object) e não é necessária nenhuma conversão, melhorando o desempenho.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Quando um tipo T substitui Object.Equals(object), a implementação precisa converter o argumento de objeto no tipo T correto antes de executar a comparação. Se o tipo implementa IEquatable&lt;T&gt; e, portanto, oferece o método T.Equals(T) e se, no tempo de compilação, o argumento é reconhecido como do tipo T, o compilador pode chamar IEquatable&lt;T&gt;.Equals(T) em vez de Object.Equals(object) e não é necessária nenhuma conversão, melhorando o desempenho.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} deve definir os operadores '{1}' e Equals, pois implementa IComparable</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} deve definir os operadores '{1}' e Equals, pois implementa IComparable</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Remova a chamada para GC.Collect de {0}. Normalmente, é desnecessário forçar a coleta de lixo. Fazer isso pode impactar severamente o desempenho.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Remova a chamada para GC.Collect de {0}. Normalmente, é desnecessário forçar a coleta de lixo. Fazer isso pode impactar severamente o desempenho.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Remova a chamada para Thread.Resume de {0}. Suspender e resumir threads pode ser perigoso quando o sistema está em meio a uma operação crítica como a execução de um construtor de classe de um tipo de sistema importante ou resolvendo a segurança para um assembly compartilhado.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Remova a chamada para Thread.Resume de {0}. Suspender e resumir threads pode ser perigoso quando o sistema está em meio a uma operação crítica como a execução de um construtor de classe de um tipo de sistema importante ou resolvendo a segurança para um assembly compartilhado.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Remova a chamada para Thread.Suspend de {0}. Suspender e resumir threads pode ser perigoso quando o sistema está em meio a uma operação crítica como a execução de um construtor de classe de um tipo de sistema importante ou resolvendo a segurança para um assembly compartilhado.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Remova a chamada para Thread.Suspend de {0}. Suspender e resumir threads pode ser perigoso quando o sistema está em meio a uma operação crítica como a execução de um construtor de classe de um tipo de sistema importante ou resolvendo a segurança para um assembly compartilhado.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Remova a chamada para System.Type.InvokeMember com BindingFlags.NonPublic de {0}. Usar uma dependência em um membro privado aumenta a chance de haver uma alteração interruptiva no futuro.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Remova a chamada para System.Type.InvokeMember com BindingFlags.NonPublic de {0}. Usar uma dependência em um membro privado aumenta a chance de haver uma alteração interruptiva no futuro.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} é uma declaração P/Invoke para uma API OLE32 que não pode ser chamada de forma confiável após a inicialização do tempo de execução. A solução alternativa é gravar um shim não gerenciado que chamará a rotina e ativará e chamará o código gerenciado. É possível fazer isso usando uma exportação de uma DLL C++ de modo misto ao registrar um componente gerenciado para uso pelo COM ou ao usar a API de hospedagem do tempo de execução.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} é uma declaração P/Invoke para uma API OLE32 que não pode ser chamada de forma confiável após a inicialização do tempo de execução. A solução alternativa é gravar um shim não gerenciado que chamará a rotina e ativará e chamará o código gerenciado. É possível fazer isso usando uma exportação de uma DLL C++ de modo misto ao registrar um componente gerenciado para uso pelo COM ou ao usar a API de hospedagem do tempo de execução.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} é uma declaração P/Invoke para uma API OLE32 que não pode ser chamada de forma confiável com relação a um runtime callable wrapper (um objeto gerenciado que encapsula um objeto COM). Runtime callable wrappers buscam ponteiros de interface dinamicamente, de modo que o efeito da chamada pode ser arbitrariamente perdido. Runtime callable wrappers para um determinado objeto COM também são compartilhados ao longo de um domínio de aplicativos. Assim, a chamada poderia afetar outros usuários. Substitua esta chamada por um objeto COM wrapper nativo para o ponteiro de interface que faz as chamadas CoSetProxyBlanket apropriadas.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} é uma declaração P/Invoke para uma API OLE32 que não pode ser chamada de forma confiável com relação a um runtime callable wrapper (um objeto gerenciado que encapsula um objeto COM). Runtime callable wrappers buscam ponteiros de interface dinamicamente, de modo que o efeito da chamada pode ser arbitrariamente perdido. Runtime callable wrappers para um determinado objeto COM também são compartilhados ao longo de um domínio de aplicativos. Assim, a chamada poderia afetar outros usuários. Substitua esta chamada por um objeto COM wrapper nativo para o ponteiro de interface que faz as chamadas CoSetProxyBlanket apropriadas.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Remova a chamada para SafeHandle.DangerousGetHandle de {0}</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Remova a chamada para SafeHandle.DangerousGetHandle de {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Remova a chamada para Assembly.LoadFrom de {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Remova a chamada para Assembly.LoadFrom de {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Remova a chamada para Assembly.LoadFile de {0}</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Remova a chamada para Assembly.LoadFile de {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Remova a chamada para Assembly.LoadWithPartialName de {0}</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Remova a chamada para Assembly.LoadWithPartialName de {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, uma variável declarada em {1}, tem o mesmo nome de um campo de instância no tipo. Altere o nome de um desses itens.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, uma variável declarada em {1}, tem o mesmo nome de um campo de instância no tipo. Altere o nome de um desses itens.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0}, um parâmetro declarado em {1}, tem o mesmo nome de um campo de instância no tipo. Altere o nome de um desses itens.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0}, um parâmetro declarado em {1}, tem o mesmo nome de um campo de instância no tipo. Altere o nome de um desses itens.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">O parâmetro {0} do método {1} nunca é usado. Remova o parâmetro ou use-o no corpo do método.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">O parâmetro {0} do método {1} nunca é usado. Remova o parâmetro ou use-o no corpo do método.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} cria uma nova instância de {1} que nunca é usada. Passe a instância como argumento para outro método, atribua a instância a uma variável ou remova a criação do objeto se ela for desnecessária.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} cria uma nova instância de {1} que nunca é usada. Passe a instância como argumento para outro método, atribua a instância a uma variável ou remova a criação do objeto se ela for desnecessária.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} chama {1}, mas não usa a instância da nova cadeia de caracteres retornada pelo método. Passe a instância como argumento para outro método, atribua a instância a uma variável ou remova a chamada se ela for desnecessária.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} chama {1}, mas não usa a instância da nova cadeia de caracteres retornada pelo método. Passe a instância como argumento para outro método, atribua a instância a uma variável ou remova a chamada se ela for desnecessária.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} chama {1}, mas não usa HRESULT ou o código do erro retornado pelo método. Isso poderia levar a um comportamento inesperado em condições de erro ou situações de poucos recursos. Use o resultado em uma instrução condicional, atribua o resultado a uma variável ou passe-o como argumento para outro método.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} chama {1}, mas não usa HRESULT ou o código do erro retornado pelo método. Isso poderia levar a um comportamento inesperado em condições de erro ou situações de poucos recursos. Use o resultado em uma instrução condicional, atribua o resultado a uma variável ou passe-o como argumento para outro método.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} chama {1}, mas não verifica explicitamente se a conversão foi bem-sucedida. Use o valor retornado em uma instrução condicional ou verifique se o local da chamada espera que o argumento de saída seja definido como o valor padrão quando a conversão falha.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} chama {1}, mas não verifica explicitamente se a conversão foi bem-sucedida. Use o valor retornado em uma instrução condicional ou verifique se o local da chamada espera que o argumento de saída seja definido como o valor padrão quando a conversão falha.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} é uma classe interna cuja instância aparentemente nunca é criada. Caso seja, remova o código do assembly. Se essa classe destina-se a conter apenas membros estáticos, torne-a estática (Shared no Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} é uma classe interna cuja instância aparentemente nunca é criada. Caso seja, remova o código do assembly. Se essa classe destina-se a conter apenas membros estáticos, torne-a estática (Shared no Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} chama {1}, mas não usa o valor retornado pelo método. Como {1} é marcado como um método Pure, ele não pode ter efeitos colaterais. Use o resultado em uma instrução condicional, atribua o resultado a uma variável ou passe-o como argumento para outro método.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} chama {1}, mas não usa o valor retornado pelo método. Como {1} é marcado como um método Pure, ele não pode ter efeitos colaterais. Use o resultado em uma instrução condicional, atribua o resultado a uma variável ou passe-o como argumento para outro método.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">A propriedade {0} não deve ser atribuída a si mesma</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">A propriedade {0} não deve ser atribuída a si mesma</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} é uma matriz multidimensional. Se possível, substitua-a por uma matriz denteada.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} é uma matriz multidimensional. Se possível, substitua-a por uma matriz denteada.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} retorna uma matriz multidimensional de {1}. Se possível, substitua-a por uma matriz denteada.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} retorna uma matriz multidimensional de {1}. Se possível, substitua-a por uma matriz denteada.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} usa uma matriz multidimensional de {1}. Se possível, substitua-a por uma matriz denteada.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} usa uma matriz multidimensional de {1}. Se possível, substitua-a por uma matriz denteada.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Избегание Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Избегание Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Избегание Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Избегание Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Имена асинхронных методов должны заканчиваться на Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Имена асинхронных методов должны заканчиваться на Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Имена асинхронных методов должны заканчиваться на Async</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Имена асинхронных методов должны заканчиваться на Async</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">Измените архитектуру, так чтобы число параметров типа в "{0}" не превышало {1}.</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">Измените архитектуру, так чтобы число параметров типа в "{0}" не превышало {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">Не используйте параметры out</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">Не используйте параметры out</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; является универсальной коллекцией, которая предназначена для повышения производительности, а не для наследования. List&lt;T&gt; не содержит виртуальные члены, которые упрощают изменение поведения наследуемого класса.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; является универсальной коллекцией, которая предназначена для повышения производительности, а не для наследования. List&lt;T&gt; не содержит виртуальные члены, которые упрощают изменение поведения наследуемого класса.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Не передавайте асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Не передавайте асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Не передавайте асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Не передавайте асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Для передачи типов по ссылке (с использованием "out" или "ref") необходим опыт работы с указателями, понимание различий между типами значений и ссылочными типами, а также использование методов с несколькими возвращаемыми значениями. Кроме того, разница между параметрами "out" и "ref" не является очевидной.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Для передачи типов по ссылке (с использованием "out" или "ref") необходим опыт работы с указателями, понимание различий между типами значений и ссылочными типами, а также использование методов с несколькими возвращаемыми значениями. Кроме того, разница между параметрами "out" и "ref" не является очевидной.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Не храните асинхронные лямбда-выражения как Void, возвращающие типы делегатов</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">Удалите метод завершения из типа '{0}', переопределите Dispose(bool disposing) и поместите логику завершения в путь кода, туда где 'disposing' имеет значение false. В противном случае это может привести к дублированию вызовов метода Dispose, так как базовый тип '{1}' также предоставляет метод завершения.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">Удалите метод завершения из типа '{0}', переопределите Dispose(bool disposing) и поместите логику завершения в путь кода, туда где 'disposing' имеет значение false. В противном случае это может привести к дублированию вызовов метода Dispose, так как базовый тип '{1}' также предоставляет метод завершения.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">По мере возможности распространяйте токены CancellationToken</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">По мере возможности распространяйте токены CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">По мере возможности распространяйте токены CancellationToken</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">По мере возможности распространяйте токены CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Не смешивайте блокирующую и асинхронную операции</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Не смешивайте блокирующую и асинхронную операции</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Не смешивайте блокирующую и асинхронную операции</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Не смешивайте блокирующую и асинхронную операции</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">В перечислении {0} измените имя {1} на "None".</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">В перечислении {0} измените имя {1} на "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">Удалите из {0} все члены с нулевым значением, за исключением одного, с именем "None".</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">Удалите из {0} все члены с нулевым значением, за исключением одного, с именем "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">Добавьте в {0} член с нулевым значением и предлагаемым именем "None".</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">Добавьте в {0} член с нулевым значением и предлагаемым именем "None".</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Спецификация CLS определяет ограничения именования, типы данных и правила, которым должны соответствовать сборки, если они будут использоваться в разных языках программирования. Принципы хорошего проектирования требуют, чтобы все сборки явно указывали соответствие спецификации CLS с помощью CLSCompliantAttribute. Сборки без этого атрибута считаются несоответствующими.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Спецификация CLS определяет ограничения именования, типы данных и правила, которым должны соответствовать сборки, если они будут использоваться в разных языках программирования. Принципы хорошего проектирования требуют, чтобы все сборки явно указывали соответствие спецификации CLS с помощью CLSCompliantAttribute. Сборки без этого атрибута считаются несоответствующими.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Пометить сборки как CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Пометить сборки как CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Пометить сборки как ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Пометить сборки как ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">Так как {0} публикует типы, видимые извне, пометьте его как ComVisible(false) на уровне сборки, а затем пометьте все типы в сборке, которые должны быть предоставлены COM-клиентам как ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">Так как {0} публикует типы, видимые извне, пометьте его как ComVisible(false) на уровне сборки, а затем пометьте все типы в сборке, которые должны быть предоставлены COM-клиентам как ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Пометить атрибуты как AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Пометить атрибуты как AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Определяя настраиваемый атрибут, пометьте его с помощью AttributeUsageAttribute, чтобы указать, где можно применять исходный код этого атрибута. Значение и предназначение атрибута определяют допустимые расположения для него в коде.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Определяя настраиваемый атрибут, пометьте его с помощью AttributeUsageAttribute, чтобы указать, где можно применять исходный код этого атрибута. Значение и предназначение атрибута определяют допустимые расположения для него в коде.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">Укажите AttributeUsage в {0}.</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">Укажите AttributeUsage в {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">Хотя атрибут {0} наследует AttributeUsage от своего базового типа, следует рассмотреть вариант явного указания AttributeUsage для типа, чтобы улучшить читаемость кода и его документирование.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">Хотя атрибут {0} наследует AttributeUsage от своего базового типа, следует рассмотреть вариант явного указания AttributeUsage для типа, чтобы улучшить читаемость кода и его документирование.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">Добавьте открытый метод доступа для свойства доступа только для чтения к позиционному аргументу {0} для атрибута {1}.</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">Добавьте открытый метод доступа для свойства доступа только для чтения к позиционному аргументу {0} для атрибута {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">Удалите метод задания свойства из {0} или уменьшите область его доступности, так как он соответствует позиционному аргументу {1}.</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">Удалите метод задания свойства из {0} или уменьшите область его доступности, так как он соответствует позиционному аргументу {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">Если {0} — это метод доступа к свойству для позиционного аргумента {1}, сделайте его открытым.</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">Если {0} — это метод доступа к свойству для позиционного аргумента {1}, сделайте его открытым.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Общедоступный метод имеет имя, начинающееся с "Get", не принимает параметры и возвращает значение, отличное от массива. Этот метод может быть хорошим кандидатом на то, чтобы стать свойством.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Общедоступный метод имеет имя, начинающееся с "Get", не принимает параметры и возвращает значение, отличное от массива. Этот метод может быть хорошим кандидатом на то, чтобы стать свойством.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Пометьте перечисления с помощью FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Пометьте перечисления с помощью FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Перечисление — это тип значения, определяющий набор связанных именованных констант. Примените FlagsAttribute к перечислению, когда его именованные константы можно объединить значимым образом.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Перечисление — это тип значения, определяющий набор связанных именованных констант. Примените FlagsAttribute к перечислению, когда его именованные константы можно объединить значимым образом.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Пометьте перечисления с помощью FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Пометьте перечисления с помощью FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Общедоступный или защищенный тип реализует интерфейс System.IComparable. Он не переопределяет Object.Equals и не перегружает языковой оператор на предмет сравнений равно, неравно, меньше, меньше или равно, больше, больше или равно.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Общедоступный или защищенный тип реализует интерфейс System.IComparable. Он не переопределяет Object.Equals и не перегружает языковой оператор на предмет сравнений равно, неравно, меньше, меньше или равно, больше, больше или равно.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0} должен переопределить оператор Equals, так как он реализует IComparable.</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} должен переопределить оператор Equals, так как он реализует IComparable.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0} должен определять операторы "{1}", так как он реализует IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} должен определять операторы "{1}", так как он реализует IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Имя видимых снаружи интерфейсов не начинается с прописной буквы "I". Имя параметра универсального типа для видимого снаружи типа или метода не начинается с прописной буквы "T".</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Имя видимых снаружи интерфейсов не начинается с прописной буквы "I". Имя параметра универсального типа для видимого снаружи типа или метода не начинается с прописной буквы "T".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">Добавьте префикс "I" к имени интерфейса {0}.</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">Добавьте префикс "I" к имени интерфейса {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Добавьте префикс "T" к имени параметра универсального типа {0}.</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Добавьте префикс "T" к имени параметра универсального типа {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Не помечайте перечисления с помощью FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Не помечайте перечисления с помощью FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Видимое снаружи перечисление помечается с помощью FlagsAttribute и имеет одно или несколько значений, отличных от степеней двойки или сочетания других определенных значений в этом перечислении.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Видимое снаружи перечисление помечается с помощью FlagsAttribute и имеет одно или несколько значений, отличных от степеней двойки или сочетания других определенных значений в этом перечислении.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Не помечайте перечисления с помощью FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Не помечайте перечисления с помощью FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Предоставьте метод с именем "{0}" в качестве понятной альтернативы оператору {1}.</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Предоставьте метод с именем "{0}" в качестве понятной альтернативы оператору {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">Предоставьте свойство с именем "{0}" в качестве понятной альтернативы оператору {1}.</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Предоставьте свойство с именем "{0}" в качестве понятной альтернативы оператору {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">Предоставьте метод с именем "{0}" или "{1}" в качестве альтернативы оператору {2}.</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">Предоставьте метод с именем "{0}" или "{1}" в качестве альтернативы оператору {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">Пометьте {0} как открытый, так как он является понятной альтернативой оператору {1}</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">Пометьте {0} как открытый, так как он является понятной альтернативой оператору {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Реализуйте IEquatable при переопределении Object.Equals</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Реализуйте IEquatable при переопределении Object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">Тип {0} должен реализовывать IEquatable&lt;T&gt;, так как он переопределяет Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">Тип {0} должен реализовывать IEquatable&lt;T&gt;, так как он переопределяет Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">Параметры CancellationToken должны находиться в конце</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">Параметры CancellationToken должны находиться в конце</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">Так как {0} публикует типы, видимые извне, пометьте его как ComVisible(false) на уровне сборки, а затем пометьте все типы в сборке, которые должны быть предоставлены COM-клиентам, как ComVisible(true).</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">Так как {0} публикует типы, видимые извне, пометьте его как ComVisible(false) на уровне сборки, а затем пометьте все типы в сборке, которые должны быть предоставлены COM-клиентам, как ComVisible(true).</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">Рекомендуется присвоить атрибуту ComVisible {0} значение "false" и дать согласие на уровне типов.</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">Рекомендуется присвоить атрибуту ComVisible {0} значение "false" и дать согласие на уровне типов.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">Реализуйте IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">Реализуйте IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">Реализуйте интерфейс IDisposable</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">Реализуйте интерфейс IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Удалите FlagsAttribute из перечисления.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Удалите FlagsAttribute из перечисления.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Примените FlagsAttribute к перечислению.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Примените FlagsAttribute к перечислению.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Хранилище перечислений должно относиться к типу Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Хранилище перечислений должно относиться к типу Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">По возможности используйте для {0} базовый тип System.Int32 вместо {1}.</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">По возможности используйте для {0} базовый тип System.Int32 вместо {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">Добавьте в {0} следующий конструктор: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">Добавьте в {0} следующий конструктор: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">Измените доступность {0} на {1}.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">Измените доступность {0} на {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">Не делайте тип {0} вложенным. Вместо этого измените режим доступа к нему так, чтобы он не был виден снаружи.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">Не делайте тип {0} вложенным. Вместо этого измените режим доступа к нему так, чтобы он не был виден снаружи.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">Не делайте тип {0} вложенным. Вместо этого измените режим доступа к нему так, чтобы он не был виден снаружи. Если данный тип был определен в модуле Visual Basic, другими языками .NET он будет рассматриваться как вложенный тип. В этом случае рекомендуется переместить тип за пределы модуля.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">Не делайте тип {0} вложенным. Вместо этого измените режим доступа к нему так, чтобы он не был виден снаружи. Если данный тип был определен в модуле Visual Basic, другими языками .NET он будет рассматриваться как вложенный тип. В этом случае рекомендуется переместить тип за пределы модуля.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">Укажите сообщение ObsoleteAttribute</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">Укажите сообщение ObsoleteAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Тип или член помечен с помощью атрибута System.ObsoleteAttribute, для которого не задано свойство ObsoleteAttribute.Message. При компиляции типа или члена, помеченного с помощью ObsoleteAttribute, отображается свойство Message этого атрибута. Оно предоставляет пользователю сведения об устаревшем типе или члене.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Тип или член помечен с помощью атрибута System.ObsoleteAttribute, для которого не задано свойство ObsoleteAttribute.Message. При компиляции типа или члена, помеченного с помощью ObsoleteAttribute, отображается свойство Message этого атрибута. Оно предоставляет пользователю сведения об устаревшем типе или члене.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">Укажите сообщение для ObsoleteAttribute, помечающего {0} как устаревший</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">Укажите сообщение для ObsoleteAttribute, помечающего {0} как устаревший</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">Так как свойство {0} доступно только для чтения, добавьте для него метод получения, уровень доступности которого больше или равен уровню доступности метода задания, либо преобразуйте это свойство в метод.</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">Так как свойство {0} доступно только для чтения, добавьте для него метод получения, уровень доступности которого больше или равен уровню доступности метода задания, либо преобразуйте это свойство в метод.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">Так как метод получения свойства {0} имеет меньшую видимость, чем метод задания, увеличьте уровень доступности для метода получения или уменьшите его для метода задания.</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">Так как метод получения свойства {0} имеет меньшую видимость, чем метод задания, увеличьте уровень доступности для метода получения или уменьшите его для метода задания.</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">Правильно реализуйте IDisposable</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">Правильно реализуйте IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Во всех типах IDisposable шаблон Dispose должен быть реализован правильно.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Во всех типах IDisposable шаблон Dispose должен быть реализован правильно.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">Удалите IDisposable из списка интерфейсов, реализованных в "{0}", так как он уже реализован базовым типом "{1}".</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">Удалите IDisposable из списка интерфейсов, реализованных в "{0}", так как он уже реализован базовым типом "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">Удалите "{0}", переопределите Dispose(bool disposing) и поместите логику метода dispose в пути кода, там где "disposing" имеет значение true.</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">Удалите "{0}", переопределите Dispose(bool disposing) и поместите логику метода dispose в пути кода, там где "disposing" имеет значение true.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">Измените "{0}", так чтобы он вызывал Dispose(true), затем вызывал GC.SuppressFinalize для экземпляра текущего объекта ("this" или "Me" в Visual Basic) и затем выполнял возврат.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">Измените "{0}", так чтобы он вызывал Dispose(true), затем вызывал GC.SuppressFinalize для экземпляра текущего объекта ("this" или "Me" в Visual Basic) и затем выполнял возврат.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">Измените "{0}", так чтобы он вызывал Dispose(false) и затем выполнял возврат.</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">Измените "{0}", так чтобы он вызывал Dispose(false) и затем выполнял возврат.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">Предоставьте переопределяемую реализацию Dispose(bool) в '{0}' или пометьте тип как запечатанный. При вызове Dispose(false) должны удаляться только собственные ресурсы. При вызове Dispose(true) должны удаляться как управляемые, так и собственные ресурсы.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">Предоставьте переопределяемую реализацию Dispose(bool) в '{0}' или пометьте тип как запечатанный. При вызове Dispose(false) должны удаляться только собственные ресурсы. При вызове Dispose(true) должны удаляться как управляемые, так и собственные ресурсы.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Внутреннее исключение видно только внутри своей внутренней области. Когда исключение выходит за пределы внутренней области, для его перехвата можно использовать только базовое исключение. Если внутреннее исключение унаследовано от T:System.Exception, T:System.SystemException или T:System.ApplicationException, внешний код не будет располагать достаточной информацией о том, что нужно сделать с этим исключением.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Внутреннее исключение видно только внутри своей внутренней области. Когда исключение выходит за пределы внутренней области, для его перехвата можно использовать только базовое исключение. Если внутреннее исключение унаследовано от T:System.Exception, T:System.SystemException или T:System.ApplicationException, внешний код не будет располагать достаточной информацией о том, что нужно сделать с этим исключением.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} создает исключение типа {1}, который не должен порождаться в свойстве. Если этот экземпляр исключения может быть порожден, используйте другой тип исключения, преобразуйте это свойство в метод или измените логику этого свойства, чтобы оно больше не порождало исключение.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} создает исключение типа {1}, который не должен порождаться в свойстве. Если этот экземпляр исключения может быть порожден, используйте другой тип исключения, преобразуйте это свойство в метод или измените логику этого свойства, чтобы оно больше не порождало исключение.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} создает исключение типа {1}, который не должен порождаться в этом типе метода. Если этот экземпляр исключения может быть порожден, используйте другой тип исключения или измените логику этого метода, чтобы он больше не порождал исключение.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} создает исключение типа {1}, который не должен порождаться в этом типе метода. Если этот экземпляр исключения может быть порожден, используйте другой тип исключения или измените логику этого метода, чтобы он больше не порождал исключение.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} создает исключение типа {1}. В этом типе метода не должны порождаться исключения. Если этот экземпляр исключения может быть порожден, измените логику этого метода, чтобы он больше не порождал исключение.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} создает исключение типа {1}. В этом типе метода не должны порождаться исключения. Если этот экземпляр исключения может быть порожден, измените логику этого метода, чтобы он больше не порождал исключение.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">По соглашению имена идентификаторов не содержат символ подчеркивания (_). Это правило проверяет пространства имен, типы, члены и параметры.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">По соглашению имена идентификаторов не содержат символ подчеркивания (_). Это правило проверяет пространства имен, типы, члены и параметры.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">Удалите символы подчеркивания из имени сборки {0}.</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">Удалите символы подчеркивания из имени сборки {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">Удалите символы подчеркивания из имени типа {0}.</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">Удалите символы подчеркивания из имени типа {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">Удалите символы подчеркивания из имени члена {0}.</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">Удалите символы подчеркивания из имени члена {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">В типе {0} удалите символы подчеркивания из имени параметра универсального типа {1}.</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">В типе {0} удалите символы подчеркивания из имени параметра универсального типа {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">В методе {0} удалите символы подчеркивания из имени параметра универсального типа {1}.</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">В методе {0} удалите символы подчеркивания из имени параметра универсального типа {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">В члене {0} удалите символы подчеркивания из имени параметра {1}.</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">В члене {0} удалите символы подчеркивания из имени параметра {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">В делегате {0} удалите символы подчеркивания из имени параметра {1}.</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">В делегате {0} удалите символы подчеркивания из имени параметра {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">Переименуйте {0}, чтобы в конце стояло "{1}".</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">Переименуйте {0}, чтобы в конце стояло "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">Переименуйте {0}, чтобы в конце стояло "Collection" или "{1}".</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">Переименуйте {0}, чтобы в конце стояло "Collection" или "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">Измените имя типа {0}, чтобы оно не заканчивалось на "{1}".</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">Измените имя типа {0}, чтобы оно не заканчивалось на "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">Либо замените суффикс "{0}" в имени члена {1} предложенным числом "2", либо подберите более значимый суффикс, который отличит его от заменяемого члена.</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">Либо замените суффикс "{0}" в имени члена {1} предложенным числом "2", либо подберите более значимый суффикс, который отличит его от заменяемого члена.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">Либо замените суффикс "{0}" в имени типа {1} предложенным числом "2", либо подберите более значимый суффикс, который отличит его от заменяемого типа.</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">Либо замените суффикс "{0}" в имени типа {1} предложенным числом "2", либо подберите более значимый суффикс, который отличит его от заменяемого типа.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">В виртуальном члене или в члене интерфейса {0} переименуйте параметр {1} так, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{2}". Использование зарезервированного ключевого слова в качестве имени параметра виртуального члена или члена интерфейса затрудняет переопределение или реализацию члена для потребителей в других языках.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">В виртуальном члене или в члене интерфейса {0} переименуйте параметр {1} так, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{2}". Использование зарезервированного ключевого слова в качестве имени параметра виртуального члена или члена интерфейса затрудняет переопределение или реализацию члена для потребителей в других языках.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">Переименуйте виртуальный член или член интерфейса {0}, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени виртуального члена или члена интерфейса затрудняет переопределение или реализацию члена для потребителей в других языках.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">Переименуйте виртуальный член или член интерфейса {0}, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени виртуального члена или члена интерфейса затрудняет переопределение или реализацию члена для потребителей в других языках.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">Переименуйте тип {0}, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени типа затрудняет использование этого типа потребителями в других языках.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">Переименуйте тип {0}, чтобы он больше не находился в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени типа затрудняет использование этого типа потребителями в других языках.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">Переименуйте пространство имен {0}, чтобы оно больше не находилось в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени пространства имен затрудняет использование этого пространства имен потребителями в других языках.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">Переименуйте пространство имен {0}, чтобы оно больше не находилось в конфликте с зарезервированным ключевым словом языка "{1}". Использование зарезервированного ключевого слова в качестве имени пространства имен затрудняет использование этого пространства имен потребителями в других языках.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Имя общего или защищенного члена начинается с "Get" и по остальным признакам соответствует имени общего или защищенного свойства. Свойства и методы "Get" должны иметь имена, явно различающие их функции.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Имя общего или защищенного члена начинается с "Get" и по остальным признакам соответствует имени общего или защищенного свойства. Свойства и методы "Get" должны иметь имена, явно различающие их функции.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">Имя типа {0} полностью или частично конфликтует с именем пространства имен "{1}". Измените одно из имен, чтобы устранить конфликт.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">Имя типа {0} полностью или частично конфликтует с именем пространства имен "{1}". Измените одно из имен, чтобы устранить конфликт.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">Имя типа {0} полностью или частично конфликтует с именем пространства имен "{1}", определенным в .NET Framework. Переименуйте тип, чтобы устранить конфликт.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">Имя типа {0} полностью или частично конфликтует с именем пространства имен "{1}", определенным в .NET Framework. Переименуйте тип, чтобы устранить конфликт.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">В члене {0} измените имя параметра {1} на {2}, чтобы привести идентификатор в соответствие с объявлением в {3}.</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">В члене {0} измените имя параметра {1} на {2}, чтобы привести идентификатор в соответствие с объявлением в {3}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Замените термин "{0}" в имени сборки {1} на предпочитаемый вариант "{2}".</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени сборки {1} на предпочитаемый вариант "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">В члене {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант "{3}".</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">В члене {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">В делегате {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант "{3}".</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">В делегате {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">В типе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант "{3}".</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">В типе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">В методе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант "{3}".</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">В методе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант "{3}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Замените термин "{0}" в имени типа {1} на предпочитаемый вариант "{2}".</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени типа {1} на предпочитаемый вариант "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">Замените термин "{0}" в имени члена {1} на предпочитаемый вариант "{2}".</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени члена {1} на предпочитаемый вариант "{2}".</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Замените термин "{0}" в имени сборки {1} на предпочитаемый вариант или вообще удалите его.</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени сборки {1} на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">В члене {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант или вообще удалите его.</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">В члене {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">В делегате {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант или вообще удалите его.</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">В делегате {0} замените термин "{1}" в имени параметра {2} на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">В типе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант или вообще удалите его.</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">В типе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">В методе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант или вообще удалите его.</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">В методе {0} замените термин "{1}" в имени параметра {2} универсального типа на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Замените термин "{0}" в имени типа {1} на предпочитаемый вариант или вообще удалите его.</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени типа {1} на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">Замените термин "{0}" в имени члена {1} на предпочитаемый вариант или вообще удалите его.</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">Замените термин "{0}" в имени члена {1} на предпочитаемый вариант или вообще удалите его.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} должен переопределить метод Equals.</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} должен переопределить метод Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} должен переопределить операторы равенства (==) и неравенства (!=).</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} должен переопределить операторы равенства (==) и неравенства (!=).</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">Подпишите {0} с использованием ключа строгого имени.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">Подпишите {0} с использованием ключа строгого имени.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">Перед развертыванием убедитесь, что {0} имеет допустимое строгое имя.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">Перед развертыванием убедитесь, что {0} имеет допустимое строгое имя.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Переопределите GetHashCode при переопределении Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Переопределите GetHashCode при переопределении Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode возвращает значение, основанное на текущем экземпляре, которое подходит для хэш-алгоритмов и структур данных, таких как хэш-таблица. Два равных объекта одного типа должны возвращать одинаковый хэш-код.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode возвращает значение, основанное на текущем экземпляре, которое подходит для хэш-алгоритмов и структур данных, таких как хэш-таблица. Два равных объекта одного типа должны возвращать одинаковый хэш-код.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Переопределите GetHashCode при переопределении Equals</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Переопределите GetHashCode при переопределении Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Переопределите Equals при перегрузке оператора равенства</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Переопределите Equals при перегрузке оператора равенства</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Общий тип реализует оператор равенства, но не переопределяет Object.Equals.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Общий тип реализует оператор равенства, но не переопределяет Object.Equals.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Переопределите Equals при перегрузке оператора равенства</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Переопределите Equals при перегрузке оператора равенства</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Переопределите object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Переопределите object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">Переопределите object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">Переопределите object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">Переопределите object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">Переопределите object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Сделайте класс статическим</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Сделайте класс статическим</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">Тип {0} должен переопределять Equals, так как он реализует IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Тип {0} должен переопределять Equals, так как он реализует IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">Переопределите Object.Equals(object) при реализации IEquatable&lt;T&gt;</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">Переопределите Object.Equals(object) при реализации IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Когда асинхронный метод непосредственно ожидает задачу, продолжение происходит в том же потоке, в котором была создана задача. Попробуйте вызвать Task.ConfigureAwait(Boolean), чтобы сообщить о том, что планируется продолжение. Вызовите ConfigureAwait(false) для задачи, чтобы запланировать продолжения для пула потоков, избежав таким образом взаимоблокировки в потоке пользовательского интерфейса. Передача значения false является хорошим вариантом для библиотек, независимых от приложений. Поведение при вызове ConfigureAwait(true) для задачи такое же, как при неявном вызове ConfigureAwait. При явном вызове этого метода вы сообщаете читателям, что вы намеренно хотите выполнить продолжение в исходном контексте синхронизации.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Когда асинхронный метод непосредственно ожидает задачу, продолжение происходит в том же потоке, в котором была создана задача. Попробуйте вызвать Task.ConfigureAwait(Boolean), чтобы сообщить о том, что планируется продолжение. Вызовите ConfigureAwait(false) для задачи, чтобы запланировать продолжения для пула потоков, избежав таким образом взаимоблокировки в потоке пользовательского интерфейса. Передача значения false является хорошим вариантом для библиотек, независимых от приложений. Поведение при вызове ConfigureAwait(true) для задачи такое же, как при неявном вызове ConfigureAwait. При явном вызове этого метода вы сообщаете читателям, что вы намеренно хотите выполнить продолжение в исходном контексте синхронизации.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Попробуйте вызвать ConfigureAwait для ожидаемой задачи</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Попробуйте вызвать ConfigureAwait для ожидаемой задачи</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Попробуйте вызвать ConfigureAwait для ожидаемой задачи</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Попробуйте вызвать ConfigureAwait для ожидаемой задачи</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Если тип T переопределяет Object.Equals(object), реализация должна привести аргумент object к правильному типу T перед выполнением сравнения. Если тип реализует IEquatable&lt;T&gt;и поэтому предоставляет метод T.Equals(T), а также известно, что этот аргумент во время компиляции имеет тип T, компилятор может вызывать IEquatable&lt;T&gt;.Equals(T) вместо Object.Equals(object) и приведение не требуется, что повышает производительность.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Если тип T переопределяет Object.Equals(object), реализация должна привести аргумент object к правильному типу T перед выполнением сравнения. Если тип реализует IEquatable&lt;T&gt;и поэтому предоставляет метод T.Equals(T), а также известно, что этот аргумент во время компиляции имеет тип T, компилятор может вызывать IEquatable&lt;T&gt;.Equals(T) вместо Object.Equals(object) и приведение не требуется, что повышает производительность.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0} должен определять операторы "{1}" и Equals, так как он реализует IComparable.</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0} должен определять операторы "{1}" и Equals, так как он реализует IComparable.</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">Удалите вызов GC.Collect из {0}. В общем случае принудительная сборка мусора не требуется, кроме того, она может существенно снизить производительность.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">Удалите вызов GC.Collect из {0}. В общем случае принудительная сборка мусора не требуется, кроме того, она может существенно снизить производительность.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Удалите вызов Thread.Resume из {0}. Приостановка и возобновление работы потоков могут быть опасны, если система в это время выполняет критическую операцию, например, выполняется конструктор класса важного системного типа или определяются параметры безопасности для общей сборки.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Удалите вызов Thread.Resume из {0}. Приостановка и возобновление работы потоков могут быть опасны, если система в это время выполняет критическую операцию, например, выполняется конструктор класса важного системного типа или определяются параметры безопасности для общей сборки.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">Удалите вызов Thread.Suspend из {0}. Приостановка и возобновление работы потоков могут быть опасны, если система в это время выполняет критическую операцию, например, выполняется конструктор класса важного системного типа или определяются параметры безопасности для общей сборки.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">Удалите вызов Thread.Suspend из {0}. Приостановка и возобновление работы потоков могут быть опасны, если система в это время выполняет критическую операцию, например, выполняется конструктор класса важного системного типа или определяются параметры безопасности для общей сборки.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">Удалите вызов System.Type.InvokeMember с BindingFlags.NonPublic из {0}. Использование зависимости от частных членов повышает риск критического изменения в будущем.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">Удалите вызов System.Type.InvokeMember с BindingFlags.NonPublic из {0}. Использование зависимости от частных членов повышает риск критического изменения в будущем.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} — объявление PInvoke для интерфейса OLE32 API, который не может быть надежно вызван после инициализации среды выполнения. Обходной путь заключается в том, чтобы написать неуправляемый модификатор, который будет вызывать подпрограмму, а затем активировать и вызывать управляемый код. Это можно сделать с помощью экспорта из библиотеки DLL C++ смешанного режима, с помощью регистрации управляемого компонента для использования в модели COM или с помощью API для размещения среды выполнения</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} — объявление PInvoke для интерфейса OLE32 API, который не может быть надежно вызван после инициализации среды выполнения. Обходной путь заключается в том, чтобы написать неуправляемый модификатор, который будет вызывать подпрограмму, а затем активировать и вызывать управляемый код. Это можно сделать с помощью экспорта из библиотеки DLL C++ смешанного режима, с помощью регистрации управляемого компонента для использования в модели COM или с помощью API для размещения среды выполнения</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} — объявление PInvoke для интерфейса OLE32 API, который не может быть надежно вызван при использовании вызываемой оболочки времени выполнения (управляемый объект, используемый в качестве оболочки для COM-объекта). Вызываемые оболочки времени выполнения динамически извлекают указатели на интерфейс, поэтому результат вызова может быть произвольно потерян. Вызываемые оболочки времени выполнения для указанного COM-объекта также находятся в режиме общего доступа в пределах домена приложения, поэтому вызов вполне может затронуть других пользователей. Замените этот вызов COM-объектом в машинной оболочке для указателя интерфейса, который выполняет соответствующие вызовы CoSetProxyBlanket.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} — объявление PInvoke для интерфейса OLE32 API, который не может быть надежно вызван при использовании вызываемой оболочки времени выполнения (управляемый объект, используемый в качестве оболочки для COM-объекта). Вызываемые оболочки времени выполнения динамически извлекают указатели на интерфейс, поэтому результат вызова может быть произвольно потерян. Вызываемые оболочки времени выполнения для указанного COM-объекта также находятся в режиме общего доступа в пределах домена приложения, поэтому вызов вполне может затронуть других пользователей. Замените этот вызов COM-объектом в машинной оболочке для указателя интерфейса, который выполняет соответствующие вызовы CoSetProxyBlanket.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">Удалите вызов SafeHandle.DangerousGetHandle из {0}.</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">Удалите вызов SafeHandle.DangerousGetHandle из {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">Удалите вызов Assembly.LoadFrom из {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Удалите вызов Assembly.LoadFrom из {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">Удалите вызов Assembly.LoadFile из {0}.</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">Удалите вызов Assembly.LoadFile из {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">Удалите вызов Assembly.LoadWithPartialName из {0}.</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">Удалите вызов Assembly.LoadWithPartialName из {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">Переменная {0}, объявленная в {1}, и поле экземпляра типа имеют одно и то же имя. Измените имя одного из этих элементов.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">Переменная {0}, объявленная в {1}, и поле экземпляра типа имеют одно и то же имя. Измените имя одного из этих элементов.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">Параметр {0}, объявленный в {1}, и поле экземпляра типа имеют одно и то же имя. Измените имя одного из этих элементов.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">Параметр {0}, объявленный в {1}, и поле экземпляра типа имеют одно и то же имя. Измените имя одного из этих элементов.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">Параметр {0} метода {1} не используется. Удалите этот параметр или используйте его в теле метода.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">Параметр {0} метода {1} не используется. Удалите этот параметр или используйте его в теле метода.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} создает экземпляр {1}, который не используется. Передайте этот экземпляр в качестве аргумента другому методу, присвойте экземпляр переменной, или удалите создание объекта, если он не нужен.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} создает экземпляр {1}, который не используется. Передайте этот экземпляр в качестве аргумента другому методу, присвойте экземпляр переменной, или удалите создание объекта, если он не нужен.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} вызывает {1}, но не использует новый экземпляр строки, возвращаемый методом. Передайте этот экземпляр в качестве аргумента другому методу, присвойте экземпляр переменной или удалите вызов, если он не нужен.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} вызывает {1}, но не использует новый экземпляр строки, возвращаемый методом. Передайте этот экземпляр в качестве аргумента другому методу, присвойте экземпляр переменной или удалите вызов, если он не нужен.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} вызывает {1}, но не использует HRESULT или код ошибки, возвращаемые методом. Это может привести к непредвиденному поведению при возникновении ошибок или нехватке ресурсов. Используйте результат в условном операторе, присвойте его переменной или передайте его в качестве аргумента другому методу.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} вызывает {1}, но не использует HRESULT или код ошибки, возвращаемые методом. Это может привести к непредвиденному поведению при возникновении ошибок или нехватке ресурсов. Используйте результат в условном операторе, присвойте его переменной или передайте его в качестве аргумента другому методу.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} вызывает {1}, но явно не проверяет успешность преобразования. Либо используйте возвращаемое значение в условном операторе, либо проверьте, что источник вызова предполагает, что при ошибке преобразования для аргумента out будет установлено значение по умолчанию.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} вызывает {1}, но явно не проверяет успешность преобразования. Либо используйте возвращаемое значение в условном операторе, либо проверьте, что источник вызова предполагает, что при ошибке преобразования для аргумента out будет установлено значение по умолчанию.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} является внутренним классом, экземпляр которого никогда не создается. Если это так, удалите код из сборки. Если этот класс должен содержать только статические методы, сделайте его статическим (Shared в Visual Basic).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} является внутренним классом, экземпляр которого никогда не создается. Если это так, удалите код из сборки. Если этот класс должен содержать только статические методы, сделайте его статическим (Shared в Visual Basic).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} вызывает {1}, но не использует значение, возвращаемое методом. Так как {1} помечен как метод Pure, он не может иметь побочные эффекты. Используйте результат в условном операторе, присвойте его переменной или передайте его в качестве аргумента другому методу.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} вызывает {1}, но не использует значение, возвращаемое методом. Так как {1} помечен как метод Pure, он не может иметь побочные эффекты. Используйте результат в условном операторе, присвойте его переменной или передайте его в качестве аргумента другому методу.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">Свойство {0} запрещено назначать самому себе.</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">Свойство {0} запрещено назначать самому себе.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} является многомерным массивом. По возможности замените его массивом массивов.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} является многомерным массивом. По возможности замените его массивом массивов.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} возвращает многомерный массив размером {1}. По возможности замените его массивом массивов.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} возвращает многомерный массив размером {1}. По возможности замените его массивом массивов.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} использует многомерный массив размером {1}. По возможности замените его массивом массивов.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} использует многомерный массив размером {1}. По возможности замените его массивом массивов.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void Kullanmayın</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void Kullanmayın</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">Async Void Kullanmayın</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">Async Void Kullanmayın</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Zaman Uyumsuz Yöntem Adları Async ile Bitmelidir</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Zaman Uyumsuz Yöntem Adları Async ile Bitmelidir</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Zaman Uyumsuz Yöntem Adları Async ile Bitmelidir</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Zaman Uyumsuz Yöntem Adları Async ile Bitmelidir</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">'{0}' öğesinin {1} tür parametresinden fazlasına sahip olmadığı bir tasarım kullanabilirsiniz</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">'{0}' öğesinin {1} tür parametresinden fazlasına sahip olmadığı bir tasarım kullanabilirsiniz</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">out parametrelerinden kaçının</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">out parametrelerinden kaçının</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt;, devralma için değil performans için tasarlanmış genel amaçlı bir koleksiyondur. List&lt;T&gt;, devralınan bir sınıfın davranışını değiştirmeyi kolaylaştıran sanal üyeler içermez.</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt;, devralma için değil performans için tasarlanmış genel amaçlı bir koleksiyondur. List&lt;T&gt;, devralınan bir sınıfın davranışını değiştirmeyi kolaylaştıran sanal üyeler içermez.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Geçirme</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Geçirme</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Geçirme</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Geçirme</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">Türleri başvuruya göre geçirmek (out veya ref kullanılarak) için işaretçiler konusunda deneyim sahibi olmak, değer ve başvuru türleri arasındaki farkları anlamak ve birden çok dönüş değeri içeren metotları işlemeyi bilmek gerekir. Ayrıca out ve ref parametreleri arasındaki fark genelde kapsamlı bir şekilde anlaşılmaz.</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">Türleri başvuruya göre geçirmek (out veya ref kullanılarak) için işaretçiler konusunda deneyim sahibi olmak, değer ve başvuru türleri arasındaki farkları anlamak ve birden çok dönüş değeri içeren metotları işlemeyi bilmek gerekir. Ayrıca out ve ref parametreleri arasındaki fark genelde kapsamlı bir şekilde anlaşılmaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">Temsilci Türlerini Döndüren Void Olarak Async Lambdaları Depolamayın</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">'{0}' türünden sonlandırıcıyı kaldırın, Dispose(bool disposing) metodunu geçersiz kılın ve sonlandırma mantığını 'disposing' değerinin false olduğu kod yoluna yerleştirin. Aksi takdirde, '{1}' Temel türü de bir sonlandırıcı sağladığından yinelenen Dispose çağrılarına yol açabilir.</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">'{0}' türünden sonlandırıcıyı kaldırın, Dispose(bool disposing) metodunu geçersiz kılın ve sonlandırma mantığını 'disposing' değerinin false olduğu kod yoluna yerleştirin. Aksi takdirde, '{1}' Temel türü de bir sonlandırıcı sağladığından yinelenen Dispose çağrılarına yol açabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Mümkün Olduğunda CancellationToken’ları Yay</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Mümkün Olduğunda CancellationToken’ları Yay</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">Mümkün Olduğunda CancellationToken’ları Yay</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">Mümkün Olduğunda CancellationToken’ları Yay</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Engelleyen ile Zaman Uyumsuzu Karıştırma</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Engelleyen ile Zaman Uyumsuzu Karıştırma</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">Engelleyen ile Zaman Uyumsuzu Karıştırma</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">Engelleyen ile Zaman Uyumsuzu Karıştırma</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">{0} sabit listesinde {1} öğesinin adını 'None' olarak değiştirin</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">{0} sabit listesinde {1} öğesinin adını 'None' olarak değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">{0} öğesinden 'None' olarak adlandırılmış tek üye dışındaki sıfır değerine sahip tüm üyeleri kaldırın</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">{0} öğesinden 'None' olarak adlandırılmış tek üye dışındaki sıfır değerine sahip tüm üyeleri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">{0} öğesine, değeri sıfır ve önerilen adı 'None' olan bir üye ekleyin</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">{0} öğesine, değeri sıfır ve önerilen adı 'None' olan bir üye ekleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Ortak Dil Belirtimi (CLS), farklı programlama dillerinde kullanılacaksa bütünleştirilmiş kodların uyması gereken adlandırma kısıtlamalarını, veri türlerini ve kuralları tanımlar. İyi bir tasarım için tüm bütünleştirilmiş kodlar CLSCompliantAttribute kullanarak CLS uyumluluğunu açıkça belirtmelidir. Bütünleştirilmiş kodda bu öznitelik yoksa bütünleştirilmiş kod uyumlu değildir.</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Ortak Dil Belirtimi (CLS), farklı programlama dillerinde kullanılacaksa bütünleştirilmiş kodların uyması gereken adlandırma kısıtlamalarını, veri türlerini ve kuralları tanımlar. İyi bir tasarım için tüm bütünleştirilmiş kodlar CLSCompliantAttribute kullanarak CLS uyumluluğunu açıkça belirtmelidir. Bütünleştirilmiş kodda bu öznitelik yoksa bütünleştirilmiş kod uyumlu değildir.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">Bütünleştirilmiş kodları CLSCompliant ile işaretleyin</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">Bütünleştirilmiş kodları CLSCompliant ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">Bütünleştirilmiş kodları ComVisible ile işaretleyin</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">Bütünleştirilmiş kodları ComVisible ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">{0} öğesi dışarıdan görünen türleri kullanıma sunduğundan, bunu bütünleştirilmiş kod düzeyinde ComVisible(false) ile işaretleyin, sonra bütünleştirilmiş kodda bulunan ve COM istemcilerinin kullanımına sunulması gereken tüm türleri ComVisible(true) ile işaretleyin.</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">{0} öğesi dışarıdan görünen türleri kullanıma sunduğundan, bunu bütünleştirilmiş kod düzeyinde ComVisible(false) ile işaretleyin, sonra bütünleştirilmiş kodda bulunan ve COM istemcilerinin kullanımına sunulması gereken tüm türleri ComVisible(true) ile işaretleyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">Öznitelikleri AttributeUsageAttribute ile işaretleyin</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">Öznitelikleri AttributeUsageAttribute ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">Özel bir öznitelik tanımladığınızda, özel özniteliğin kaynak kodunun neresinde uygulanabileceğini belirtmek için bunu AttributeUsageAttribute kullanarak işaretleyin. Bir özniteliğin anlamı ve amaçlanan kullanımı, koddaki geçerli konumlarını belirler.</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">Özel bir öznitelik tanımladığınızda, özel özniteliğin kaynak kodunun neresinde uygulanabileceğini belirtmek için bunu AttributeUsageAttribute kullanarak işaretleyin. Bir özniteliğin anlamı ve amaçlanan kullanımı, koddaki geçerli konumlarını belirler.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">{0} üzerinde AttributeUsage belirtin</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">{0} üzerinde AttributeUsage belirtin</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">{0} özniteliği AttributeUsage’ı temel türünden devralsa da kodun okunabilirliğini e belgeleri geliştirmek için AttributeUsage’ı açıkça belirtmeyi göz önünde bulundurmalısınız.</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">{0} özniteliği AttributeUsage’ı temel türünden devralsa da kodun okunabilirliğini e belgeleri geliştirmek için AttributeUsage’ı açıkça belirtmeyi göz önünde bulundurmalısınız.</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">{1} Özniteliğinin {0} konumsal bağımsız değişkeni için genel bir salt okunur özellik erişimcisi ekleyin</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">{1} Özniteliğinin {0} konumsal bağımsız değişkeni için genel bir salt okunur özellik erişimcisi ekleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">{1} konumsal bağımsız değişkenine karşılık geldiğinden, {0} öğesinden özellik ayarlayıcısını kaldırın veya erişilebilirliğini azaltın</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">{1} konumsal bağımsız değişkenine karşılık geldiğinden, {0} öğesinden özellik ayarlayıcısını kaldırın veya erişilebilirliğini azaltın</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">{0}, {1} konumsal bağımsız değişkeninin özellik erişimcisiyse bunu genel yapın</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">{0}, {1} konumsal bağımsız değişkeninin özellik erişimcisiyse bunu genel yapın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">Genel veya korumalı bir yöntem, ""Get"" ile başlayan bir ada sahip olur, parametre almaz ve dizi olmayan bir değer döndürür. Yöntem, bir özelliğe dönüşmek için iyi bir aday olabilir.</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">Genel veya korumalı bir yöntem, ""Get"" ile başlayan bir ada sahip olur, parametre almaz ve dizi olmayan bir değer döndürür. Yöntem, bir özelliğe dönüşmek için iyi bir aday olabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Sabit listelerini FlagsAttribute ile işaretleyin</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Sabit listelerini FlagsAttribute ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">Sabit listesi, bir ilgili adlandırılmış sabitler kümesini tanımlayan bir değer türüdür. Bir sabit listesinin adlandırılmış sabitleri anlamlı bir şekilde birleştirilebiliyorsa sabit listesine FlagsAttribute uygulayın.</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">Sabit listesi, bir ilgili adlandırılmış sabitler kümesini tanımlayan bir değer türüdür. Bir sabit listesinin adlandırılmış sabitleri anlamlı bir şekilde birleştirilebiliyorsa sabit listesine FlagsAttribute uygulayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">Sabit listelerini FlagsAttribute ile işaretleyin</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Sabit listelerini FlagsAttribute ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">Genel veya korumalı bir tür, System.IComparable arabirimini uygular. Object.Equals’ı geçersiz kılmaz veya eşitlik, eşitsizlik, küçüktür, küçük eşittir, büyüktür ya da büyük eşittir için dile özgü işleci aşırı yüklemez.</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">Genel veya korumalı bir tür, System.IComparable arabirimini uygular. Object.Equals’ı geçersiz kılmaz veya eşitlik, eşitsizlik, küçüktür, küçük eşittir, büyüktür ya da büyük eşittir için dile özgü işleci aşırı yüklemez.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">{0}, IComparable'ı uyguladığından Equals'ı geçersiz kılmalıdır</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}, IComparable'ı uyguladığından Equals'ı geçersiz kılmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">{0}, IComparable'ı uyguladığından '{1}' işleçlerini tanımlamalıdır</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}, IComparable'ı uyguladığından '{1}' işleçlerini tanımlamalıdır</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">Dışarıdan görünen bir arabirimin adı büyük ""I"" harfiyle başlamaz. Dışarıdan görünen bir tür veya yöntemdeki genel türde bir parametrenin adı büyük ""T"" harfiyle başlamaz.</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">Dışarıdan görünen bir arabirimin adı büyük ""I"" harfiyle başlamaz. Dışarıdan görünen bir tür veya yöntemdeki genel türde bir parametrenin adı büyük ""T"" harfiyle başlamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">{0} arabirim adının önüne 'I' ekleyin</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">{0} arabirim adının önüne 'I' ekleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">Genel türdeki {0} parametre adının önüne 'T' ekleyin</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">Genel türdeki {0} parametre adının önüne 'T' ekleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Sabit listelerini FlagsAttribute ile işaretlemeyin</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Sabit listelerini FlagsAttribute ile işaretlemeyin</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">Dışarıdan görünen bir sabit listesi FlagsAttribute kullanılarak işaretlenir ve ikinin üssü olmayan bir veya daha fazla değere ya da sabit listesindeki diğer tanımlı değerlerin bir birleşimine sahip olur.</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">Dışarıdan görünen bir sabit listesi FlagsAttribute kullanılarak işaretlenir ve ikinin üssü olmayan bir veya daha fazla değere ya da sabit listesindeki diğer tanımlı değerlerin bir birleşimine sahip olur.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">Sabit listelerini FlagsAttribute ile işaretlemeyin</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">Sabit listelerini FlagsAttribute ile işaretlemeyin</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">{1} işleci için kolay bir alternatif olarak '{0}' adlı bir metot sağlayın</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{1} işleci için kolay bir alternatif olarak '{0}' adlı bir metot sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">{1} işleci için kolay bir alternatif olarak '{0}' adlı bir özellik sağlayın</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{1} işleci için kolay bir alternatif olarak '{0}' adlı bir özellik sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">{2} işleci için bir alternatif olarak '{0}' veya '{1}' adlı bir metot sağlayın</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">{2} işleci için bir alternatif olarak '{0}' veya '{1}' adlı bir metot sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">{0}, {1} işleci için kolay bir alternatif olduğundan öğeyi genel olarak işaretleyin</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">{0}, {1} işleci için kolay bir alternatif olduğundan öğeyi genel olarak işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">Object.Equals’ı geçersiz kılarken IEquatable uygulayın</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">Object.Equals’ı geçersiz kılarken IEquatable uygulayın</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">{0} türü Equals metodunu geçersiz kıldığından IEquatable&lt;T&gt; uygulamalıdır</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">{0} türü Equals metodunu geçersiz kıldığından IEquatable&lt;T&gt; uygulamalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken parametreleri en sonda olmalıdır</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken parametreleri en sonda olmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">{0} öğesi dışarıdan görünen türleri kullanıma sunduğundan, bunu bütünleştirilmiş kod düzeyinde ComVisible(false) ile işaretleyin, sonra bütünleştirilmiş kodda bulunan ve COM istemcilerinin kullanımına sunulması gereken tüm türleri ComVisible(true) ile işaretleyin</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">{0} öğesi dışarıdan görünen türleri kullanıma sunduğundan, bunu bütünleştirilmiş kod düzeyinde ComVisible(false) ile işaretleyin, sonra bütünleştirilmiş kodda bulunan ve COM istemcilerinin kullanımına sunulması gereken tüm türleri ComVisible(true) ile işaretleyin</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">{0} öğesindeki ComVisible özniteliğini false olarak değiştirmeyi ve tür düzeyinde kabul etmeyi deneyin</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">{0} öğesindeki ComVisible özniteliğini false olarak değiştirmeyi ve tür düzeyinde kabul etmeyi deneyin</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">IEquatable Uygulayın</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">IEquatable Uygulayın</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">IDisposable Arabirimi Uygulayın</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">IDisposable Arabirimi Uygulayın</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">Sabit listesinden FlagsAttribute öğesini kaldırın.</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">Sabit listesinden FlagsAttribute öğesini kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">Sabit listesine FlagsAttribute öğesini uygulayın.</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">Sabit listesine FlagsAttribute öğesini uygulayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">Sabit Listesi Depolama Alanı Int32 olmalıdır</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">Sabit Listesi Depolama Alanı Int32 olmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">Mümkünse {0} temel türünü {1} yerine System.Int32 yapın</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">Mümkünse {0} temel türünü {1} yerine System.Int32 yapın</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">{0} öğesine şu oluşturucuyu ekleyin: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">{0} öğesine şu oluşturucuyu ekleyin: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">{0} öğesinin erişilebilirliğini {1} olarak değiştirin.</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">{0} öğesinin erişilebilirliğini {1} olarak değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">{0} türünü iç içe tür olarak kullanmayın. Alternatif olarak, erişilebilirliğini dışarıdan görünmeyecek şekilde değiştirin.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">{0} türünü iç içe tür olarak kullanmayın. Alternatif olarak, erişilebilirliğini dışarıdan görünmeyecek şekilde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">{0} türünü iç içe tür olarak kullanmayın. Alternatif olarak, erişilebilirliğini dışarıdan görünmeyecek şekilde değiştirin. Bu tür bir Visual Basic Modülünde tanımlanırsa, diğer .NET dilleri tarafından iç içe bir tür olarak değerlendirilir. Bu durumda, türü Modülün dışına taşımayı deneyin.</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">{0} türünü iç içe tür olarak kullanmayın. Alternatif olarak, erişilebilirliğini dışarıdan görünmeyecek şekilde değiştirin. Bu tür bir Visual Basic Modülünde tanımlanırsa, diğer .NET dilleri tarafından iç içe bir tür olarak değerlendirilir. Bu durumda, türü Modülün dışına taşımayı deneyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">ObsoleteAttribute iletisi sağlayın</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">ObsoleteAttribute iletisi sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">Bir tür veya üye, ObsoleteAttribute.Message özelliği belirtilmemiş bir System.ObsoleteAttribute özniteliği kullanılarak işaretlenir. ObsoleteAttribute kullanılarak işaretlenmiş bir tür veya üye derlendiğinde, özniteliğin Message özelliği görüntülenir. Bu, kullanıcıya eski tür veya üye hakkında bilgi verir.</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">Bir tür veya üye, ObsoleteAttribute.Message özelliği belirtilmemiş bir System.ObsoleteAttribute özniteliği kullanılarak işaretlenir. ObsoleteAttribute kullanılarak işaretlenmiş bir tür veya üye derlendiğinde, özniteliğin Message özelliği görüntülenir. Bu, kullanıcıya eski tür veya üye hakkında bilgi verir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">{0} öğesini Obsolete olarak işaretleyen ObsoleteAttribute için bir ileti sağlayın</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">{0} öğesini Obsolete olarak işaretleyen ObsoleteAttribute için bir ileti sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">{0} özelliği sadece yazılabilir olduğundan, erişilebilirliği en az özellik ayarlayıcısı kadar olan bir özellik alıcısı ekleyin ya da bu özelliği bir metoda dönüştürün</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">{0} özelliği sadece yazılabilir olduğundan, erişilebilirliği en az özellik ayarlayıcısı kadar olan bir özellik alıcısı ekleyin ya da bu özelliği bir metoda dönüştürün</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">{0} için özellik alıcısı, ayarlayıcısından daha az görünür olduğundan alıcının erişilebilirliğini artırın veya ayarlayıcının erişilebilirliğini azaltın</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">{0} için özellik alıcısı, ayarlayıcısından daha az görünür olduğundan alıcının erişilebilirliğini artırın veya ayarlayıcının erişilebilirliğini azaltın</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">IDisposable’ı Doğru Uygulayın</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">IDisposable’ı Doğru Uygulayın</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">Tüm IDisposable türleri, Dispose desenini doğru uygulamalıdır.</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">Tüm IDisposable türleri, Dispose desenini doğru uygulamalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">IDisposable zaten '{1}' temel türü tarafından uygulandığından bunu '{0}' tarafından uygulanan arabirimler listesinden kaldırın</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">IDisposable zaten '{1}' temel türü tarafından uygulandığından bunu '{0}' tarafından uygulanan arabirimler listesinden kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">'{0}' öğesini kaldırın, Dispose(bool disposing) metodunu geçersiz kılın ve atma mantığını 'disposing' değerinin true olduğu kod yoluna yerleştirin</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">'{0}' öğesini kaldırın, Dispose(bool disposing) metodunu geçersiz kılın ve atma mantığını 'disposing' değerinin true olduğu kod yoluna yerleştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">'{0}' metodunu Dispose(true) çağrısı yapacak, sonra geçerli nesne örneğinde (Visual Basic'te 'this' veya 'Me') GC.SuppressFinalize çağrısı yapacak ve sonra dönüş yapacak şekilde değiştirin</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">'{0}' metodunu Dispose(true) çağrısı yapacak, sonra geçerli nesne örneğinde (Visual Basic'te 'this' veya 'Me') GC.SuppressFinalize çağrısı yapacak ve sonra dönüş yapacak şekilde değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">'{0}' metodunu Dispose(false) çağrısı yapacak ve sonra dönüş yapacak şekilde değiştirin</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">'{0}' metodunu Dispose(false) çağrısı yapacak ve sonra dönüş yapacak şekilde değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">'{0}' üzerinde geçersiz kılınabilen bir Dispose(bool) uygulaması sağlayın veya türü mühürlü olarak işaretleyin. Bir Dispose(false) çağrısı yalnızca yerel kaynakları temizlemelidir. Bir Dispose(true) çağrısı hem yönetilen hem yerel kaynakları temizlemelidir.</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">'{0}' üzerinde geçersiz kılınabilen bir Dispose(bool) uygulaması sağlayın veya türü mühürlü olarak işaretleyin. Bir Dispose(false) çağrısı yalnızca yerel kaynakları temizlemelidir. Bir Dispose(true) çağrısı hem yönetilen hem yerel kaynakları temizlemelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">Bir iç özel durum yalnızca kendi iç kapsamı içinde görünür. Özel durum iç kapsamın dışında kaldığında, özel durumun yakalanması için yalnızca temel özel durum kullanılabilir. İç özel durum T:System.Exception, T:System.SystemException veya T:System.ApplicationException öğesinden devralınırsa, dış kod özel durumla ne yapılacağı konusunda yeterli bilgiye sahip olmaz.</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">Bir iç özel durum yalnızca kendi iç kapsamı içinde görünür. Özel durum iç kapsamın dışında kaldığında, özel durumun yakalanması için yalnızca temel özel durum kullanılabilir. İç özel durum T:System.Exception, T:System.SystemException veya T:System.ApplicationException öğesinden devralınırsa, dış kod özel durumla ne yapılacağı konusunda yeterli bilgiye sahip olmaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0}, bir özellikte tetiklenmemesi gereken {1} türünde bir özel durum oluşturuyor. Bu özel durum tetiklenebilirse, farklı bir özel durum türü kullanın, bu özelliği bir yönteme dönüştürün veya bu özelliğin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}, bir özellikte tetiklenmemesi gereken {1} türünde bir özel durum oluşturuyor. Bu özel durum tetiklenebilirse, farklı bir özel durum türü kullanın, bu özelliği bir yönteme dönüştürün veya bu özelliğin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0}, bu tür bir yöntemde tetiklenmemesi gereken {1} türünde bir özel durum oluşturuyor. Bu özel durum tetiklenebilirse, farklı bir özel durum türü kullanın veya bu yöntemin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}, bu tür bir yöntemde tetiklenmemesi gereken {1} türünde bir özel durum oluşturuyor. Bu özel durum tetiklenebilirse, farklı bir özel durum türü kullanın veya bu yöntemin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0}, {1} türünde bir özel durum oluşturuyor. Bu tür bir yöntemde özel durum tetiklenmemelidir. Bu özel durum tetiklenebilirse, bu yöntemin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0}, {1} türünde bir özel durum oluşturuyor. Bu tür bir yöntemde özel durum tetiklenmemelidir. Bu özel durum tetiklenebilirse, bu yöntemin mantığını artık özel durum tetiklemeyecek şekilde değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">Kurallar gereği, tanımlayıcı adları alt çizgi (_) karakterini içermez. Bu kural ad alanlarını, türleri, üyeleri ve parametreleri denetler.</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">Kurallar gereği, tanımlayıcı adları alt çizgi (_) karakterini içermez. Bu kural ad alanlarını, türleri, üyeleri ve parametreleri denetler.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">{0} bütünleştirilmiş kod adından alt çizgileri kaldırın</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">{0} bütünleştirilmiş kod adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">{0} tür adından alt çizgileri kaldırın</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">{0} tür adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">{0} üye adından alt çizgileri kaldırın</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">{0} üye adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">{0} türünde, {1} genel tür parametre adından alt çizgileri kaldırın</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} türünde, {1} genel tür parametre adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">{0} metodunda, {1} genel tür parametre adından alt çizgileri kaldırın</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} metodunda, {1} genel tür parametre adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">{0} üyesinde, {1} parametre adından alt çizgileri kaldırın</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} üyesinde, {1} parametre adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">{0} temsilcisinde, {1} parametre adından alt çizgileri kaldırın</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">{0} temsilcisinde, {1} parametre adından alt çizgileri kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">{0} öğesini '{1}' ile bitecek şekilde yeniden adlandırın</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">{0} öğesini '{1}' ile bitecek şekilde yeniden adlandırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">{0} öğesini 'Collection' veya '{1}' ile bitecek şekilde yeniden adlandırın</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">{0} öğesini 'Collection' veya '{1}' ile bitecek şekilde yeniden adlandırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">{0} tür adını '{1}' ile bitmeyecek şekilde yeniden adlandırın</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">{0} tür adını '{1}' ile bitmeyecek şekilde yeniden adlandırın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">{1} üye adındaki '{0}' sonekini önerilen '2' sayısal alternatifi ile değiştirin ya da bunu, yerini aldığı üyeden ayırt edecek daha anlamlı bir sonek sağlayın</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">{1} üye adındaki '{0}' sonekini önerilen '2' sayısal alternatifi ile değiştirin ya da bunu, yerini aldığı üyeden ayırt edecek daha anlamlı bir sonek sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">{1} tür adındaki '{0}' sonekini önerilen '2' sayısal alternatifi ile değiştirin ya da bunu, yerini aldığı türden ayırt edecek daha anlamlı bir sonek sağlayın</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">{1} tür adındaki '{0}' sonekini önerilen '2' sayısal alternatifi ile değiştirin ya da bunu, yerini aldığı türden ayırt edecek daha anlamlı bir sonek sağlayın</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">{0} sanal/arabirim üyesinde, {1} parametresini ayrılmış dil anahtar sözcüğü '{2}' ile çakışmayacak şekilde yeniden adlandırın. Bir sanal/arabirim üyesindeki bir parametrenin adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların üyeyi geçersiz kılmasını/uygulamasını zorlaştırır.</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">{0} sanal/arabirim üyesinde, {1} parametresini ayrılmış dil anahtar sözcüğü '{2}' ile çakışmayacak şekilde yeniden adlandırın. Bir sanal/arabirim üyesindeki bir parametrenin adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların üyeyi geçersiz kılmasını/uygulamasını zorlaştırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">{0} sanal/arabirim üyesini, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir sanal/arabirim üyesinin adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların üyeyi geçersiz kılmasını/uygulamasını zorlaştırır.</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">{0} sanal/arabirim üyesini, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir sanal/arabirim üyesinin adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların üyeyi geçersiz kılmasını/uygulamasını zorlaştırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">{0} türünü, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir türün adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların türü kullanmasını zorlaştırır.</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">{0} türünü, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir türün adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların türü kullanmasını zorlaştırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">{0} ad alanını, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir ad alanının adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların ad alanını kullanmasını zorlaştırır.</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">{0} ad alanını, ayrılmış dil anahtar sözcüğü '{1}' ile çakışmayacak şekilde yeniden adlandırın. Bir ad alanının adı olarak ayrılmış bir anahtar sözcüğün kullanılması, diğer dillerde kullanıcıların ad alanını kullanmasını zorlaştırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">Genel veya korumalı bir üyenin adı ""Get"" ile başlar ve diğer durumlarda genel veya korumalı bir özelliğin adıyla eşleşir. ""Get"" yöntemleri ve özellikleri, işlevlerini açıkça ayırt eden adlara sahip olmalıdır.</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">Genel veya korumalı bir üyenin adı ""Get"" ile başlar ve diğer durumlarda genel veya korumalı bir özelliğin adıyla eşleşir. ""Get"" yöntemleri ve özellikleri, işlevlerini açıkça ayırt eden adlara sahip olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">{0} tür adı, '{1}' ad alanı adıyla tamamen veya kısmen çakışıyor. Çakışmayı ortadan kaldırmak için iki addan birini değiştirin.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">{0} tür adı, '{1}' ad alanı adıyla tamamen veya kısmen çakışıyor. Çakışmayı ortadan kaldırmak için iki addan birini değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">{0} tür adı, .NET Framework’te tanımlanan '{1}' ad alanı adıyla tamamen veya kısmen çakışıyor. Çakışmayı ortadan kaldırmak için türü yeniden adlandırın.</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">{0} tür adı, .NET Framework’te tanımlanan '{1}' ad alanı adıyla tamamen veya kısmen çakışıyor. Çakışmayı ortadan kaldırmak için türü yeniden adlandırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">{0} üyesinde, {1} parametre adının {3} içinde bildirilen şekilde tanımlayıcıyla eşleşmesini sağlamak için adı {2} olarak değiştirin</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">{0} üyesinde, {1} parametre adının {3} içinde bildirilen şekilde tanımlayıcıyla eşleşmesini sağlamak için adı {2} olarak değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">{1} bütünleştirilmiş kod adındaki '{0}' terimini, tercih edilen '{2}' alternatifiyle değiştirin</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">{1} bütünleştirilmiş kod adındaki '{0}' terimini, tercih edilen '{2}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} üyesinde, {2} parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} üyesinde, {2} parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} temsilcisinde, {2} parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} temsilcisinde, {2} parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} türünde, {2} genel tür parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} türünde, {2} genel tür parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">{0} metodunda, {2} genel tür parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">{0} metodunda, {2} genel tür parametre adındaki '{1}' terimini tercih edilen '{3}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">{1} tür adındaki '{0}' terimini tercih edilen '{2}' alternatifiyle değiştirin</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">{1} tür adındaki '{0}' terimini tercih edilen '{2}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">{1} üye adındaki '{0}' terimini tercih edilen '{2}' alternatifiyle değiştirin</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">{1} üye adındaki '{0}' terimini tercih edilen '{2}' alternatifiyle değiştirin</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{1} bütünleştirilmiş kod adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{1} bütünleştirilmiş kod adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} üyesinde, {2} parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} üyesinde, {2} parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} temsilcisinde, {2} parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} temsilcisinde, {2} parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} türünde, {2} genel tür parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} türünde, {2} genel tür parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{0} metodunda, {2} genel tür parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{0} metodunda, {2} genel tür parametre adındaki '{1}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{1} tür adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{1} tür adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">{1} üye adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">{1} üye adındaki '{0}' terimini uygun bir alternatifle değiştirin veya tamamen kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0}, Equals’ı geçersiz kılmalıdır</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0}, Equals’ı geçersiz kılmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0}, eşitlik (==) ve eşitsizlik (!=) işleçlerini geçersiz kılmalıdır</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0}, eşitlik (==) ve eşitsizlik (!=) işleçlerini geçersiz kılmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">{0} öğesini bir tanımlayıcı ad anahtarıyla imzalayın.</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">{0} öğesini bir tanımlayıcı ad anahtarıyla imzalayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">{0} öğesini dağıtmadan önce öğenin geçerli bir tanımlayıcı adı olduğunu doğrulayın.</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">{0} öğesini dağıtmadan önce öğenin geçerli bir tanımlayıcı adı olduğunu doğrulayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Equals geçersiz kılındığında GetHashCode’u geçersiz kılın</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Equals geçersiz kılındığında GetHashCode’u geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode, geçerli örnek temel alınarak bir değer döndürür ve bu değer, algoritmaların ve veri yapılarının bir karma tablo gibi karmasını oluşturmak için uygundur. Aynı türde ve eşit olan iki nesne, aynı karma kodu döndürmelidir.</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode, geçerli örnek temel alınarak bir değer döndürür ve bu değer, algoritmaların ve veri yapılarının bir karma tablo gibi karmasını oluşturmak için uygundur. Aynı türde ve eşit olan iki nesne, aynı karma kodu döndürmelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">Equals geçersiz kılındığında GetHashCode’u geçersiz kılın</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">Equals geçersiz kılındığında GetHashCode’u geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Aşırı yükleme işleci eşit olduğunda Equals’ı geçersiz kılın</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Aşırı yükleme işleci eşit olduğunda Equals’ı geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">Genel bir tür eşitlik işlecini uygular, ancak Object.Equals’ı geçersiz kılmaz.</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">Genel bir tür eşitlik işlecini uygular, ancak Object.Equals’ı geçersiz kılmaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">Aşırı yükleme işleci eşit olduğunda Equals’ı geçersiz kılın</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">Aşırı yükleme işleci eşit olduğunda Equals’ı geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals’ı geçersiz kılın</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals’ı geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">object.Equals’ı geçersiz kılın</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">object.Equals’ı geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">object.GetHashCode’u geçersiz kılın</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">object.GetHashCode’u geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">Sınıfı Statik Yapın</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">Sınıfı Statik Yapın</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">{0} türü IEquatable&lt;T&gt; uyguladığından Equals metodunu geçersiz kılmalıdır</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">{0} türü IEquatable&lt;T&gt; uyguladığından Equals metodunu geçersiz kılmalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">IEquatable&lt;T&gt; uygularken Object.Equals(object)’i geçersiz kılın</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">IEquatable&lt;T&gt; uygularken Object.Equals(object)’i geçersiz kılın</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">Bir asenkron metot bir Görevi doğrudan bekliyorsa, görevi oluşturan iş parçacığında devamlılık gerçekleşir. Devamlılığa yönelik amacınızı belirtmek için Task.ConfigureAwait(Boolean) çağrısı yapmayı düşünün. İş parçacığı havuzuna devamlılıkları zamanlamaya yönelik görev üzerinde ConfigureAwait(false) çağrısı yaparak kullanıcı arabirimi iş parçacığında kilitlenmeyi önleyin. False geçirmek, uygulamadan bağımsız kitaplıklar için iyi bir seçenektir. Görevde ConfigureAwait(true) çağrısı yapmak, ConfigureAwait öğesini açıkça çağırmamakla aynı davranışa sahiptir. Bu yöntemi açık bir şekilde çağırarak, okuyuculara devamlılığı özgün eşitleme bağlamında gerçekleştirmek istediğinizi bildirirsiniz.</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">Bir asenkron metot bir Görevi doğrudan bekliyorsa, görevi oluşturan iş parçacığında devamlılık gerçekleşir. Devamlılığa yönelik amacınızı belirtmek için Task.ConfigureAwait(Boolean) çağrısı yapmayı düşünün. İş parçacığı havuzuna devamlılıkları zamanlamaya yönelik görev üzerinde ConfigureAwait(false) çağrısı yaparak kullanıcı arabirimi iş parçacığında kilitlenmeyi önleyin. False geçirmek, uygulamadan bağımsız kitaplıklar için iyi bir seçenektir. Görevde ConfigureAwait(true) çağrısı yapmak, ConfigureAwait öğesini açıkça çağırmamakla aynı davranışa sahiptir. Bu yöntemi açık bir şekilde çağırarak, okuyuculara devamlılığı özgün eşitleme bağlamında gerçekleştirmek istediğinizi bildirirsiniz.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Beklenen görevde ConfigureAwait çağrısı yapmayı düşünün</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Beklenen görevde ConfigureAwait çağrısı yapmayı düşünün</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">Beklenen görevde ConfigureAwait çağrısı yapmayı düşünün</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">Beklenen görevde ConfigureAwait çağrısı yapmayı düşünün</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">Bir T türü Object.Equals(object) öğesini geçersiz kıldığında, uygulama karşılaştırma gerçekleştirmeden önce nesne bağımsız değişkenini doğru T türüne dönüştürmelidir. Tür IEquatable&lt;T&gt; arabirimini uyguluyor, dolayısıyla T.Equals(T) metodunu sunuyorsa ve bağımsız değişkenin derleme zamanında T türünde olduğu biliniyorsa, derleyici Object.Equals(object) yerine IEquatable&lt;T&gt;.Equals(T) çağrısı yapabilir ve tür dönüştürmeye gerek kalmadığından performansın artırılması sağlanır.</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">Bir T türü Object.Equals(object) öğesini geçersiz kıldığında, uygulama karşılaştırma gerçekleştirmeden önce nesne bağımsız değişkenini doğru T türüne dönüştürmelidir. Tür IEquatable&lt;T&gt; arabirimini uyguluyor, dolayısıyla T.Equals(T) metodunu sunuyorsa ve bağımsız değişkenin derleme zamanında T türünde olduğu biliniyorsa, derleyici Object.Equals(object) yerine IEquatable&lt;T&gt;.Equals(T) çağrısı yapabilir ve tür dönüştürmeye gerek kalmadığından performansın artırılması sağlanır.</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">{0}, IComparable'ı uyguladığından '{1}' işleçlerini ve Equals'ı tanımlamalıdır</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">{0}, IComparable'ı uyguladığından '{1}' işleçlerini ve Equals'ı tanımlamalıdır</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">{0} öğesinden GC.Collect çağrısını kaldırın. Çöp toplamanın zorlanması genelde gereksizdir ve performansı önemli ölçüde düşürebilir.</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">{0} öğesinden GC.Collect çağrısını kaldırın. Çöp toplamanın zorlanması genelde gereksizdir ve performansı önemli ölçüde düşürebilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">{0} öğesinden Thread.Resume çağrısını kaldırın. Sistem önemli bir sistem türünün sınıf oluşturucusunu yürütme ya da paylaşılan bir bütünleştirilmiş kod için güvenliği çözümleme gibi kritik bir işlemin ortasındaysa iş parçacıklarının askıya alınıp sürdürülmesi tehlikeli olabilir.</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">{0} öğesinden Thread.Resume çağrısını kaldırın. Sistem önemli bir sistem türünün sınıf oluşturucusunu yürütme ya da paylaşılan bir bütünleştirilmiş kod için güvenliği çözümleme gibi kritik bir işlemin ortasındaysa iş parçacıklarının askıya alınıp sürdürülmesi tehlikeli olabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">{0} öğesinden Thread.Suspend çağrısını kaldırın. Sistem önemli bir sistem türünün sınıf oluşturucusunu yürütme ya da paylaşılan bir bütünleştirilmiş kod için güvenliği çözümleme gibi kritik bir işlemin ortasındaysa iş parçacıklarının askıya alınıp sürdürülmesi tehlikeli olabilir.</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">{0} öğesinden Thread.Suspend çağrısını kaldırın. Sistem önemli bir sistem türünün sınıf oluşturucusunu yürütme ya da paylaşılan bir bütünleştirilmiş kod için güvenliği çözümleme gibi kritik bir işlemin ortasındaysa iş parçacıklarının askıya alınıp sürdürülmesi tehlikeli olabilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">{0} öğesinden BindingFlags.NonPublic bağlamalı System.Type.InvokeMember çağrısını kaldırın. Özel bir üyede bağımlılık alınması, gelecekte bozucu değişiklik olasılığını artırır.</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">{0} öğesinden BindingFlags.NonPublic bağlamalı System.Type.InvokeMember çağrısını kaldırın. Özel bir üyede bağımlılık alınması, gelecekte bozucu değişiklik olasılığını artırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0}, çalışma zamanı başlatıldıktan sonra güvenilir bir şekilde çağrılamayacak OLE32 API’ye yönelik bir P/Invoke bildirimi. Geçici çözüm, rutini çağıracak yönetilmeyen bir dolgu yazmak, sonra da etkinleştirip yönetilen koda çağırmaktır. Bunu karışık modlu bir C++ DLL’den dışarı aktarmayı kullanarak, COM ile kullanılmak üzere yönetilen bir bileşen kaydederek ya da çalışma zamanı barındırma API’sini kullanarak yapabilirsiniz.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0}, çalışma zamanı başlatıldıktan sonra güvenilir bir şekilde çağrılamayacak OLE32 API’ye yönelik bir P/Invoke bildirimi. Geçici çözüm, rutini çağıracak yönetilmeyen bir dolgu yazmak, sonra da etkinleştirip yönetilen koda çağırmaktır. Bunu karışık modlu bir C++ DLL’den dışarı aktarmayı kullanarak, COM ile kullanılmak üzere yönetilen bir bileşen kaydederek ya da çalışma zamanı barındırma API’sini kullanarak yapabilirsiniz.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0}, çalışma zamanında çağrılabilecek bir sarmalayıcıya (bir COM nesnesini sarmalayan bir yönetilen nesne) göre güvenilir bir şekilde çağrılamayacak OLE32 API’ye yönelik bir P/Invoke bildirimi. Çalışma zamanında çağrılabilen sarmalayıcılar arabirim işaretçilerini dinamik olarak getirdiğinden, çağrının etkisi rastgele olarak kaybolabilir. Belirli bir COM nesnesi için çalışma zamanında çağrılabilen sarmalayıcılar uygulama etki alanının tamamında da paylaşıldığından, çağrının diğer kullanıcıları etkileme olasılığı vardır. Bu çağrıyı, uygun CoSetProxyBlanket çağrılarını gerçekleştiren arabirim işaretçisi için yerel bir sarmalayıcı COM nesnesiyle değiştirin.</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0}, çalışma zamanında çağrılabilecek bir sarmalayıcıya (bir COM nesnesini sarmalayan bir yönetilen nesne) göre güvenilir bir şekilde çağrılamayacak OLE32 API’ye yönelik bir P/Invoke bildirimi. Çalışma zamanında çağrılabilen sarmalayıcılar arabirim işaretçilerini dinamik olarak getirdiğinden, çağrının etkisi rastgele olarak kaybolabilir. Belirli bir COM nesnesi için çalışma zamanında çağrılabilen sarmalayıcılar uygulama etki alanının tamamında da paylaşıldığından, çağrının diğer kullanıcıları etkileme olasılığı vardır. Bu çağrıyı, uygun CoSetProxyBlanket çağrılarını gerçekleştiren arabirim işaretçisi için yerel bir sarmalayıcı COM nesnesiyle değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">{0} öğesinden SafeHandle.DangerousGetHandle çağrısını kaldırın</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">{0} öğesinden SafeHandle.DangerousGetHandle çağrısını kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">{0} öğesinden Assembly.LoadFrom çağrısını kaldırın</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">{0} öğesinden Assembly.LoadFrom çağrısını kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">{0} öğesinden Assembly.LoadFile çağrısını kaldırın</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">{0} öğesinden Assembly.LoadFile çağrısını kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">{0} öğesinden Assembly.LoadWithPartialName çağrısını kaldırın</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">{0} öğesinden Assembly.LoadWithPartialName çağrısını kaldırın</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} {1} içinde tanımlanmış bir değişkendir ve tür üzerindeki bir örnek alanıyla aynı ada sahiptir. Bu öğelerden birinin adını değiştirin.</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} {1} içinde tanımlanmış bir değişkendir ve tür üzerindeki bir örnek alanıyla aynı ada sahiptir. Bu öğelerden birinin adını değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} {1} içinde tanımlanmış bir parametredir ve tür üzerindeki bir örnek alanıyla aynı ada sahiptir. Bu öğelerden birinin adını değiştirin.</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} {1} içinde tanımlanmış bir parametredir ve tür üzerindeki bir örnek alanıyla aynı ada sahiptir. Bu öğelerden birinin adını değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">{1} yönteminin {0} parametresi hiçbir zaman kullanılmıyor. Parametreyi kaldırın veya yöntem gövdesinde kullanın.</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">{1} yönteminin {0} parametresi hiçbir zaman kullanılmıyor. Parametreyi kaldırın veya yöntem gövdesinde kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} hiçbir zaman kullanılmayan yeni bir {1} örneği oluşturuyor. Örneği bir bağımsız değişken olarak başka yönteme geçirin, örneği bir değişkene atayın ya da gereksizse nesne oluşturmayı kaldırın.</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} hiçbir zaman kullanılmayan yeni bir {1} örneği oluşturuyor. Örneği bir bağımsız değişken olarak başka yönteme geçirin, örneği bir değişkene atayın ya da gereksizse nesne oluşturmayı kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0}, {1} çağırıyor ancak yöntemin döndürdüğü yeni dize örneğini kullanmıyor. Örneği bir bağımsız değişken olarak başka yönteme geçirin, örneği bir değişkene atayın ya da gereksizse çağrıyı kaldırın.</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0}, {1} çağırıyor ancak yöntemin döndürdüğü yeni dize örneğini kullanmıyor. Örneği bir bağımsız değişken olarak başka yönteme geçirin, örneği bir değişkene atayın ya da gereksizse çağrıyı kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0}, {1} çağırıyor ancak yöntemin döndürdüğü HRESULT veya hata kodunu kullanmıyor. Bu, hata koşullarında ya da düşük kaynak durumlarında beklenmedik davranışlara neden olabilir. Bir koşullu ifadedeki sonucu kullanın, sonucu bir değişkene atayın veya bir bağımsız değişken olarak başka bir yönteme geçirin.</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0}, {1} çağırıyor ancak yöntemin döndürdüğü HRESULT veya hata kodunu kullanmıyor. Bu, hata koşullarında ya da düşük kaynak durumlarında beklenmedik davranışlara neden olabilir. Bir koşullu ifadedeki sonucu kullanın, sonucu bir değişkene atayın veya bir bağımsız değişken olarak başka bir yönteme geçirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0}, {1} çağırıyor ancak dönüşümün başarılı olup olmadığını açıkça denetlemiyor. Dönüş değerini koşullu bir ifadede kullanın veya çağırma sitesinin çıkış değerinin dönüşüm başarısız olduğunda varsayılan değere ayarlanmasını beklediğini doğrulayın.</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0}, {1} çağırıyor ancak dönüşümün başarılı olup olmadığını açıkça denetlemiyor. Dönüş değerini koşullu bir ifadede kullanın veya çağırma sitesinin çıkış değerinin dönüşüm başarısız olduğunda varsayılan değere ayarlanmasını beklediğini doğrulayın.</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} hiç örneklenmemiş gibi görünen bir iç sınıftır. Öyleyse, kodu derlemeden kaldırın. Bu sınıfın yalnızca statik üyeler içermesi gerekiyorsa, statik yapın (Visual Basic’te Shared).</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} hiç örneklenmemiş gibi görünen bir iç sınıftır. Öyleyse, kodu derlemeden kaldırın. Bu sınıfın yalnızca statik üyeler içermesi gerekiyorsa, statik yapın (Visual Basic’te Shared).</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} {1} çağırıyor ancak yöntemin döndürdüğü değeri kullanmıyor. {1} Saf yöntem olarak işaretlendiğinden yan etkilere sahip olamaz. Bir koşullu ifadedeki sonucu kullanın, sonucu bir değişkene atayın veya bir bağımsız değişken olarak başka bir yönteme geçirin.</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} {1} çağırıyor ancak yöntemin döndürdüğü değeri kullanmıyor. {1} Saf yöntem olarak işaretlendiğinden yan etkilere sahip olamaz. Bir koşullu ifadedeki sonucu kullanın, sonucu bir değişkene atayın veya bir bağımsız değişken olarak başka bir yönteme geçirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">{0} özelliği kendisine atanmamalıdır</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">{0} özelliği kendisine atanmamalıdır</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}, çok boyutlu bir dizi. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}, çok boyutlu bir dizi. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}, çok boyutlu {1} dizisini döndürüyor. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}, çok boyutlu {1} dizisini döndürüyor. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0}, çok boyutlu {1} dizisini kullanıyor. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0}, çok boyutlu {1} dizisini kullanıyor. Mümkünse bunu düzensiz bir diziyle değiştirin.</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">避免使用 Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">避免使用 Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">避免使用 Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">避免使用 Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">异步方法名称应以 Async 结尾</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">异步方法名称应以 Async 结尾</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">异步方法名称应以 Async 结尾</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">异步方法名称应以 Async 结尾</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">考虑使用“{0}”所含类型参数不超过 {1} 个的设计</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">考虑使用“{0}”所含类型参数不超过 {1} 个的设计</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">避免使用 out 参数</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">避免使用 out 参数</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; 是设计用于性能和非继承的泛型集合。List&lt;T&gt; 不包含可使更改继承类的行为变得更容易的虚拟成员。</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; 是设计用于性能和非继承的泛型集合。List&lt;T&gt; 不包含可使更改继承类的行为变得更容易的虚拟成员。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型传递</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">不要将异步 Lambda 作为 Void 返回委托类型传递</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型传递</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">不要将异步 Lambda 作为 Void 返回委托类型传递</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">要按引用传递类型(使用 out 或 ref)，需具备指针方面的经验、了解值类型和引用类型之间的区别，并处理具有多个返回值的方法。此外，out 和 ref 参数之间的差异未被广泛理解。</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">要按引用传递类型(使用 out 或 ref)，需具备指针方面的经验、了解值类型和引用类型之间的区别，并处理具有多个返回值的方法。此外，out 和 ref 参数之间的差异未被广泛理解。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型存储</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">不要将异步 Lambda 作为 Void 返回委托类型存储</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">不要将异步 Lambda 作为 Void 返回委托类型存储</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">不要将异步 Lambda 作为 Void 返回委托类型存储</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">从类型“{0}”中删除终结器，替代 Dispose(bool disposing)，并在 "disposing" 为 false 的代码路径中放置终结逻辑。否则，它可能导致出现重复的 Dispose 调用，因为基类型“{1}”也提供终结器。</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">从类型“{0}”中删除终结器，替代 Dispose(bool disposing)，并在 "disposing" 为 false 的代码路径中放置终结逻辑。否则，它可能导致出现重复的 Dispose 调用，因为基类型“{1}”也提供终结器。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">如有可能，传播 CancellationTokens</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">如有可能，传播 CancellationTokens</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">如有可能，传播 CancellationTokens</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">如有可能，传播 CancellationTokens</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">不要混合阻止和异步</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">不要混合阻止和异步</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">不要混合阻止和异步</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">不要混合阻止和异步</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">在枚举 {0} 中，将 {1} 的名称改为 "None"</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">在枚举 {0} 中，将 {1} 的名称改为 "None"</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">从 {0} 中删除所有值为零的成员(名为 "None" 的成员除外)</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">从 {0} 中删除所有值为零的成员(名为 "None" 的成员除外)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">将一个值为零且建议名称为 "None" 的成员添加到 {0} 中</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">将一个值为零且建议名称为 "None" 的成员添加到 {0} 中</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">公共语言规范 (CLS) 定义命名限制、数据类型和跨编程语言使用程序集时程序集必须遵循的规则。好的设计要求所有程序集使用 CLSCompliantAttribute 显式指示 CLS 符合性。如果程序集上不存在此属性，则程序集不符合。</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">公共语言规范 (CLS) 定义命名限制、数据类型和跨编程语言使用程序集时程序集必须遵循的规则。好的设计要求所有程序集使用 CLSCompliantAttribute 显式指示 CLS 符合性。如果程序集上不存在此属性，则程序集不符合。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">用 CLSCompliant 标记程序集</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">用 CLSCompliant 标记程序集</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">用 ComVisible 标记程序集</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">用 ComVisible 标记程序集</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">因为 {0} 公开外部可见的类型，请在程序集级别使用 ComVisible(false) 来标记它，然后使用 ComVisible(true) 来标记该程序集内应当向 COM 客户端公开的所有类型。</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">因为 {0} 公开外部可见的类型，请在程序集级别使用 ComVisible(false) 来标记它，然后使用 ComVisible(true) 来标记该程序集内应当向 COM 客户端公开的所有类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">用 AttributeUsageAttribute 标记属性</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">用 AttributeUsageAttribute 标记属性</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">定义自定义属性时，使用 AttributeUsageAttribute 标记该属性，指示可在源代码中应用该自定义属性的位置。属性的含义和目标用途确定其在代码中的有效位置。</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">定义自定义属性时，使用 AttributeUsageAttribute 标记该属性，指示可在源代码中应用该自定义属性的位置。属性的含义和目标用途确定其在代码中的有效位置。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">在 {0} 上指定 AttributeUsage</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">在 {0} 上指定 AttributeUsage</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">虽然属性 {0} 从其基类型继承了 AttributeUsage 属性，但你还是应该考虑在该类型中显式指定 AttributeUsage 属性，以便提高代码可读性和便于文档制作。</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">虽然属性 {0} 从其基类型继承了 AttributeUsage 属性，但你还是应该考虑在该类型中显式指定 AttributeUsage 属性，以便提高代码可读性和便于文档制作。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">为特性 {1} 的位置参数 {0} 添加一个公共的只读属性访问器</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">为特性 {1} 的位置参数 {0} 添加一个公共的只读属性访问器</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">由于属性 setter 对应于位置参数 {1}，因此请将它从 {0} 中删除或者降低它的可访问性</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">由于属性 setter 对应于位置参数 {1}，因此请将它从 {0} 中删除或者降低它的可访问性</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">如果 {0} 是位置参数 {1} 的属性访问器，请使它成为公共访问器</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">如果 {0} 是位置参数 {1} 的属性访问器，请使它成为公共访问器</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">公共或受保护的方法具有以 "Get" 开头的名称，不包含参数，并返回非数组的值。该方法可能是成为属性的不错选择。</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">公共或受保护的方法具有以 "Get" 开头的名称，不包含参数，并返回非数组的值。该方法可能是成为属性的不错选择。</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">用 FlagsAttribute 标记枚举</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">用 FlagsAttribute 标记枚举</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">枚举是一种值类型，它定义一组相关的命名常量。可以有意地合并 FlagsAttribute 的命名常量时，将其应用于枚举。</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">枚举是一种值类型，它定义一组相关的命名常量。可以有意地合并 FlagsAttribute 的命名常量时，将其应用于枚举。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">用 FlagsAttribute 标记枚举</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">用 FlagsAttribute 标记枚举</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">公共类型或受保护的类型实现 System.IComparable 接口。它不重写 Object.Equals，也不重载用于等式、不等式、小于、小于等于、大于或大于等于的语言特定的运算符。</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">公共类型或受保护的类型实现 System.IComparable 接口。它不重写 Object.Equals，也不重载用于等式、不等式、小于、小于等于、大于或大于等于的语言特定的运算符。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">由于 {0} 实现 IComparable，因此，它应重写等于运算符</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">由于 {0} 实现 IComparable，因此，它应重写等于运算符</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">由于 {0} 实现 IComparable，因此它应定义“{1}”运算符</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">由于 {0} 实现 IComparable，因此它应定义“{1}”运算符</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">外部可见的接口的名称不以大写字母 "I" 开头。外部可见的类型或方法上的泛型类型参数的名称不以大写字母 "T" 开头。</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">外部可见的接口的名称不以大写字母 "I" 开头。外部可见的类型或方法上的泛型类型参数的名称不以大写字母 "T" 开头。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">为接口名称 {0} 加上前缀 "I"</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">为接口名称 {0} 加上前缀 "I"</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">为泛型类型参数名称 {0} 加上前缀 "T"</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">为泛型类型参数名称 {0} 加上前缀 "T"</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">不要使用 FlagsAttribute 标记枚举</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">不要使用 FlagsAttribute 标记枚举</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">外部可见的枚举通过 FlagsAttribute 标记，并且它的一个或多个值不是 2 的幂或枚举上定义的其他值的组合。</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">外部可见的枚举通过 FlagsAttribute 标记，并且它的一个或多个值不是 2 的幂或枚举上定义的其他值的组合。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">不要使用 FlagsAttribute 标记枚举</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">不要使用 FlagsAttribute 标记枚举</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">提供名为“{0}”的方法作为运算符 {1} 的友好备用项</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">提供名为“{0}”的方法作为运算符 {1} 的友好备用项</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">提供名为“{0}”的属性作为运算符 {1} 的友好备用项</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">提供名为“{0}”的属性作为运算符 {1} 的友好备用项</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">提供名为“{0}”或“{1}”的方法作为运算符 {2} 的备用项</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">提供名为“{0}”或“{1}”的方法作为运算符 {2} 的备用项</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">将 {0} 标记为 public，因为它是运算符 {1} 的友好备用项</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">将 {0} 标记为 public，因为它是运算符 {1} 的友好备用项</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">重写 Object.Equals 时实现 IEquatable</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">重写 Object.Equals 时实现 IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">类型 {0} 应实现 IEquatable&lt;T&gt; ，因为它将替代 Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">类型 {0} 应实现 IEquatable&lt;T&gt; ，因为它将替代 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken 参数必须最后出现</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken 参数必须最后出现</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">因为 {0} 公开外部可见的类型，请在程序集级别使用 ComVisible(false) 来标记它，然后使用 ComVisible(true) 来标记该程序集内应当向 COM 客户端公开的所有类型</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">因为 {0} 公开外部可见的类型，请在程序集级别使用 ComVisible(false) 来标记它，然后使用 ComVisible(true) 来标记该程序集内应当向 COM 客户端公开的所有类型</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">考虑将 {0} 的 ComVisible 属性改为 false，然后在类型级别进行选择</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">考虑将 {0} 的 ComVisible 属性改为 false，然后在类型级别进行选择</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">实现 IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">实现 IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">实现 IDisposable 接口</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">实现 IDisposable 接口</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">从枚举中删除 FlagsAttribute。</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">从枚举中删除 FlagsAttribute。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">向枚举应用 FlagsAttribute。</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">向枚举应用 FlagsAttribute。</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">枚举存储应为 Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">枚举存储应为 Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">如有可能，请将 {0} 的基础类型设为 System.Int32，而不是 {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">如有可能，请将 {0} 的基础类型设为 System.Int32，而不是 {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">将下列构造函数添加到 {0}: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">将下列构造函数添加到 {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">将 {0} 的可访问性更改为 {1}。</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">将 {0} 的可访问性更改为 {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">不要嵌套类型 {0}。或者，更改其可访问性，使它在外部不可见。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">不要嵌套类型 {0}。或者，更改其可访问性，使它在外部不可见。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">不要嵌套类型 {0}。或者，更改其可访问性，使它在外部不可见。如果此类型是在 Visual Basic 模块中定义的，则其他 .NET 语言会将其视为嵌套类型。在这种情况下，请考虑将该类型移出 Visual Basic 模块。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">不要嵌套类型 {0}。或者，更改其可访问性，使它在外部不可见。如果此类型是在 Visual Basic 模块中定义的，则其他 .NET 语言会将其视为嵌套类型。在这种情况下，请考虑将该类型移出 Visual Basic 模块。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">提供 ObsoleteAttribute 消息</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">提供 ObsoleteAttribute 消息</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">使用 System.ObsoleteAttribute 特性标记类型或成员，该特性的 ObsoleteAttribute.Message 属性尚未指定。编译使用 ObsoleteAttribute 标记的类型或成员时，将显示该特性的消息属性。这为用户提供有关过时的类型或成员的信息。</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">使用 System.ObsoleteAttribute 特性标记类型或成员，该特性的 ObsoleteAttribute.Message 属性尚未指定。编译使用 ObsoleteAttribute 标记的类型或成员时，将显示该特性的消息属性。这为用户提供有关过时的类型或成员的信息。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">为将 {0} 标记为过时的 ObsoleteAttribute 提供消息</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">为将 {0} 标记为过时的 ObsoleteAttribute 提供消息</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">由于属性 {0} 是只写的，因此，要么添加一个可访问性高于或等于 setter 的 getter 属性，要么将该属性转换为方法</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">由于属性 {0} 是只写的，因此，要么添加一个可访问性高于或等于 setter 的 getter 属性，要么将该属性转换为方法</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">由于 {0} 的属性 getter 的可见性低于 setter，因此，要么提高 getter 的可访问性，要么降低 getter 的可访问性</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">由于 {0} 的属性 getter 的可见性低于 setter，因此，要么提高 getter 的可访问性，要么降低 getter 的可访问性</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">正确实现 IDisposable</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">正确实现 IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">所有 IDisposable 类型都应正确实现 Dispose 模式。</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">所有 IDisposable 类型都应正确实现 Dispose 模式。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">从“{0}”实现的接口列表中删除 IDisposable，因为它已由基类型“{1}”实现</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">从“{0}”实现的接口列表中删除 IDisposable，因为它已由基类型“{1}”实现</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">删除“{0}”，替代 Dispose(bool disposing)，并在 "disposing" 为 true 的代码路径中加入释放逻辑</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">删除“{0}”，替代 Dispose(bool disposing)，并在 "disposing" 为 true 的代码路径中加入释放逻辑</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">修改“{0}”，使其调用 Dispose(true)，再对当前对象实例调用 GC.SuppressFinalize (Visual Basic 中的“此项”或“我”)，然后返回</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">修改“{0}”，使其调用 Dispose(true)，再对当前对象实例调用 GC.SuppressFinalize (Visual Basic 中的“此项”或“我”)，然后返回</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">修改“{0}”，使其调用 Dispose(false)，然后再返回</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">修改“{0}”，使其调用 Dispose(false)，然后再返回</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">对 {0} 提供 Dispose(bool) 的可重写实现或将该类型标记为“已密封”。对 Dispose(false) 的调用应仅清理本机资源。对 Dispose(true) 的调用应同时清理托管资源和本机资源。</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">对 {0} 提供 Dispose(bool) 的可重写实现或将该类型标记为“已密封”。对 Dispose(false) 的调用应仅清理本机资源。对 Dispose(true) 的调用应同时清理托管资源和本机资源。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">内部异常仅在其内部范围内可见。在异常超出内部范围后，只能使用基异常来捕获异常。如果内部异常继承自 T:System.Exception、T:System.SystemException 或 T:System.ApplicationException，则外部代码将不具有足够的信息用于处理异常。</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">内部异常仅在其内部范围内可见。在异常超出内部范围后，只能使用基异常来捕获异常。如果内部异常继承自 T:System.Exception、T:System.SystemException 或 T:System.ApplicationException，则外部代码将不具有足够的信息用于处理异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} 创建 {1} 类型的异常，该异常类型不应当在属性中引发。如果有可能会引发此异常实例，请使用其他异常类型，将该属性转换为方法，或者更改该属性的逻辑，使它不再引发异常。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 创建 {1} 类型的异常，该异常类型不应当在属性中引发。如果有可能会引发此异常实例，请使用其他异常类型，将该属性转换为方法，或者更改该属性的逻辑，使它不再引发异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} 创建 {1} 类型的异常，该异常类型不应当在这种类型的方法中引发。如果有可能会引发此异常实例，请使用其他异常类型，或者更改该方法的逻辑，使它不再引发异常。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 创建 {1} 类型的异常，该异常类型不应当在这种类型的方法中引发。如果有可能会引发此异常实例，请使用其他异常类型，或者更改该方法的逻辑，使它不再引发异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} 创建 {1} 类型的异常。不应在这种类型的方法中引发异常。如果有可能会引发此异常实例，请更改该方法的逻辑，使它不再引发异常。</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 创建 {1} 类型的异常。不应在这种类型的方法中引发异常。如果有可能会引发此异常实例，请更改该方法的逻辑，使它不再引发异常。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">按照惯例，标识符名称不包含下划线(_)字符。此规则检查命名空间、类型、成员和参数。</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">按照惯例，标识符名称不包含下划线(_)字符。此规则检查命名空间、类型、成员和参数。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">从程序集名称 {0} 中删除下划线</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">从程序集名称 {0} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">从类型名称 {0} 中删除下划线</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">从类型名称 {0} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">从成员名称 {0} 中删除下划线</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">从成员名称 {0} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">在类型 {0} 上，从泛型类型参数名称 {1} 中删除下划线</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">在类型 {0} 上，从泛型类型参数名称 {1} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">在方法 {0} 上，从泛型类型参数名称 {1} 中删除下划线</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">在方法 {0} 上，从泛型类型参数名称 {1} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">在成员 {0} 中，从参数名称 {1} 中删除下划线</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">在成员 {0} 中，从参数名称 {1} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">在委托 {0} 中，从参数名称 {1} 中删除下划线</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">在委托 {0} 中，从参数名称 {1} 中删除下划线</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">重命名 {0}，使其以“{1}”结尾</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">重命名 {0}，使其以“{1}”结尾</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">重命名 {0}，使其以 "Collection" 或“{1}”结尾</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">重命名 {0}，使其以 "Collection" 或“{1}”结尾</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">重命名类型名称 {0}，使其不以“{1}”结尾</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">重命名类型名称 {0}，使其不以“{1}”结尾</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">要么将成员名称 {1} 中的后缀“{0}”替换为所建议的数值“2”，要么提供一个更能体现其意义的后缀，将它与它所替换的成员区分开来</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">要么将成员名称 {1} 中的后缀“{0}”替换为所建议的数值“2”，要么提供一个更能体现其意义的后缀，将它与它所替换的成员区分开来</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">要么将类型名称 {1} 中的后缀“{0}”替换为所建议的数值“2”，要么提供一个更能体现其意义的后缀，将它与它所替换的类型区分开来</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">要么将类型名称 {1} 中的后缀“{0}”替换为所建议的数值“2”，要么提供一个更能体现其意义的后缀，将它与它所替换的类型区分开来</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">在虚拟/接口成员 {0} 中，重命名参数 {1}，使它不再与保留的语言关键字“{2}”冲突。如果使用保留的关键字作为虚拟/接口成员上参数的名称，则会使其他语言的使用者很难重写/实现该成员。</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">在虚拟/接口成员 {0} 中，重命名参数 {1}，使它不再与保留的语言关键字“{2}”冲突。如果使用保留的关键字作为虚拟/接口成员上参数的名称，则会使其他语言的使用者很难重写/实现该成员。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">重命名虚拟/接口成员 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为虚拟/接口成员的名称，则会使其他语言的使用者很难重写/实现该成员。</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">重命名虚拟/接口成员 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为虚拟/接口成员的名称，则会使其他语言的使用者很难重写/实现该成员。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">重命名类型 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为类型的名称，则会使其他语言的使用者很难使用该类型。</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">重命名类型 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为类型的名称，则会使其他语言的使用者很难使用该类型。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">重命名命名空间 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为命名空间的名称，则会使其他语言的使用者很难使用该命名空间。</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">重命名命名空间 {0}，使它不再与保留的语言关键字“{1}”冲突。如果使用保留的关键字作为命名空间的名称，则会使其他语言的使用者很难使用该命名空间。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">公共或受保护成员的名称以 "Get" 开头，否则与公共或受保护属性的名称相匹配。"Get" 方法和属性应具有明确区分其功能的名称。</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">公共或受保护成员的名称以 "Get" 开头，否则与公共或受保护属性的名称相匹配。"Get" 方法和属性应具有明确区分其功能的名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">类型名 {0} 与命名空间名称“{1}”整体或部分冲突。请更改其中任一名称以消除冲突。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">类型名 {0} 与命名空间名称“{1}”整体或部分冲突。请更改其中任一名称以消除冲突。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">类型名 {0} 与在 .NET Framework 中定义的命名空间名称“{1}”整体或部分冲突。请重命名该类型以消除冲突。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">类型名 {0} 与在 .NET Framework 中定义的命名空间名称“{1}”整体或部分冲突。请重命名该类型以消除冲突。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">在成员 {0} 中，将参数名 {1} 改为 {2}，使其与已在 {3} 中声明的标识符匹配</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">在成员 {0} 中，将参数名 {1} 改为 {2}，使其与已在 {3} 中声明的标识符匹配</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">将程序集名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">将程序集名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在成员 {0} 中，将参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在成员 {0} 中，将参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在委托 {0} 中，将参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在委托 {0} 中，将参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在类型 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在类型 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在方法 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在方法 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为首选替代项“{3}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">将类型名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">将类型名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">将成员名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">将成员名称 {1} 中的词条“{0}”替换为首选替代项“{2}”</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">将程序集名称 {1} 中的词条“{0}”替换为相应的替代项或者完全删除</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">将程序集名称 {1} 中的词条“{0}”替换为相应的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在成员 {0} 中，将参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在成员 {0} 中，将参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在委托 {0} 中，将参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在委托 {0} 中，将参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在类型 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在类型 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为相应的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在方法 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为合适的替代项或者完全删除</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在方法 {0} 中，将泛型类型参数名称 {2} 中的词条“{1}”替换为合适的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">将类型名称 {1} 中的词条“{0}”替换为相应的替代项或者完全删除</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">将类型名称 {1} 中的词条“{0}”替换为相应的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">将成员名称 {1} 中的词条“{0}”替换为合适的替代项或者完全删除</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">将成员名称 {1} 中的词条“{0}”替换为合适的替代项或者完全删除</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} 应重写 Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} 应重写 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} 应重写相等(==)和不相等(!=)运算符</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} 应重写相等(==)和不相等(!=)运算符</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">用强名称密钥对 {0} 进行签名。</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">用强名称密钥对 {0} 进行签名。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">在部署前验证 {0} 是否具有有效的强名称。</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">在部署前验证 {0} 是否具有有效的强名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">重写 Equals 时重写 GetHashCode</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">重写 Equals 时重写 GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode 基于当前实例返回一个值，该值适用于哈希算法和数据结构(如哈希表)。类型相同且相等的两个对象必须返回相同哈希代码。</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode 基于当前实例返回一个值，该值适用于哈希算法和数据结构(如哈希表)。类型相同且相等的两个对象必须返回相同哈希代码。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">重写 Equals 时重写 GetHashCode</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">重写 Equals 时重写 GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">重载相等运算符时重写 Equals 方法</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">重载相等运算符时重写 Equals 方法</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">公共类型实现相等运算符但不重写 Object.Equals。</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">公共类型实现相等运算符但不重写 Object.Equals。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">重载相等运算符时重写 Equals 方法</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">重载相等运算符时重写 Equals 方法</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">重写 object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">重写 object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">重写 object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">重写 object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">重写 object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">重写 object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">使类变为静态</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">使类变为静态</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">类型 {0} 应替代 Equals，因为它实现 IEquatable&lt;T&gt;</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">类型 {0} 应替代 Equals，因为它实现 IEquatable&lt;T&gt;</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">在实现 IEquatable&lt;T&gt; 时替代 Object.Equals(object)</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">在实现 IEquatable&lt;T&gt; 时替代 Object.Equals(object)</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">当异步方法直接等待任务时，在创建该任务的同一线程中执行继续操作。请考虑调用 Task.ConfigureAwait(Boolean)以告知你打算继续。对任务调用 ConfigureAwait(false)以将继续操作安排到线程池，从而避免 UI 线程上出现死锁。对于独立于应用的库，最好选择传递 false。对任务调用 ConfigureAwait(true) 的行为与不显式调用 ConfigureAwait 相同。通过显式调用此方法，可以让读者知道你有意要对原始同步上下文执行继续操作。</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">当异步方法直接等待任务时，在创建该任务的同一线程中执行继续操作。请考虑调用 Task.ConfigureAwait(Boolean)以告知你打算继续。对任务调用 ConfigureAwait(false)以将继续操作安排到线程池，从而避免 UI 线程上出现死锁。对于独立于应用的库，最好选择传递 false。对任务调用 ConfigureAwait(true) 的行为与不显式调用 ConfigureAwait 相同。通过显式调用此方法，可以让读者知道你有意要对原始同步上下文执行继续操作。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">考虑对等待的任务调用 ConfigureAwait</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">考虑对等待的任务调用 ConfigureAwait</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">考虑对等待的任务调用 ConfigureAwait</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">考虑对等待的任务调用 ConfigureAwait</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">当类型 T 替代 Object.Equals(object) 时，该实现必须在执行比较前将 object 参数强制转换为正确的类型 T。如果该类型实现了 IEquatable&lt;T&gt;，并因此提供了方法 T.Equals(T)，如果在编译时已知参数为类型 T，则编译器可以调用 IEquatable&lt;T&gt;.Equals(T) 而不是 Object.Equals(object) 来提高性能，并且无需强制转换。</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">当类型 T 替代 Object.Equals(object) 时，该实现必须在执行比较前将 object 参数强制转换为正确的类型 T。如果该类型实现了 IEquatable&lt;T&gt;，并因此提供了方法 T.Equals(T)，如果在编译时已知参数为类型 T，则编译器可以调用 IEquatable&lt;T&gt;.Equals(T) 而不是 Object.Equals(object) 来提高性能，并且无需强制转换。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">由于 {0} 实现 IComparable，因此它应定义“{1}”运算符和等于运算符</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">由于 {0} 实现 IComparable，因此它应定义“{1}”运算符和等于运算符</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">从 {0} 中删除对 GC.Collect 的调用。通常不必强制进行垃圾回收，强制进行垃圾回收可能会严重降低性能。</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">从 {0} 中删除对 GC.Collect 的调用。通常不必强制进行垃圾回收，强制进行垃圾回收可能会严重降低性能。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">从 {0} 中删除对 Thread.Resume 的调用。如果系统正在进行关键操作(例如，正在执行重要系统类型的类构造函数或正在解析共享程序集的安全性)，挂起和恢复线程可能十分危险。</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">从 {0} 中删除对 Thread.Resume 的调用。如果系统正在进行关键操作(例如，正在执行重要系统类型的类构造函数或正在解析共享程序集的安全性)，挂起和恢复线程可能十分危险。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">从 {0} 中移除对 Thread.Suspend 的调用。如果系统正在进行关键操作(例如，正在执行重要系统类型的类构造函数或正在解析共享程序集的安全性)，挂起和恢复线程可能十分危险。</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">从 {0} 中移除对 Thread.Suspend 的调用。如果系统正在进行关键操作(例如，正在执行重要系统类型的类构造函数或正在解析共享程序集的安全性)，挂起和恢复线程可能十分危险。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">从 {0} 中删除对带有 BindingFlags.NonPublic 的 System.Type.InvokeMember 的调用。依赖私有成员会增加以后进行重大更改的可能性。</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">从 {0} 中删除对带有 BindingFlags.NonPublic 的 System.Type.InvokeMember 的调用。依赖私有成员会增加以后进行重大更改的可能性。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} 是对 OLE32 API 的 P/Invoke 声明，在运行时初始化后无法可靠地调用该声明。解决方法是写入一个非托管程序，该程序调用例程，然后激活并调入托管代码。通过注册供 COM 使用的托管组件或使用运行时承载 API，就可以使用混合模式 C++ DLL 的导出内容实现上述功能。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} 是对 OLE32 API 的 P/Invoke 声明，在运行时初始化后无法可靠地调用该声明。解决方法是写入一个非托管程序，该程序调用例程，然后激活并调入托管代码。通过注册供 COM 使用的托管组件或使用运行时承载 API，就可以使用混合模式 C++ DLL 的导出内容实现上述功能。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} 是对 OLE32 API 的 P/Invoke 声明，无法针对运行时可调用包装器(用于包装 COM 对象的托管对象)可靠地调用该声明。运行时可调用包装器动态提取接口指针，因此调用的效果可能会无故丢失。还可跨应用程序域共享给定 COM 对象的运行时可调用包装器，因此该调用可能会影响其他用户。用执行相应 CoSetProxyBlanket 调用的接口指针的本机包装器 COM 对象替换此调用。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} 是对 OLE32 API 的 P/Invoke 声明，无法针对运行时可调用包装器(用于包装 COM 对象的托管对象)可靠地调用该声明。运行时可调用包装器动态提取接口指针，因此调用的效果可能会无故丢失。还可跨应用程序域共享给定 COM 对象的运行时可调用包装器，因此该调用可能会影响其他用户。用执行相应 CoSetProxyBlanket 调用的接口指针的本机包装器 COM 对象替换此调用。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">从 {0} 中删除对 SafeHandle.DangerousGetHandle 的调用</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">从 {0} 中删除对 SafeHandle.DangerousGetHandle 的调用</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">从 {0} 中删除对 Assembly.LoadFrom 的调用</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">从 {0} 中删除对 Assembly.LoadFrom 的调用</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">从 {0} 中删除对 Assembly.LoadFile 的调用</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">从 {0} 中删除对 Assembly.LoadFile 的调用</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">从 {0} 中删除对 Assembly.LoadWithPartialName 的调用</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">从 {0} 中删除对 Assembly.LoadWithPartialName 的调用</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} ({1} 中声明的变量)与该类型的某一实例字段同名。请更改其中一项的名称。</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} ({1} 中声明的变量)与该类型的某一实例字段同名。请更改其中一项的名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} ({1} 中声明的参数)与该类型的某一实例字段同名。请更改其中一项的名称。</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} ({1} 中声明的参数)与该类型的某一实例字段同名。请更改其中一项的名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">从未用过方法 {1} 的参数 {0}。请删除该参数或在方法体中使用它。</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">从未用过方法 {1} 的参数 {0}。请删除该参数或在方法体中使用它。</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} 创建 {1} 的新实例，但该实例从未使用过。如果不需要此实例，请将它作为参数传递给另一个方法，将此实例赋给变量或删除对象创建。</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} 创建 {1} 的新实例，但该实例从未使用过。如果不需要此实例，请将它作为参数传递给另一个方法，将此实例赋给变量或删除对象创建。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} 调用 {1}，但不使用该方法返回的新字符串实例。如果不需要此实例，请将它作为参数传递给另一个方法，将此实例赋给变量或删除调用。</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} 调用 {1}，但不使用该方法返回的新字符串实例。如果不需要此实例，请将它作为参数传递给另一个方法，将此实例赋给变量或删除调用。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} 调用 {1}，但不使用该方法返回的 HRESULT 或错误代码。这可能会导致在出错或资源较少的情况下出现意外行为。请使用条件语句中的结果，并将结果赋给变量或将其作为自变量传递给另一个方法。</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} 调用 {1}，但不使用该方法返回的 HRESULT 或错误代码。这可能会导致在出错或资源较少的情况下出现意外行为。请使用条件语句中的结果，并将结果赋给变量或将其作为自变量传递给另一个方法。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} 调用 {1}，但不显式检查转换是否成功。请使用条件语句中的返回值，或验证在转换失败时调用站点是否希望将 out 参数设置为默认值。</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} 调用 {1}，但不显式检查转换是否成功。请使用条件语句中的返回值，或验证在转换失败时调用站点是否希望将 out 参数设置为默认值。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} 是显然从未实例化过的内部类。如果是这样，请从程序集中删除该代码。如果此内部类只用于包含静态成员，请使其成为静态类(在 Visual Basic 中为 Shared)。</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} 是显然从未实例化过的内部类。如果是这样，请从程序集中删除该代码。如果此内部类只用于包含静态成员，请使其成为静态类(在 Visual Basic 中为 Shared)。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} 调用 {1}，但不使用方法返回的值。{1} 被标记为纯方法，所以不会有副作用。请使用条件语句中的结果，并将结果赋给变量或将其作为自变量传递给另一个方法。</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} 调用 {1}，但不使用方法返回的值。{1} 被标记为纯方法，所以不会有副作用。请使用条件语句中的结果，并将结果赋给变量或将其作为自变量传递给另一个方法。</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">不得将属性 {0} 分配给其自身</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">不得将属性 {0} 分配给其自身</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 是多维数组。如有可能，请使用交错数组来替代它。</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 是多维数组。如有可能，请使用交错数组来替代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 返回多维数组 {1}。如有可能，请使用交错数组来替代它。</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 返回多维数组 {1}。如有可能，请使用交错数组来替代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 使用多维数组 {1}。如有可能，请使用交错数组来替代它。</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 使用多维数组 {1}。如有可能，请使用交错数组来替代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidTitle">
-        <source>Avoid Async Void</source>
-        <target state="translated">避免 Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">避免 Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidAsyncVoidMessage">
-        <source>Avoid Async Void</source>
-        <target state="translated">避免 Async Void</target>
+        <source>Avoid 'async void'.</source>
+        <target state="needs-review-translation">避免 Async Void</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncTitle">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Async 方法名稱應以 Async 結尾</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Async 方法名稱應以 Async 結尾</target>
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncDescription">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AsyncMethodNamesShouldEndInAsyncMessage">
-        <source>Async Method Names Should End in Async</source>
-        <target state="translated">Async 方法名稱應以 Async 結尾</target>
+        <source>Async method names should end in 'Async'</source>
+        <target state="needs-review-translation">Async 方法名稱應以 Async 結尾</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesDescription">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesMessage">
-        <source>Consider a design where '{0}' has no more than {1} type parameters</source>
-        <target state="translated">請考慮設計成 '{0}' 最多僅有 {1} 個型別參數的樣子</target>
+        <source>Consider a design where '{0}' has no more than '{1}' type parameters</source>
+        <target state="needs-review-translation">請考慮設計成 '{0}' 最多僅有 {1} 個型別參數的樣子</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidExcessiveParametersOnGenericTypesTitle">
@@ -93,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidOutParametersTitle">
-        <source>Avoid out parameters</source>
-        <target state="translated">避免使用 out 參數</target>
+        <source>Avoid 'out' parameters</source>
+        <target state="needs-review-translation">避免使用 out 參數</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCatchGeneralExceptionTypesDescription">
@@ -158,8 +158,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsDescription">
-        <source>System.Collections.Generic.List&lt;T&gt; is a generic collection that's designed for performance and not inheritance. List&lt;T&gt; does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
-        <target state="translated">System.Collections.Generic.List&lt;T&gt; 是為效能而非繼承所設計的泛型集合。List&lt;T&gt; 不包含讓已繼承類別行為更容易變更的虛擬成員。</target>
+        <source>'System.Collections.Generic.List&lt;T&gt;' is a generic collection that's designed for performance and not inheritance. 'List&lt;T&gt;' does not contain virtual members that make it easier to change the behavior of an inherited class.</source>
+        <target state="needs-review-translation">System.Collections.Generic.List&lt;T&gt; 是為效能而非繼承所設計的泛型集合。List&lt;T&gt; 不包含讓已繼承類別行為更容易變更的虛擬成員。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotExposeGenericListsMessage">
@@ -203,8 +203,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">請勿將 Async Lambdas 傳遞為 Void 傳回委派類型</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">請勿將 Async Lambdas 傳遞為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -213,13 +213,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Pass Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">請勿將 Async Lambdas 傳遞為 Void 傳回委派類型</target>
+        <source>Don't pass async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">請勿將 Async Lambdas 傳遞為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceDescription">
-        <source>Passing types by reference (using out or ref) requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between out and ref parameters is not widely understood.</source>
-        <target state="translated">藉傳址傳遞類型 (使用 out 或 ref) 需有指標經驗、了解實值型別與參考型別之間的差異，以及處理具有多個傳回值的方法。而且，大家普遍不了解 out 與 ref 參數之間的差異。</target>
+        <source>Passing types by reference (using 'out' or 'ref') requires experience with pointers, understanding how value types and reference types differ, and handling methods that have multiple return values. Also, the difference between 'out' and 'ref' parameters is not widely understood.</source>
+        <target state="needs-review-translation">藉傳址傳遞類型 (使用 out 或 ref) 需有指標經驗、了解實值型別與參考型別之間的差異，以及處理具有多個傳回值的方法。而且，大家普遍不了解 out 與 ref 參數之間的差異。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotPassTypesByReferenceMessage">
@@ -248,8 +248,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesTitle">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesDescription">
@@ -258,8 +258,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotStoreAsyncLambdasAsVoidReturningDelegateTypesMessage">
-        <source>Don't Store Async Lambdas as Void Returning Delegate Types</source>
-        <target state="translated">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>
+        <source>Don't store async lambdas as void returning delegate types</source>
+        <target state="needs-review-translation">請勿將 Async Lambdas 儲存為 Void 傳回委派類型</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumShouldNotHaveDuplicatedValuesMessageDuplicatedBitwiseValuePart">
@@ -293,8 +293,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeOverride">
-        <source>Remove the finalizer from type '{0}', override Dispose(bool disposing), and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
-        <target state="translated">從類型 '{0}' 移除完成項，覆寫 Dispose(bool disposing)，然後在程式碼路徑中放置完成項邏輯，其中 'disposing' 為 false。否則這可能導致 Dispose 引動過程重複，原因是基底類型 ‘{1}’ 也提供了完成項。</target>
+        <source>Remove the finalizer from type '{0}', override 'Dispose(bool disposing)', and put the finalization logic in the code path where 'disposing' is false. Otherwise, it might lead to duplicate Dispose invocations as the Base type '{1}' also provides a finalizer.</source>
+        <target state="needs-review-translation">從類型 '{0}' 移除完成項，覆寫 Dispose(bool disposing)，然後在程式碼路徑中放置完成項邏輯，其中 'disposing' 為 false。否則這可能導致 Dispose 引動過程重複，原因是基底類型 ‘{1}’ 也提供了完成項。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageCodeFix">
@@ -303,8 +303,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleTitle">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">於可能時散佈 CancellationToken</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">於可能時散佈 CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleDescription">
@@ -313,13 +313,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropagateCancellationTokensWhenPossibleMessage">
-        <source>Propagate CancellationTokens When Possible</source>
-        <target state="translated">於可能時散佈 CancellationToken</target>
+        <source>Propagate 'CancellationToken's when possible</source>
+        <target state="needs-review-translation">於可能時散佈 CancellationToken</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncTitle">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">請勿混合 Blocking 與 Async</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">請勿混合 Blocking 與 Async</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncDescription">
@@ -328,8 +328,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMixBlockingAndAsyncMessage">
-        <source>Don't Mix Blocking and Async</source>
-        <target state="translated">請勿混合 Blocking 與 Async</target>
+        <source>Don't mix blocking and async</source>
+        <target state="needs-review-translation">請勿混合 Blocking 與 Async</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantElementInitializationCodeFixTitle">
@@ -368,18 +368,18 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsRename">
-        <source>In enum {0}, change the name of {1} to 'None'</source>
-        <target state="translated">在列舉 {0} 中，將 {1} 的名稱變更為 'None'</target>
+        <source>In enum '{0}', change the name of '{1}' to 'None'</source>
+        <target state="needs-review-translation">在列舉 {0} 中，將 {1} 的名稱變更為 'None'</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageFlagsMultipleZeros">
-        <source>Remove all members that have the value zero from {0} except for one member that is named 'None'</source>
-        <target state="translated">從 {0} 中移除值為零的所有成員，但名為 'None' 的成員除外</target>
+        <source>Remove all members that have the value zero from '{0}' except for one member that is named 'None'</source>
+        <target state="needs-review-translation">從 {0} 中移除值為零的所有成員，但名為 'None' 的成員除外</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldHaveZeroValueMessageNotFlagsNoZeroValue">
-        <source>Add a member to {0} that has a value of zero with a suggested name of 'None'</source>
-        <target state="translated">將成員新增至值為零且建議名稱為 'None' 的 {0}</target>
+        <source>Add a member to '{0}' that has a value of zero with a suggested name of 'None'</source>
+        <target state="needs-review-translation">將成員新增至值為零且建議名稱為 'None' 的 {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="AbstractTypesShouldNotHaveConstructorsTitle">
@@ -403,13 +403,13 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantDescription">
-        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using CLSCompliantAttribute . If this attribute is not present on an assembly, the assembly is not compliant.</source>
-        <target state="translated">Common Language Specification (CLS) 會定義命名限制、資料類型及組件必須遵守的規則 (若組件會跨程式設計語言使用)。良好的設計會要求所有組件使用 CLSCompliantAttribute 明確地表示 CLS 合規性。若此屬性未出現於組件中，則表示組件不符合標準。</target>
+        <source>The Common Language Specification (CLS) defines naming restrictions, data types, and rules to which assemblies must conform if they will be used across programming languages. Good design dictates that all assemblies explicitly indicate CLS compliance by using 'CLSCompliantAttribute' . If this attribute is not present on an assembly, the assembly is not compliant.</source>
+        <target state="needs-review-translation">Common Language Specification (CLS) 會定義命名限制、資料類型及組件必須遵守的規則 (若組件會跨程式設計語言使用)。良好的設計會要求所有組件使用 CLSCompliantAttribute 明確地表示 CLS 合規性。若此屬性未出現於組件中，則表示組件不符合標準。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithClsCompliantMessage">
-        <source>Mark assemblies with CLSCompliant</source>
-        <target state="translated">將組件標記為 CLSCompliant</target>
+        <source>Mark assemblies with 'CLSCompliant'</source>
+        <target state="needs-review-translation">將組件標記為 CLSCompliant</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithAssemblyVersionTitle">
@@ -428,8 +428,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleTitle">
-        <source>Mark assemblies with ComVisible</source>
-        <target state="translated">將組件標記為 ComVisible</target>
+        <source>Mark assemblies with 'ComVisible'</source>
+        <target state="needs-review-translation">將組件標記為 ComVisible</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleDescription">
@@ -438,8 +438,8 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageNoAttribute">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true).</source>
-        <target state="translated">因為 {0} 會公開外部可見的類型，所以請在組件層級將其標記為 ComVisible(false)，然後將應公開給 COM 用戶端之組件內的所有類型，標記為 ComVisible(true)。</target>
+        <source>Because '{0}' exposes externally visible types, mark it with 'ComVisible(false)' at the assembly level and then mark all types within the assembly that should be exposed to COM clients with 'ComVisible(true)'.</source>
+        <target state="needs-review-translation">因為 {0} 會公開外部可見的類型，所以請在組件層級將其標記為 ComVisible(false)，然後將應公開給 COM 用戶端之組件內的所有類型，標記為 ComVisible(true)。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAssembliesWithComVisibleMessageAttributeTrue">
@@ -448,23 +448,23 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageTitle">
-        <source>Mark attributes with AttributeUsageAttribute</source>
-        <target state="translated">將屬性標記為 AttributeUsageAttribute</target>
+        <source>Mark attributes with 'AttributeUsageAttribute'</source>
+        <target state="needs-review-translation">將屬性標記為 AttributeUsageAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageDescription">
-        <source>When you define a custom attribute, mark it by using AttributeUsageAttribute to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
-        <target state="translated">當您定義自訂屬性時，請使用 AttributeUsageAttribute 進行標記，以指出可以在原始程式碼的何處套用自訂屬性。屬性的意義與預期用法將可決定其在程式碼中的有效位置。</target>
+        <source>When you define a custom attribute, mark it by using 'AttributeUsageAttribute' to indicate where in the source code the custom attribute can be applied. The meaning and intended usage of an attribute will determine its valid locations in code.</source>
+        <target state="needs-review-translation">當您定義自訂屬性時，請使用 AttributeUsageAttribute 進行標記，以指出可以在原始程式碼的何處套用自訂屬性。屬性的意義與預期用法將可決定其在程式碼中的有效位置。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageDefault">
-        <source>Specify AttributeUsage on {0}</source>
-        <target state="translated">在 {0} 上指定 AttributeUsage</target>
+        <source>Specify AttributeUsage on '{0}'</source>
+        <target state="needs-review-translation">在 {0} 上指定 AttributeUsage</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkAttributesWithAttributeUsageMessageInherited">
-        <source>Even though attribute {0} inherits AttributeUsage from its base type, you should consider explicitly specifying AttributeUsage on the type to improve code readability and documentation.</source>
-        <target state="translated">即使屬性 {0} 自其基底類型繼承 AttributeUsage，仍應考慮在類型上明確指定 AttributeUsage，以改善程式碼可讀性與記錄功能。</target>
+        <source>Even though attribute '{0}' inherits 'AttributeUsage' from its base type, you should consider explicitly specifying 'AttributeUsage' on the type to improve code readability and documentation.</source>
+        <target state="needs-review-translation">即使屬性 {0} 自其基底類型繼承 AttributeUsage，仍應考慮在類型上明確指定 AttributeUsage，以改善程式碼可讀性與記錄功能。</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsTitle">
@@ -478,18 +478,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageDefault">
-        <source>Add a public read-only property accessor for positional argument {0} of Attribute {1}</source>
-        <target state="translated">為屬性 (Attribute) {1} 的位置引數 {0} 新增公用唯讀屬性 (Property) 存取子</target>
+        <source>Add a public read-only property accessor for positional argument '{0}' of Attribute '{1}'</source>
+        <target state="needs-review-translation">為屬性 (Attribute) {1} 的位置引數 {0} 新增公用唯讀屬性 (Property) 存取子</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageRemoveSetter">
-        <source>Remove the property setter from {0} or reduce its accessibility because it corresponds to positional argument {1}</source>
-        <target state="translated">因為屬性 setter 會對應到位置引數 {1}，所以請從 {0} 移除屬性 setter 或縮小其存取範圍</target>
+        <source>Remove the property setter from '{0}' or reduce its accessibility because it corresponds to positional argument '{1}'</source>
+        <target state="needs-review-translation">因為屬性 setter 會對應到位置引數 {1}，所以請從 {0} 移除屬性 setter 或縮小其存取範圍</target>
         <note />
       </trans-unit>
       <trans-unit id="DefineAccessorsForAttributeArgumentsMessageIncreaseVisibility">
-        <source>If {0} is the property accessor for positional argument {1}, make it public</source>
-        <target state="translated">若 {0} 是位置引數 {1} 的屬性存取子，請將其設為公用</target>
+        <source>If '{0}' is the property accessor for positional argument '{1}', make it public</source>
+        <target state="needs-review-translation">若 {0} 是位置引數 {1} 的屬性存取子，請將其設為公用</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateTitle">
@@ -498,8 +498,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateDescription">
-        <source>A public or protected method has a name that starts with ""Get"", takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
-        <target state="translated">公用或受保護的方法具有以 ""Get"" 開頭的名稱，該名稱沒有使用任何參數，且會傳回不是陣列的值。此方法可能很適合成為屬性。</target>
+        <source>A public or protected method has a name that starts with 'Get', takes no parameters, and returns a value that is not an array. The method might be a good candidate to become a property.</source>
+        <target state="needs-review-translation">公用或受保護的方法具有以 ""Get"" 開頭的名稱，該名稱沒有使用任何參數，且會傳回不是陣列的值。此方法可能很適合成為屬性。</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePropertiesWhereAppropriateMessage">
@@ -508,18 +508,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsTitle">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">將列舉標記為 FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">將列舉標記為 FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsDescription">
-        <source>An enumeration is a value type that defines a set of related named constants. Apply FlagsAttribute to an enumeration when its named constants can be meaningfully combined.</source>
-        <target state="translated">列舉是一種實值型別，用以定義一組相關的具名常數。當列舉的具名常數可以有意義地加以合併時，可將 FlagsAttribute 套用至此列舉。</target>
+        <source>An enumeration is a value type that defines a set of related named constants. Apply 'FlagsAttribute' to an enumeration when its named constants can be meaningfully combined.</source>
+        <target state="needs-review-translation">列舉是一種實值型別，用以定義一組相關的具名常數。當列舉的具名常數可以有意義地加以合併時，可將 FlagsAttribute 套用至此列舉。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsMessage">
-        <source>Mark enums with FlagsAttribute</source>
-        <target state="translated">將列舉標記為 FlagsAttribute</target>
+        <source>Mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">將列舉標記為 FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="InterfaceMethodsShouldBeCallableByChildTypesTitle">
@@ -543,18 +543,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesDescription">
-        <source>A public or protected type implements the System.IComparable interface. It does not override Object.Equals nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
-        <target state="translated">公用或受保護的類型會實作 System.IComparable 介面。它不會覆寫 Object.Equals，也不會多載語言專屬的等號比較、不相等比較、小於、小於或等於、大於或是大於或等於運算子。</target>
+        <source>A public or protected type implements the 'System.IComparable' interface. It does not override 'Object.Equals' nor does it overload the language-specific operator for equality, inequality, less than, less than or equal, greater than or greater than or equal.</source>
+        <target state="needs-review-translation">公用或受保護的類型會實作 System.IComparable 介面。它不會覆寫 Object.Equals，也不會多載語言專屬的等號比較、不相等比較、小於、小於或等於、大於或是大於或等於運算子。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageEquals">
-        <source>{0} should override Equals since it implements IComparable</source>
-        <target state="translated">因為 {0} 會實作 IComparable，所以應該覆寫 Equals</target>
+        <source>'{0}' should override 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">因為 {0} 會實作 IComparable，所以應該覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageOperator">
-        <source>{0} should define operator(s) '{1}' since it implements IComparable</source>
-        <target state="translated">因為 {0} 會實作 IComparable，所以應該定義運算子 '{1}'</target>
+        <source>'{0}' should define operator(s) '{1}' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">因為 {0} 會實作 IComparable，所以應該定義運算子 '{1}'</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="MovePInvokesToNativeMethodsClassTitle">
@@ -593,18 +593,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixDescription">
-        <source>The name of an externally visible interface does not start with an uppercase ""I"". The name of a generic type parameter on an externally visible type or method does not start with an uppercase ""T"".</source>
-        <target state="translated">外部可見介面的名稱未以大寫 ""I"" 開頭。外部可見類型或方法上，泛型型別參數的名稱未以大寫 ""T"" 開頭。</target>
+        <source>The name of an externally visible interface does not start with an uppercase 'I'. The name of a generic type parameter on an externally visible type or method does not start with an uppercase 'T'.</source>
+        <target state="needs-review-translation">外部可見介面的名稱未以大寫 ""I"" 開頭。外部可見類型或方法上，泛型型別參數的名稱未以大寫 ""T"" 開頭。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageInterface">
-        <source>Prefix interface name {0} with 'I'</source>
-        <target state="translated">在介面名稱 {0} 前面加上 'I'</target>
+        <source>Prefix interface name '{0}' with 'I'</source>
+        <target state="needs-review-translation">在介面名稱 {0} 前面加上 'I'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectPrefixMessageTypeParameter">
-        <source>Prefix generic type parameter name {0} with 'T'</source>
-        <target state="translated">在泛型型別參數名稱 {0} 前面加上 'T'</target>
+        <source>Prefix generic type parameter name '{0}' with 'T'</source>
+        <target state="needs-review-translation">在泛型型別參數名稱 {0} 前面加上 'T'</target>
         <note />
       </trans-unit>
       <trans-unit id="NonConstantFieldsShouldNotBeVisibleTitle">
@@ -623,18 +623,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsTitle">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">請勿將列舉標記為 FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">請勿將列舉標記為 FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsDescription">
-        <source>An externally visible enumeration is marked by using FlagsAttribute, and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
-        <target state="translated">外部可見的列舉會使用 FlagsAttribute 加以標記，且有一或多個值不是二的次方或列舉上其他定義值的組合。</target>
+        <source>An externally visible enumeration is marked by using 'FlagsAttribute', and it has one or more values that are not powers of two or a combination of the other defined values on the enumeration.</source>
+        <target state="needs-review-translation">外部可見的列舉會使用 FlagsAttribute 加以標記，且有一或多個值不是二的次方或列舉上其他定義值的組合。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsMessage">
-        <source>Do not mark enums with FlagsAttribute</source>
-        <target state="translated">請勿將列舉標記為 FlagsAttribute</target>
+        <source>Do not mark enums with 'FlagsAttribute'</source>
+        <target state="needs-review-translation">請勿將列舉標記為 FlagsAttribute</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesTitle">
@@ -648,23 +648,23 @@
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageDefault">
-        <source>Provide a method named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">請提供名為 '{0}' 的方法作為運算子 {1} 的易記替代項</target>
+        <source>Provide a method named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">請提供名為 '{0}' 的方法作為運算子 {1} 的易記替代項</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageProperty">
-        <source>Provide a property named '{0}' as a friendly alternate for operator {1}</source>
-        <target state="translated">請提供名為 '{0}' 的屬性作為運算子 {1} 的易記替代項</target>
+        <source>Provide a property named '{0}' as a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">請提供名為 '{0}' 的屬性作為運算子 {1} 的易記替代項</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageMultiple">
-        <source>Provide a method named '{0}' or '{1}' as an alternate for operator {2}</source>
-        <target state="translated">請提供名為 '{0}' 或 '{1}' 的方法作為運算子 {2} 的替代項</target>
+        <source>Provide a method named '{0}' or '{1}' as an alternate for operator '{2}'</source>
+        <target state="needs-review-translation">請提供名為 '{0}' 或 '{1}' 的方法作為運算子 {2} 的替代項</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorOverloadsHaveNamedAlternatesMessageVisibility">
-        <source>Mark {0} as public because it is a friendly alternate for operator {1}</source>
-        <target state="translated">因為 {0} 是運算子 {1} 的易記替代項，所以將其標記為公用</target>
+        <source>Mark '{0}' as public because it is a friendly alternate for operator '{1}'</source>
+        <target state="needs-review-translation">因為 {0} 是運算子 {1} 的易記替代項，所以將其標記為公用</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatorsShouldHaveSymmetricalOverloadsTitle">
@@ -728,18 +728,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsTitle">
-        <source>Implement IEquatable when overriding Object.Equals</source>
-        <target state="translated">覆寫 Object.Equals 時實作 IEquatable</target>
+        <source>Implement 'IEquatable' when overriding 'Object.Equals'</source>
+        <target state="needs-review-translation">覆寫 Object.Equals 時實作 IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsMessage">
-        <source>Type {0} should implement IEquatable&lt;T&gt; because it overrides Equals</source>
-        <target state="translated">類型 {0} 應先實作 IEquatable&lt;T&gt;，因為它會覆寫 Equals</target>
+        <source>Type '{0}' should implement 'IEquatable&lt;T&gt;' because it overrides Equals</source>
+        <target state="needs-review-translation">類型 {0} 應先實作 IEquatable&lt;T&gt;，因為它會覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastTitle">
-        <source>CancellationToken parameters must come last</source>
-        <target state="translated">CancellationToken 參數必須位於最後</target>
+        <source>'CancellationToken' parameters must come last</source>
+        <target state="needs-review-translation">CancellationToken 參數必須位於最後</target>
         <note />
       </trans-unit>
       <trans-unit id="CancellationTokenParametersMustComeLastMessage">
@@ -793,13 +793,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AddAssemblyLevelComVisibleFalse">
-        <source>Because {0} exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
-        <target state="translated">因為 {0} 會公開外部可見的型別，所以請在組件層級將其標記為 ComVisible(false)，然後將應公開給 COM 用戶端之組件內的所有型別，標記為 ComVisible(true)</target>
+        <source>Because '{0}' exposes externally visible types, mark it with ComVisible(false) at the assembly level and then mark all types within the assembly that should be exposed to COM clients with ComVisible(true)</source>
+        <target state="needs-review-translation">因為 {0} 會公開外部可見的型別，所以請在組件層級將其標記為 ComVisible(false)，然後將應公開給 COM 用戶端之組件內的所有型別，標記為 ComVisible(true)</target>
         <note />
       </trans-unit>
       <trans-unit id="ChangeAssemblyLevelComVisibleToFalse">
-        <source>Consider changing the ComVisible attribute on {0} to false, and opting in at the type level</source>
-        <target state="translated">請考慮將 {0} 上的 ComVisible 屬性變更為 false，並於型別層級選擇加入</target>
+        <source>Consider changing the 'ComVisible' attribute on '{0}' to false, and opting in at the type level</source>
+        <target state="needs-review-translation">請考慮將 {0} 上的 ComVisible 屬性變更為 false，並於型別層級選擇加入</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementComparable">
@@ -808,23 +808,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementEquatable">
-        <source>Implement IEquatable</source>
-        <target state="translated">實作 IEquatable</target>
+        <source>Implement 'IEquatable'</source>
+        <target state="needs-review-translation">實作 IEquatable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableInterface">
-        <source>Implement IDisposable Interface</source>
-        <target state="translated">實作 IDisposable 介面</target>
+        <source>Implement 'IDisposable' Interface</source>
+        <target state="needs-review-translation">實作 IDisposable 介面</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotMarkEnumsWithFlagsCodeFix">
-        <source>Remove FlagsAttribute from enum.</source>
-        <target state="translated">從列舉移除 FlagsAttribute。</target>
+        <source>Remove 'FlagsAttribute' from enum.</source>
+        <target state="needs-review-translation">從列舉移除 FlagsAttribute。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkEnumsWithFlagsCodeFix">
-        <source>Apply FlagsAttribute to enum.</source>
-        <target state="translated">將 FlagsAttribute 套用至列舉。</target>
+        <source>Apply 'FlagsAttribute' to enum.</source>
+        <target state="needs-review-translation">將 FlagsAttribute 套用至列舉。</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumsShouldZeroValueFlagsMultipleZeroCodeFix">
@@ -878,8 +878,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Title">
-        <source>Enum Storage should be Int32</source>
-        <target state="translated">列舉儲存體應為 Int32</target>
+        <source>Enum Storage should be 'Int32'</source>
+        <target state="needs-review-translation">列舉儲存體應為 Int32</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Description">
@@ -888,8 +888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumStorageShouldBeInt32Message">
-        <source>If possible, make the underlying type of {0} System.Int32 instead of {1}</source>
-        <target state="translated">若是可能，請將 {0} 的基礎型別變更為 System.Int32，而非 {1}</target>
+        <source>If possible, make the underlying type of '{0}' 'System.Int32' instead of '{1}'</source>
+        <target state="needs-review-translation">若是可能，請將 {0} 的基礎型別變更為 System.Int32，而非 {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UseEventsWhereAppropriateTitle">
@@ -918,13 +918,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageMissingConstructor">
-        <source>Add the following constructor to {0}: {1}</source>
-        <target state="translated">將下列建構函式新增至 {0}: {1}</target>
+        <source>Add the following constructor to '{0}': '{1}'</source>
+        <target state="needs-review-translation">將下列建構函式新增至 {0}: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementStandardExceptionConstructorsMessageAccessibility">
-        <source>Change the accessibility of {0} to {1}.</source>
-        <target state="translated">將 {0} 的存取範圍變更為 {1}。</target>
+        <source>Change the accessibility of '{0}' to '{1}.'</source>
+        <target state="needs-review-translation">將 {0} 的存取範圍變更為 {1}。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleTitle">
@@ -938,13 +938,13 @@
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageDefault">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible.</source>
-        <target state="translated">請勿將類型 {0} 巢狀化。或者，變更其存取範圍，使其非外部可見。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible.</source>
+        <target state="needs-review-translation">請勿將類型 {0} 巢狀化。或者，變更其存取範圍，使其非外部可見。</target>
         <note />
       </trans-unit>
       <trans-unit id="NestedTypesShouldNotBeVisibleMessageVisualBasicModule">
-        <source>Do not nest type {0}. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
-        <target state="translated">請勿將類型 {0} 巢狀化。或者，變更其存取範圍，使其非外部可見。若此類型定義於 Visual Basic 模組中，則其對於其他 .NET 語言而言會視作為巢狀型別。在這種情況下，請考慮將該類型移出模組。</target>
+        <source>Do not nest type '{0}'. Alternatively, change its accessibility so that it is not externally visible. If this type is defined in a Visual Basic Module, it will be considered a nested type to other .NET languages. In that case, consider moving the type outside of the Module.</source>
+        <target state="needs-review-translation">請勿將類型 {0} 巢狀化。或者，變更其存取範圍，使其非外部可見。若此類型定義於 Visual Basic 模組中，則其對於其他 .NET 語言而言會視作為巢狀型別。在這種情況下，請考慮將該類型移出模組。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidEmptyInterfacesTitle">
@@ -963,18 +963,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageTitle">
-        <source>Provide ObsoleteAttribute message</source>
-        <target state="translated">提供 ObsoleteAttribute 訊息</target>
+        <source>Provide 'ObsoleteAttribute' message</source>
+        <target state="needs-review-translation">提供 ObsoleteAttribute 訊息</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageDescription">
-        <source>A type or member is marked by using a System.ObsoleteAttribute attribute that does not have its ObsoleteAttribute.Message property specified. When a type or member that is marked by using ObsoleteAttribute is compiled, the Message property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
-        <target state="translated">類型或成員使用並未指定其 ObsoleteAttribute.Message 屬性 (Property) 的 System.ObsoleteAttribute 屬性 (Attribute) 加以標記。編譯使用 ObsoleteAttribute 標記的類型或成員之後，會顯示屬性 (Attribute) 的 Message 屬性 (Property)，以便提供使用者有關過時類型或成員的資訊。</target>
+        <source>A type or member is marked by using a 'System.ObsoleteAttribute' attribute that does not have its 'ObsoleteAttribute.Message' property specified. When a type or member that is marked by using 'ObsoleteAttribute' is compiled, the 'Message' property of the attribute is displayed. This gives the user information about the obsolete type or member.</source>
+        <target state="needs-review-translation">類型或成員使用並未指定其 ObsoleteAttribute.Message 屬性 (Property) 的 System.ObsoleteAttribute 屬性 (Attribute) 加以標記。編譯使用 ObsoleteAttribute 標記的類型或成員之後，會顯示屬性 (Attribute) 的 Message 屬性 (Property)，以便提供使用者有關過時類型或成員的資訊。</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideObsoleteAttributeMessageMessage">
-        <source>Provide a message for the ObsoleteAttribute that marks {0} as Obsolete</source>
-        <target state="translated">提供將 {0} 標記為 Obsolete 的 ObsoleteAttribute 之訊息</target>
+        <source>Provide a message for the 'ObsoleteAttribute' that marks '{0}' as 'Obsolete'</source>
+        <target state="needs-review-translation">提供將 {0} 標記為 Obsolete 的 ObsoleteAttribute 之訊息</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyTitle">
@@ -988,13 +988,13 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageAddGetter">
-        <source>Because property {0} is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
-        <target state="translated">因為屬性 {0} 是唯寫屬性，所以請以大於或等於其 setter 的存取範圍，新增屬性 getter，或是將此屬性轉換為方法</target>
+        <source>Because property '{0}' is write-only, either add a property getter with an accessibility that is greater than or equal to its setter or convert this property into a method</source>
+        <target state="needs-review-translation">因為屬性 {0} 是唯寫屬性，所以請以大於或等於其 setter 的存取範圍，新增屬性 getter，或是將此屬性轉換為方法</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotBeWriteOnlyMessageMakeMoreAccessible">
-        <source>Because the property getter for {0} is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
-        <target state="translated">因為 {0} 的屬性 getter 較其 setter 的可見性低，所以請加大其 getter 的存取範圍，或是縮小其 setter 的存取範圍</target>
+        <source>Because the property getter for '{0}' is less visible than its setter, either increase the accessibility of its getter or decrease the accessibility of its setter</source>
+        <target state="needs-review-translation">因為 {0} 的屬性 getter 較其 setter 的可見性低，所以請加大其 getter 的存取範圍，或是縮小其 setter 的存取範圍</target>
         <note />
       </trans-unit>
       <trans-unit id="DeclareTypesInNamespacesTitle">
@@ -1073,23 +1073,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyTitle">
-        <source>Implement IDisposable Correctly</source>
-        <target state="translated">正確實作 IDisposable</target>
+        <source>Implement 'IDisposable' Correctly</source>
+        <target state="needs-review-translation">正確實作 IDisposable</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyDescription">
-        <source>All IDisposable types should implement the Dispose pattern correctly.</source>
-        <target state="translated">所有 IDisposable 類型都應正確地實作 Dispose 模式。</target>
+        <source>All 'IDisposable' types should implement the Dispose pattern correctly.</source>
+        <target state="needs-review-translation">所有 IDisposable 類型都應正確地實作 Dispose 模式。</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageIDisposableReimplementation">
-        <source>Remove IDisposable from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
-        <target state="translated">從 '{0}' 實作的介面清單中移除 IDisposable，原因是基底類型 '{1}' 已實作該項</target>
+        <source>Remove 'IDisposable' from the list of interfaces implemented by '{0}' as it is already implemented by base type '{1}'</source>
+        <target state="needs-review-translation">從 '{0}' 實作的介面清單中移除 IDisposable，原因是基底類型 '{1}' 已實作該項</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeOverride">
-        <source>Remove '{0}', override Dispose(bool disposing), and put the dispose logic in the code path where 'disposing' is true</source>
-        <target state="translated">移除 '{0}'，覆寫 Dispose(bool disposing)，並在程式碼路徑中放置處置邏輯，其中 'disposing' 為 true</target>
+        <source>Remove '{0}', override 'Dispose(bool disposing)', and put the dispose logic in the code path where 'disposing' is true</source>
+        <target state="needs-review-translation">移除 '{0}'，覆寫 Dispose(bool disposing)，並在程式碼路徑中放置處置邏輯，其中 'disposing' 為 true</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeSignature">
@@ -1108,18 +1108,18 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageDisposeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(true), then calls GC.SuppressFinalize on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
-        <target state="translated">修改 '{0}'，以便其呼叫 Dispose(true)，並在目前的物件執行個體 (Visual Basic 中的 'this' 或 'Me') 上呼叫 GC.SuppressFinalize，然後傳回</target>
+        <source>Modify '{0}' so that it calls 'Dispose(true)', then calls 'GC.SuppressFinalize' on the current object instance ('this' or 'Me' in Visual Basic), and then returns</source>
+        <target state="needs-review-translation">修改 '{0}'，以便其呼叫 Dispose(true)，並在目前的物件執行個體 (Visual Basic 中的 'this' 或 'Me') 上呼叫 GC.SuppressFinalize，然後傳回</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageFinalizeImplementation">
-        <source>Modify '{0}' so that it calls Dispose(false) and then returns</source>
-        <target state="translated">修改 '{0}'，以便其呼叫 Dispose(false) 然後傳回</target>
+        <source>Modify '{0}' so that it calls 'Dispose(false)' and then returns</source>
+        <target state="needs-review-translation">修改 '{0}'，以便其呼叫 Dispose(false) 然後傳回</target>
         <note />
       </trans-unit>
       <trans-unit id="ImplementIDisposableCorrectlyMessageProvideDisposeBool">
-        <source>Provide an overridable implementation of Dispose(bool) on '{0}' or mark the type as sealed. A call to Dispose(false) should only clean up native resources. A call to Dispose(true) should clean up both managed and native resources.</source>
-        <target state="translated">在 '{0}' 上提供 Dispose(bool) 的可覆寫實作，或將該類型標記為密封。呼叫 Dispose(false) 只能清除原生資源。呼叫 Dispose(true) 則能同時清除受控與原生資源。</target>
+        <source>Provide an overridable implementation of 'Dispose(bool)' on '{0}' or mark the type as sealed. A call to 'Dispose(false)' should only clean up native resources. A call to 'Dispose(true)' should clean up both managed and native resources.</source>
+        <target state="needs-review-translation">在 '{0}' 上提供 Dispose(bool) 的可覆寫實作，或將該類型標記為密封。呼叫 Dispose(false) 只能清除原生資源。呼叫 Dispose(true) 則能同時清除受控與原生資源。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicTitle">
@@ -1128,8 +1128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicDescription">
-        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from T:System.Exception, T:System.SystemException, or T:System.ApplicationException, the external code will not have sufficient information to know what to do with the exception.</source>
-        <target state="translated">內部例外狀況只有在其本身的內部範圍內才可看到。當例外狀況超出內部範圍之後，只能使用基底例外狀況來攔截例外狀況。若內部例外狀況繼承自 T:System.Exception、T:System.SystemException 或 T:System.ApplicationException，則外部程式碼將不會有足夠的資訊可以知道應如何處理此例外狀況。</target>
+        <source>An internal exception is visible only inside its own internal scope. After the exception falls outside the internal scope, only the base exception can be used to catch the exception. If the internal exception is inherited from 'System.Exception', 'System.SystemException', or 'System.ApplicationException', the external code will not have sufficient information to know what to do with the exception.</source>
+        <target state="needs-review-translation">內部例外狀況只有在其本身的內部範圍內才可看到。當例外狀況超出內部範圍之後，只能使用基底例外狀況來攔截例外狀況。若內部例外狀況繼承自 T:System.Exception、T:System.SystemException 或 T:System.ApplicationException，則外部程式碼將不會有足夠的資訊可以知道應如何處理此例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionsShouldBePublicMessage">
@@ -1148,18 +1148,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessagePropertyGetter">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} 會建立類型 {1} 的例外狀況，而這種例外狀況類型不應在屬性中引發。若可能引發此例外狀況執行個體，請使用其他例外狀況類型，將這個屬性轉換為方法，或是變更這個屬性的邏輯，使其不會再引發例外狀況。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in a property. If this exception instance might be raised, use a different exception type, convert this property into a method, or change this property's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 會建立類型 {1} 的例外狀況，而這種例外狀況類型不應在屬性中引發。若可能引發此例外狀況執行個體，請使用其他例外狀況類型，將這個屬性轉換為方法，或是變更這個屬性的邏輯，使其不會再引發例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageHasAllowedExceptions">
-        <source>{0} creates an exception of type {1}, an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
-        <target state="translated">{0} 會建立類型 {1} 的例外狀況，而這種例外狀況類型不應在此類型的方法中引發。若可能引發此例外狀況執行個體，請使用其他例外狀況類型，或是變更此方法的邏輯，使其不會再引發例外狀況。</target>
+        <source>'{0}' creates an exception of type '{1}', an exception type that should not be raised in this type of method. If this exception instance might be raised, either use a different exception type or change this method's logic so that it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 會建立類型 {1} 的例外狀況，而這種例外狀況類型不應在此類型的方法中引發。若可能引發此例外狀況執行個體，請使用其他例外狀況類型，或是變更此方法的邏輯，使其不會再引發例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotRaiseExceptionsInUnexpectedLocationsMessageNoAllowedExceptions">
-        <source>{0} creates an exception of type {1}. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
-        <target state="translated">{0} 會建立類型 {1} 的例外狀況。不應於此類型的方法中引發例外狀況。若可能引發此例外狀況執行個體，請變更這個方法的邏輯，使其不會再引發例外狀況。</target>
+        <source>'{0}' creates an exception of type '{1}'. Exceptions should not be raised in this type of method. If this exception instance might be raised, change this method's logic so it no longer raises an exception.</source>
+        <target state="needs-review-translation">{0} 會建立類型 {1} 的例外狀況。不應於此類型的方法中引發例外狀況。若可能引發此例外狀況執行個體，請變更這個方法的邏輯，使其不會再引發例外狀況。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresTitle">
@@ -1168,13 +1168,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresDescription">
-        <source>By convention, identifier names do not contain the underscore (_) character. This rule checks namespaces, types, members, and parameters.</source>
-        <target state="translated">依照慣例，識別項名稱不包含底線 (_) 字元。此規則會檢查命名空間、類型、成員與參數。</target>
+        <source>By convention, identifier names do not contain the underscore '_' character. This rule checks namespaces, types, members, and parameters.</source>
+        <target state="needs-review-translation">依照慣例，識別項名稱不包含底線 (_) 字元。此規則會檢查命名空間、類型、成員與參數。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageAssembly">
-        <source>Remove the underscores from assembly name {0}</source>
-        <target state="translated">移除組件名稱 {0} 中的底線</target>
+        <source>Remove the underscores from assembly name '{0}'</source>
+        <target state="needs-review-translation">移除組件名稱 {0} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageNamespace">
@@ -1183,33 +1183,33 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageType">
-        <source>Remove the underscores from type name {0}</source>
-        <target state="translated">移除型別名稱 {0} 中的底線</target>
+        <source>Remove the underscores from type name '{0}'</source>
+        <target state="needs-review-translation">移除型別名稱 {0} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMember">
-        <source>Remove the underscores from member name {0}</source>
-        <target state="translated">移除成員名稱 {0} 中的底線</target>
+        <source>Remove the underscores from member name '{0}'</source>
+        <target state="needs-review-translation">移除成員名稱 {0} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageTypeTypeParameter">
-        <source>On type {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">在型別 {0} 上，移除泛型型別參數名稱 {1} 中的底線</target>
+        <source>On type '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">在型別 {0} 上，移除泛型型別參數名稱 {1} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMethodTypeParameter">
-        <source>On method {0}, remove the underscores from generic type parameter name {1}</source>
-        <target state="translated">在方法 {0} 上，移除泛型型別參數名稱 {1} 中的底線</target>
+        <source>On method '{0}', remove the underscores from generic type parameter name '{1}'</source>
+        <target state="needs-review-translation">在方法 {0} 上，移除泛型型別參數名稱 {1} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageMemberParameter">
-        <source>In member {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">在成員 {0} 中，移除參數名稱 {1} 中的底線</target>
+        <source>In member '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">在成員 {0} 中，移除參數名稱 {1} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotContainUnderscoresMessageDelegateParameter">
-        <source>In delegate {0}, remove the underscores from parameter name {1}</source>
-        <target state="translated">在委派 {0} 中，移除參數名稱 {1} 中的底線</target>
+        <source>In delegate '{0}', remove the underscores from parameter name '{1}'</source>
+        <target state="needs-review-translation">在委派 {0} 中，移除參數名稱 {1} 中的底線</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixTitle">
@@ -1223,13 +1223,13 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageDefault">
-        <source>Rename {0} to end in '{1}'</source>
-        <target state="translated">重新命名 {0}，使其以 '{1}' 結尾</target>
+        <source>Rename '{0}' to end in '{1}'</source>
+        <target state="needs-review-translation">重新命名 {0}，使其以 '{1}' 結尾</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldHaveCorrectSuffixMessageSpecialCollection">
-        <source>Rename {0} to end in either 'Collection' or '{1}'</source>
-        <target state="translated">重新命名 {0}，使其以 'Collection' 或 '{1}' 結尾</target>
+        <source>Rename '{0}' to end in either 'Collection' or '{1}'</source>
+        <target state="needs-review-translation">重新命名 {0}，使其以 'Collection' 或 '{1}' 結尾</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixTitle">
@@ -1243,18 +1243,18 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNoAlternate">
-        <source>Rename type name {0} so that it does not end in '{1}'</source>
-        <target state="translated">重新命名型別名稱 {0}，使其結尾不是 '{1}'</target>
+        <source>Rename type name '{0}' so that it does not end in '{1}'</source>
+        <target state="needs-review-translation">重新命名型別名稱 {0}，使其結尾不是 '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberNewerVersion">
-        <source>Either replace the suffix '{0}' in member name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
-        <target state="translated">以建議的數字替代項 '2' 取代成員名稱 {1} 中的尾碼 '{0}'，或是提供區分此成員與其所取代之成員而更具意義的尾碼</target>
+        <source>Either replace the suffix '{0}' in member name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the member it replaces</source>
+        <target state="needs-review-translation">以建議的數字替代項 '2' 取代成員名稱 {1} 中的尾碼 '{0}'，或是提供區分此成員與其所取代之成員而更具意義的尾碼</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageTypeNewerVersion">
-        <source>Either replace the suffix '{0}' in type name {1} with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
-        <target state="translated">以建議的數字替代項 '2' 取代型別名稱 {1} 中的尾碼 '{0}'，或是提供區分此型別與其所取代之型別而更具意義的尾碼</target>
+        <source>Either replace the suffix '{0}' in type name '{1}' with the suggested numeric alternate '2' or provide a more meaningful suffix that distinguishes it from the type it replaces</source>
+        <target state="needs-review-translation">以建議的數字替代項 '2' 取代型別名稱 {1} 中的尾碼 '{0}'，或是提供區分此型別與其所取代之型別而更具意義的尾碼</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotHaveIncorrectSuffixMessageMemberWithAlternate">
@@ -1273,23 +1273,23 @@
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMemberParameter">
-        <source>In virtual/interface member {0}, rename parameter {1} so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">在虛擬/介面成員 {0} 中，重新命名參數 {1}，使其不再與保留的語言關鍵字 '{2}' 相衝突。將保留關鍵字用作為虛擬/介面成員上參數的名稱，會讓其他語言的消費者難以覆寫/實作該成員。</target>
+        <source>In virtual/interface member '{0}', rename parameter '{1}' so that it no longer conflicts with the reserved language keyword '{2}'. Using a reserved keyword as the name of a parameter on a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">在虛擬/介面成員 {0} 中，重新命名參數 {1}，使其不再與保留的語言關鍵字 '{2}' 相衝突。將保留關鍵字用作為虛擬/介面成員上參數的名稱，會讓其他語言的消費者難以覆寫/實作該成員。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageMember">
-        <source>Rename virtual/interface member {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
-        <target state="translated">重新命名虛擬/介面成員 {0}，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為虛擬/介面成員的名稱，會讓其他語言的消費者難以覆寫/實作該成員。</target>
+        <source>Rename virtual/interface member '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a virtual/interface member makes it harder for consumers in other languages to override/implement the member.</source>
+        <target state="needs-review-translation">重新命名虛擬/介面成員 {0}，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為虛擬/介面成員的名稱，會讓其他語言的消費者難以覆寫/實作該成員。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageType">
-        <source>Rename type {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
-        <target state="translated">重新命名類型 {0}，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為類型的名稱，會讓其他語言的消費者難以使用該類型。</target>
+        <source>Rename type '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a type makes it harder for consumers in other languages to use the type.</source>
+        <target state="needs-review-translation">重新命名類型 {0}，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為類型的名稱，會讓其他語言的消費者難以使用該類型。</target>
         <note />
       </trans-unit>
       <trans-unit id="IdentifiersShouldNotMatchKeywordsMessageNamespace">
-        <source>Rename namespace {0} so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
-        <target state="translated">重新命名命名空間 {0} ，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為命名空間的名稱，會讓其他語言的消費者難以使用該命名空間。</target>
+        <source>Rename namespace '{0}' so that it no longer conflicts with the reserved language keyword '{1}'. Using a reserved keyword as the name of a namespace makes it harder for consumers in other languages to use the namespace.</source>
+        <target state="needs-review-translation">重新命名命名空間 {0} ，使其不再與保留的語言關鍵字 '{1}' 相衝突。將保留關鍵字用作為命名空間的名稱，會讓其他語言的消費者難以使用該命名空間。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsTitle">
@@ -1298,8 +1298,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsDescription">
-        <source>The name of a public or protected member starts with ""Get"" and otherwise matches the name of a public or protected property. ""Get"" methods and properties should have names that clearly distinguish their function.</source>
-        <target state="translated">公用或受保護成員的名稱以 ""Get"" 開頭，否則需與公用或受保護屬性的名稱相符。""Get"" 方法與屬性的名稱，皆應該清楚區別其功能。</target>
+        <source>The name of a public or protected member starts with 'Get' and otherwise matches the name of a public or protected property. 'Get' methods and properties should have names that clearly distinguish their function.</source>
+        <target state="needs-review-translation">公用或受保護成員的名稱以 ""Get"" 開頭，否則需與公用或受保護屬性的名稱相符。""Get"" 方法與屬性的名稱，皆應該清楚區別其功能。</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertyNamesShouldNotMatchGetMethodsMessage">
@@ -1318,13 +1318,13 @@
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageDefault">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
-        <target state="translated">整個類型名稱 {0} 或其中的一部分，與命名空間名稱 '{1}' 相衝突。變更任一名稱以排除該衝突。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}'. Change either name to eliminate the conflict.</source>
+        <target state="needs-review-translation">整個類型名稱 {0} 或其中的一部分，與命名空間名稱 '{1}' 相衝突。變更任一名稱以排除該衝突。</target>
         <note />
       </trans-unit>
       <trans-unit id="TypeNamesShouldNotMatchNamespacesMessageSystem">
-        <source>The type name {0} conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
-        <target state="translated">整個類型名稱 {0} 或其中的一部分，與 .NET Framework 中定義的命名空間名稱 '{1}' 相衝突。重新命名類型以排除該衝突。</target>
+        <source>The type name '{0}' conflicts in whole or in part with the namespace name '{1}' defined in the .NET Framework. Rename the type to eliminate the conflict.</source>
+        <target state="needs-review-translation">整個類型名稱 {0} 或其中的一部分，與 .NET Framework 中定義的命名空間名稱 '{1}' 相衝突。重新命名類型以排除該衝突。</target>
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationTitle">
@@ -1338,8 +1338,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ParameterNamesShouldMatchBaseDeclarationMessage">
-        <source>In member {0}, change parameter name {1} to {2} in order to match the identifier as it has been declared in {3}</source>
-        <target state="translated">在成員 {0} 中，將參數名稱從 {1} 變更為 {2}，以符合已於 {3} 中宣告的識別項</target>
+        <source>In member '{0}', change parameter name '{1}' to '{2}' in order to match the identifier as it has been declared in '{3}'</source>
+        <target state="needs-review-translation">在成員 {0} 中，將參數名稱從 {1} 變更為 {2}，以符合已於 {3} 中宣告的識別項</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsTitle">
@@ -1353,8 +1353,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssembly">
-        <source>Replace the term '{0}' in assembly name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">以慣用替代項 '{2}' 取代組件名稱 {1} 中的字詞 '{0}'</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">以慣用替代項 '{2}' 取代組件名稱 {1} 中的字詞 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespace">
@@ -1363,38 +1363,38 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameter">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在成員 {0} 中，以慣用的替代項 '{3}' 取代參數名稱 {2} 中的字詞 '{1}'</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在成員 {0} 中，以慣用的替代項 '{3}' 取代參數名稱 {2} 中的字詞 '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameter">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在委派 {0} 中，以慣用的替代項 '{3}' 取代參數名稱 {2} 中的字詞 '{1}'</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在委派 {0} 中，以慣用的替代項 '{3}' 取代參數名稱 {2} 中的字詞 '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameter">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在型別 {0} 上，以慣用的替代項 '{3}' 取代泛型型別參數名稱 {2} 中的字詞 '{1}'</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在型別 {0} 上，以慣用的替代項 '{3}' 取代泛型型別參數名稱 {2} 中的字詞 '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameter">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with the preferred alternate '{3}'</source>
-        <target state="translated">在方法 {0} 上，以慣用的替代項 '{3}' 取代泛型型別參數名稱 {2} 中的字詞 '{1}'</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with the preferred alternate '{3}'</source>
+        <target state="needs-review-translation">在方法 {0} 上，以慣用的替代項 '{3}' 取代泛型型別參數名稱 {2} 中的字詞 '{1}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageType">
-        <source>Replace the term '{0}' in type name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">以慣用替代項 '{2}' 取代型別名稱 {1} 中的字詞 '{0}'</target>
+        <source>Replace the term '{0}' in type name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">以慣用替代項 '{2}' 取代型別名稱 {1} 中的字詞 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMember">
-        <source>Replace the term '{0}' in member name {1} with the preferred alternate '{2}'</source>
-        <target state="translated">以慣用的替代項 '{2}' 取代成員名稱 {1} 中的字詞 '{0}'</target>
+        <source>Replace the term '{0}' in member name '{1}' with the preferred alternate '{2}'</source>
+        <target state="needs-review-translation">以慣用的替代項 '{2}' 取代成員名稱 {1} 中的字詞 '{0}'</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageAssemblyNoAlternate">
-        <source>Replace the term '{0}' in assembly name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">以適當的替代項取代組件名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
+        <source>Replace the term '{0}' in assembly name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">以適當的替代項取代組件名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageNamespaceNoAlternate">
@@ -1403,33 +1403,33 @@
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberParameterNoAlternate">
-        <source>In member {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在成員 {0} 中，以適當的替代項取代參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
+        <source>In member '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在成員 {0} 中，以適當的替代項取代參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageDelegateParameterNoAlternate">
-        <source>In delegate {0}, replace the term '{1}' in parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在委派 {0} 中，以適當的替代項取代參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
+        <source>In delegate '{0}', replace the term '{1}' in parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在委派 {0} 中，以適當的替代項取代參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeTypeParameterNoAlternate">
-        <source>On type {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在型別 {0} 上，以適當的替代項取代泛型型別參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
+        <source>On type '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在型別 {0} 上，以適當的替代項取代泛型型別參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMethodTypeParameterNoAlternate">
-        <source>On method {0}, replace the term '{1}' in generic type parameter name {2} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">在方法 {0} 上，以適當的替代項取代泛型型別參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
+        <source>On method '{0}', replace the term '{1}' in generic type parameter name '{2}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">在方法 {0} 上，以適當的替代項取代泛型型別參數名稱 {2} 中的字詞 '{1}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageTypeNoAlternate">
-        <source>Replace the term '{0}' in type name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">以適當的替代項取代型別名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
+        <source>Replace the term '{0}' in type name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">以適當的替代項取代型別名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="UsePreferredTermsMessageMemberNoAlternate">
-        <source>Replace the term '{0}' in member name {1} with an appropriate alternate or remove it entirely</source>
-        <target state="translated">以適當的替代項取代成員名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
+        <source>Replace the term '{0}' in member name '{1}' with an appropriate alternate or remove it entirely</source>
+        <target state="needs-review-translation">以適當的替代項取代成員名稱 {1} 中的字詞 '{0}'，或是將其完全移除</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesTitle">
@@ -1443,13 +1443,13 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageEquals">
-        <source>{0} should override Equals</source>
-        <target state="translated">{0} 應該覆寫 Equals</target>
+        <source>'{0}' should override 'Equals'</source>
+        <target state="needs-review-translation">{0} 應該覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsAndOperatorEqualsOnValueTypesMessageOpEquality">
-        <source>{0} should override the equality (==) and inequality (!=) operators</source>
-        <target state="translated">{0} 應該覆寫等號比較運算子 (==) 以及不等比較運算子 (!=)</target>
+        <source>'{0}' should override the equality (==) and inequality (!=) operators</source>
+        <target state="needs-review-translation">{0} 應該覆寫等號比較運算子 (==) 以及不等比較運算子 (!=)</target>
         <note />
       </trans-unit>
       <trans-unit id="PropertiesShouldNotReturnArraysTitle">
@@ -1478,43 +1478,43 @@
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNoStrongName">
-        <source>Sign {0} with a strong name key.</source>
-        <target state="translated">以強式名稱金鑰簽署 {0}。</target>
+        <source>Sign '{0}' with a strong name key.</source>
+        <target state="needs-review-translation">以強式名稱金鑰簽署 {0}。</target>
         <note />
       </trans-unit>
       <trans-unit id="AssembliesShouldHaveValidStrongNamesMessageNotValid">
-        <source>Verify that {0} has a valid strong name before deploying.</source>
-        <target state="translated">請先確認 {0} 具有有效的強式名稱，然後再進行部署。</target>
+        <source>Verify that '{0}' has a valid strong name before deploying.</source>
+        <target state="needs-review-translation">請先確認 {0} 具有有效的強式名稱，然後再進行部署。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsTitle">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">覆寫 Equals 時覆寫 GetHashCode</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">覆寫 Equals 時覆寫 GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsDescription">
-        <source>GetHashCode returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
-        <target state="translated">GetHashCode 會依據目前執行個體傳回值，適用於雜湊演算法以及像是雜湊資料表等的資料結構。兩個具有相同類型且相等的物件，必須傳回相同的雜湊碼。</target>
+        <source>'GetHashCode' returns a value, based on the current instance, that is suited for hashing algorithms and data structures such as a hash table. Two objects that are the same type and are equal must return the same hash code.</source>
+        <target state="needs-review-translation">GetHashCode 會依據目前執行個體傳回值，適用於雜湊演算法以及像是雜湊資料表等的資料結構。兩個具有相同類型且相等的物件，必須傳回相同的雜湊碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsMessage">
-        <source>Override GetHashCode on overriding Equals</source>
-        <target state="translated">覆寫 Equals 時覆寫 GetHashCode</target>
+        <source>Override 'GetHashCode' on overriding 'Equals'</source>
+        <target state="needs-review-translation">覆寫 Equals 時覆寫 GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsTitle">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">多載等號比較運算子時覆寫 Equals</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">多載等號比較運算子時覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsDescription">
-        <source>A public type implements the equality operator but does not override Object.Equals.</source>
-        <target state="translated">公用類型會實作等號比較運算子，但不會覆寫 Object.Equals。</target>
+        <source>A public type implements the equality operator but does not override 'Object.Equals'.</source>
+        <target state="needs-review-translation">公用類型會實作等號比較運算子，但不會覆寫 Object.Equals。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsMessage">
-        <source>Override Equals on overloading operator equals</source>
-        <target state="translated">多載等號比較運算子時覆寫 Equals</target>
+        <source>Override 'Equals' on overloading operator equals</source>
+        <target state="needs-review-translation">多載等號比較運算子時覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="Since_0_redefines_operator_1_it_should_also_redefine_operator_2">
@@ -1528,18 +1528,18 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnOverloadingOperatorEqualsCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">覆寫 object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">覆寫 object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideEqualsOnImplementingIEquatableCodeActionTitle">
-        <source>Override object.Equals</source>
-        <target state="translated">覆寫 object.Equals</target>
+        <source>Override 'object.Equals'</source>
+        <target state="needs-review-translation">覆寫 object.Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideGetHashCodeOnOverridingEqualsCodeActionTitle">
-        <source>Override object.GetHashCode</source>
-        <target state="translated">覆寫 object.GetHashCode</target>
+        <source>Override 'object.GetHashCode'</source>
+        <target state="needs-review-translation">覆寫 object.GetHashCode</target>
         <note />
       </trans-unit>
       <trans-unit id="MakeExceptionPublic">
@@ -1573,18 +1573,18 @@
         <note />
       </trans-unit>
       <trans-unit id="MakeClassStatic">
-        <source>Make Class Static</source>
-        <target state="translated">將類別設為靜態</target>
+        <source>Make class static</source>
+        <target state="needs-review-translation">將類別設為靜態</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsMessage">
-        <source>Type {0} should override Equals because it implements IEquatable&lt;T&gt;</source>
-        <target state="translated">因為類型 {0} 會實作 IEquatable&lt;T&gt;，所以其應覆寫 Equals</target>
+        <source>Type '{0}' should override 'Equals' because it implements 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">因為類型 {0} 會實作 IEquatable&lt;T&gt;，所以其應覆寫 Equals</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsTitle">
-        <source>Override Object.Equals(object) when implementing IEquatable&lt;T&gt;</source>
-        <target state="translated">實作 IEquatable&lt;T&gt; 時覆寫 Object.Equals(object)</target>
+        <source>Override 'Object.Equals(object)' when implementing 'IEquatable&lt;T&gt;'</source>
+        <target state="needs-review-translation">實作 IEquatable&lt;T&gt; 時覆寫 Object.Equals(object)</target>
         <note />
       </trans-unit>
       <trans-unit id="UseIntegralOrStringArgumentForIndexersDescription">
@@ -1603,18 +1603,18 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskDescription">
-        <source>When an asynchronous method awaits a Task directly, continuation occurs in the same thread that created the task. Consider calling Task.ConfigureAwait(Boolean) to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling ConfigureAwait(true) on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
-        <target state="translated">當非同步方法直接等候 Task 時，接續會發生在建立工作的同一個執行緒中。請考慮呼叫 Task.ConfigureAwait(Boolean) 以表示您打算接續。對工作呼叫 ConfigureAwait(false) 可對執行緒集區排程接續，從而避免 UI 執行緒上產生死結。傳遞 false 是適用於應用程式獨立程式庫的選項。對工作呼叫 ConfigureAwait(true) 的行為與未明確呼叫 ConfigureAwait 的行為相同。明確呼叫此方法，表示要讓讀取器知道您打算對原始同步內容執行接續。</target>
+        <source>When an asynchronous method awaits a 'Task' directly, continuation occurs in the same thread that created the task. Consider calling 'Task.ConfigureAwait(Boolean)' to signal your intention for continuation. Call ConfigureAwait(false) on the task to schedule continuations to the thread pool, thereby avoiding a deadlock on the UI thread. Passing false is a good option for app-independent libraries. Calling 'ConfigureAwait(true)' on the task has the same behavior as not explicitly calling ConfigureAwait. By explicitly calling this method, you're letting readers know you intentionally want to perform the continuation on the original synchronization context.</source>
+        <target state="needs-review-translation">當非同步方法直接等候 Task 時，接續會發生在建立工作的同一個執行緒中。請考慮呼叫 Task.ConfigureAwait(Boolean) 以表示您打算接續。對工作呼叫 ConfigureAwait(false) 可對執行緒集區排程接續，從而避免 UI 執行緒上產生死結。傳遞 false 是適用於應用程式獨立程式庫的選項。對工作呼叫 ConfigureAwait(true) 的行為與未明確呼叫 ConfigureAwait 的行為相同。明確呼叫此方法，表示要讓讀取器知道您打算對原始同步內容執行接續。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskMessage">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">請考慮對等候的工作呼叫 ConfigureAwait</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">請考慮對等候的工作呼叫 ConfigureAwait</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotDirectlyAwaitATaskTitle">
-        <source>Consider calling ConfigureAwait on the awaited task</source>
-        <target state="translated">請考慮對等候的工作呼叫 ConfigureAwait</target>
+        <source>Consider calling 'ConfigureAwait' on the awaited task</source>
+        <target state="needs-review-translation">請考慮對等候的工作呼叫 ConfigureAwait</target>
         <note />
       </trans-unit>
       <trans-unit id="AppendConfigureAwaitFalse">
@@ -1623,8 +1623,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ImplementIEquatableWhenOverridingObjectEqualsDescription">
-        <source>When a type T overrides Object.Equals(object), the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements IEquatable&lt;T&gt;, and therefore offers the method T.Equals(T), and if the argument is known at compile time to be of type T, then the compiler can call IEquatable&lt;T&gt;.Equals(T) instead of Object.Equals(object), and no cast is necessary, improving performance.</source>
-        <target state="translated">當類型 T 覆寫 Object.Equals(object) 時，實作必須將物件引數轉換為正確的類型 T，然後才可執行比較。如果此類型會實作 IEquatable&lt;T&gt;，因而提供方法 T.Equals(T)，且引數若在編譯時期即已知為類型 T，則編譯器可呼叫 IEquatable&lt;T&gt;.Equals(T) 而非 Object.Equals(object)，而不需要轉換，如此即可改進效能。</target>
+        <source>When a type T overrides 'Object.Equals(object)', the implementation must cast the object argument to the correct type T before performing the comparison. If the type implements 'IEquatable&lt;T&gt;', and therefore offers the method 'T.Equals(T)', and if the argument is known at compile time to be of type 'T', then the compiler can call 'IEquatable&lt;T&gt;.Equals(T)' instead of 'Object.Equals(object)', and no cast is necessary, improving performance.</source>
+        <target state="needs-review-translation">當類型 T 覆寫 Object.Equals(object) 時，實作必須將物件引數轉換為正確的類型 T，然後才可執行比較。如果此類型會實作 IEquatable&lt;T&gt;，因而提供方法 T.Equals(T)，且引數若在編譯時期即已知為類型 T，則編譯器可呼叫 IEquatable&lt;T&gt;.Equals(T) 而非 Object.Equals(object)，而不需要轉換，如此即可改進效能。</target>
         <note />
       </trans-unit>
       <trans-unit id="OverrideObjectEqualsDescription">
@@ -1683,8 +1683,8 @@
         <note />
       </trans-unit>
       <trans-unit id="OverrideMethodsOnComparableTypesMessageBoth">
-        <source>{0} should define operator(s) '{1}' and Equals since it implements IComparable</source>
-        <target state="translated">因為 {0} 會實作 IComparable，所以應該定義運算子 '{1}' 與 Equals</target>
+        <source>'{0}' should define operator(s) '{1}' and 'Equals' since it implements 'IComparable'</source>
+        <target state="needs-review-translation">因為 {0} 會實作 IComparable，所以應該定義運算子 '{1}' 與 Equals</target>
         <note>1 is a comma-separated list</note>
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsTitle">
@@ -1698,53 +1698,53 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemGCCollect">
-        <source>Remove the call to GC.Collect from {0}. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
-        <target state="translated">從 {0} 移除對 GC.Collect 的呼叫。一般情況下，並不需要強制進行記憶體回收，且如此做可能會大幅降低效能。</target>
+        <source>Remove the call to GC.Collect from '{0}'. It is usually unnecessary to force garbage collection, and doing so can severely degrade performance.</source>
+        <target state="needs-review-translation">從 {0} 移除對 GC.Collect 的呼叫。一般情況下，並不需要強制進行記憶體回收，且如此做可能會大幅降低效能。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadResume">
-        <source>Remove the call to Thread.Resume from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">從 {0} 移除對 Thread.Resume 的呼叫。如果系統目前正在進行重要的作業，例如正在執行某個重要系統類型的類別建構函式，或是正在解決某個共用組件的安全性，則暫止與繼續執行緒都可能會造成危險。</target>
+        <source>Remove the call to 'Thread.Resume' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">從 {0} 移除對 Thread.Resume 的呼叫。如果系統目前正在進行重要的作業，例如正在執行某個重要系統類型的類別建構函式，或是正在解決某個共用組件的安全性，則暫止與繼續執行緒都可能會造成危險。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemThreadingThreadSuspend">
-        <source>Remove the call to Thread.Suspend from {0}. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
-        <target state="translated">從 {0} 移除對 Thread.Suspend 的呼叫。如果系統目前正在進行重要的作業，例如正在執行某個重要系統類型的類別建構函式，或是正在解決某個共用組件的安全性，則暫止與繼續執行緒都可能會造成危險。</target>
+        <source>Remove the call to 'Thread.Suspend' from '{0}'. Suspending and resuming threads can be dangerous if the system is in the middle of a critical operation such as executing a class constructor of an important system type or resolving security for a shared assembly.</source>
+        <target state="needs-review-translation">從 {0} 移除對 Thread.Suspend 的呼叫。如果系統目前正在進行重要的作業，例如正在執行某個重要系統類型的類別建構函式，或是正在解決某個共用組件的安全性，則暫止與繼續執行緒都可能會造成危險。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemTypeInvokeMember">
-        <source>Remove the call to System.Type.InvokeMember with BindingFlags.NonPublic from {0}. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
-        <target state="translated">從 {0} 移除利用 BindingFlags.NonPublic 對 System.Type.InvokeMember 的呼叫。相依於私用成員會增加日後阻礙變更的可能性。</target>
+        <source>Remove the call to 'System.Type.InvokeMember' with 'BindingFlags.NonPublic' from '{0}'. Taking a dependency on a private member increases the chance of a breaking change in the future.</source>
+        <target state="needs-review-translation">從 {0} 移除利用 BindingFlags.NonPublic 對 System.Type.InvokeMember 的呼叫。相依於私用成員會增加日後阻礙變更的可能性。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoInitializeSecurity">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
-        <target state="translated">{0} 是對 OLE32 API 的 P/Invoke 宣告，執行階段初始化之後可能無法正常地呼叫它。因應措施是撰寫一個在呼叫常式後會將其啟用，並呼叫受控程式碼的非受控填充碼。您可使用來自混合模式 C++ DLL 的匯出、註冊 COM 使用的受控元件，或是使用執行階段裝載 API 來執行這項作業。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called after the runtime has been initialized. The workaround is to write an unmanaged shim that will call the routine and then activate and call into managed code. You can do this using an export from a mixed-mode C++ DLL, by registering a managed component for use by COM, or by using the runtime hosting API.</source>
+        <target state="needs-review-translation">{0} 是對 OLE32 API 的 P/Invoke 宣告，執行階段初始化之後可能無法正常地呼叫它。因應措施是撰寫一個在呼叫常式後會將其啟用，並呼叫受控程式碼的非受控填充碼。您可使用來自混合模式 C++ DLL 的匯出、註冊 COM 使用的受控元件，或是使用執行階段裝載 API 來執行這項作業。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageCoSetProxyBlanket">
-        <source>{0} is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
-        <target state="translated">{0} 是對 OLE32 API 的 P/Invoke 宣告，無法正常地對執行階段可呼叫包裝函式 (包裝 COM 物件的受控物件) 進行呼叫。執行階段可呼叫包裝函式會動態擷取介面指標，因此有可能有時會出現遺漏呼叫的情況。指定的 COM 物件之執行階段可呼叫包裝函式，也會跨應用程式定義域共用，所以該呼叫可能會影響其他使用者。針對進行適當 CoSetProxyBlanket 呼叫的介面指標，以原生包裝函式 COM 物件來取代此呼叫。</target>
+        <source>'{0}' is a P/Invoke declaration to an OLE32 API that cannot be reliably called against a runtime callable wrapper (a managed object wrapping a COM object). Runtime callable wrappers dynamically fetch interface pointers so the effect of the call might be arbitrarily lost. Runtime callable wrappers for a given COM object are also shared across an application domain so the call could possibly affect other users. Replace this call with a native wrapper COM object for the interface pointer that does the appropriate CoSetProxyBlanket calls.</source>
+        <target state="needs-review-translation">{0} 是對 OLE32 API 的 P/Invoke 宣告，無法正常地對執行階段可呼叫包裝函式 (包裝 COM 物件的受控物件) 進行呼叫。執行階段可呼叫包裝函式會動態擷取介面指標，因此有可能有時會出現遺漏呼叫的情況。指定的 COM 物件之執行階段可呼叫包裝函式，也會跨應用程式定義域共用，所以該呼叫可能會影響其他使用者。針對進行適當 CoSetProxyBlanket 呼叫的介面指標，以原生包裝函式 COM 物件來取代此呼叫。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemRuntimeInteropServicesSafeHandleDangerousGetHandle">
-        <source>Remove the call to SafeHandle.DangerousGetHandle from {0}</source>
-        <target state="translated">從 {0} 移除對 SafeHandle.DangerousGetHandle 的呼叫</target>
+        <source>Remove the call to 'SafeHandle.DangerousGetHandle' from '{0}'</source>
+        <target state="needs-review-translation">從 {0} 移除對 SafeHandle.DangerousGetHandle 的呼叫</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFrom">
-        <source>Remove the call to Assembly.LoadFrom from {0}</source>
-        <target state="translated">從 {0} 移除對 Assembly.LoadFrom 的呼叫</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">從 {0} 移除對 Assembly.LoadFrom 的呼叫</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadFile">
-        <source>Remove the call to Assembly.LoadFile from {0}</source>
-        <target state="translated">從 {0} 移除對 Assembly.LoadFile 的呼叫</target>
+        <source>Remove the call to 'Assembly.LoadFile' from '{0}'</source>
+        <target state="needs-review-translation">從 {0} 移除對 Assembly.LoadFile 的呼叫</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidCallingProblematicMethodsMessageSystemReflectionAssemblyLoadWithPartialName">
-        <source>Remove the call to Assembly.LoadWithPartialName from {0}</source>
-        <target state="translated">從 {0} 移除對 Assembly.LoadWithPartialName 的呼叫</target>
+        <source>Remove the call to 'Assembly.LoadWithPartialName' from '{0}'</source>
+        <target state="needs-review-translation">從 {0} 移除對 Assembly.LoadWithPartialName 的呼叫</target>
         <note />
       </trans-unit>
       <trans-unit id="CategoryReliability">
@@ -1868,13 +1868,13 @@
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageLocal">
-        <source>{0}, a variable declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} 是在 {1} 中宣告的變數，其與類型上的執行個體欄位有相同的名稱。請變更其中一個這些項目的名稱。</target>
+        <source>'{0}', a variable declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} 是在 {1} 中宣告的變數，其與類型上的執行個體欄位有相同的名稱。請變更其中一個這些項目的名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="VariableNamesShouldNotMatchFieldNamesMessageParameter">
-        <source>{0}, a parameter declared in {1}, has the same name as an instance field on the type. Change the name of one of these items.</source>
-        <target state="translated">{0} 是在 {1} 中宣告的參數，其與類型上的執行個體欄位具有相同的名稱。請變更其中一個這些項目的名稱。</target>
+        <source>'{0}', a parameter declared in '{1}', has the same name as an instance field on the type. Change the name of one of these items.</source>
+        <target state="needs-review-translation">{0} 是在 {1} 中宣告的參數，其與類型上的執行個體欄位具有相同的名稱。請變更其中一個這些項目的名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersTitle">
@@ -1888,8 +1888,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ReviewUnusedParametersMessage">
-        <source>Parameter {0} of method {1} is never used. Remove the parameter or use it in the method body.</source>
-        <target state="translated">方法 {1} 的參數 {0} 從未使用過。請移除此參數，或將其用於方法主體中。</target>
+        <source>Parameter '{0}' of method '{1}' is never used. Remove the parameter or use it in the method body.</source>
+        <target state="needs-review-translation">方法 {1} 的參數 {0} 從未使用過。請移除此參數，或將其用於方法主體中。</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveUnusedParameterMessage">
@@ -1908,23 +1908,23 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageObjectCreation">
-        <source>{0} creates a new instance of {1} which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
-        <target state="translated">{0} 建立了 {1} 的新執行個體，但從未使用過。請將執行個體以引數方式傳遞到另一個方法、將執行個體指派到變數，或是移除該物件建立 (若不需要的話)。</target>
+        <source>'{0}' creates a new instance of '{1}' which is never used. Pass the instance as an argument to another method, assign the instance to a variable, or remove the object creation if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} 建立了 {1} 的新執行個體，但從未使用過。請將執行個體以引數方式傳遞到另一個方法、將執行個體指派到變數，或是移除該物件建立 (若不需要的話)。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageStringCreation">
-        <source>{0} calls {1} but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
-        <target state="translated">{0} 呼叫了 {1}，但未使用方法傳回的新字串執行個體。請將執行個體以引數方式傳遞到另一個方法、將執行個體指派到變數，或是移除該呼叫 (若不需要的話)。</target>
+        <source>'{0}' calls '{1}' but does not use the new string instance that the method returns. Pass the instance as an argument to another method, assign the instance to a variable, or remove the call if it is unnecessary.</source>
+        <target state="needs-review-translation">{0} 呼叫了 {1}，但未使用方法傳回的新字串執行個體。請將執行個體以引數方式傳遞到另一個方法、將執行個體指派到變數，或是移除該呼叫 (若不需要的話)。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageHResultOrErrorCode">
-        <source>{0} calls {1} but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} 呼叫了 {1}，但未使用方法傳回的 HRESULT 或錯誤碼。如此可能會導致錯誤情況或資源不足時出現非預期的行為。請使用條件陳述式中的結果、將結果指派到變數，或將其以引數方式傳遞到另一個方法。</target>
+        <source>'{0}' calls '{1}' but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} 呼叫了 {1}，但未使用方法傳回的 HRESULT 或錯誤碼。如此可能會導致錯誤情況或資源不足時出現非預期的行為。請使用條件陳述式中的結果、將結果指派到變數，或將其以引數方式傳遞到另一個方法。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessageTryParse">
-        <source>{0} calls {1} but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
-        <target state="translated">{0} 呼叫了 {1}，但未明確地檢查轉換是否成功。請在條件陳述式中使用傳回值，或確認呼叫位置在轉換失敗時，預期會將 out 引數設為預設值。</target>
+        <source>'{0}' calls '{1}' but does not explicitly check whether the conversion succeeded. Either use the return value in a conditional statement or verify that the call site expects that the out argument will be set to the default value when the conversion fails.</source>
+        <target state="needs-review-translation">{0} 呼叫了 {1}，但未明確地檢查轉換是否成功。請在條件陳述式中使用傳回值，或確認呼叫位置在轉換失敗時，預期會將 out 引數設為預設值。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesTitle">
@@ -1938,8 +1938,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidUninstantiatedInternalClassesMessage">
-        <source>{0} is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
-        <target state="translated">{0} 是明顯從未具現化的內部類別。若是如此，請從組件中移除該程式碼。如果此類別預計只會包含靜態成員，請將其設為 Static (在 Visual Basic 中為 Shared)。</target>
+        <source>'{0}' is an internal class that is apparently never instantiated. If so, remove the code from the assembly. If this class is intended to contain only static members, make it static (Shared in Visual Basic).</source>
+        <target state="needs-review-translation">{0} 是明顯從未具現化的內部類別。若是如此，請從組件中移除該程式碼。如果此類別預計只會包含靜態成員，請將其設為 Static (在 Visual Basic 中為 Shared)。</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidUnusedPrivateFieldsTitle">
@@ -1958,8 +1958,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotIgnoreMethodResultsMessagePureMethod">
-        <source>{0} calls {1} but does not use the value the method returns. Because {1} is marked as a Pure method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
-        <target state="translated">{0} 呼叫了 {1}，但未使用方法傳回的值。因為 {1} 標記為 Pure 方法，所以不能有副作用。請使用條件陳述式中的結果、將結果指派到變數，或將其以引數方式傳遞到另一個方法。</target>
+        <source>'{0}' calls '{1}' but does not use the value the method returns. Because '{1}' is marked as a 'Pure' method, it cannot have side effects. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.</source>
+        <target state="needs-review-translation">{0} 呼叫了 {1}，但未使用方法傳回的值。因為 {1} 標記為 Pure 方法，所以不能有副作用。請使用條件陳述式中的結果、將結果指派到變數，或將其以引數方式傳遞到另一個方法。</target>
         <note />
       </trans-unit>
       <trans-unit id="UseNameOfInPlaceOfStringDescription">
@@ -1978,8 +1978,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentMessage">
-        <source>The property {0} should not be assigned to itself</source>
-        <target state="translated">不應將屬性 {0} 指派給屬性自身</target>
+        <source>The property '{0}' should not be assigned to itself</source>
+        <target state="needs-review-translation">不應將屬性 {0} 指派給屬性自身</target>
         <note />
       </trans-unit>
       <trans-unit id="AvoidPropertySelfAssignmentTitle">
@@ -2043,18 +2043,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageDefault">
-        <source>{0} is a multidimensional array. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 是多維度陣列。如果可能，請用不規則陣列取代它。</target>
+        <source>'{0}' is a multidimensional array. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 是多維度陣列。如果可能，請用不規則陣列取代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageReturn">
-        <source>{0} returns a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 會傳回多維度陣列 {1}。如果可能，請用不規則陣列取代它。</target>
+        <source>'{0}' returns a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 會傳回多維度陣列 {1}。如果可能，請用不規則陣列取代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="PreferJaggedArraysOverMultidimensionalMessageBody">
-        <source>{0} uses a multidimensional array of {1}. Replace it with a jagged array if possible.</source>
-        <target state="translated">{0} 使用多維度陣列 {1}。如果可能，請用不規則陣列取代它。</target>
+        <source>'{0}' uses a multidimensional array of '{1}'. Replace it with a jagged array if possible.</source>
+        <target state="needs-review-translation">{0} 使用多維度陣列 {1}。如果可能，請用不規則陣列取代它。</target>
         <note />
       </trans-unit>
       <trans-unit id="MarkMembersAsStaticTitle">


### PR DESCRIPTION
<!--

Make sure to run `msbuild /t:pack /v:m` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.


-->
