### PR TITLE
Don't report RS0027 if overload is obsolete

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -321,6 +321,12 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                                 continue;
                             }
 
+                            // Don't flag obsolete overloads
+                            if (overload.HasAttribute(obsoleteAttribute))
+                            {
+                                continue;
+                            }
+
                             // RS0026: Symbol '{0}' violates the backcompat requirement: 'Do not add multiple overloads with optional parameters'. See '{1}' for details.
                             var overloadHasOptionalParams = overload.HasOptionalParameters();
                             if (overloadHasOptionalParams)
@@ -335,7 +341,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             }
 
                             // RS0027: Symbol '{0}' violates the backcompat requirement: 'Public API with optional parameter(s) should have the most parameters amongst its public overloads'. See '{1}' for details.
-                            if (method.Parameters.Length <= overload.Parameters.Length && !overload.HasAttribute(obsoleteAttribute))
+                            if (method.Parameters.Length <= overload.Parameters.Length)
                             {
                                 // 'method' is unshipped: Flag regardless of whether the overload is shipped/unshipped.
                                 // 'method' is shipped:   Flag only if overload is unshipped and has no optional parameters (overload will already be flagged with RS0026)

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -984,6 +984,33 @@ C.Method6(string p1) -> void
                 GetCSharpResultAt(32, 17, DeclarePublicApiAnalyzer.OverloadWithOptionalParametersShouldHaveMostParameters, "Method6", DeclarePublicApiAnalyzer.OverloadWithOptionalParametersShouldHaveMostParameters.HelpLinkUri));
         }
 
+        [Fact, WorkItem(4766, "https://github.com/dotnet/roslyn-analyzers/issues/4766")]
+        public async Task TestObsoleteOverloadWithOptionalParameters_NoDiagnostic()
+        {
+            var source = @"
+using System;
+
+public class C
+{
+    public void M(int p1 = 0) { }
+
+    [Obsolete]
+    public void M(char p1, int p2) { }
+}
+";
+
+            string shippedText = string.Empty;
+            string unshippedText = $@"
+C
+C.C() -> void
+
+C.M(char p1, int p2) -> void
+C.M(int p1 = 0) -> void
+";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
         [Fact]
         public async Task ObliviousMember_Simple()
         {

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -1000,13 +1000,36 @@ public class C
 ";
 
             string shippedText = string.Empty;
-            string unshippedText = $@"
+            string unshippedText = @"
 C
 C.C() -> void
 
 C.M(char p1, int p2) -> void
 C.M(int p1 = 0) -> void
 ";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [Fact, WorkItem(4766, "https://github.com/dotnet/roslyn-analyzers/issues/4766")]
+        public async Task TestMultipleOverloadsWithOptionalParameter_OneIsObsolete()
+        {
+            var source = @"
+using System;
+
+public class C
+{
+    public void M(int p1 = 0) { }
+
+    [Obsolete]
+    public void M(char p1 = '0') { }
+}
+";
+
+            string shippedText = @"C
+C.C() -> void
+C.M(char p1 = '0') -> void";
+            string unshippedText = "C.M(int p1 = 0) -> void";
 
             await VerifyCSharpAsync(source, shippedText, unshippedText);
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4766.

~~I currently excluded obsolete overloads from RS0027 analysis only. Let me know if the same should be done for RS0026.~~ (Done.)