### PR TITLE
Fix 'testRunTitle' and 'Artifact Name' for Ubuntu jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,13 +102,13 @@ jobs:
         testRunner: XUnit
         testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_configuration)/*.xml'
         mergeTestResults: true
-        testRunTitle: 'Windows $(_configuration)'
+        testRunTitle: 'Ubuntu $(_configuration)'
       condition: always()
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_configuration)'
-        ArtifactName: 'Windows $(_configuration)'
+        ArtifactName: 'Ubuntu $(_configuration)'
       continueOnError: true
       condition: always()
 


### PR DESCRIPTION
Noticed this error while looking for platform-specific tests in Azure:

![image](https://user-images.githubusercontent.com/31348972/106922755-08d43b00-6716-11eb-8d2d-3736869afd13.png)
