### PR TITLE
Fix Windows-only tests

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -56,7 +56,7 @@ class MyAnalyzer : DiagnosticAnalyzer
             await VerifyCSharpAsync(source, shippedText, unshippedText);
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public async Task TestCodeFixToEnableAnalyzerReleaseTracking()
         {
             var source = @"

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -335,8 +335,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 // sanitize the literal to ensure it's not multi-line
                 // replace any newline characters with a space
-                var sanitizedLiteral = literal.Replace(Environment.NewLine, " ");
-                sanitizedLiteral = sanitizedLiteral.Replace((char)13, ' ');
+                var sanitizedLiteral = literal.Replace((char)13, ' ');
                 sanitizedLiteral = sanitizedLiteral.Replace((char)10, ' ');
 
                 if (literals.Length > 0)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -183,7 +183,7 @@ End Class
 ");
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public async Task ParameterWithLocalizableAttribute_MultipleLineStringLiteralArgument_Method_Diagnostic()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -206,7 +206,7 @@ public class Test
 }
 ".NormalizeLineEndings(),
                 // Test0.cs(16,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a a".
-                GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a a"));
+                GetCSharpResultAt(16, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a  a"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports Microsoft.VisualBasic
@@ -225,7 +225,7 @@ Public Class Test
 End Class
 ".NormalizeLineEndings(),
                 // Test0.vb(13,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a a".
-                GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a a"));
+                GetBasicResultAt(13, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a  a"));
         }
 
         [Fact]
@@ -1793,7 +1793,7 @@ public class Test
             await csharpTest.RunAsync();
         }
 
-        [WindowsOnlyTheory]
+        [Theory]
         [InlineData(null)]
         [InlineData(PointsToAnalysisKind.None)]
         [InlineData(PointsToAnalysisKind.PartialWithoutTrackingFieldsAndProperties)]
@@ -1834,7 +1834,7 @@ public class Test
             {
                 csTest.ExpectedDiagnostics.Add(
                     // Test0.cs(17,13): warning CA1303: Method 'void Test.M1(C c)' passes a literal string as parameter 'param' of a call to 'void C.M(string param)'. Retrieve the following string(s) from a resource table instead: "a a".
-                    GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a a"));
+                    GetCSharpResultAt(17, 13, "void Test.M1(C c)", "param", "void C.M(string param)", "a  a"));
             }
 
             await csTest.RunAsync();
@@ -1866,7 +1866,7 @@ End Class
             {
                 vbTest.ExpectedDiagnostics.Add(
                     // Test0.vb(14,13): warning CA1303: Method 'Sub Test.M1(c As C)' passes a literal string as parameter 'param' of a call to 'Sub C.M(param As String)'. Retrieve the following string(s) from a resource table instead: "a a".
-                    GetBasicResultAt(14, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a a"));
+                    GetBasicResultAt(14, 13, "Sub Test.M1(c As C)", "param", "Sub C.M(param As String)", "a  a"));
             }
 
             await vbTest.RunAsync();


### PR DESCRIPTION
Fixing part of https://github.com/dotnet/roslyn-analyzers/issues/4586.