### PR TITLE
WIP on public API analyzer symbol exclusion

### DIFF
--- a/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
+++ b/src/Utilities/Compiler/Options/AbstractCategorizedAnalyzerConfigOptions.cs
@@ -14,6 +14,7 @@ namespace Analyzer.Utilities
     {
         private const string DotnetCodeQualityKeyPrefix = "dotnet_code_quality.";
         private const string BuildPropertyKeyPrefix = "build_property.";
+        private const string DotnetPublicApiAnalyzerPrefix = "dotnet_public_api_analyzer.";
 
         private readonly ConcurrentDictionary<string, (bool found, object? value)> _computedOptionValuesMap;
 
@@ -54,6 +55,12 @@ namespace Analyzer.Utilities
             if (key.StartsWith(BuildPropertyKeyPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 keyPrefix = BuildPropertyKeyPrefix;
+                return true;
+            }
+
+            if (key.StartsWith(DotnetPublicApiAnalyzerPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                keyPrefix = DotnetPublicApiAnalyzerPrefix;
                 return true;
             }
 


### PR DESCRIPTION
This is a draft for adding `excluded_symbol_names` support to PublicApiAnalyzers, to see that I'm on the right track.

One thing I ran up against... Ideally the user defines `dotnet_public_api_analyzer.excluded_symbol_names` in .editorconfig, and it applies to all the analyzers. However, the current infrastructure for global/specific options - which `excluded_symbol_names` depends on - supports either a totally global option (for all analyzers, not just PublicApiAnalyzers), or for specific rules; there's no middle ground for defining stuff on a prefix like `dotnet_public_api_analyzer`.

I can work on adding that 3rd layer of options if it seems to make sense - let me know.

/cc @mavasani @drewnoakes 