### PR TITLE
Introduce a base class for globalization analyzers

### DIFF
--- a/src/NetAnalyzers/Core/AbstractGlobalizationDiagnosticAnalyzer.cs
+++ b/src/NetAnalyzers/Core/AbstractGlobalizationDiagnosticAnalyzer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.NetAnalyzers
+{
+    public abstract class AbstractGlobalizationDiagnosticAnalyzer : DiagnosticAnalyzer
+    {
+        protected virtual GeneratedCodeAnalysisFlags GeneratedCodeAnalysisFlags { get; } = GeneratedCodeAnalysisFlags.None;
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags);
+            context.RegisterCompilationStartAction(context =>
+            {
+                var value = context.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.InvariantGlobalization, context.Compilation, context.CancellationToken);
+                if (value is not "true")
+                {
+                    InitializeWorker(context);
+                }
+            });
+        }
+
+        protected abstract void InitializeWorker(CompilationStartAnalysisContext compilationContext);
+    }
+}

--- a/src/NetAnalyzers/Core/AbstractGlobalizationDiagnosticAnalyzer.cs
+++ b/src/NetAnalyzers/Core/AbstractGlobalizationDiagnosticAnalyzer.cs
@@ -16,13 +16,13 @@ namespace Microsoft.CodeAnalysis.NetAnalyzers
             context.RegisterCompilationStartAction(context =>
             {
                 var value = context.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.InvariantGlobalization, context.Compilation, context.CancellationToken);
-                if (value is not "true")
+                if (value != "true")
                 {
                     InitializeWorker(context);
                 }
             });
         }
 
-        protected abstract void InitializeWorker(CompilationStartAnalysisContext compilationContext);
+        protected abstract void InitializeWorker(CompilationStartAnalysisContext context);
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzer.cs
@@ -121,7 +121,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 // CA2101 - Specify marshalling for PInvoke string arguments
-                if (dllImportData.BestFitMapping != false)
+                if (dllImportData.BestFitMapping != false ||
+                    context.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.InvariantGlobalization, context.Compilation, context.CancellationToken) is not "true")
                 {
                     bool appliedCA2101ToMethod = false;
                     foreach (IParameterSymbol parameter in methodSymbol.Parameters)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -8,13 +8,14 @@ using System.Linq;
 using System.Text;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
@@ -27,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     ///   3. The name of the string parameter that is passed to a Console.Write or Console.WriteLine method is either "value" or "format".
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotPassLiteralsAsLocalizedParameters : DiagnosticAnalyzer
+    public sealed class DoNotPassLiteralsAsLocalizedParameters : AbstractGlobalizationDiagnosticAnalyzer
     {
         internal const string RuleId = "CA1303";
 
@@ -46,135 +47,129 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            INamedTypeSymbol? localizableStateAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemComponentModelLocalizableAttribute);
+            INamedTypeSymbol? conditionalAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticsConditionalAttribute);
+            INamedTypeSymbol? systemConsoleSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemConsole);
+            ImmutableHashSet<INamedTypeSymbol> typesToIgnore = GetTypesToIgnore(compilationContext.Compilation);
 
-            context.RegisterCompilationStartAction(compilationContext =>
+            compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
             {
-                INamedTypeSymbol? localizableStateAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemComponentModelLocalizableAttribute);
-                INamedTypeSymbol? conditionalAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticsConditionalAttribute);
-                INamedTypeSymbol? systemConsoleSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemConsole);
-                ImmutableHashSet<INamedTypeSymbol> typesToIgnore = GetTypesToIgnore(compilationContext.Compilation);
-
-                compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+                if (operationBlockStartContext.OwningSymbol is not IMethodSymbol containingMethod ||
+                    operationBlockStartContext.Options.IsConfiguredToSkipAnalysis(Rule, containingMethod, operationBlockStartContext.Compilation, operationBlockStartContext.CancellationToken))
                 {
-                    if (operationBlockStartContext.OwningSymbol is not IMethodSymbol containingMethod ||
-                        operationBlockStartContext.Options.IsConfiguredToSkipAnalysis(Rule, containingMethod, operationBlockStartContext.Compilation, operationBlockStartContext.CancellationToken))
+                    return;
+                }
+
+                Lazy<DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>?> lazyValueContentResult = new Lazy<DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>?>(
+                    valueFactory: ComputeValueContentAnalysisResult, isThreadSafe: false);
+
+                operationBlockStartContext.RegisterOperationAction(operationContext =>
+                {
+                    var argument = (IArgumentOperation)operationContext.Operation;
+                    IMethodSymbol? targetMethod = null;
+                    switch (argument.Parent)
                     {
-                        return;
+                        case IInvocationOperation invocation:
+                            targetMethod = invocation.TargetMethod;
+                            break;
+
+                        case IObjectCreationOperation objectCreation:
+                            targetMethod = objectCreation.Constructor;
+                            break;
                     }
 
-                    Lazy<DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>?> lazyValueContentResult = new Lazy<DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>?>(
-                        valueFactory: ComputeValueContentAnalysisResult, isThreadSafe: false);
-
-                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                    if (ShouldAnalyze(targetMethod))
                     {
-                        var argument = (IArgumentOperation)operationContext.Operation;
-                        IMethodSymbol? targetMethod = null;
-                        switch (argument.Parent)
-                        {
-                            case IInvocationOperation invocation:
-                                targetMethod = invocation.TargetMethod;
-                                break;
+                        AnalyzeArgument(argument.Parameter, containingPropertySymbol: null, operation: argument, reportDiagnostic: operationContext.ReportDiagnostic, GetUseNamingHeuristicOption(operationContext));
+                    }
+                }, OperationKind.Argument);
 
-                            case IObjectCreationOperation objectCreation:
-                                targetMethod = objectCreation.Constructor;
-                                break;
-                        }
-
-                        if (ShouldAnalyze(targetMethod))
-                        {
-                            AnalyzeArgument(argument.Parameter, containingPropertySymbol: null, operation: argument, reportDiagnostic: operationContext.ReportDiagnostic, GetUseNamingHeuristicOption(operationContext));
-                        }
-                    }, OperationKind.Argument);
-
-                    operationBlockStartContext.RegisterOperationAction(operationContext =>
+                operationBlockStartContext.RegisterOperationAction(operationContext =>
+                {
+                    var propertyReference = (IPropertyReferenceOperation)operationContext.Operation;
+                    if (propertyReference.Parent is IAssignmentOperation assignment &&
+                        assignment.Target == propertyReference &&
+                        !propertyReference.Property.IsIndexer &&
+                        propertyReference.Property.SetMethod?.Parameters.Length == 1 &&
+                        ShouldAnalyze(propertyReference.Property))
                     {
-                        var propertyReference = (IPropertyReferenceOperation)operationContext.Operation;
-                        if (propertyReference.Parent is IAssignmentOperation assignment &&
-                            assignment.Target == propertyReference &&
-                            !propertyReference.Property.IsIndexer &&
-                            propertyReference.Property.SetMethod?.Parameters.Length == 1 &&
-                            ShouldAnalyze(propertyReference.Property))
-                        {
-                            IParameterSymbol valueSetterParam = propertyReference.Property.SetMethod.Parameters[0];
-                            AnalyzeArgument(valueSetterParam, propertyReference.Property, assignment, operationContext.ReportDiagnostic, GetUseNamingHeuristicOption(operationContext));
-                        }
-                    }, OperationKind.PropertyReference);
+                        IParameterSymbol valueSetterParam = propertyReference.Property.SetMethod.Parameters[0];
+                        AnalyzeArgument(valueSetterParam, propertyReference.Property, assignment, operationContext.ReportDiagnostic, GetUseNamingHeuristicOption(operationContext));
+                    }
+                }, OperationKind.PropertyReference);
 
-                    return;
+                return;
 
-                    // Local functions
-                    bool ShouldAnalyze(ISymbol? symbol)
-                        => symbol != null && !operationBlockStartContext.Options.IsConfiguredToSkipAnalysis(Rule, symbol, operationBlockStartContext.OwningSymbol, operationBlockStartContext.Compilation, operationBlockStartContext.CancellationToken);
+                // Local functions
+                bool ShouldAnalyze(ISymbol? symbol)
+                    => symbol != null && !operationBlockStartContext.Options.IsConfiguredToSkipAnalysis(Rule, symbol, operationBlockStartContext.OwningSymbol, operationBlockStartContext.Compilation, operationBlockStartContext.CancellationToken);
 
-                    static bool GetUseNamingHeuristicOption(OperationAnalysisContext operationContext)
-                        => operationContext.Options.GetBoolOptionValue(EditorConfigOptionNames.UseNamingHeuristic, Rule,
-                            operationContext.Operation.Syntax.SyntaxTree, operationContext.Compilation, defaultValue: false, operationContext.CancellationToken);
+                static bool GetUseNamingHeuristicOption(OperationAnalysisContext operationContext)
+                    => operationContext.Options.GetBoolOptionValue(EditorConfigOptionNames.UseNamingHeuristic, Rule,
+                        operationContext.Operation.Syntax.SyntaxTree, operationContext.Compilation, defaultValue: false, operationContext.CancellationToken);
 
-                    void AnalyzeArgument(IParameterSymbol parameter, IPropertySymbol? containingPropertySymbol, IOperation operation, Action<Diagnostic> reportDiagnostic, bool useNamingHeuristic)
+                void AnalyzeArgument(IParameterSymbol parameter, IPropertySymbol? containingPropertySymbol, IOperation operation, Action<Diagnostic> reportDiagnostic, bool useNamingHeuristic)
+                {
+                    if (ShouldBeLocalized(parameter.OriginalDefinition, containingPropertySymbol?.OriginalDefinition, localizableStateAttributeSymbol, conditionalAttributeSymbol, systemConsoleSymbol, typesToIgnore, useNamingHeuristic) &&
+                        lazyValueContentResult.Value != null)
                     {
-                        if (ShouldBeLocalized(parameter.OriginalDefinition, containingPropertySymbol?.OriginalDefinition, localizableStateAttributeSymbol, conditionalAttributeSymbol, systemConsoleSymbol, typesToIgnore, useNamingHeuristic) &&
-                            lazyValueContentResult.Value != null)
+                        ValueContentAbstractValue stringContentValue = lazyValueContentResult.Value[operation.Kind, operation.Syntax];
+                        if (stringContentValue.IsLiteralState)
                         {
-                            ValueContentAbstractValue stringContentValue = lazyValueContentResult.Value[operation.Kind, operation.Syntax];
-                            if (stringContentValue.IsLiteralState)
+                            Debug.Assert(!stringContentValue.LiteralValues.IsEmpty);
+
+                            if (stringContentValue.LiteralValues.Any(l => l is not string))
                             {
-                                Debug.Assert(!stringContentValue.LiteralValues.IsEmpty);
+                                return;
+                            }
 
-                                if (stringContentValue.LiteralValues.Any(l => l is not string))
-                                {
-                                    return;
-                                }
+                            var stringLiteralValues = stringContentValue.LiteralValues.Cast<string?>();
 
-                                var stringLiteralValues = stringContentValue.LiteralValues.Cast<string?>();
+                            // FxCop compat: Do not fire if the literal value came from a default parameter value
+                            if (stringContentValue.LiteralValues.Count == 1 &&
+                                parameter.IsOptional &&
+                                parameter.ExplicitDefaultValue is string defaultValue &&
+                                defaultValue == stringLiteralValues.Single())
+                            {
+                                return;
+                            }
 
-                                // FxCop compat: Do not fire if the literal value came from a default parameter value
-                                if (stringContentValue.LiteralValues.Count == 1 &&
-                                    parameter.IsOptional &&
-                                    parameter.ExplicitDefaultValue is string defaultValue &&
-                                    defaultValue == stringLiteralValues.Single())
-                                {
-                                    return;
-                                }
+                            // FxCop compat: Do not fire if none of the string literals have any non-control character.
+                            if (!LiteralValuesHaveNonControlCharacters(stringLiteralValues))
+                            {
+                                return;
+                            }
 
-                                // FxCop compat: Do not fire if none of the string literals have any non-control character.
-                                if (!LiteralValuesHaveNonControlCharacters(stringLiteralValues))
-                                {
-                                    return;
-                                }
-
-                                // FxCop compat: Filter out xml string literals.
-                                IEnumerable<string> filteredStrings = stringLiteralValues.Where(literal => literal != null && !LooksLikeXmlTag(literal))!;
-                                if (filteredStrings.Any())
-                                {
-                                    // Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".
-                                    var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                                    var arg2 = parameter.Name;
-                                    var arg3 = parameter.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                                    var arg4 = FormatLiteralValues(filteredStrings);
-                                    var diagnostic = operation.CreateDiagnostic(Rule, arg1, arg2, arg3, arg4);
-                                    reportDiagnostic(diagnostic);
-                                }
+                            // FxCop compat: Filter out xml string literals.
+                            IEnumerable<string> filteredStrings = stringLiteralValues.Where(literal => literal != null && !LooksLikeXmlTag(literal))!;
+                            if (filteredStrings.Any())
+                            {
+                                // Method '{0}' passes a literal string as parameter '{1}' of a call to '{2}'. Retrieve the following string(s) from a resource table instead: "{3}".
+                                var arg1 = containingMethod.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                var arg2 = parameter.Name;
+                                var arg3 = parameter.ContainingSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                                var arg4 = FormatLiteralValues(filteredStrings);
+                                var diagnostic = operation.CreateDiagnostic(Rule, arg1, arg2, arg3, arg4);
+                                reportDiagnostic(diagnostic);
                             }
                         }
                     }
+                }
 
-                    DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>? ComputeValueContentAnalysisResult()
+                DataFlowAnalysisResult<ValueContentBlockAnalysisResult, ValueContentAbstractValue>? ComputeValueContentAnalysisResult()
+                {
+                    var cfg = operationBlockStartContext.OperationBlocks.GetControlFlowGraph();
+                    if (cfg != null)
                     {
-                        var cfg = operationBlockStartContext.OperationBlocks.GetControlFlowGraph();
-                        if (cfg != null)
-                        {
-                            var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
-                            return ValueContentAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
-                                operationBlockStartContext.Options, Rule, PointsToAnalysisKind.PartialWithoutTrackingFieldsAndProperties, operationBlockStartContext.CancellationToken);
-                        }
-
-                        return null;
+                        var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(operationBlockStartContext.Compilation);
+                        return ValueContentAnalysis.TryGetOrComputeResult(cfg, containingMethod, wellKnownTypeProvider,
+                            operationBlockStartContext.Options, Rule, PointsToAnalysisKind.PartialWithoutTrackingFieldsAndProperties, operationBlockStartContext.CancellationToken);
                     }
-                });
+
+                    return null;
+                }
             });
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParameters.cs
@@ -47,14 +47,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
-            INamedTypeSymbol? localizableStateAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemComponentModelLocalizableAttribute);
-            INamedTypeSymbol? conditionalAttributeSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticsConditionalAttribute);
-            INamedTypeSymbol? systemConsoleSymbol = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemConsole);
-            ImmutableHashSet<INamedTypeSymbol> typesToIgnore = GetTypesToIgnore(compilationContext.Compilation);
+            INamedTypeSymbol? localizableStateAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemComponentModelLocalizableAttribute);
+            INamedTypeSymbol? conditionalAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticsConditionalAttribute);
+            INamedTypeSymbol? systemConsoleSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemConsole);
+            ImmutableHashSet<INamedTypeSymbol> typesToIgnore = GetTypesToIgnore(context.Compilation);
 
-            compilationContext.RegisterOperationBlockStartAction(operationBlockStartContext =>
+            context.RegisterOperationBlockStartAction(operationBlockStartContext =>
             {
                 if (operationBlockStartContext.OwningSymbol is not IMethodSymbol containingMethod ||
                     operationBlockStartContext.Options.IsConfiguredToSkipAnalysis(Rule, containingMethod, operationBlockStartContext.Compilation, operationBlockStartContext.CancellationToken))

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercase.cs
@@ -6,6 +6,7 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
@@ -19,7 +20,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// </para>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class NormalizeStringsToUppercaseAnalyzer : DiagnosticAnalyzer
+    public sealed class NormalizeStringsToUppercaseAnalyzer : AbstractGlobalizationDiagnosticAnalyzer
     {
         internal const string RuleId = "CA1308";
 
@@ -39,64 +40,58 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ToUpperRule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-            context.RegisterCompilationStartAction(compilationStartContext =>
+            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            if (stringType == null)
             {
-                var stringType = compilationStartContext.Compilation.GetSpecialType(SpecialType.System_String);
-                if (stringType == null)
+                return;
+            }
+
+            var cultureInfo = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            var invariantCulture = cultureInfo?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
+
+            // We want to flag calls to "ToLowerInvariant" and "ToLower(CultureInfo.InvariantCulture)".
+            var toLowerInvariant = stringType.GetMembers("ToLowerInvariant").OfType<IMethodSymbol>().FirstOrDefault();
+            var toLowerWithCultureInfo = cultureInfo != null ?
+                stringType.GetMembers("ToLower").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1 && Equals(m.Parameters[0].Type, cultureInfo)) :
+                null;
+
+            if (toLowerInvariant == null && toLowerWithCultureInfo == null)
+            {
+                return;
+            }
+
+            // We want to recommend calling "ToUpperInvariant" or "ToUpper(CultureInfo.InvariantCulture)".
+            var toUpperInvariant = stringType.GetMembers("ToUpperInvariant").OfType<IMethodSymbol>().FirstOrDefault();
+            var toUpperWithCultureInfo = cultureInfo != null ?
+                stringType.GetMembers("ToUpper").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1 && Equals(m.Parameters[0].Type, cultureInfo)) :
+                null;
+
+            if (toUpperInvariant == null && toUpperWithCultureInfo == null)
+            {
+                return;
+            }
+
+            compilationContext.RegisterOperationAction(operationAnalysisContext =>
+            {
+                var invocation = (IInvocationOperation)operationAnalysisContext.Operation;
+                if (invocation.TargetMethod == null)
                 {
                     return;
                 }
-
-                var cultureInfo = compilationStartContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
-                var invariantCulture = cultureInfo?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
-
-                // We want to flag calls to "ToLowerInvariant" and "ToLower(CultureInfo.InvariantCulture)".
-                var toLowerInvariant = stringType.GetMembers("ToLowerInvariant").OfType<IMethodSymbol>().FirstOrDefault();
-                var toLowerWithCultureInfo = cultureInfo != null ?
-                    stringType.GetMembers("ToLower").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1 && Equals(m.Parameters[0].Type, cultureInfo)) :
-                    null;
-
-                if (toLowerInvariant == null && toLowerWithCultureInfo == null)
+                var method = invocation.TargetMethod;
+                if (method.Equals(toLowerInvariant) ||
+                    (method.Equals(toLowerWithCultureInfo) &&
+                     ((invocation.Arguments.FirstOrDefault()?.Value as IMemberReferenceOperation)?.Member.Equals(invariantCulture) ?? false)))
                 {
-                    return;
+                    IMethodSymbol suggestedMethod = toUpperInvariant ?? toUpperWithCultureInfo!;
+
+                    // In method {0}, replace the call to {1} with {2}.
+                    var diagnostic = invocation.CreateDiagnostic(ToUpperRule, operationAnalysisContext.ContainingSymbol.Name, method.Name, suggestedMethod.Name);
+                    operationAnalysisContext.ReportDiagnostic(diagnostic);
                 }
-
-                // We want to recommend calling "ToUpperInvariant" or "ToUpper(CultureInfo.InvariantCulture)".
-                var toUpperInvariant = stringType.GetMembers("ToUpperInvariant").OfType<IMethodSymbol>().FirstOrDefault();
-                var toUpperWithCultureInfo = cultureInfo != null ?
-                    stringType.GetMembers("ToUpper").OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == 1 && Equals(m.Parameters[0].Type, cultureInfo)) :
-                    null;
-
-                if (toUpperInvariant == null && toUpperWithCultureInfo == null)
-                {
-                    return;
-                }
-
-                compilationStartContext.RegisterOperationAction(operationAnalysisContext =>
-                {
-                    var invocation = (IInvocationOperation)operationAnalysisContext.Operation;
-                    if (invocation.TargetMethod == null)
-                    {
-                        return;
-                    }
-                    var method = invocation.TargetMethod;
-                    if (method.Equals(toLowerInvariant) ||
-                        (method.Equals(toLowerWithCultureInfo) &&
-                         ((invocation.Arguments.FirstOrDefault()?.Value as IMemberReferenceOperation)?.Member.Equals(invariantCulture) ?? false)))
-                    {
-                        IMethodSymbol suggestedMethod = toUpperInvariant ?? toUpperWithCultureInfo!;
-
-                        // In method {0}, replace the call to {1} with {2}.
-                        var diagnostic = invocation.CreateDiagnostic(ToUpperRule, operationAnalysisContext.ContainingSymbol.Name, method.Name, suggestedMethod.Name);
-                        operationAnalysisContext.ReportDiagnostic(diagnostic);
-                    }
-                }, OperationKind.Invocation);
-            });
+            }, OperationKind.Invocation);
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercase.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/NormalizeStringsToUppercase.cs
@@ -40,15 +40,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ToUpperRule);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
-            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            var stringType = context.Compilation.GetSpecialType(SpecialType.System_String);
             if (stringType == null)
             {
                 return;
             }
 
-            var cultureInfo = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            var cultureInfo = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
             var invariantCulture = cultureInfo?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
 
             // We want to flag calls to "ToLowerInvariant" and "ToLower(CultureInfo.InvariantCulture)".
@@ -73,7 +73,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
-            compilationContext.RegisterOperationAction(operationAnalysisContext =>
+            context.RegisterOperationAction(operationAnalysisContext =>
             {
                 var invocation = (IInvocationOperation)operationAnalysisContext.Operation;
                 if (invocation.TargetMethod == null)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfo.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfo.cs
@@ -7,6 +7,7 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
@@ -15,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// CA1304: Specify CultureInfo
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class SpecifyCultureInfoAnalyzer : DiagnosticAnalyzer
+    public sealed class SpecifyCultureInfoAnalyzer : AbstractGlobalizationDiagnosticAnalyzer
     {
         internal const string RuleId = "CA1304";
 
@@ -34,56 +35,50 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            var obsoleteAttributeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
 
-            context.RegisterCompilationStartAction(csaContext =>
+            var cultureInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            if (cultureInfoType != null)
             {
-                var obsoleteAttributeType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
-
-                var cultureInfoType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
-                if (cultureInfoType != null)
+                compilationContext.RegisterOperationAction(oaContext =>
                 {
-                    csaContext.RegisterOperationAction(oaContext =>
+                    var invocationExpression = (IInvocationOperation)oaContext.Operation;
+                    var targetMethod = invocationExpression.TargetMethod;
+                    if (targetMethod.ContainingType == null || targetMethod.ContainingType.IsErrorType() || targetMethod.IsGenericMethod)
                     {
-                        var invocationExpression = (IInvocationOperation)oaContext.Operation;
-                        var targetMethod = invocationExpression.TargetMethod;
-                        if (targetMethod.ContainingType == null || targetMethod.ContainingType.IsErrorType() || targetMethod.IsGenericMethod)
-                        {
-                            return;
-                        }
+                        return;
+                    }
 
-                        if (oaContext.Options.IsConfiguredToSkipAnalysis(Rule, targetMethod, oaContext.ContainingSymbol, oaContext.Compilation, oaContext.CancellationToken))
-                        {
-                            return;
-                        }
+                    if (oaContext.Options.IsConfiguredToSkipAnalysis(Rule, targetMethod, oaContext.ContainingSymbol, oaContext.Compilation, oaContext.CancellationToken))
+                    {
+                        return;
+                    }
 
-                        IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>().WhereMethodDoesNotContainAttribute(obsoleteAttributeType).ToList();
-                        if (methodsWithSameNameAsTargetMethod.HasFewerThan(2))
-                        {
-                            return;
-                        }
+                    IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>().WhereMethodDoesNotContainAttribute(obsoleteAttributeType).ToList();
+                    if (methodsWithSameNameAsTargetMethod.HasFewerThan(2))
+                    {
+                        return;
+                    }
 
-                        var correctOverloads = methodsWithSameNameAsTargetMethod.GetMethodOverloadsWithDesiredParameterAtLeadingOrTrailing(targetMethod, cultureInfoType).ToList();
+                    var correctOverloads = methodsWithSameNameAsTargetMethod.GetMethodOverloadsWithDesiredParameterAtLeadingOrTrailing(targetMethod, cultureInfoType).ToList();
 
-                        // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
-                        // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
-                        var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(cultureInfoType)) ?? correctOverloads.FirstOrDefault();
+                    // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
+                    // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
+                    var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(cultureInfoType)) ?? correctOverloads.FirstOrDefault();
 
-                        if (correctOverload != null)
-                        {
-                            oaContext.ReportDiagnostic(
-                                invocationExpression.Syntax.CreateDiagnostic(
-                                    Rule,
-                                    targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                    oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                    correctOverload.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
-                        }
-                    }, OperationKind.Invocation);
-                }
-            });
+                    if (correctOverload != null)
+                    {
+                        oaContext.ReportDiagnostic(
+                            invocationExpression.Syntax.CreateDiagnostic(
+                                Rule,
+                                targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                                oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                                correctOverload.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
+                    }
+                }, OperationKind.Invocation);
+            }
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfo.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfo.cs
@@ -35,14 +35,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
-            var obsoleteAttributeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
+            var obsoleteAttributeType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
 
-            var cultureInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            var cultureInfoType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
             if (cultureInfoType != null)
             {
-                compilationContext.RegisterOperationAction(oaContext =>
+                context.RegisterOperationAction(oaContext =>
                 {
                     var invocationExpression = (IInvocationOperation)oaContext.Operation;
                     var targetMethod = invocationExpression.TargetMethod;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -120,10 +120,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                           GetParameterInfo(stringType),
                                                                                           GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
 
-            var currentCultureProperty = cultureInfoType?.GetMembers("CurrentCulture").OfType<IPropertySymbol>().FirstOrDefault();
-            var invariantCultureProperty = cultureInfoType?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
-            var currentUICultureProperty = cultureInfoType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
-            var installedUICultureProperty = cultureInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var currentCultureProperty = cultureInfoType.GetMembers("CurrentCulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var invariantCultureProperty = cultureInfoType.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var currentUICultureProperty = cultureInfoType.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var installedUICultureProperty = cultureInfoType.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
             var threadType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingThread);
             var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
@@ -154,12 +154,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 #endregion
 
                 #region "IFormatProviderAlternateStringRule Only"
-                if (stringType != null && cultureInfoType != null &&
-                stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
-                (targetMethod.Equals(stringFormatMemberWithStringAndObjectParameter) ||
-                 targetMethod.Equals(stringFormatMemberWithStringObjectAndObjectParameter) ||
-                 targetMethod.Equals(stringFormatMemberWithStringObjectObjectAndObjectParameter) ||
-                 targetMethod.Equals(stringFormatMemberWithStringAndParamsObjectParameter)))
+                if (stringType != null && stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
+                    (targetMethod.Equals(stringFormatMemberWithStringAndObjectParameter) ||
+                     targetMethod.Equals(stringFormatMemberWithStringObjectAndObjectParameter) ||
+                     targetMethod.Equals(stringFormatMemberWithStringObjectObjectAndObjectParameter) ||
+                     targetMethod.Equals(stringFormatMemberWithStringAndParamsObjectParameter)))
                 {
                     // Sample message for IFormatProviderAlternateStringRule: Because the behavior of string.Format(string, object) could vary based on the current user's locale settings,
                     // replace this call in IFormatProviderStringTest.M() with a call to string.Format(IFormatProvider, string, params object[]).

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -7,6 +7,7 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
@@ -15,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// CA1305: Specify IFormatProvider
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class SpecifyIFormatProviderAnalyzer : DiagnosticAnalyzer
+    public sealed class SpecifyIFormatProviderAnalyzer : AbstractGlobalizationDiagnosticAnalyzer
     {
         internal const string RuleId = "CA1305";
 
@@ -64,186 +65,182 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(IFormatProviderAlternateStringRule, IFormatProviderAlternateRule, UICultureStringRule, UICultureRule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            context.RegisterCompilationStartAction(csaContext =>
+            #region "Get All the WellKnown Types and Members"
+            var iformatProviderType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIFormatProvider);
+            var cultureInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            if (iformatProviderType == null || cultureInfoType == null)
             {
-                #region "Get All the WellKnown Types and Members"
-                var iformatProviderType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIFormatProvider);
-                var cultureInfoType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
-                if (iformatProviderType == null || cultureInfoType == null)
+                return;
+            }
+
+            var objectType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Object);
+            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            if (objectType == null || stringType == null)
+            {
+                return;
+            }
+
+            var charType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Char);
+            var boolType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Boolean);
+            var guidType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGuid);
+
+            var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+            builder.AddIfNotNull(charType);
+            builder.AddIfNotNull(boolType);
+            builder.AddIfNotNull(stringType);
+            builder.AddIfNotNull(guidType);
+            var invariantToStringTypes = builder.ToImmutableHashSet();
+
+            var dateTimeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTime);
+            var dateTimeOffsetType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTimeOffset);
+            var timeSpanType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTimeSpan);
+
+            var stringFormatMembers = stringType.GetMembers("Format").OfType<IMethodSymbol>();
+
+            var stringFormatMemberWithStringAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
+                                                                     GetParameterInfo(stringType),
+                                                                     GetParameterInfo(objectType));
+            var stringFormatMemberWithStringObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
+                                                                           GetParameterInfo(stringType),
+                                                                           GetParameterInfo(objectType),
+                                                                           GetParameterInfo(objectType));
+            var stringFormatMemberWithStringObjectObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
+                                                                                 GetParameterInfo(stringType),
+                                                                                 GetParameterInfo(objectType),
+                                                                                 GetParameterInfo(objectType),
+                                                                                 GetParameterInfo(objectType));
+            var stringFormatMemberWithStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
+                                                                           GetParameterInfo(stringType),
+                                                                           GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
+            var stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
+                                                                                          GetParameterInfo(iformatProviderType),
+                                                                                          GetParameterInfo(stringType),
+                                                                                          GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
+
+            var currentCultureProperty = cultureInfoType?.GetMembers("CurrentCulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var invariantCultureProperty = cultureInfoType?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var currentUICultureProperty = cultureInfoType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+            var installedUICultureProperty = cultureInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+
+            var threadType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingThread);
+            var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+
+            var activatorType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemActivator);
+            var resourceManagerType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemResourcesResourceManager);
+
+            var computerInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualBasicDevicesComputerInfo);
+            var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
+
+            var obsoleteAttributeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
+            #endregion
+
+            compilationContext.RegisterOperationAction(oaContext =>
+            {
+                var invocationExpression = (IInvocationOperation)oaContext.Operation;
+                var targetMethod = invocationExpression.TargetMethod;
+
+                #region "Exceptions"
+                if (targetMethod.IsGenericMethod ||
+                targetMethod.ContainingType.IsErrorType() ||
+                (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
+                (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType)) ||
+                IsValidToStringCall(invocationExpression, invariantToStringTypes, dateTimeType, dateTimeOffsetType, timeSpanType))
                 {
                     return;
                 }
-
-                var objectType = csaContext.Compilation.GetSpecialType(SpecialType.System_Object);
-                var stringType = csaContext.Compilation.GetSpecialType(SpecialType.System_String);
-                if (objectType == null || stringType == null)
-                {
-                    return;
-                }
-
-                var charType = csaContext.Compilation.GetSpecialType(SpecialType.System_Char);
-                var boolType = csaContext.Compilation.GetSpecialType(SpecialType.System_Boolean);
-                var guidType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGuid);
-
-                var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
-                builder.AddIfNotNull(charType);
-                builder.AddIfNotNull(boolType);
-                builder.AddIfNotNull(stringType);
-                builder.AddIfNotNull(guidType);
-                var invariantToStringTypes = builder.ToImmutableHashSet();
-
-                var dateTimeType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTime);
-                var dateTimeOffsetType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTimeOffset);
-                var timeSpanType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTimeSpan);
-
-                var stringFormatMembers = stringType.GetMembers("Format").OfType<IMethodSymbol>();
-
-                var stringFormatMemberWithStringAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
-                                                                         GetParameterInfo(stringType),
-                                                                         GetParameterInfo(objectType));
-                var stringFormatMemberWithStringObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
-                                                                               GetParameterInfo(stringType),
-                                                                               GetParameterInfo(objectType),
-                                                                               GetParameterInfo(objectType));
-                var stringFormatMemberWithStringObjectObjectAndObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
-                                                                                     GetParameterInfo(stringType),
-                                                                                     GetParameterInfo(objectType),
-                                                                                     GetParameterInfo(objectType),
-                                                                                     GetParameterInfo(objectType));
-                var stringFormatMemberWithStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
-                                                                               GetParameterInfo(stringType),
-                                                                               GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
-                var stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter = stringFormatMembers.GetFirstOrDefaultMemberWithParameterInfos(
-                                                                                              GetParameterInfo(iformatProviderType),
-                                                                                              GetParameterInfo(stringType),
-                                                                                              GetParameterInfo(objectType, isArray: true, arrayRank: 1, isParams: true));
-
-                var currentCultureProperty = cultureInfoType?.GetMembers("CurrentCulture").OfType<IPropertySymbol>().FirstOrDefault();
-                var invariantCultureProperty = cultureInfoType?.GetMembers("InvariantCulture").OfType<IPropertySymbol>().FirstOrDefault();
-                var currentUICultureProperty = cultureInfoType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
-                var installedUICultureProperty = cultureInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
-
-                var threadType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingThread);
-                var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
-
-                var activatorType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemActivator);
-                var resourceManagerType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemResourcesResourceManager);
-
-                var computerInfoType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualBasicDevicesComputerInfo);
-                var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
-
-                var obsoleteAttributeType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
                 #endregion
 
-                csaContext.RegisterOperationAction(oaContext =>
+                #region "IFormatProviderAlternateStringRule Only"
+                if (stringType != null && cultureInfoType != null &&
+                stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
+                (targetMethod.Equals(stringFormatMemberWithStringAndObjectParameter) ||
+                 targetMethod.Equals(stringFormatMemberWithStringObjectAndObjectParameter) ||
+                 targetMethod.Equals(stringFormatMemberWithStringObjectObjectAndObjectParameter) ||
+                 targetMethod.Equals(stringFormatMemberWithStringAndParamsObjectParameter)))
                 {
-                    var invocationExpression = (IInvocationOperation)oaContext.Operation;
-                    var targetMethod = invocationExpression.TargetMethod;
+                    // Sample message for IFormatProviderAlternateStringRule: Because the behavior of string.Format(string, object) could vary based on the current user's locale settings,
+                    // replace this call in IFormatProviderStringTest.M() with a call to string.Format(IFormatProvider, string, params object[]).
+                    oaContext.ReportDiagnostic(
+                    invocationExpression.Syntax.CreateDiagnostic(
+                        IFormatProviderAlternateStringRule,
+                        targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                        oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                        stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
 
-                    #region "Exceptions"
-                    if (targetMethod.IsGenericMethod ||
-                        targetMethod.ContainingType.IsErrorType() ||
-                        (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
-                        (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType)) ||
-                        IsValidToStringCall(invocationExpression, invariantToStringTypes, dateTimeType, dateTimeOffsetType, timeSpanType))
-                    {
-                        return;
-                    }
-                    #endregion
+                    return;
+                }
+                #endregion
 
-                    #region "IFormatProviderAlternateStringRule Only"
-                    if (stringType != null && cultureInfoType != null &&
-                        stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
-                        (targetMethod.Equals(stringFormatMemberWithStringAndObjectParameter) ||
-                         targetMethod.Equals(stringFormatMemberWithStringObjectAndObjectParameter) ||
-                         targetMethod.Equals(stringFormatMemberWithStringObjectObjectAndObjectParameter) ||
-                         targetMethod.Equals(stringFormatMemberWithStringAndParamsObjectParameter)))
+                #region "IFormatProviderAlternateStringRule & IFormatProviderAlternateRule"
+
+                IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>().WhereMethodDoesNotContainAttribute(obsoleteAttributeType).ToList();
+                if (methodsWithSameNameAsTargetMethod.HasMoreThan(1))
+                {
+                    var correctOverloads = methodsWithSameNameAsTargetMethod.GetMethodOverloadsWithDesiredParameterAtLeadingOrTrailing(targetMethod, iformatProviderType).ToList();
+
+                    // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
+                    // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
+                    var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(iformatProviderType)) ?? correctOverloads.FirstOrDefault();
+
+                    // Sample message for IFormatProviderAlternateRule: Because the behavior of Convert.ToInt64(string) could vary based on the current user's locale settings,
+                    // replace this call in IFormatProviderStringTest.TestMethod() with a call to Convert.ToInt64(string, IFormatProvider).
+                    if (correctOverload != null)
                     {
-                        // Sample message for IFormatProviderAlternateStringRule: Because the behavior of string.Format(string, object) could vary based on the current user's locale settings,
-                        // replace this call in IFormatProviderStringTest.M() with a call to string.Format(IFormatProvider, string, params object[]).
                         oaContext.ReportDiagnostic(
                             invocationExpression.Syntax.CreateDiagnostic(
-                                IFormatProviderAlternateStringRule,
+                                targetMethod.ReturnType.Equals(stringType) ?
+                                 IFormatProviderAlternateStringRule :
+                                 IFormatProviderAlternateRule,
                                 targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
                                 oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
-
-                        return;
+                                correctOverload.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
                     }
-                    #endregion
+                }
+                #endregion
 
-                    #region "IFormatProviderAlternateStringRule & IFormatProviderAlternateRule"
+                #region "UICultureStringRule & UICultureRule"
+                IEnumerable<int> IformatProviderParameterIndices = GetIndexesOfParameterType(targetMethod, iformatProviderType);
+                foreach (var index in IformatProviderParameterIndices)
+                {
+                    var argument = invocationExpression.Arguments[index];
 
-                    IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>().WhereMethodDoesNotContainAttribute(obsoleteAttributeType).ToList();
-                    if (methodsWithSameNameAsTargetMethod.HasMoreThan(1))
+                    if (argument != null && currentUICultureProperty != null &&
+                        installedUICultureProperty != null && currentThreadCurrentUICultureProperty != null)
                     {
-                        var correctOverloads = methodsWithSameNameAsTargetMethod.GetMethodOverloadsWithDesiredParameterAtLeadingOrTrailing(targetMethod, iformatProviderType).ToList();
+                        var semanticModel = argument.SemanticModel;
 
-                        // If there are two matching overloads, one with CultureInfo as the first parameter and one with CultureInfo as the last parameter,
-                        // report the diagnostic on the overload with CultureInfo as the last parameter, to match the behavior of FxCop.
-                        var correctOverload = correctOverloads.FirstOrDefault(overload => overload.Parameters.Last().Type.Equals(iformatProviderType)) ?? correctOverloads.FirstOrDefault();
+                        var symbol = semanticModel.GetSymbolInfo(argument.Value.Syntax, oaContext.CancellationToken).Symbol;
 
-                        // Sample message for IFormatProviderAlternateRule: Because the behavior of Convert.ToInt64(string) could vary based on the current user's locale settings,
-                        // replace this call in IFormatProviderStringTest.TestMethod() with a call to Convert.ToInt64(string, IFormatProvider).
-                        if (correctOverload != null)
+                        if (symbol != null &&
+                            (symbol.Equals(currentUICultureProperty) ||
+                             symbol.Equals(installedUICultureProperty) ||
+                             symbol.Equals(currentThreadCurrentUICultureProperty) ||
+                             (installedUICulturePropertyOfComputerInfoType != null && symbol.Equals(installedUICulturePropertyOfComputerInfoType))))
                         {
+                            // Sample message
+                            // 1. UICultureStringRule - 'TestClass.TestMethod()' passes 'Thread.CurrentUICulture' as the 'IFormatProvider' parameter to 'TestClass.CalleeMethod(string, IFormatProvider)'.
+                            // This property returns a culture that is inappropriate for formatting methods.
+                            // 2. UICultureRule -'TestClass.TestMethod()' passes 'CultureInfo.CurrentUICulture' as the 'IFormatProvider' parameter to 'TestClass.Callee(IFormatProvider, string)'.
+                            // This property returns a culture that is inappropriate for formatting methods.
+
                             oaContext.ReportDiagnostic(
-                                invocationExpression.Syntax.CreateDiagnostic(
-                                    targetMethod.ReturnType.Equals(stringType) ?
-                                     IFormatProviderAlternateStringRule :
-                                     IFormatProviderAlternateRule,
-                                    targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                    oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                    correctOverload.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
+                            invocationExpression.Syntax.CreateDiagnostic(
+                                targetMethod.ReturnType.Equals(stringType) ?
+                                    UICultureStringRule :
+                                    UICultureRule,
+                                oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                                symbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
+                                targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
                         }
                     }
-                    #endregion
+                }
+                #endregion
 
-                    #region "UICultureStringRule & UICultureRule"
-                    IEnumerable<int> IformatProviderParameterIndices = GetIndexesOfParameterType(targetMethod, iformatProviderType);
-                    foreach (var index in IformatProviderParameterIndices)
-                    {
-                        var argument = invocationExpression.Arguments[index];
+            }, OperationKind.Invocation);
 
-                        if (argument != null && currentUICultureProperty != null &&
-                            installedUICultureProperty != null && currentThreadCurrentUICultureProperty != null)
-                        {
-                            var semanticModel = argument.SemanticModel;
-
-                            var symbol = semanticModel.GetSymbolInfo(argument.Value.Syntax, oaContext.CancellationToken).Symbol;
-
-                            if (symbol != null &&
-                                (symbol.Equals(currentUICultureProperty) ||
-                                 symbol.Equals(installedUICultureProperty) ||
-                                 symbol.Equals(currentThreadCurrentUICultureProperty) ||
-                                 (installedUICulturePropertyOfComputerInfoType != null && symbol.Equals(installedUICulturePropertyOfComputerInfoType))))
-                            {
-                                // Sample message
-                                // 1. UICultureStringRule - 'TestClass.TestMethod()' passes 'Thread.CurrentUICulture' as the 'IFormatProvider' parameter to 'TestClass.CalleeMethod(string, IFormatProvider)'.
-                                // This property returns a culture that is inappropriate for formatting methods.
-                                // 2. UICultureRule -'TestClass.TestMethod()' passes 'CultureInfo.CurrentUICulture' as the 'IFormatProvider' parameter to 'TestClass.Callee(IFormatProvider, string)'.
-                                // This property returns a culture that is inappropriate for formatting methods.
-
-                                oaContext.ReportDiagnostic(
-                                    invocationExpression.Syntax.CreateDiagnostic(
-                                        targetMethod.ReturnType.Equals(stringType) ?
-                                            UICultureStringRule :
-                                            UICultureRule,
-                                        oaContext.ContainingSymbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                        symbol.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat),
-                                        targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));
-                            }
-                        }
-                    }
-                    #endregion
-
-                }, OperationKind.Invocation);
-            });
         }
 
         private static IEnumerable<int> GetIndexesOfParameterType(IMethodSymbol targetMethod, INamedTypeSymbol formatProviderType)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -65,27 +65,27 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(IFormatProviderAlternateStringRule, IFormatProviderAlternateRule, UICultureStringRule, UICultureRule);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
 
             #region "Get All the WellKnown Types and Members"
-            var iformatProviderType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIFormatProvider);
-            var cultureInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
+            var iformatProviderType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIFormatProvider);
+            var cultureInfoType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGlobalizationCultureInfo);
             if (iformatProviderType == null || cultureInfoType == null)
             {
                 return;
             }
 
-            var objectType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Object);
-            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            var objectType = context.Compilation.GetSpecialType(SpecialType.System_Object);
+            var stringType = context.Compilation.GetSpecialType(SpecialType.System_String);
             if (objectType == null || stringType == null)
             {
                 return;
             }
 
-            var charType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Char);
-            var boolType = compilationContext.Compilation.GetSpecialType(SpecialType.System_Boolean);
-            var guidType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGuid);
+            var charType = context.Compilation.GetSpecialType(SpecialType.System_Char);
+            var boolType = context.Compilation.GetSpecialType(SpecialType.System_Boolean);
+            var guidType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemGuid);
 
             var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
             builder.AddIfNotNull(charType);
@@ -94,9 +94,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             builder.AddIfNotNull(guidType);
             var invariantToStringTypes = builder.ToImmutableHashSet();
 
-            var dateTimeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTime);
-            var dateTimeOffsetType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTimeOffset);
-            var timeSpanType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTimeSpan);
+            var dateTimeType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTime);
+            var dateTimeOffsetType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDateTimeOffset);
+            var timeSpanType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTimeSpan);
 
             var stringFormatMembers = stringType.GetMembers("Format").OfType<IMethodSymbol>();
 
@@ -125,19 +125,19 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var currentUICultureProperty = cultureInfoType.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
             var installedUICultureProperty = cultureInfoType.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
-            var threadType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingThread);
+            var threadType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingThread);
             var currentThreadCurrentUICultureProperty = threadType?.GetMembers("CurrentUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
-            var activatorType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemActivator);
-            var resourceManagerType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemResourcesResourceManager);
+            var activatorType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemActivator);
+            var resourceManagerType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemResourcesResourceManager);
 
-            var computerInfoType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualBasicDevicesComputerInfo);
+            var computerInfoType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualBasicDevicesComputerInfo);
             var installedUICulturePropertyOfComputerInfoType = computerInfoType?.GetMembers("InstalledUICulture").OfType<IPropertySymbol>().FirstOrDefault();
 
-            var obsoleteAttributeType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
+            var obsoleteAttributeType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemObsoleteAttribute);
             #endregion
 
-            compilationContext.RegisterOperationAction(oaContext =>
+            context.RegisterOperationAction(oaContext =>
             {
                 var invocationExpression = (IInvocationOperation)oaContext.Operation;
                 var targetMethod = invocationExpression.TargetMethod;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -239,7 +239,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 #endregion
 
             }, OperationKind.Invocation);
-
         }
 
         private static IEnumerable<int> GetIndexesOfParameterType(IMethodSymbol targetMethod, INamedTypeSymbol formatProviderType)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -154,7 +154,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 #endregion
 
                 #region "IFormatProviderAlternateStringRule Only"
-                if (stringType != null && stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
+                if (stringFormatMemberWithIFormatProviderStringAndParamsObjectParameter != null &&
                     (targetMethod.Equals(stringFormatMemberWithStringAndObjectParameter) ||
                      targetMethod.Equals(stringFormatMemberWithStringObjectAndObjectParameter) ||
                      targetMethod.Equals(stringFormatMemberWithStringObjectObjectAndObjectParameter) ||

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparison.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparison.cs
@@ -7,6 +7,7 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
@@ -15,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// CA1307: Specify StringComparison
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class SpecifyStringComparisonAnalyzer : DiagnosticAnalyzer
+    public sealed class SpecifyStringComparisonAnalyzer : AbstractGlobalizationDiagnosticAnalyzer
     {
         private const string RuleId_CA1307 = "CA1307";
         private const string RuleId_CA1310 = "CA1310";
@@ -51,84 +52,78 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule_CA1307, Rule_CA1310);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            var stringComparisonType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison);
+            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
 
-            context.RegisterCompilationStartAction(csaContext =>
+            // Without these symbols the rule cannot run
+            if (stringComparisonType == null || stringType == null)
             {
-                var stringComparisonType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison);
-                var stringType = csaContext.Compilation.GetSpecialType(SpecialType.System_String);
+                return;
+            }
 
-                // Without these symbols the rule cannot run
-                if (stringComparisonType == null || stringType == null)
+            var overloadMap = GetWellKnownStringOverloads(compilationContext.Compilation, stringType, stringComparisonType);
+
+            var linqExpressionType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
+
+            compilationContext.RegisterOperationAction(oaContext =>
+            {
+                var invocationExpression = (IInvocationOperation)oaContext.Operation;
+                var targetMethod = invocationExpression.TargetMethod;
+
+                if (targetMethod.IsGenericMethod ||
+                    targetMethod.ContainingType == null ||
+                    targetMethod.ContainingType.IsErrorType())
                 {
                     return;
                 }
 
-                var overloadMap = GetWellKnownStringOverloads(csaContext.Compilation, stringType, stringComparisonType);
-
-                var linqExpressionType = csaContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
-
-                csaContext.RegisterOperationAction(oaContext =>
+                // Check if we are in a Expression<Func<T...>> context, in which case it is possible
+                // that the underlying call doesn't have the comparison option so we want to bail-out.
+                if (invocationExpression.IsWithinExpressionTree(linqExpressionType))
                 {
-                    var invocationExpression = (IInvocationOperation)oaContext.Operation;
-                    var targetMethod = invocationExpression.TargetMethod;
+                    return;
+                }
 
-                    if (targetMethod.IsGenericMethod ||
-                        targetMethod.ContainingType == null ||
-                        targetMethod.ContainingType.IsErrorType())
-                    {
-                        return;
-                    }
+                // Report correctness issue CA1310 for known string comparison methods that default to culture specific string comparison:
+                // https://docs.microsoft.com/dotnet/standard/base-types/best-practices-strings#string-comparisons-that-use-the-current-culture
+                if (targetMethod.ContainingType.SpecialType == SpecialType.System_String &&
+                    !overloadMap.IsEmpty &&
+                    overloadMap.ContainsKey(targetMethod))
+                {
+                    ReportDiagnostic(
+                        Rule_CA1310,
+                        oaContext,
+                        invocationExpression,
+                        targetMethod,
+                        overloadMap[targetMethod]);
 
-                    // Check if we are in a Expression<Func<T...>> context, in which case it is possible
-                    // that the underlying call doesn't have the comparison option so we want to bail-out.
-                    if (invocationExpression.IsWithinExpressionTree(linqExpressionType))
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    // Report correctness issue CA1310 for known string comparison methods that default to culture specific string comparison:
-                    // https://docs.microsoft.com/dotnet/standard/base-types/best-practices-strings#string-comparisons-that-use-the-current-culture
-                    if (targetMethod.ContainingType.SpecialType == SpecialType.System_String &&
-                        !overloadMap.IsEmpty &&
-                        overloadMap.ContainsKey(targetMethod))
+                // Report maintainability issue CA1307 for any method that has an additional overload with the exact same parameter list,
+                // plus as additional StringComparison parameter. Default StringComparison may or may not match user's intent,
+                // but it is recommended to explicitly specify it for clarity and readability:
+                // https://docs.microsoft.com/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage
+                IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>();
+                if (methodsWithSameNameAsTargetMethod.HasMoreThan(1))
+                {
+                    var correctOverload = methodsWithSameNameAsTargetMethod
+                                            .GetMethodOverloadsWithDesiredParameterAtTrailing(targetMethod, stringComparisonType)
+                                            .FirstOrDefault();
+
+                    if (correctOverload != null)
                     {
                         ReportDiagnostic(
-                            Rule_CA1310,
+                            Rule_CA1307,
                             oaContext,
                             invocationExpression,
                             targetMethod,
-                            overloadMap[targetMethod]);
-
-                        return;
+                            correctOverload);
                     }
-
-                    // Report maintainability issue CA1307 for any method that has an additional overload with the exact same parameter list,
-                    // plus as additional StringComparison parameter. Default StringComparison may or may not match user's intent,
-                    // but it is recommended to explicitly specify it for clarity and readability:
-                    // https://docs.microsoft.com/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage
-                    IEnumerable<IMethodSymbol> methodsWithSameNameAsTargetMethod = targetMethod.ContainingType.GetMembers(targetMethod.Name).OfType<IMethodSymbol>();
-                    if (methodsWithSameNameAsTargetMethod.HasMoreThan(1))
-                    {
-                        var correctOverload = methodsWithSameNameAsTargetMethod
-                                                .GetMethodOverloadsWithDesiredParameterAtTrailing(targetMethod, stringComparisonType)
-                                                .FirstOrDefault();
-
-                        if (correctOverload != null)
-                        {
-                            ReportDiagnostic(
-                                Rule_CA1307,
-                                oaContext,
-                                invocationExpression,
-                                targetMethod,
-                                correctOverload);
-                        }
-                    }
-                }, OperationKind.Invocation);
-            });
+                }
+            }, OperationKind.Invocation);
 
             static ImmutableDictionary<IMethodSymbol, IMethodSymbol> GetWellKnownStringOverloads(
                 Compilation compilation,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparison.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyStringComparison.cs
@@ -52,10 +52,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule_CA1307, Rule_CA1310);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
-            var stringComparisonType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison);
-            var stringType = compilationContext.Compilation.GetSpecialType(SpecialType.System_String);
+            var stringComparisonType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemStringComparison);
+            var stringType = context.Compilation.GetSpecialType(SpecialType.System_String);
 
             // Without these symbols the rule cannot run
             if (stringComparisonType == null || stringType == null)
@@ -63,11 +63,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return;
             }
 
-            var overloadMap = GetWellKnownStringOverloads(compilationContext.Compilation, stringType, stringComparisonType);
+            var overloadMap = GetWellKnownStringOverloads(context.Compilation, stringType, stringComparisonType);
 
-            var linqExpressionType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
+            var linqExpressionType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
 
-            compilationContext.RegisterOperationAction(oaContext =>
+            context.RegisterOperationAction(oaContext =>
             {
                 var invocationExpression = (IInvocationOperation)oaContext.Operation;
                 var targetMethod = invocationExpression.TargetMethod;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseOrdinalStringComparison.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseOrdinalStringComparison.cs
@@ -7,11 +7,12 @@ using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.NetAnalyzers;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Microsoft.NetCore.Analyzers.Runtime
 {
-    public abstract class UseOrdinalStringComparisonAnalyzer : DiagnosticAnalyzer
+    public abstract class UseOrdinalStringComparisonAnalyzer : AbstractGlobalizationDiagnosticAnalyzer
     {
         internal const string RuleId = "CA1309";
 
@@ -37,50 +38,43 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        public override void Initialize(AnalysisContext context)
+        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
         {
-            context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-            context.RegisterCompilationStartAction(
-                (context) =>
+            INamedTypeSymbol? stringComparisonType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(StringComparisonTypeName);
+            if (stringComparisonType != null)
+            {
+                compilationContext.RegisterOperationAction(operationContext =>
                 {
-                    INamedTypeSymbol? stringComparisonType = context.Compilation.GetOrCreateTypeByMetadataName(StringComparisonTypeName);
-                    if (stringComparisonType != null)
+                    var operation = (IInvocationOperation)operationContext.Operation;
+                    IMethodSymbol methodSymbol = operation.TargetMethod;
+                    if (methodSymbol != null &&
+                        methodSymbol.ContainingType.SpecialType == SpecialType.System_String &&
+                        IsEqualsOrCompare(methodSymbol.Name))
                     {
-                        context.RegisterOperationAction(operationContext =>
+                        if (!IsAcceptableOverload(methodSymbol, stringComparisonType))
+                        {
+                            // wrong overload
+                            operationContext.ReportDiagnostic(Diagnostic.Create(Rule, GetMethodNameLocation(operation.Syntax)));
+                        }
+                        else
+                        {
+                            IArgumentOperation lastArgument = operation.Arguments.Last();
+                            if (lastArgument.Value.Kind == OperationKind.FieldReference)
                             {
-                                var operation = (IInvocationOperation)operationContext.Operation;
-                                IMethodSymbol methodSymbol = operation.TargetMethod;
-                                if (methodSymbol != null &&
-                                    methodSymbol.ContainingType.SpecialType == SpecialType.System_String &&
-                                    IsEqualsOrCompare(methodSymbol.Name))
+                                IFieldSymbol fieldSymbol = ((IFieldReferenceOperation)lastArgument.Value).Field;
+                                if (fieldSymbol != null &&
+                                    fieldSymbol.ContainingType.Equals(stringComparisonType) &&
+                                    !IsOrdinalOrOrdinalIgnoreCase(fieldSymbol.Name))
                                 {
-                                    if (!IsAcceptableOverload(methodSymbol, stringComparisonType))
-                                    {
-                                        // wrong overload
-                                        operationContext.ReportDiagnostic(Diagnostic.Create(Rule, GetMethodNameLocation(operation.Syntax)));
-                                    }
-                                    else
-                                    {
-                                        IArgumentOperation lastArgument = operation.Arguments.Last();
-                                        if (lastArgument.Value.Kind == OperationKind.FieldReference)
-                                        {
-                                            IFieldSymbol fieldSymbol = ((IFieldReferenceOperation)lastArgument.Value).Field;
-                                            if (fieldSymbol != null &&
-                                                fieldSymbol.ContainingType.Equals(stringComparisonType) &&
-                                                !IsOrdinalOrOrdinalIgnoreCase(fieldSymbol.Name))
-                                            {
-                                                // right overload, wrong value
-                                                operationContext.ReportDiagnostic(lastArgument.Syntax.CreateDiagnostic(Rule));
-                                            }
-                                        }
-                                    }
+                                    // right overload, wrong value
+                                    operationContext.ReportDiagnostic(lastArgument.Syntax.CreateDiagnostic(Rule));
                                 }
-                            },
-                            OperationKind.Invocation);
+                            }
+                        }
                     }
-                });
+                },
+                    OperationKind.Invocation);
+            }
         }
 
         private static bool IsEqualsOrCompare(string methodName)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseOrdinalStringComparison.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseOrdinalStringComparison.cs
@@ -38,12 +38,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
-        protected override void InitializeWorker(CompilationStartAnalysisContext compilationContext)
+        protected override void InitializeWorker(CompilationStartAnalysisContext context)
         {
-            INamedTypeSymbol? stringComparisonType = compilationContext.Compilation.GetOrCreateTypeByMetadataName(StringComparisonTypeName);
+            INamedTypeSymbol? stringComparisonType = context.Compilation.GetOrCreateTypeByMetadataName(StringComparisonTypeName);
             if (stringComparisonType != null)
             {
-                compilationContext.RegisterOperationAction(operationContext =>
+                context.RegisterOperationAction(operationContext =>
                 {
                     var operation = (IInvocationOperation)operationContext.Operation;
                     IMethodSymbol methodSymbol = operation.TargetMethod;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
@@ -15,6 +16,28 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class SpecifyCultureInfoTests
     {
+        [Theory]
+        [InlineData("build_property.InvariantCulture = false", @"[|""aaa"".ToLower()|]")]
+        [InlineData("build_property.InvariantCulture = true", @"""aaa"".ToLower()")]
+        public async Task CA1304_PlainString_CSharp_InvariantCulture(string property, string returnExpression)
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = $@"
+using System;
+using System.Globalization;
+
+public class CultureInfoTestClass0
+{{
+    public string SpecifyCultureInfo01()
+    {{
+        return {returnExpression};
+    }}
+}}",
+                AnalyzerConfigDocument = property,
+            }.RunAsync();
+        }
+
         [Fact]
         public async Task CA1304_PlainString_CSharp()
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -17,9 +17,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     public class SpecifyCultureInfoTests
     {
         [Theory]
-        [InlineData("build_property.InvariantCulture = false", @"[|""aaa"".ToLower()|]")]
-        [InlineData("build_property.InvariantCulture = true", @"""aaa"".ToLower()")]
-        public async Task CA1304_PlainString_CSharp_InvariantCulture(string property, string returnExpression)
+        [InlineData("build_property.InvariantGlobalization = false", @"[|""aaa"".ToLower()|]")]
+        [InlineData("build_property.InvariantGlobalization = true", @"""aaa"".ToLower()")]
+        public async Task CA1304_PlainString_CSharp_InvariantGlobalization(string property, string returnExpression)
         {
             await new VerifyCS.Test
             {

--- a/src/NetAnalyzers/UnitTests/MiscellaneousAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/MiscellaneousAnalyzerTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.NetAnalyzers.UnitTests
+{
+    public class MiscellaneousAnalyzerTests
+    {
+        private sealed class AnalyzerAssemblyLoader : IAnalyzerAssemblyLoader
+        {
+            public static IAnalyzerAssemblyLoader Instance = new AnalyzerAssemblyLoader();
+
+            private AnalyzerAssemblyLoader() { }
+
+            public void AddDependencyLocation(string fullPath) { }
+
+            public Assembly LoadFromPath(string fullPath) => Assembly.LoadFrom(fullPath);
+        }
+
+        [Fact]
+        public void TestGlobalizationAnalyzersSubclassAbstractGlobalizationDiagnosticAnalyzer()
+        {
+            // <repo_root>\artifacts\bin\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests\Debug\netcoreapp3.1\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.dll
+            var testsAssemblyPath = typeof(MiscellaneousAnalyzerTests).Assembly.Location;
+
+            var directory = Path.GetDirectoryName(testsAssemblyPath);
+
+            foreach (var assembly in new[] { "Microsoft.CodeAnalysis.NetAnalyzers.dll", "Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll", "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll" })
+            {
+                var path = Path.Combine(directory, assembly);
+                Assert.True(File.Exists(path), $"File {path} doesn't exist.");
+                var analyzerFileReference = new AnalyzerFileReference(path, AnalyzerAssemblyLoader.Instance);
+                analyzerFileReference.AnalyzerLoadFailed += AnalyzerFileReference_AnalyzerLoadFailed;
+                var analyzers = analyzerFileReference.GetAnalyzersForAllLanguages();
+                foreach (var analyzer in analyzers)
+                {
+                    if (analyzer.SupportedDiagnostics.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var analyzerType = analyzer.GetType();
+                    var isAbstractGlobalizationDiagnosticAnalyzer = IsSubClassOfGlobalizationAnalyzer(analyzerType);
+                    if (analyzer.SupportedDiagnostics.All(d => d.Category == "Globalization"))
+                    {
+                        Debug.Assert(isAbstractGlobalizationDiagnosticAnalyzer, $"Analyzer {analyzerType.Name} was expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
+                    }
+                    else
+                    {
+                        // Note: If an analyzer have one Globalization rule and other non-Globalization rules, it shouldn't inherit AbstractGlobalizationDiagnosticAnalyzer.
+                        // Instead, it should check for InvariantCulture MSBuild property for the Globalization rules only.
+                        Debug.Assert(!isAbstractGlobalizationDiagnosticAnalyzer, $"Analyzer {analyzerType.Name} wasn't expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
+                    }
+                }
+            }
+
+            static void AnalyzerFileReference_AnalyzerLoadFailed(object sender, AnalyzerLoadFailureEventArgs e)
+            => throw e.Exception ?? new NotSupportedException(e.Message);
+        }
+
+        private static bool IsSubClassOfGlobalizationAnalyzer(Type analyzerType)
+        {
+            var baseType = analyzerType.BaseType;
+            while (baseType != null)
+            {
+                if (baseType.Name == "AbstractGlobalizationDiagnosticAnalyzer")
+                    return true;
+                baseType = baseType.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -104,6 +104,11 @@ namespace GenerateDocumentationAndConfigFiles
 
                 foreach (var analyzer in analyzers)
                 {
+                    if (analyzer.SupportedDiagnostics.Length == 0)
+                    {
+                        continue;
+                    }
+
                     var analyzerType = analyzer.GetType();
                     var isAbstractGlobalizationDiagnosticAnalyzer = IsSubClassOfGlobalizationAnalyzer(analyzerType);
                     if (analyzer.SupportedDiagnostics.All(d => d.Category == "Globalization"))

--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -108,6 +108,11 @@ namespace GenerateDocumentationAndConfigFiles
 
                     foreach (var rule in analyzer.SupportedDiagnostics)
                     {
+                        if (rule.Category == "Globalization")
+                        {
+                            Debug.Assert(analyzerType.BaseType?.Name == "AbstractGlobalizationDiagnosticAnalyzer", $"Analyzer {analyzerType.Name} was expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
+                        }
+
                         allRulesById[rule.Id] = rule;
                         categories.Add(rule.Category);
                         assemblyRulesMetadata.rules[rule.Id] = (rule, analyzerType.Name, analyzerType.GetCustomAttribute<DiagnosticAnalyzerAttribute>(true)?.Languages);

--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -104,23 +104,7 @@ namespace GenerateDocumentationAndConfigFiles
 
                 foreach (var analyzer in analyzers)
                 {
-                    if (analyzer.SupportedDiagnostics.Length == 0)
-                    {
-                        continue;
-                    }
-
                     var analyzerType = analyzer.GetType();
-                    var isAbstractGlobalizationDiagnosticAnalyzer = IsSubClassOfGlobalizationAnalyzer(analyzerType);
-                    if (analyzer.SupportedDiagnostics.All(d => d.Category == "Globalization"))
-                    {
-                        Debug.Assert(isAbstractGlobalizationDiagnosticAnalyzer, $"Analyzer {analyzerType.Name} was expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
-                    }
-                    else
-                    {
-                        // Note: If an analyzer have one Globalization rule and other non-Globalization rules, it shouldn't inherit AbstractGlobalizationDiagnosticAnalyzer.
-                        // Instead, it should check for InvariantCulture MSBuild property for the Globalization rules only.
-                        Debug.Assert(!isAbstractGlobalizationDiagnosticAnalyzer, $"Analyzer {analyzerType.Name} wasn't expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
-                    }
 
                     foreach (var rule in analyzer.SupportedDiagnostics)
                     {
@@ -803,19 +787,6 @@ Rule ID | Missing Help Link | Title |
                     return Path.Combine(assemblyDir, assembly);
                 }
             }
-        }
-
-        private static bool IsSubClassOfGlobalizationAnalyzer(Type analyzerType)
-        {
-            var baseType = analyzerType.BaseType;
-            while (baseType != null)
-            {
-                if (baseType.Name == "AbstractGlobalizationDiagnosticAnalyzer")
-                    return true;
-                baseType = baseType.BaseType;
-            }
-
-            return false;
         }
 
         private static void CreateRuleset(

--- a/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
+++ b/src/Utilities/Compiler/Options/MSBuildPropertyOptionNames.cs
@@ -19,6 +19,7 @@ namespace Analyzer.Utilities
         public const string ProjectTypeGuids = nameof(ProjectTypeGuids);
         public const string PublishSingleFile = nameof(PublishSingleFile);
         public const string IncludeAllContentForSelfExtract = nameof(IncludeAllContentForSelfExtract);
+        public const string InvariantGlobalization = nameof(InvariantGlobalization);
     }
 
     internal static class MSBuildPropertyOptionNamesHelpers


### PR DESCRIPTION
Fixes #4629

Tagging @tarekgh for confirmation that [Globalization](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/globalization-warnings) rules shouldn't be produced if the option is set to true.


Hide whitespace changes when viewing diff will ease reviewing.