### PR TITLE
Small rewording on the PR issue template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,17 @@
 <!--
 
-Make sure to run `msbuild /t:pack /v:m` in the repository root when
-you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.
+Make sure you have read the contribution guidelines: 
+- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
+- https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md
+
+If your Pull Request is doing one of the following:
 
 - Adding a new diagnostic analyzer or a code fix
 - Adding or updating resource strings used by analyzers and code fixes
 - Updating analyzer package versions in [Versions.props](../eng/Versions.props)
 
-(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)
+Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.
 
-If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
-Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.
-
+Note: Consider merging master into your branch before you run the pack command to reduce merge conflicts.
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,6 @@ If your Pull Request is doing one of the following:
 
 Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.
 
-Note: Consider merging master into your branch before you run the pack command to reduce merge conflicts.
+Note: Consider merging the PR base branch (`2.9.x`, `master`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.
 
 -->


### PR DESCRIPTION
<!--

Make sure to run `msbuild /t:pack /v:m` in the repository root when
you have any of the following changes that affect auto-generated files. Otherwise, the CI build will fail.

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

(Consider merging master into your branch before you run msbuild pack to reduce having merge conflicts)

If you're adding a new rule, Make sure to read the guidlines in: https://github.com/dotnet/roslyn-analyzers/blob/master/GuidelinesForNewRules.md.
Also, see https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules for documentation guidelines.


-->
