### PR TITLE
Disable generated code analysis for CA-1416 

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -125,7 +125,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         public override void Initialize(AnalysisContext context)
         {
             context.EnableConcurrentExecution();
-            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
             context.RegisterCompilationStartAction(context =>
             {


### PR DESCRIPTION
As discussed with @terrajobst and @jeffhandley disabling it in 5.0. We will make it configurable by the user within 6.0 when `AnalysisContext.AnalyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions` became available in the repo

