### PR TITLE
Rewrite PreferIsKindFix using DocumentBasedFixAllProvider

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/Fixers/CSharpPreferIsKindFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/Fixers/CSharpPreferIsKindFix.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.Fixers
@@ -14,32 +13,39 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.Fixers
     [Shared]
     public sealed class CSharpPreferIsKindFix : PreferIsKindFix
     {
-        protected override async Task<Document> ConvertKindToIsKindAsync(Document document, TextSpan sourceSpan, CancellationToken cancellationToken)
+        protected override SyntaxNode? TryGetNodeToFix(SyntaxNode root, TextSpan span)
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var binaryExpression = root.FindNode(sourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<BinaryExpressionSyntax>();
-
-            if (binaryExpression.Left is not InvocationExpressionSyntax invocation)
+            var binaryExpression = root.FindNode(span, getInnermostNodeForTie: true).FirstAncestorOrSelf<BinaryExpressionSyntax>();
+            if (binaryExpression.Left is not InvocationExpressionSyntax)
             {
-                return document;
+                return null;
             }
 
-            var newInvocation = invocation
-                .WithExpression(ConvertKindNameToIsKind(invocation.Expression))
-                .AddArgumentListArguments(SyntaxFactory.Argument(binaryExpression.Right.WithoutTrailingTrivia()))
-                .WithTrailingTrivia(binaryExpression.Right.GetTrailingTrivia());
-            var negate = binaryExpression.OperatorToken.IsKind(SyntaxKind.ExclamationEqualsToken);
-            SyntaxNode newRoot;
-            if (negate)
-            {
-                newRoot = root.ReplaceNode(binaryExpression, SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, newInvocation.WithoutLeadingTrivia()).WithLeadingTrivia(newInvocation.GetLeadingTrivia()));
-            }
-            else
-            {
-                newRoot = root.ReplaceNode(binaryExpression, newInvocation);
-            }
+            return binaryExpression;
+        }
 
-            return document.WithSyntaxRoot(newRoot);
+        protected override void FixDiagnostic(DocumentEditor editor, SyntaxNode nodeToFix)
+        {
+            editor.ReplaceNode(
+                nodeToFix,
+                (nodeToFix, generator) =>
+                {
+                    var binaryExpression = (BinaryExpressionSyntax)nodeToFix;
+                    var invocation = (InvocationExpressionSyntax)binaryExpression.Left;
+                    var newInvocation = invocation
+                        .WithExpression(ConvertKindNameToIsKind(invocation.Expression))
+                        .AddArgumentListArguments(SyntaxFactory.Argument(binaryExpression.Right.WithoutTrailingTrivia()))
+                        .WithTrailingTrivia(binaryExpression.Right.GetTrailingTrivia());
+                    var negate = binaryExpression.OperatorToken.IsKind(SyntaxKind.ExclamationEqualsToken);
+                    if (negate)
+                    {
+                        return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, newInvocation.WithoutLeadingTrivia()).WithLeadingTrivia(newInvocation.GetLeadingTrivia());
+                    }
+                    else
+                    {
+                        return newInvocation;
+                    }
+                });
         }
 
         private static ExpressionSyntax ConvertKindNameToIsKind(ExpressionSyntax expression)

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/MetaAnalyzers/Fixers/BasicPreferIsKindFix.vb
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/MetaAnalyzers/Fixers/BasicPreferIsKindFix.vb
@@ -1,9 +1,9 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Composition
-Imports System.Threading
 Imports Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
 Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -13,29 +13,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Analyzers.MetaAnalyzers.CodeFixes
     Public NotInheritable Class BasicPreferIsKindFix
         Inherits PreferIsKindFix
 
-        Protected Overrides Async Function ConvertKindToIsKindAsync(document As Document, sourceSpan As TextSpan, cancellationToken As CancellationToken) As Task(Of Document)
-            Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
-            Dim binaryExpression = root.FindNode(sourceSpan, getInnermostNodeForTie:=True).FirstAncestorOrSelf(Of BinaryExpressionSyntax)()
+        Protected Overrides Function TryGetNodeToFix(root As SyntaxNode, span As TextSpan) As SyntaxNode
+            Dim binaryExpression = root.FindNode(span, getInnermostNodeForTie:=True).FirstAncestorOrSelf(Of BinaryExpressionSyntax)()
             Dim invocation = TryCast(binaryExpression.Left, InvocationExpressionSyntax)
             invocation = If(invocation, TryConvertMemberAccessToInvocation(binaryExpression.Left))
             If invocation Is Nothing Then
-                Return document
+                Return Nothing
             End If
 
-            Dim newInvocation = invocation _
-                .WithExpression(ConvertKindNameToIsKind(invocation.Expression)) _
-                .AddArgumentListArguments(SyntaxFactory.SimpleArgument(binaryExpression.Right.WithoutTrailingTrivia())) _
-                .WithTrailingTrivia(binaryExpression.Right.GetTrailingTrivia())
-            Dim negate = binaryExpression.OperatorToken.IsKind(SyntaxKind.LessThanGreaterThanToken)
-            Dim newRoot As SyntaxNode
-            If negate Then
-                newRoot = root.ReplaceNode(binaryExpression, SyntaxFactory.NotExpression(newInvocation.WithoutLeadingTrivia()).WithLeadingTrivia(newInvocation.GetLeadingTrivia()))
-            Else
-                newRoot = root.ReplaceNode(binaryExpression, newInvocation)
-            End If
-
-            Return document.WithSyntaxRoot(newRoot)
+            Return binaryExpression
         End Function
+
+        Protected Overrides Sub FixDiagnostic(editor As DocumentEditor, nodeToFix As SyntaxNode)
+            editor.ReplaceNode(
+                nodeToFix,
+                Function(nodeToFix2, generator)
+                    Dim binaryExpression = DirectCast(nodeToFix2, BinaryExpressionSyntax)
+                    Dim invocation = TryCast(binaryExpression.Left, InvocationExpressionSyntax)
+                    invocation = If(invocation, TryConvertMemberAccessToInvocation(binaryExpression.Left))
+
+                    Dim newInvocation = invocation _
+                        .WithExpression(ConvertKindNameToIsKind(invocation.Expression)) _
+                        .AddArgumentListArguments(SyntaxFactory.SimpleArgument(binaryExpression.Right.WithoutTrailingTrivia())) _
+                        .WithTrailingTrivia(binaryExpression.Right.GetTrailingTrivia())
+                    Dim negate = binaryExpression.OperatorToken.IsKind(SyntaxKind.LessThanGreaterThanToken)
+                    If negate Then
+                        Return SyntaxFactory.NotExpression(newInvocation.WithoutLeadingTrivia()).WithLeadingTrivia(newInvocation.GetLeadingTrivia())
+                    Else
+                        Return newInvocation
+                    End If
+                End Function)
+        End Sub
 
         Private Shared Function TryConvertMemberAccessToInvocation(expression As ExpressionSyntax) As InvocationExpressionSyntax
             Dim memberAccessExpression = TryCast(expression, MemberAccessExpressionSyntax)


### PR DESCRIPTION
This change allows PreferIsKindFix to complete without crashing in projects with thousands of violations.