### PR TITLE
Additional performance work from compilation traces collected for dotnet/roslyn-analyzers

### DIFF
--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -69,6 +69,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\NullableContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\SemanticModelExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\MSBuildItemOptionNames.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OptionKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\OptionKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\MSBuildPropertyOptionNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\SyntaxTreeCategorizedAnalyzerConfigOptions.cs" />

--- a/src/Utilities/Compiler/HashUtilities.cs
+++ b/src/Utilities/Compiler/HashUtilities.cs
@@ -10,7 +10,13 @@ namespace Analyzer.Utilities
 {
     internal static class HashUtilities
     {
-        internal static int GetHashCodeOrDefault(this object? obj) => obj?.GetHashCode() ?? 0;
+        internal static int GetHashCodeOrDefault<T>(this T? obj)
+            where T : class
+            => obj?.GetHashCode() ?? 0;
+
+        internal static int GetHashCodeOrDefault<T>(this T? obj)
+            where T : struct
+            => obj?.GetHashCode() ?? 0;
 
         internal static int Combine<T>(ImmutableArray<T> array)
         {

--- a/src/Utilities/Compiler/Options/OptionKey.cs
+++ b/src/Utilities/Compiler/Options/OptionKey.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Analyzer.Utilities
+{
+    internal readonly struct OptionKey : IEquatable<OptionKey>
+    {
+        private static readonly ConcurrentDictionary<(string ruleId, string optionName), OptionKey> s_keys = new();
+        private static int s_lastOrdinal;
+
+        private readonly int _ordinal;
+
+        private OptionKey(string name)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            _ordinal = Interlocked.Increment(ref s_lastOrdinal);
+        }
+
+        public string Name { get; }
+
+        public static OptionKey GetOrCreate(string? ruleId, string optionName)
+        {
+            return s_keys.GetOrAdd(
+                (ruleId ?? "", optionName),
+                static pair => new OptionKey(pair.ruleId is not null ? $"{pair.ruleId}.{pair.optionName}" : pair.optionName));
+        }
+
+        public static bool operator ==(OptionKey left, OptionKey right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(OptionKey left, OptionKey right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is OptionKey other
+                && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _ordinal;
+        }
+
+        public bool Equals(OptionKey other)
+        {
+            return _ordinal == other._ordinal;
+        }
+    }
+}

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PropertySetAnalysis/HazardousUsageEvaluator.cs
@@ -120,7 +120,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.PropertySetAnalysis
                 this.ContainingTypeName.GetHashCodeOrDefault(),
                 this.MethodName.GetHashCodeOrDefault(),
                 this.ParameterNameOfPropertySetObject.GetHashCodeOrDefault(),
-                this.DerivedClass.GetHashCodeOrDefault(),
+                this.DerivedClass.GetHashCode(),
                 this.InvocationEvaluator.GetHashCodeOrDefault());
         }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataConfig.cs
@@ -38,6 +38,12 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             = ImmutableDictionary.Create<SinkKind, ImmutableHashSet<SanitizerInfo>>();
 
         /// <summary>
+        /// Caches the results for <see cref="HasTaintArraySource(SinkKind)"/>.
+        /// </summary>
+        private static ImmutableDictionary<SinkKind, bool> s_sinkKindHasTaintArraySource
+            = ImmutableDictionary.Create<SinkKind, bool>();
+
+        /// <summary>
         /// <see cref="WellKnownTypeProvider"/> for this instance's <see cref="Compilation"/>.
         /// </summary>
         private WellKnownTypeProvider WellKnownTypeProvider { get; }
@@ -174,7 +180,10 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
         public static bool HasTaintArraySource(SinkKind sinkKind)
         {
-            return GetSourceInfos(sinkKind).Any(o => o.TaintConstantArray);
+            return ImmutableInterlocked.GetOrAdd(
+                ref s_sinkKindHasTaintArraySource,
+                sinkKind,
+                static sinkKind => GetSourceInfos(sinkKind).Any(static o => o.TaintConstantArray));
         }
 
         private TaintedDataSymbolMap<T> GetFromMap<T>(SinkKind sinkKind, ImmutableDictionary<SinkKind, Lazy<TaintedDataSymbolMap<T>>> map)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 && CaptureId.GetHashCodeOrDefault() == other.CaptureId.GetHashCodeOrDefault()
                 && Type.GetHashCodeOrDefault() == other.Type.GetHashCodeOrDefault()
                 && Parent.GetHashCodeOrDefault() == other.Parent.GetHashCodeOrDefault()
-                && IsThisOrMeInstance.GetHashCodeOrDefault() == other.IsThisOrMeInstance.GetHashCodeOrDefault();
+                && IsThisOrMeInstance.GetHashCode() == other.IsThisOrMeInstance.GetHashCode();
         }
 
         public int EqualsIgnoringInstanceLocationId { get; private set; }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ArgumentInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             hashCode.Add(Operation.GetHashCode());
             hashCode.Add(AnalysisEntity.GetHashCodeOrDefault());
             hashCode.Add(InstanceLocation.GetHashCode());
-            hashCode.Add(Value.GetHashCodeOrDefault());
+            hashCode.Add(Value?.GetHashCode() ?? 0);
         }
 
         protected override bool ComputeEqualsByHashCodeParts(CacheBasedEquatable<ArgumentInfo<TAbstractAnalysisValue>> obj)
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return Operation.GetHashCode() == other.Operation.GetHashCode()
                 && AnalysisEntity.GetHashCodeOrDefault() == other.AnalysisEntity.GetHashCodeOrDefault()
                 && InstanceLocation.GetHashCode() == other.InstanceLocation.GetHashCode()
-                && Value.GetHashCodeOrDefault() == other.Value.GetHashCodeOrDefault();
+                && (Value?.GetHashCode() ?? 0) == (other.Value?.GetHashCode() ?? 0);
         }
     }
 }


### PR DESCRIPTION
These changes have less impact from the previous round, but address some low-hanging fruit.

Fixes #4905