### PR TITLE
Add support for lambdas in taint analysis

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
@@ -1396,6 +1396,41 @@ namespace VulnerableWebApp
         }
 
         [Fact]
+        public async Task SimpleLambda()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+namespace VulnerableWebApp
+{
+    using System;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Linq;
+    using System.Web;
+    using System.Web.UI;
+
+    public partial class WebForm : System.Web.UI.Page
+    {
+        protected void Page_Load(object sender, EventArgs e)
+        {
+            string taintedInput = this.Request[""input""];
+
+            Func<string, SqlCommand> injectSql = (sqlInjection) =>
+            {
+                return new SqlCommand()
+                {
+                    CommandText = ""SELECT * FROM users WHERE username = '"" + sqlInjection + ""'"",
+                    CommandType = CommandType.Text,
+                };
+            };
+
+            injectSql(taintedInput);
+        }
+    }
+}",
+                GetCSharpResultAt(21, 21, 15, 35, "string SqlCommand.CommandText", "lambda expression", "string HttpRequest.this[string key]", "void WebForm.Page_Load(object sender, EventArgs e)"));
+        }
+
+        [Fact]
         public async Task IntermediateMethodReturnsTainted()
         {
             await VerifyCSharpWithDependenciesAsync(@"

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis;
 using Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis;
@@ -427,6 +428,20 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 if (taintedArguments.Any())
                 {
                     ProcessTaintedDataEnteringInvocationOrCreation(localFunction, taintedArguments, originalOperation);
+                }
+
+                return baseValue;
+            }
+
+            public override TaintedDataAbstractValue VisitInvocation_Lambda(IFlowAnonymousFunctionOperation lambda, ImmutableArray<IArgumentOperation> visitedArguments, IOperation originalOperation, TaintedDataAbstractValue defaultValue)
+            {
+                // Always invoke base visit.
+                TaintedDataAbstractValue baseValue = base.VisitInvocation_Lambda(lambda, visitedArguments, originalOperation, defaultValue);
+
+                IEnumerable<IArgumentOperation> taintedArguments = GetTaintedArguments(visitedArguments);
+                if (taintedArguments.Any())
+                {
+                    ProcessTaintedDataEnteringInvocationOrCreation(lambda.Symbol, taintedArguments, originalOperation);
                 }
 
                 return baseValue;


### PR DESCRIPTION
This PR adds support for taint analysis in lambda expressions as described in #4823.
The implementation is quite simple and follows the suggestion made by @dotpaul in the issue discussion to implement `VisitInvocation_Lambda` in `TaintedDataOperationVisitor`. Because they are quite similar, I just adapted this and the corresponding test case from `VisitInvocation_LocalFunction`. 

I can't really answer the question, whether it was intentional to leave out `VisitInvocation_Lambda` when implementing `TaintedDataOperationVisitor`, as I don't really know the code base. Likewise, I can not judge whether this breaks something, but at least it doesn't break the unit tests 😄 

Closes #4823