### PR TITLE
Update DesiredFileMissing_GetFile_ReturnsNull to work with Test Explorer

### DIFF
--- a/src/Utilities.UnitTests/AdditionalFileProviderTests.cs
+++ b/src/Utilities.UnitTests/AdditionalFileProviderTests.cs
@@ -19,10 +19,10 @@ namespace Analyzers.Utilities.UnitTests
     public sealed class AdditionalFileProviderTests
     {
         [Theory]
-        [InlineData]
-        [InlineData("b.txt")]
-        [InlineData("a.bat")]
-        public void DesiredFileMissing_GetFile_ReturnsNull(params string[] fileNames)
+        [InlineData(new object[] { new string[] { } })]
+        [InlineData(new object[] { new string[] { "b.txt" } })]
+        [InlineData(new object[] { new string[] { "a.bat" } })]
+        public void DesiredFileMissing_GetFile_ReturnsNull(string[] fileNames)
         {
             var fileProvider = new AdditionalFileProvider(CreateAdditionalFiles(fileNames));
 


### PR DESCRIPTION
One of these tests failed in Test Explorer without this change. Not sure why, but this fixes it.