### PR TITLE
Add main to yml trigger list

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -1,6 +1,7 @@
 # Branches that trigger a build on commit
 trigger:
   - master
+  - main
   - release/*
   - 2.9.x
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,14 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- main
 - release/*
 - 2.9.x
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:
 - master
+- main
 - release/*
 - 2.9.x
 


### PR DESCRIPTION
Adds main to yml trigger list while we switch from master -> main. Hopefully keeping master in the trigger list for now avoids the build breakage seen yesterday in the roslyn repo. Once the transition is complete, master will be removed from the list and I will fix up the rest of the references in the repo.