### PR TITLE
Fix the global flow state analysis merge algorithm to handle duplicat…

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
                             var newValue = new GlobalFlowStateAnalysisValueSet(infosBuilder[i]);
-                            value = i == 0 ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
+                            value = (i == 0 || value == newValue) ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
                             var newValue = GlobalFlowStateAnalysisValueSet.Create(infosBuilder[i]);
-                            value = i == 0 ? newValue : GlobalFlowStateAnalysisValueSet.CreateWithParents(value, newValue);
+                            value = i == 0 ? newValue : GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.Instance.Merge(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -42,8 +42,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     {
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
-                            var newValue = new GlobalFlowStateAnalysisValueSet(infosBuilder[i]);
-                            value = (i == 0 || value == newValue) ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
+                            var newValue = GlobalFlowStateAnalysisValueSet.Create(infosBuilder[i]);
+                            value = i == 0 ? newValue : GlobalFlowStateAnalysisValueSet.CreateWithParents(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3426,7 +3426,7 @@ class Test
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/4920")]
+        [Fact]
         [WorkItem(4920, "https://github.com/dotnet/roslyn-analyzers/issues/4920")]
         public async Task TestTimelyTermination()
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -79,12 +79,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
-                if (value1 == value2)
-                {
-                    return value1;
-                }
-
-                return new GlobalFlowStateAnalysisValueSet(value1, value2);
+                return GlobalFlowStateAnalysisValueSet.CreateWithParents(value1, value2);
             }
 
             public static GlobalFlowStateAnalysisValueSet Intersect(GlobalFlowStateAnalysisValueSet value1, GlobalFlowStateAnalysisValueSet value2)
@@ -220,7 +215,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                     }
                     else
                     {
-                        result = new GlobalFlowStateAnalysisValueSet(sets, value1.Parents, value1.Height, GlobalFlowStateAnalysisValueSetKind.Known);
+                        result = GlobalFlowStateAnalysisValueSet.Create(sets, value1.Parents, value1.Height);
                     }
 
                     return true;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -79,6 +79,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
+                if (value1 == value2)
+                {
+                    return value1;
+                }
+
                 return new GlobalFlowStateAnalysisValueSet(value1, value2);
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -79,7 +80,36 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
-                return GlobalFlowStateAnalysisValueSet.CreateWithParents(value1, value2);
+                // Perform some early bail out checks.
+                if (Equals(value1, value2))
+                {
+                    return value1;
+                }
+
+                if (value1.Height == 0 && value1.AnalysisValues.IsSubsetOf(value2.AnalysisValues))
+                {
+                    return value2;
+                }
+
+                if (value2.Height == 0 && value2.AnalysisValues.IsSubsetOf(value1.AnalysisValues))
+                {
+                    return value1;
+                }
+
+                // Check if value1 and value2 are negations of each other.
+                // If so, the analysis values nullify each other and we return an empty set.
+                if (value1.Height == value2.Height &&
+                    value1.AnalysisValues.Count == value2.AnalysisValues.Count &&
+                    Equals(value1, value2.GetNegatedValue()))
+                {
+                    return GlobalFlowStateAnalysisValueSet.Empty;
+                }
+
+                // Create a new value set with value1 and value2 as parent sets.
+                return GlobalFlowStateAnalysisValueSet.Create(
+                    ImmutableHashSet<IAbstractAnalysisValue>.Empty,
+                    ImmutableHashSet.Create(value1, value2),
+                    height: Math.Max(value1.Height, value2.Height) + 1);
             }
 
             public static GlobalFlowStateAnalysisValueSet Intersect(GlobalFlowStateAnalysisValueSet value1, GlobalFlowStateAnalysisValueSet value2)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
@@ -52,39 +52,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         public static GlobalFlowStateAnalysisValueSet Create(IAbstractAnalysisValue analysisValue)
             => new(ImmutableHashSet.Create(analysisValue), ImmutableHashSet<GlobalFlowStateAnalysisValueSet>.Empty, height: 0, GlobalFlowStateAnalysisValueSetKind.Known);
 
-        public static GlobalFlowStateAnalysisValueSet CreateWithParents(GlobalFlowStateAnalysisValueSet parent1, GlobalFlowStateAnalysisValueSet parent2)
-        {
-            Debug.Assert(parent1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
-            Debug.Assert(parent2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
-
-            if (Equals(parent1, parent2))
-            {
-                return parent1;
-            }
-
-            if (parent1.Height == 0 && parent1.AnalysisValues.IsSubsetOf(parent2.AnalysisValues))
-            {
-                return parent2;
-            }
-
-            if (parent2.Height == 0 && parent2.AnalysisValues.IsSubsetOf(parent1.AnalysisValues))
-            {
-                return parent1;
-            }
-
-            if (parent1.Height == parent2.Height &&
-                parent1.AnalysisValues.Count == parent2.AnalysisValues.Count &&
-                Equals(parent1, parent2.GetNegatedValue()))
-            {
-                return Empty;
-            }
-
-            return new(ImmutableHashSet<IAbstractAnalysisValue>.Empty,
-                       ImmutableHashSet.Create(parent1, parent2),
-                       height: Math.Max(parent1.Height, parent2.Height) + 1,
-                       GlobalFlowStateAnalysisValueSetKind.Known);
-        }
-
         public ImmutableHashSet<IAbstractAnalysisValue> AnalysisValues { get; }
         public ImmutableHashSet<GlobalFlowStateAnalysisValueSet> Parents { get; }
         public int Height { get; }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                    height: Math.Max(parent1.Height, parent2.Height) + 1,
                    GlobalFlowStateAnalysisValueSetKind.Known)
         {
+            Debug.Assert(parent1 != parent2);
         }
 
         public ImmutableHashSet<IAbstractAnalysisValue> AnalysisValues { get; }


### PR DESCRIPTION
### Related Issues:

[dotnet build doesn't terminate in 5.0.200](https://github.com/dotnet/roslyn-analyzers/issues/4920)
[C# compiler freezes in certain platform analysis scenarios](https://github.com/dotnet/roslyn/issues/51652)
 

### Context: 
The DFA for Platform Compatibility Analyzer enters an infinite loop in certain edge case code patterns where platform checks are performed inside/outside a loop and there is a try/catch within the loop.  This was untested edge case scenario was hidden under [another bug](https://github.com/dotnet/roslyn-analyzers/issues/4372) that is [fixed in 5.0.2](https://github.com/dotnet/roslyn-analyzers/pull/4393) but revealed this bug. Since 5.0.2 release 2 customers reported above issues. As this analyzer is enabled by default with a build warning level, it runs as part of every build with .NET5 SDK. We think we should fix it for 5.0.2 servicing
 
### Risk: 
Low risk. The PR adds couple of bail out checks in DFA merge algorithm which prevents infinite analysis loop. This will also likely improve the overall performance of the analysis in other cases

CC @jaredpar @jeffhandley @danmoseley @marcpopMSFT  @jmarolf 