### PR TITLE
Add arcade-powered-source-build local and ci builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,7 @@
       CS1712: Type parameter 'parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
     -->
     <NoWarn Condition="'$(Language)' == 'C#'">$(NoWarn),1573,1591,1712</NoWarn>
+    <NoWarn Condition=" '$(DotnetBuildFromSource)' == 'true' ">$(NoWarn);AD0001;CS8600;CS8601;CS8602;CS8603;CS8604;CS8605;CS8609;CS8619;CS8620;CS8625;CS8621;CS8631;CS8714;CS8762;CS8765;IDE0005</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,8 @@ jobs:
       continueOnError: true
       condition: always()
 
+- template: eng/common/templates/job/source-build.yml
+
 - job: Markdownlint
   pool:
       vmImage: ubuntu-18.04

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,23 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>roslyn-analyzers</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+  <Target Name="ApplySourceBuildPatchFiles"
+          Condition="
+            '$(ArcadeBuildFromSource)' == 'true' and
+            '$(ArcadeInnerBuildFromSource)' == 'true'"
+          BeforeTargets="Execute">
+    <ItemGroup>
+      <SourceBuildPatchFile Include="$(RepositoryEngineeringDir)source-build-patches\*.patch" />
+    </ItemGroup>
+
+    <Exec
+      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      WorkingDirectory="$(RepoRoot)"
+      Condition="'@(SourceBuildPatchFile)' != ''" />
+  </Target>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -6,6 +6,7 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="6.0.0-beta.21125.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>15246f4af00a1cb2e580783d32ec2937b1878a64</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/source-build-patches/0001-WIP-for-source-build.patch
+++ b/eng/source-build-patches/0001-WIP-for-source-build.patch
@@ -1,0 +1,491 @@
+From 48442474744a416eee4f367d3e389a0916047842 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Thu, 29 Oct 2020 18:20:09 -0400
+Subject: [PATCH 1/4] WIP for source-build
+
+This is a grab-bag of fixes to make roslyn-analzyers build in a
+source-build context.
+
+- Fix up TargetFrameworks:
+  - Remove net46, net47, etc
+  - Move from netstandard 1.3 to 2.0
+
+- Remove FxCopAnalyzers.sln, which is not needed for source-build
+
+---
+ RoslynAnalyzers.sln                           | 256 ---------------
+ eng/Versions.props                            |   4 +
+ eng/common/dotnet-install.sh                  |   0
+ 37 files changed, 436 insertions(+), 492 deletions(-)
+ delete mode 100644 FxCopAnalyzers.sln
+ mode change 100644 => 100755 eng/common/dotnet-install.sh
+
+diff --git a/RoslynAnalyzers.sln b/RoslynAnalyzers.sln
+index 82e87f32e..6807ca029 100644
+--- a/RoslynAnalyzers.sln
++++ b/RoslynAnalyzers.sln
+@@ -10,16 +10,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.Diagnostics.CSharp.A
+ EndProject
+ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Roslyn.Diagnostics.VisualBasic.Analyzers", "src\Roslyn.Diagnostics.Analyzers\VisualBasic\Roslyn.Diagnostics.VisualBasic.Analyzers.vbproj", "{70BBA457-2CC1-4929-8FEE-359EBB7C398A}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.Diagnostics.Analyzers.UnitTests", "src\Roslyn.Diagnostics.Analyzers\UnitTests\Roslyn.Diagnostics.Analyzers.UnitTests.csproj", "{D90E7402-70E7-4A95-A292-47EA163D6309}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.Diagnostics.Analyzers.Setup", "src\Roslyn.Diagnostics.Analyzers\Setup\Roslyn.Diagnostics.Analyzers.Setup.csproj", "{BD80CDC4-25FF-4268-8131-F7A43260122B}"
+ EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{80E410B3-D8D1-4C67-93FF-078530E20816}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Utilities", "src\Test.Utilities\Test.Utilities.csproj", "{0A0621F2-D1DC-47FF-B643-C6646557505E}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utilities", "Utilities", "{1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}"
+-EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.Analyzers", "Microsoft.CodeAnalysis.Analyzers", "{041E93F2-E703-4AB1-B6DF-13EC899D1C6E}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzers", "src\Microsoft.CodeAnalysis.Analyzers\Core\Microsoft.CodeAnalysis.Analyzers.csproj", "{D8762A0A-3832-47BE-BCF6-8B1060BE6B28}"
+@@ -28,22 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSha
+ EndProject
+ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.Analyzers", "src\Microsoft.CodeAnalysis.Analyzers\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.Analyzers.vbproj", "{B1A6A74B-E484-48FB-8745-7A30A06DB631}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzers.UnitTests", "src\Microsoft.CodeAnalysis.Analyzers\UnitTests\Microsoft.CodeAnalysis.Analyzers.UnitTests.csproj", "{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Analyzers.Setup", "src\Microsoft.CodeAnalysis.Analyzers\Setup\Microsoft.CodeAnalysis.Analyzers.Setup.csproj", "{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF}"
+ EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Text.Analyzers", "Text.Analyzers", "{446787CE-66C8-43F0-9D51-585BB41FC770}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Analyzers", "src\Text.Analyzers\Core\Text.Analyzers.csproj", "{730C2D1C-0276-4132-85EA-675CE60068BB}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.CSharp.Analyzers", "src\Text.Analyzers\CSharp\Text.CSharp.Analyzers.csproj", "{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Analyzers.Setup", "src\Text.Analyzers\Setup\Text.Analyzers.Setup.csproj", "{EA61DA2E-D175-4430-A56B-17BAC4B227A9}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Analyzers.UnitTests", "src\Text.Analyzers\UnitTests\Text.Analyzers.UnitTests.csproj", "{6762EB1D-517C-4746-80EB-D11717ACD469}"
+-EndProject
+-Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Text.VisualBasic.Analyzers", "src\Text.Analyzers\VisualBasic\Text.VisualBasic.Analyzers.vbproj", "{938F2420-14B8-4C7C-93BE-C9E89E08E823}"
+-EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{77D6EC8A-02B7-4EC9-B14A-E8C3A1543AAE}"
+ 	ProjectSection(SolutionItems) = preProject
+ 		.editorconfig = .editorconfig
+@@ -54,26 +32,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Anal
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Roslyn.Diagnostics.Analyzers.Package", "nuget\Roslyn.Diagnostics.Analyzers\Roslyn.Diagnostics.Analyzers.Package.csproj", "{2569B087-6465-425E-986D-BD0D32FC8AA5}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Analyzers.Package", "nuget\Text.Analyzers\Text.Analyzers.Package.csproj", "{0A7C9A18-888A-4028-B88F-989DA6A0140B}"
+-EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Analyzer.Utilities", "src\Utilities\Compiler\Analyzer.Utilities.shproj", "{EC946164-1E17-410B-B7D9-7DE7E6268D63}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{C0B86774-8307-444F-9EE4-98D62C3424F9}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestReferenceAssembly", "TestReferenceAssembly", "{4F3DD6F3-121C-4D38-9B8E-5065783EA832}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestReferenceAssembly", "src\TestReferenceAssembly\TestReferenceAssembly.csproj", "{774B5DF6-D14F-4839-95F3-D3632B754765}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Analyzer.Utilities.UnitTests", "src\Utilities.UnitTests\Analyzer.Utilities.UnitTests.csproj", "{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers", "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers", "{34430BD4-4D66-4FE6-8076-51B87B4FBCD4}"
+-EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Workspaces.Utilities", "src\Utilities\Workspaces\Workspaces.Utilities.shproj", "{99F594B1-3916-471D-A761-A6731FC50E9A}"
+-EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "FlowAnalysis.Utilities", "src\Utilities\FlowAnalysis\FlowAnalysis.Utilities.shproj", "{FCB56CBA-FA35-46A8-86B7-BAE5433197D9}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.AnalyzerUtilities", "Microsoft.CodeAnalysis.AnalyzerUtilities", "{1A3624C9-EB8A-4F27-98F8-9FAEAB30604E}"
+-EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.BannedApiAnalyzers", "Microsoft.CodeAnalysis.BannedApiAnalyzers", "{8D64F6D4-951C-413E-8A53-FB708F9FB5CD}"
+ EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers", "Microsoft.CodeAnalysis.PublicApiAnalyzers", "{8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}"
+@@ -82,44 +40,20 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Bann
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers.Package", "nuget\PublicApiAnalyzers\Microsoft.CodeAnalysis.PublicApiAnalyzers.Package.csproj", "{18CE822A-A46D-494B-BBFC-C52EF1D048BE}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package", "nuget\PerformanceSensitiveAnalyzers\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj", "{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers", "src\PerformanceSensitiveAnalyzers\Core\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj", "{F2985136-DCB2-492F-A66D-32968A0266F1}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Setup", "src\PerformanceSensitiveAnalyzers\Setup\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Setup.csproj", "{5C9B8805-6489-41C5-8FE6-195599C6497F}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.UnitTests", "src\PerformanceSensitiveAnalyzers\UnitTests\Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.UnitTests.csproj", "{F86DCF03-7C4D-40FE-91D2-6206D532DEFD}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers", "src\PublicApiAnalyzers\Core\Analyzers\Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj", "{9A3072A5-FC2D-4183-9420-DE5DE323441E}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes", "src\PublicApiAnalyzers\Core\CodeFixes\Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj", "{0DC347C1-660D-45D8-BDC8-DC439C2E4A67}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup", "src\PublicApiAnalyzers\Setup\Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj", "{720DF809-C0D0-440A-B4B8-BFD41358CDA2}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests", "src\PublicApiAnalyzers\UnitTests\Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests.csproj", "{0F68246D-5645-486C-9CED-A8C8A97996DE}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.BannedApiAnalyzers", "src\Microsoft.CodeAnalysis.BannedApiAnalyzers\Core\Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj", "{A94F29CC-56BF-4CF6-93B1-3BB13725B776}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers", "src\Microsoft.CodeAnalysis.BannedApiAnalyzers\CSharp\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj", "{FF1C6979-CD73-46DC-94BF-A6D59A252B66}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup", "src\Microsoft.CodeAnalysis.BannedApiAnalyzers\Setup\Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj", "{FCA9533D-04BB-4654-94A7-B9B2065CE0EF}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests", "src\Microsoft.CodeAnalysis.BannedApiAnalyzers\UnitTests\Microsoft.CodeAnalysis.BannedApiAnalyzers.UnitTests.csproj", "{697FE592-9EB8-493C-87DA-6C218A3B113D}"
+-EndProject
+ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers", "src\Microsoft.CodeAnalysis.BannedApiAnalyzers\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj", "{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1}"
+ EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Metrics", "Metrics", "{50FB229D-38DB-4A34-8588-D33671AB68DE}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metrics", "src\Tools\Metrics\Metrics.csproj", "{CADE5623-CC57-43A2-9D2A-B7AB29225406}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metrics.Legacy", "src\Tools\Metrics\Metrics.Legacy.csproj", "{2A4AF3A4-307B-4252-888E-E6546244585A}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.Metrics.Package", "nuget\Microsoft.CodeAnalysis.Metrics\Microsoft.CodeAnalysis.Metrics.Package.csproj", "{C96D2F95-3090-4376-942C-2C934C55283B}"
+-EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReleaseNotesUtil", "ReleaseNotesUtil", "{6AAE1FC7-D96E-40CB-8B52-EA87EF9BF00A}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReleaseNotesUtil", "src\Tools\ReleaseNotesUtil\ReleaseNotesUtil.csproj", "{01518AF6-AE8F-4ADA-ABE4-C78F8234899F}"
+-EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.CodeAnalysis.NetAnalyzers", "Microsoft.CodeAnalysis.NetAnalyzers", "{31F86414-C34B-462A-AFB5-BDA7724904F3}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.NetAnalyzers", "src\NetAnalyzers\Core\Microsoft.CodeAnalysis.NetAnalyzers.csproj", "{1C62A2F6-7A44-4030-9D1A-7E7A966736E5}"
+@@ -128,73 +62,31 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSha
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.NetAnalyzers.Setup", "src\NetAnalyzers\Setup\Microsoft.CodeAnalysis.NetAnalyzers.Setup.csproj", "{9F4C5E8F-10EE-4193-BB36-A2FDE07B5557}"
+ EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.NetAnalyzers.UnitTests", "src\NetAnalyzers\UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj", "{F4F111E0-7108-47A7-97A1-A5B10207C0D8}"
+-EndProject
+ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers", "src\NetAnalyzers\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.vbproj", "{C75555DC-D059-4665-A421-4EF5F30BD9B6}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.NetAnalyzers.Package", "nuget\NetAnalyzers\Microsoft.CodeAnalysis.NetAnalyzers.Package.csproj", "{8AC54A99-5655-435B-8417-BF2F995BE66A}"
+ EndProject
+-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RulesetToEditorconfigConverter", "RulesetToEditorconfigConverter", "{02F88961-A08F-451A-93AB-328792A32EBC}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RulesetToEditorconfigConverter", "src\Tools\RulesetToEditorconfigConverter\Source\RulesetToEditorconfigConverter.csproj", "{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RulesetToEditorconfigConverter.UnitTests", "src\Tools\RulesetToEditorconfigConverter\Tests\RulesetToEditorconfigConverter.UnitTests.csproj", "{813C80EB-D614-4258-BD07-42660BEB738A}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.AnalyzerUtilities", "src\Microsoft.CodeAnalysis.AnalyzerUtilities\Microsoft.CodeAnalysis.AnalyzerUtilities.csproj", "{B969F316-815C-47B9-82B3-67FDD9ED694F}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.AnalyzerUtilities.Package", "nuget\Microsoft.CodeAnalysis.AnalyzerUtilities\Microsoft.CodeAnalysis.AnalyzerUtilities.Package.csproj", "{3F998217-4174-4AD0-A015-A9BFFADB075F}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.Package", "nuget\Microsoft.CodeAnalysis.RulesetToEditorconfigConverter\Microsoft.CodeAnalysis.RulesetToEditorconfigConverter.Package.csproj", "{64D70469-18B0-446C-80E9-A7C45A747B3E}"
+-EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GenerateDocumentationAndConfigFiles", "GenerateDocumentationAndConfigFiles", "{DB2DD702-8301-4FC6-B8C0-029C7DCC2931}"
+ EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateDocumentationAndConfigFiles", "src\Tools\GenerateDocumentationAndConfigFiles\GenerateDocumentationAndConfigFiles.csproj", "{563654BA-4C05-4EA2-91D3-28A14723B7D5}"
+ EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Refactoring.Utilities", "src\Utilities\Refactoring\Refactoring.Utilities.shproj", "{68528C1C-B163-49A6-A19D-24E10F500F90}"
+-EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Refactoring.CSharp.Utilities", "src\Utilities\Refactoring.CSharp\Refactoring.CSharp.Utilities.shproj", "{3055F932-0D1E-4823-A03A-7B62C7639BDA}"
+-EndProject
+-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Refactoring.VisualBasic.Utilities", "src\Utilities\Refactoring.VisualBasic\Refactoring.VisualBasic.Utilities.shproj", "{4C362C30-C4B1-4C4B-A545-DBF67C7E9153}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers", "src\PerformanceSensitiveAnalyzers\CSharp\Analyzers\Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.csproj", "{8197A037-FF9E-4660-8C6D-2F722FEA0C10}"
+-EndProject
+-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes", "src\PerformanceSensitiveAnalyzers\CSharp\CodeFixes\Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes.csproj", "{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}"
+-EndProject
+ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GenerateAnalyzerNuspec", "src\Tools\GenerateAnalyzerNuspec\GenerateAnalyzerNuspec.csproj", "{81E21880-3F26-42DC-9423-9DACB8933597}"
+ EndProject
+ Global
+ 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{046419a7-c60d-40ff-ad7e-2bae461b7ce5}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{0a0621f2-d1dc-47ff-b643-c6646557505e}*SharedItemsImports = 5
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{0a0621f2-d1dc-47ff-b643-c6646557505e}*SharedItemsImports = 5
+ 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{0dc347c1-660d-45d8-bdc8-dc439c2e4a67}*SharedItemsImports = 5
+ 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{1c62a2f6-7a44-4030-9d1a-7e7a966736e5}*SharedItemsImports = 5
+ 		src\Utilities\FlowAnalysis\FlowAnalysis.Utilities.projitems*{1c62a2f6-7a44-4030-9d1a-7e7a966736e5}*SharedItemsImports = 5
+ 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{1c62a2f6-7a44-4030-9d1a-7e7a966736e5}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{2a4af3a4-307b-4252-888e-e6546244585a}*SharedItemsImports = 5
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{2a4af3a4-307b-4252-888e-e6546244585a}*SharedItemsImports = 5
+-		src\Utilities\Refactoring.CSharp\Refactoring.CSharp.Utilities.projitems*{3055f932-0d1e-4823-a03a-7b62c7639bda}*SharedItemsImports = 13
+-		src\Utilities\Refactoring.VisualBasic\Refactoring.VisualBasic.Utilities.projitems*{4c362c30-c4b1-4c4b-a545-dbf67c7e9153}*SharedItemsImports = 13
+-		src\Utilities\Refactoring\Refactoring.Utilities.projitems*{68528c1c-b163-49a6-a19d-24e10f500f90}*SharedItemsImports = 13
+ 		src\Utilities\Refactoring.CSharp\Refactoring.CSharp.Utilities.projitems*{697e2991-39a8-46c2-aa9c-fe576fbbcd90}*SharedItemsImports = 5
+ 		src\Utilities\Refactoring.VisualBasic\Refactoring.VisualBasic.Utilities.projitems*{70bba457-2cc1-4929-8fee-359ebb7c398a}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{730c2d1c-0276-4132-85ea-675ce60068bb}*SharedItemsImports = 5
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{730c2d1c-0276-4132-85ea-675ce60068bb}*SharedItemsImports = 5
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{99f594b1-3916-471d-a761-a6731fc50e9a}*SharedItemsImports = 13
+ 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{9a3072a5-fc2d-4183-9420-de5de323441e}*SharedItemsImports = 5
+ 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{a94f29cc-56bf-4cf6-93b1-3bb13725b776}*SharedItemsImports = 5
+ 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{b475c173-a39d-4a75-93ff-69c3d2742cad}*SharedItemsImports = 5
+ 		src\Utilities\Refactoring\Refactoring.Utilities.projitems*{b475c173-a39d-4a75-93ff-69c3d2742cad}*SharedItemsImports = 5
+ 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{b475c173-a39d-4a75-93ff-69c3d2742cad}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{b969f316-815c-47b9-82b3-67fdd9ed694f}*SharedItemsImports = 5
+-		src\Utilities\FlowAnalysis\FlowAnalysis.Utilities.projitems*{b969f316-815c-47b9-82b3-67fdd9ed694f}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{cade5623-cc57-43a2-9d2a-b7ab29225406}*SharedItemsImports = 5
+-		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{cade5623-cc57-43a2-9d2a-b7ab29225406}*SharedItemsImports = 5
+ 		src\Utilities\Compiler\Analyzer.Utilities.projitems*{d8762a0a-3832-47be-bcf6-8b1060be6b28}*SharedItemsImports = 5
+ 		src\Utilities\Workspaces\Workspaces.Utilities.projitems*{d8762a0a-3832-47be-bcf6-8b1060be6b28}*SharedItemsImports = 5
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{ec946164-1e17-410b-b7d9-7de7e6268d63}*SharedItemsImports = 13
+-		src\Utilities\Compiler\Analyzer.Utilities.projitems*{f2985136-dcb2-492f-a66d-32968a0266f1}*SharedItemsImports = 5
+-		src\Utilities\FlowAnalysis\FlowAnalysis.Utilities.projitems*{fcb56cba-fa35-46a8-86b7-bae5433197d9}*SharedItemsImports = 13
+ 	EndGlobalSection
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Any CPU = Debug|Any CPU
+@@ -213,18 +105,10 @@ Global
+ 		{70BBA457-2CC1-4929-8FEE-359EBB7C398A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{70BBA457-2CC1-4929-8FEE-359EBB7C398A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{70BBA457-2CC1-4929-8FEE-359EBB7C398A}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{D90E7402-70E7-4A95-A292-47EA163D6309}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{D90E7402-70E7-4A95-A292-47EA163D6309}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{D90E7402-70E7-4A95-A292-47EA163D6309}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{D90E7402-70E7-4A95-A292-47EA163D6309}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{BD80CDC4-25FF-4268-8131-F7A43260122B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{BD80CDC4-25FF-4268-8131-F7A43260122B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{BD80CDC4-25FF-4268-8131-F7A43260122B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{BD80CDC4-25FF-4268-8131-F7A43260122B}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{0A0621F2-D1DC-47FF-B643-C6646557505E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{0A0621F2-D1DC-47FF-B643-C6646557505E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{0A0621F2-D1DC-47FF-B643-C6646557505E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{0A0621F2-D1DC-47FF-B643-C6646557505E}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{D8762A0A-3832-47BE-BCF6-8B1060BE6B28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{D8762A0A-3832-47BE-BCF6-8B1060BE6B28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{D8762A0A-3832-47BE-BCF6-8B1060BE6B28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -237,34 +121,10 @@ Global
+ 		{B1A6A74B-E484-48FB-8745-7A30A06DB631}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{B1A6A74B-E484-48FB-8745-7A30A06DB631}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{B1A6A74B-E484-48FB-8745-7A30A06DB631}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{730C2D1C-0276-4132-85EA-675CE60068BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{730C2D1C-0276-4132-85EA-675CE60068BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{730C2D1C-0276-4132-85EA-675CE60068BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{730C2D1C-0276-4132-85EA-675CE60068BB}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{EA61DA2E-D175-4430-A56B-17BAC4B227A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{EA61DA2E-D175-4430-A56B-17BAC4B227A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{EA61DA2E-D175-4430-A56B-17BAC4B227A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{EA61DA2E-D175-4430-A56B-17BAC4B227A9}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{6762EB1D-517C-4746-80EB-D11717ACD469}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{6762EB1D-517C-4746-80EB-D11717ACD469}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{6762EB1D-517C-4746-80EB-D11717ACD469}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{6762EB1D-517C-4746-80EB-D11717ACD469}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{938F2420-14B8-4C7C-93BE-C9E89E08E823}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{938F2420-14B8-4C7C-93BE-C9E89E08E823}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{938F2420-14B8-4C7C-93BE-C9E89E08E823}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{938F2420-14B8-4C7C-93BE-C9E89E08E823}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{9E184844-18B8-446E-8EFB-25FFF76EE347}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{9E184844-18B8-446E-8EFB-25FFF76EE347}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{9E184844-18B8-446E-8EFB-25FFF76EE347}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -273,18 +133,6 @@ Global
+ 		{2569B087-6465-425E-986D-BD0D32FC8AA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{2569B087-6465-425E-986D-BD0D32FC8AA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{2569B087-6465-425E-986D-BD0D32FC8AA5}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{0A7C9A18-888A-4028-B88F-989DA6A0140B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{0A7C9A18-888A-4028-B88F-989DA6A0140B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{0A7C9A18-888A-4028-B88F-989DA6A0140B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{0A7C9A18-888A-4028-B88F-989DA6A0140B}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{774B5DF6-D14F-4839-95F3-D3632B754765}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{774B5DF6-D14F-4839-95F3-D3632B754765}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{774B5DF6-D14F-4839-95F3-D3632B754765}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{774B5DF6-D14F-4839-95F3-D3632B754765}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{B88CCE32-B1EA-45A5-AE4C-AE92B7CFD691}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{B88CCE32-B1EA-45A5-AE4C-AE92B7CFD691}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{B88CCE32-B1EA-45A5-AE4C-AE92B7CFD691}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -293,22 +141,6 @@ Global
+ 		{18CE822A-A46D-494B-BBFC-C52EF1D048BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{18CE822A-A46D-494B-BBFC-C52EF1D048BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{18CE822A-A46D-494B-BBFC-C52EF1D048BE}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{F2985136-DCB2-492F-A66D-32968A0266F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{F2985136-DCB2-492F-A66D-32968A0266F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{F2985136-DCB2-492F-A66D-32968A0266F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{F2985136-DCB2-492F-A66D-32968A0266F1}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{5C9B8805-6489-41C5-8FE6-195599C6497F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{5C9B8805-6489-41C5-8FE6-195599C6497F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{5C9B8805-6489-41C5-8FE6-195599C6497F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{5C9B8805-6489-41C5-8FE6-195599C6497F}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{F86DCF03-7C4D-40FE-91D2-6206D532DEFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{F86DCF03-7C4D-40FE-91D2-6206D532DEFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{F86DCF03-7C4D-40FE-91D2-6206D532DEFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{F86DCF03-7C4D-40FE-91D2-6206D532DEFD}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{9A3072A5-FC2D-4183-9420-DE5DE323441E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{9A3072A5-FC2D-4183-9420-DE5DE323441E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{9A3072A5-FC2D-4183-9420-DE5DE323441E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -321,10 +153,6 @@ Global
+ 		{720DF809-C0D0-440A-B4B8-BFD41358CDA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{720DF809-C0D0-440A-B4B8-BFD41358CDA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{720DF809-C0D0-440A-B4B8-BFD41358CDA2}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{0F68246D-5645-486C-9CED-A8C8A97996DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{0F68246D-5645-486C-9CED-A8C8A97996DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{0F68246D-5645-486C-9CED-A8C8A97996DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{0F68246D-5645-486C-9CED-A8C8A97996DE}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{A94F29CC-56BF-4CF6-93B1-3BB13725B776}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{A94F29CC-56BF-4CF6-93B1-3BB13725B776}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{A94F29CC-56BF-4CF6-93B1-3BB13725B776}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -337,30 +165,10 @@ Global
+ 		{FCA9533D-04BB-4654-94A7-B9B2065CE0EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{FCA9533D-04BB-4654-94A7-B9B2065CE0EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{FCA9533D-04BB-4654-94A7-B9B2065CE0EF}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{697FE592-9EB8-493C-87DA-6C218A3B113D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{697FE592-9EB8-493C-87DA-6C218A3B113D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{697FE592-9EB8-493C-87DA-6C218A3B113D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{697FE592-9EB8-493C-87DA-6C218A3B113D}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{CADE5623-CC57-43A2-9D2A-B7AB29225406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{CADE5623-CC57-43A2-9D2A-B7AB29225406}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{CADE5623-CC57-43A2-9D2A-B7AB29225406}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{CADE5623-CC57-43A2-9D2A-B7AB29225406}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{2A4AF3A4-307B-4252-888E-E6546244585A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{2A4AF3A4-307B-4252-888E-E6546244585A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{2A4AF3A4-307B-4252-888E-E6546244585A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{2A4AF3A4-307B-4252-888E-E6546244585A}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{C96D2F95-3090-4376-942C-2C934C55283B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{C96D2F95-3090-4376-942C-2C934C55283B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{C96D2F95-3090-4376-942C-2C934C55283B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{C96D2F95-3090-4376-942C-2C934C55283B}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{01518AF6-AE8F-4ADA-ABE4-C78F8234899F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{01518AF6-AE8F-4ADA-ABE4-C78F8234899F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{01518AF6-AE8F-4ADA-ABE4-C78F8234899F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{01518AF6-AE8F-4ADA-ABE4-C78F8234899F}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{1C62A2F6-7A44-4030-9D1A-7E7A966736E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{1C62A2F6-7A44-4030-9D1A-7E7A966736E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{1C62A2F6-7A44-4030-9D1A-7E7A966736E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -373,10 +181,6 @@ Global
+ 		{9F4C5E8F-10EE-4193-BB36-A2FDE07B5557}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{9F4C5E8F-10EE-4193-BB36-A2FDE07B5557}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{9F4C5E8F-10EE-4193-BB36-A2FDE07B5557}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{F4F111E0-7108-47A7-97A1-A5B10207C0D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{F4F111E0-7108-47A7-97A1-A5B10207C0D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{F4F111E0-7108-47A7-97A1-A5B10207C0D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{F4F111E0-7108-47A7-97A1-A5B10207C0D8}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{C75555DC-D059-4665-A421-4EF5F30BD9B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{C75555DC-D059-4665-A421-4EF5F30BD9B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{C75555DC-D059-4665-A421-4EF5F30BD9B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -385,38 +189,10 @@ Global
+ 		{8AC54A99-5655-435B-8417-BF2F995BE66A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{8AC54A99-5655-435B-8417-BF2F995BE66A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{8AC54A99-5655-435B-8417-BF2F995BE66A}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{813C80EB-D614-4258-BD07-42660BEB738A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{813C80EB-D614-4258-BD07-42660BEB738A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{813C80EB-D614-4258-BD07-42660BEB738A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{813C80EB-D614-4258-BD07-42660BEB738A}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{B969F316-815C-47B9-82B3-67FDD9ED694F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{B969F316-815C-47B9-82B3-67FDD9ED694F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{B969F316-815C-47B9-82B3-67FDD9ED694F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{B969F316-815C-47B9-82B3-67FDD9ED694F}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{3F998217-4174-4AD0-A015-A9BFFADB075F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{3F998217-4174-4AD0-A015-A9BFFADB075F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{3F998217-4174-4AD0-A015-A9BFFADB075F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{3F998217-4174-4AD0-A015-A9BFFADB075F}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{64D70469-18B0-446C-80E9-A7C45A747B3E}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{563654BA-4C05-4EA2-91D3-28A14723B7D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{563654BA-4C05-4EA2-91D3-28A14723B7D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{563654BA-4C05-4EA2-91D3-28A14723B7D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{563654BA-4C05-4EA2-91D3-28A14723B7D5}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{8197A037-FF9E-4660-8C6D-2F722FEA0C10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{8197A037-FF9E-4660-8C6D-2F722FEA0C10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{8197A037-FF9E-4660-8C6D-2F722FEA0C10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{8197A037-FF9E-4660-8C6D-2F722FEA0C10}.Release|Any CPU.Build.0 = Release|Any CPU
+-		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+-		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+-		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+-		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5}.Release|Any CPU.Build.0 = Release|Any CPU
+ 		{81E21880-3F26-42DC-9423-9DACB8933597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+ 		{81E21880-3F26-42DC-9423-9DACB8933597}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{81E21880-3F26-42DC-9423-9DACB8933597}.Release|Any CPU.ActiveCfg = Release|Any CPU
+@@ -429,67 +205,28 @@ Global
+ 		{B475C173-A39D-4A75-93FF-69C3D2742CAD} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+ 		{697E2991-39A8-46C2-AA9C-FE576FBBCD90} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+ 		{70BBA457-2CC1-4929-8FEE-359EBB7C398A} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+-		{D90E7402-70E7-4A95-A292-47EA163D6309} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+ 		{BD80CDC4-25FF-4268-8131-F7A43260122B} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+-		{0A0621F2-D1DC-47FF-B643-C6646557505E} = {80E410B3-D8D1-4C67-93FF-078530E20816}
+ 		{D8762A0A-3832-47BE-BCF6-8B1060BE6B28} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+ 		{921B412A-5551-4853-82B4-46AD5A05A03E} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+ 		{B1A6A74B-E484-48FB-8745-7A30A06DB631} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+-		{0C2925AD-CD97-46FA-A686-E2C1AD19DAD8} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+ 		{54F6AE18-B0CD-4799-9DF0-9B1AAD6A78AF} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+-		{730C2D1C-0276-4132-85EA-675CE60068BB} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+-		{0EA928BE-51C1-4087-B48A-ECE9C5E0C5B0} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+-		{EA61DA2E-D175-4430-A56B-17BAC4B227A9} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+-		{6762EB1D-517C-4746-80EB-D11717ACD469} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+-		{938F2420-14B8-4C7C-93BE-C9E89E08E823} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+ 		{9E184844-18B8-446E-8EFB-25FFF76EE347} = {041E93F2-E703-4AB1-B6DF-13EC899D1C6E}
+ 		{2569B087-6465-425E-986D-BD0D32FC8AA5} = {72AAA528-FD70-45DA-82F8-1D29FC27F81F}
+-		{0A7C9A18-888A-4028-B88F-989DA6A0140B} = {446787CE-66C8-43F0-9D51-585BB41FC770}
+-		{EC946164-1E17-410B-B7D9-7DE7E6268D63} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{774B5DF6-D14F-4839-95F3-D3632B754765} = {4F3DD6F3-121C-4D38-9B8E-5065783EA832}
+-		{AFCB0C5B-E3C6-45AF-940B-AA38C7EC94EA} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{99F594B1-3916-471D-A761-A6731FC50E9A} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{FCB56CBA-FA35-46A8-86B7-BAE5433197D9} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+ 		{B88CCE32-B1EA-45A5-AE4C-AE92B7CFD691} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+ 		{18CE822A-A46D-494B-BBFC-C52EF1D048BE} = {8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}
+-		{04CDAFD7-7EC6-43A0-AC42-84FFD56E78B6} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+-		{F2985136-DCB2-492F-A66D-32968A0266F1} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+-		{5C9B8805-6489-41C5-8FE6-195599C6497F} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+-		{F86DCF03-7C4D-40FE-91D2-6206D532DEFD} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+ 		{9A3072A5-FC2D-4183-9420-DE5DE323441E} = {8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}
+ 		{0DC347C1-660D-45D8-BDC8-DC439C2E4A67} = {8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}
+ 		{720DF809-C0D0-440A-B4B8-BFD41358CDA2} = {8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}
+-		{0F68246D-5645-486C-9CED-A8C8A97996DE} = {8E48BD4D-5178-47E1-A850-76B5DA2EB9D0}
+ 		{A94F29CC-56BF-4CF6-93B1-3BB13725B776} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+ 		{FF1C6979-CD73-46DC-94BF-A6D59A252B66} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+ 		{FCA9533D-04BB-4654-94A7-B9B2065CE0EF} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+-		{697FE592-9EB8-493C-87DA-6C218A3B113D} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+ 		{5AFCA3A1-C780-4E44-BFFA-D9224685FCE1} = {8D64F6D4-951C-413E-8A53-FB708F9FB5CD}
+-		{50FB229D-38DB-4A34-8588-D33671AB68DE} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+-		{CADE5623-CC57-43A2-9D2A-B7AB29225406} = {50FB229D-38DB-4A34-8588-D33671AB68DE}
+-		{2A4AF3A4-307B-4252-888E-E6546244585A} = {50FB229D-38DB-4A34-8588-D33671AB68DE}
+-		{C96D2F95-3090-4376-942C-2C934C55283B} = {50FB229D-38DB-4A34-8588-D33671AB68DE}
+-		{6AAE1FC7-D96E-40CB-8B52-EA87EF9BF00A} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+-		{01518AF6-AE8F-4ADA-ABE4-C78F8234899F} = {6AAE1FC7-D96E-40CB-8B52-EA87EF9BF00A}
+ 		{1C62A2F6-7A44-4030-9D1A-7E7A966736E5} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+ 		{DC277D4D-9479-4B55-95BB-9FDB8A682DE1} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+ 		{9F4C5E8F-10EE-4193-BB36-A2FDE07B5557} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+-		{F4F111E0-7108-47A7-97A1-A5B10207C0D8} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+ 		{C75555DC-D059-4665-A421-4EF5F30BD9B6} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+ 		{8AC54A99-5655-435B-8417-BF2F995BE66A} = {31F86414-C34B-462A-AFB5-BDA7724904F3}
+-		{02F88961-A08F-451A-93AB-328792A32EBC} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+-		{C3A4699A-4701-4EC9-9EE9-4CAB4C9B1A4E} = {02F88961-A08F-451A-93AB-328792A32EBC}
+-		{813C80EB-D614-4258-BD07-42660BEB738A} = {02F88961-A08F-451A-93AB-328792A32EBC}
+-		{B969F316-815C-47B9-82B3-67FDD9ED694F} = {1A3624C9-EB8A-4F27-98F8-9FAEAB30604E}
+-		{3F998217-4174-4AD0-A015-A9BFFADB075F} = {1A3624C9-EB8A-4F27-98F8-9FAEAB30604E}
+-		{64D70469-18B0-446C-80E9-A7C45A747B3E} = {02F88961-A08F-451A-93AB-328792A32EBC}
+-		{DB2DD702-8301-4FC6-B8C0-029C7DCC2931} = {C0B86774-8307-444F-9EE4-98D62C3424F9}
+ 		{563654BA-4C05-4EA2-91D3-28A14723B7D5} = {DB2DD702-8301-4FC6-B8C0-029C7DCC2931}
+-		{68528C1C-B163-49A6-A19D-24E10F500F90} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{3055F932-0D1E-4823-A03A-7B62C7639BDA} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{4C362C30-C4B1-4C4B-A545-DBF67C7E9153} = {1F4F7A9B-FD3B-495F-86D0-89A7DEA2128C}
+-		{8197A037-FF9E-4660-8C6D-2F722FEA0C10} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+-		{046419A7-C60D-40FF-AD7E-2BAE461B7CE5} = {34430BD4-4D66-4FE6-8076-51B87B4FBCD4}
+ 		{81E21880-3F26-42DC-9423-9DACB8933597} = {DB2DD702-8301-4FC6-B8C0-029C7DCC2931}
+ 	EndGlobalSection
+ 	GlobalSection(ExtensibilityGlobals) = postSolution
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 23f5ee1bd..ced06221d 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -25,6 +25,7 @@
+     <CodeStyleAnalyersVersion>$(MicrosoftNETCoreCompilersPackageVersion)</CodeStyleAnalyersVersion>
+     <!-- Roslyn -->
+     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
++    <MicrosoftCodeAnalysisCommonVersion>3.3.1</MicrosoftCodeAnalysisCommonVersion>
+     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.7.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
+     <MicrosoftCodeAnalysisVersionForTests>3.8.0</MicrosoftCodeAnalysisVersionForTests>
+     <DogfoodAnalyzersVersion>3.3.2</DogfoodAnalyzersVersion>
+@@ -48,4 +49,7 @@
+     <HumanizerVersion>2.2.0</HumanizerVersion>
+     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
+   </PropertyGroup>
++
++  <!-- Override isolated build dependency versions with versions from Repo API. -->
++  <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />
+ </Project>
+-- 
+2.26.2
+

--- a/eng/source-build-patches/0004-Update-to-netstandard2.0.patch
+++ b/eng/source-build-patches/0004-Update-to-netstandard2.0.patch
@@ -1,0 +1,335 @@
+From 6babb13699adca5e18525cc600858a8ffb568ad4 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Thu, 5 Nov 2020 17:31:41 -0500
+Subject: [PATCH 2/4] Update to netstandard2.0
+
+---
+ ...soft.CodeAnalysis.BannedApiAnalyzers.Package.csproj |  4 ++--
+ ...alysis.PerformanceSensitiveAnalyzers.Package.csproj |  4 ++--
+ ...soft.CodeAnalysis.PublicApiAnalyzers.Package.csproj |  4 ++--
+ .../Roslyn.Diagnostics.Analyzers.Package.csproj        | 10 +++++-----
+ ...osoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj |  4 +++-
+ .../Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj   |  4 +++-
+ ...rosoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj |  4 ++--
+ ....CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj |  4 +++-
+ ...nalysis.CSharp.PerformanceSensitiveAnalyzers.csproj |  4 +++-
+ ...t.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj |  4 +++-
+ .../Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs    |  8 ++++----
+ .../Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj   |  4 +++-
+ .../Core/CodeFixes/AnnotatePublicApiFix.cs             |  4 ++--
+ .../Core/CodeFixes/DeclarePublicApiFix.cs              |  4 ++--
+ ...ft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj |  4 +++-
+ ...rosoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj |  4 ++--
+ 16 files changed, 44 insertions(+), 30 deletions(-)
+
+diff --git a/nuget/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.Package.csproj b/nuget/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.Package.csproj
+index 140116f9d..6247917a1 100644
+--- a/nuget/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.Package.csproj
++++ b/nuget/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.Package.csproj
+@@ -1,7 +1,7 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+ 
+     <IsPackable>true</IsPackable>
+     <IncludeBuildOutput>false</IncludeBuildOutput>
+@@ -23,4 +23,4 @@
+     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.BannedApiAnalyzers\CSharp\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj" />
+     <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.BannedApiAnalyzers\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj b/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj
+index 255d61018..fd6372eab 100644
+--- a/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj
++++ b/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj
+@@ -1,7 +1,7 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <IsPackable>true</IsPackable>
+     <IncludeBuildOutput>false</IncludeBuildOutput>
+     <NuspecPackageId>Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers</NuspecPackageId>
+diff --git a/nuget/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.Package.csproj b/nuget/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.Package.csproj
+index 8e6b5fbe9..ab00c8532 100644
+--- a/nuget/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.Package.csproj
++++ b/nuget/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.Package.csproj
+@@ -1,7 +1,7 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+ 
+     <IsPackable>true</IsPackable>
+     <IncludeBuildOutput>false</IncludeBuildOutput>
+@@ -31,4 +31,4 @@
+     <ProjectReference Include="..\..\src\PublicApiAnalyzers\Core\Analyzers\Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj" />
+     <ProjectReference Include="..\..\src\PublicApiAnalyzers\Core\CodeFixes\Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj
+index c0cde9db9..f98e304ca 100644
+--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj
++++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj
+@@ -1,8 +1,10 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
++    <!--
+     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
+diff --git a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj
+index f3a0b0e5f..b8c947767 100644
+--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj
++++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/Microsoft.CodeAnalysis.BannedApiAnalyzers.csproj
+@@ -1,13 +1,15 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <!--
+       PackageId is used by Restore. If we set it to Microsoft.CodeAnalysis.BannedApiAnalyzer,
+       Restore would conclude that there is a cyclic dependency between us and the Microsoft.CodeAnalysis.BannedApiAnalyzer package.
+     -->
+     <PackageId>*$(MSBuildProjectFile)*</PackageId>
++    <!--
+     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+   <ItemGroup>
+     <Compile Include="..\..\Roslyn.Diagnostics.Analyzers\Core\RoslynDiagnosticIds.cs" Link="RoslynDiagnosticIds.cs" />
+diff --git a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj
+index 849675f30..220d325c7 100644
+--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj
++++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Setup/Microsoft.CodeAnalysis.BannedApiAnalyzers.Setup.csproj
+@@ -1,7 +1,7 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>net46</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <GeneratePkgDefFile>false</GeneratePkgDefFile>
+     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+@@ -15,4 +15,4 @@
+     <ProjectReference Include="..\CSharp\Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers.csproj" />
+     <ProjectReference Include="..\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+diff --git a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj
+index 645153bbd..4a0aec475 100644
+--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj
++++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers.vbproj
+@@ -1,8 +1,10 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
++    <!--
+     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(MicrosoftCodeAnalysisVersion)" />
+diff --git a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.csproj b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.csproj
+index 29a9d9494..d2e2317cd 100644
+--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.csproj
++++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.csproj
+@@ -1,8 +1,10 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
++    <!--
+     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+   <ItemGroup>
+     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes" />
+diff --git a/src/PerformanceSensitiveAnalyzers/Core/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj b/src/PerformanceSensitiveAnalyzers/Core/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj
+index ac9455cac..366db8ae4 100644
+--- a/src/PerformanceSensitiveAnalyzers/Core/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj
++++ b/src/PerformanceSensitiveAnalyzers/Core/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.csproj
+@@ -1,13 +1,15 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <!--
+       PackageId is used by Restore. If we set it to Microsoft.CodeAnalysis.PerformanceSensitive.Analyzers,
+       Restore would conclude that there is a cyclic dependency between us and the Microsoft.CodeAnalysis.PerformanceSensitive.Analyzers nuget package.
+     -->
+     <PackageId>*$(MSBuildProjectFile)*</PackageId>
++    <!--
+     <MicrosoftCodeAnalysisVersion>2.9.0</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+   <ItemGroup>
+     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers" />
+diff --git a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+index 9b9a767f3..e389df42b 100644
+--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
++++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+@@ -825,7 +825,7 @@ public override bool VisitNamedType(INamedTypeSymbol symbol)
+                     if (!_ignoreTopLevelNullability)
+                     {
+                         if (symbol.IsReferenceType &&
+-                            symbol.NullableAnnotation() == NullableAnnotation.None)
++                            symbol.NullableAnnotation().Equals(NullableAnnotation.None))
+                         {
+                             return true;
+                         }
+@@ -852,7 +852,7 @@ public override bool VisitNamedType(INamedTypeSymbol symbol)
+ 
+                 public override bool VisitArrayType(IArrayTypeSymbol symbol)
+                 {
+-                    if (symbol.NullableAnnotation() == NullableAnnotation.None)
++                    if (symbol.NullableAnnotation().Equals(NullableAnnotation.None))
+                     {
+                         return true;
+                     }
+@@ -869,7 +869,7 @@ public override bool VisitPointerType(IPointerTypeSymbol symbol)
+                 public override bool VisitTypeParameter(ITypeParameterSymbol symbol)
+                 {
+                     if (symbol.IsReferenceType &&
+-                        symbol.NullableAnnotation() == NullableAnnotation.None)
++                        symbol.NullableAnnotation().Equals(NullableAnnotation.None))
+                     {
+                         // Example:
+                         // I<TReferenceType~>
+@@ -896,7 +896,7 @@ public static bool VisitNamedTypeDeclaration(INamedTypeSymbol symbol)
+                 private static bool CheckTypeParameterConstraints(ITypeParameterSymbol symbol)
+                 {
+                     if (symbol.HasReferenceTypeConstraint() &&
+-                        symbol.ReferenceTypeConstraintNullableAnnotation() == NullableAnnotation.None)
++                        symbol.ReferenceTypeConstraintNullableAnnotation().Equals(NullableAnnotation.None))
+                     {
+                         // where T : class~
+                         return true;
+diff --git a/src/PublicApiAnalyzers/Core/Analyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj b/src/PublicApiAnalyzers/Core/Analyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj
+index 8ac0061a4..ba8bac56e 100644
+--- a/src/PublicApiAnalyzers/Core/Analyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj
++++ b/src/PublicApiAnalyzers/Core/Analyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj
+@@ -1,13 +1,15 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <!--
+       PackageId is used by Restore. If we set it to Microsoft.CodeAnalysis.PublicApiAnalyzer,
+       Restore would conclude that there is a cyclic dependency between us and the Microsoft.CodeAnalysis.PublicApiAnalyzer package.
+     -->
+     <PackageId>*$(MSBuildProjectFile)*</PackageId>
++    <!--
+     <MicrosoftCodeAnalysisVersion>1.2.1</MicrosoftCodeAnalysisVersion>
++    -->
+   </PropertyGroup>
+ 
+   <Choose>
+diff --git a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+index 1a13e6259..7b662212e 100644
+--- a/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
++++ b/src/PublicApiAnalyzers/Core/CodeFixes/AnnotatePublicApiFix.cs
+@@ -146,7 +146,7 @@ protected override async Task<Solution> GetChangedSolutionAsync(CancellationToke
+ 
+                     foreach (IGrouping<SyntaxTree, Diagnostic> grouping in groupedDiagnostics)
+                     {
+-                        Document document = project.GetDocument(grouping.Key);
++                        Document? document = project.GetDocument(grouping.Key);
+ 
+                         if (document == null)
+                         {
+@@ -236,7 +236,7 @@ private class PublicSurfaceAreaFixAllProvider : FixAllProvider
+                         return null;
+ 
+                     default:
+-                        Debug.Fail($"Unknown FixAllScope '{fixAllContext.Scope}'");
++                        Debug.Fail($"Unknown FixAllScope '{fixAllContext.Scope!}'");
+                         return null;
+                 }
+ 
+diff --git a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+index 0aa0149c4..41c01cd9b 100644
+--- a/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
++++ b/src/PublicApiAnalyzers/Core/CodeFixes/DeclarePublicApiFix.cs
+@@ -236,7 +236,7 @@ protected override async Task<Solution> GetChangedSolutionAsync(CancellationToke
+ 
+                     foreach (IGrouping<SyntaxTree, Diagnostic> grouping in groupedDiagnostics)
+                     {
+-                        Document document = project.GetDocument(grouping.Key);
++                        Document? document = project.GetDocument(grouping.Key);
+ 
+                         if (document == null)
+                         {
+@@ -300,7 +300,7 @@ protected override async Task<Solution> GetChangedSolutionAsync(CancellationToke
+                 foreach (KeyValuePair<ProjectId, SourceText> pair in addedPublicSurfaceAreaText)
+                 {
+                     var project = newSolution.GetProject(pair.Key);
+-                    if (uniqueProjectPaths.Add(project.FilePath ?? project.Name))
++                    if (uniqueProjectPaths.Add(project!.FilePath ?? project.Name))
+                     {
+                         newSolution = AddPublicApiFiles(project, pair.Value);
+                     }
+diff --git a/src/PublicApiAnalyzers/Core/CodeFixes/Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj b/src/PublicApiAnalyzers/Core/CodeFixes/Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj
+index bdb00b382..3178f5d2b 100644
+--- a/src/PublicApiAnalyzers/Core/CodeFixes/Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj
++++ b/src/PublicApiAnalyzers/Core/CodeFixes/Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj
+@@ -1,13 +1,15 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>netstandard1.3</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <!--
+       PackageId is used by Restore. If we set it to DotNetAnalyzers.PublicApiAnalyzer.CodeFixes,
+       Restore would conclude that there is a cyclic dependency between us and the DotNetAnalyzers.PublicApiAnalyzer.CodeFixes package.
+     -->
+     <PackageId>*$(MSBuildProjectFile)*</PackageId>
++    <!--
+     <MicrosoftCodeAnalysisVersion>1.2.1</MicrosoftCodeAnalysisVersion>
++    -->
+     <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
+   </PropertyGroup>
+ 
+diff --git a/src/PublicApiAnalyzers/Setup/Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj b/src/PublicApiAnalyzers/Setup/Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj
+index dbeee618f..dcdfeb162 100644
+--- a/src/PublicApiAnalyzers/Setup/Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj
++++ b/src/PublicApiAnalyzers/Setup/Microsoft.CodeAnalysis.PublicApiAnalyzers.Setup.csproj
+@@ -1,7 +1,7 @@
+ ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+ <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFramework>net46</TargetFramework>
++    <TargetFramework>netstandard2.0</TargetFramework>
+     <GeneratePkgDefFile>false</GeneratePkgDefFile>
+     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+@@ -14,4 +14,4 @@
+     <ProjectReference Include="..\Core\Analyzers\Microsoft.CodeAnalysis.PublicApiAnalyzers.csproj" />
+     <ProjectReference Include="..\Core\CodeFixes\Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes.csproj" />
+   </ItemGroup>
+-</Project>
+\ No newline at end of file
++</Project>
+-- 
+2.26.2

--- a/eng/source-build-patches/0005-Update-Microsoft.CodeAnalysis-packages.patch
+++ b/eng/source-build-patches/0005-Update-Microsoft.CodeAnalysis-packages.patch
@@ -1,0 +1,30 @@
+From f3f0b2eec1f707260718dbd6e44dfb785b7b5d82 Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Fri, 6 Nov 2020 18:18:48 -0500
+Subject: [PATCH 3/4] Update Microsoft.CodeAnalysis packages
+
+The version used in 5.0 SDK is Microsoft.CodeAnalysis 3.8.0
+---
+ eng/Versions.props | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 605321faf..1360b589a 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -28,9 +28,9 @@
+     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftNetCompilersToolsetVersion>
+     <CodeStyleAnalyersVersion>$(MicrosoftNETCoreCompilersPackageVersion)</CodeStyleAnalyersVersion>
+     <!-- Roslyn -->
+-    <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
+-    <MicrosoftCodeAnalysisCommonVersion>3.3.1</MicrosoftCodeAnalysisCommonVersion>
+-    <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.7.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
++    <MicrosoftCodeAnalysisVersion>3.8.0</MicrosoftCodeAnalysisVersion>
++    <MicrosoftCodeAnalysisCommonVersion>3.8.0</MicrosoftCodeAnalysisCommonVersion>
++    <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
+     <MicrosoftCodeAnalysisVersionForTests>3.8.0</MicrosoftCodeAnalysisVersionForTests>
+     <DogfoodAnalyzersVersion>3.3.2</DogfoodAnalyzersVersion>
+     <DogfoodNetAnalyzersVersion>5.0.4-preview1.21126.5</DogfoodNetAnalyzersVersion>
+-- 
+2.26.2
+

--- a/eng/source-build-patches/0008-Fix-version-for-Microsoft.CodeAnalysis.CSharp.CodeSt.patch
+++ b/eng/source-build-patches/0008-Fix-version-for-Microsoft.CodeAnalysis.CSharp.CodeSt.patch
@@ -1,0 +1,39 @@
+From 1839e0370d5416b45f0a8fbcc370f4984237f1ba Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Mon, 9 Nov 2020 11:52:28 -0500
+Subject: [PATCH 4/4] Fix version for Microsoft.CodeAnalysis.CSharp.CodeStyle
+
+---
+ eng/Versions.props        | 2 +-
+ src/Directory.Build.props | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 677b44310..f9e213be1 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -34,7 +34,7 @@
+     <!-- Dependencies from https://github.com/dotnet/roslyn -->
+     <MicrosoftNETCoreCompilersPackageVersion>3.8.0</MicrosoftNETCoreCompilersPackageVersion>
+     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftNetCompilersToolsetVersion>
+-    <CodeStyleAnalyersVersion>$(MicrosoftNETCoreCompilersPackageVersion)</CodeStyleAnalyersVersion>
++    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+     <!-- Roslyn -->
+     <MicrosoftCodeAnalysisVersion>3.8.0</MicrosoftCodeAnalysisVersion>
+     <MicrosoftCodeAnalysisCommonVersion>3.8.0</MicrosoftCodeAnalysisCommonVersion>
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 24e9fe3eb..6c95f9d7b 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -31,7 +31,7 @@
+ 
+   <!-- Code Style analyzers -->
+   <ItemGroup Condition="'$(Language)' == 'C#'">
+-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
++    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
+   </ItemGroup>
+   <ItemGroup Condition="'$(Language)' == 'VB'">
+     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+-- 
+2.26.2
+

--- a/eng/source-build-patches/0009-Disable-code-analyzers-when-building-from-source.patch
+++ b/eng/source-build-patches/0009-Disable-code-analyzers-when-building-from-source.patch
@@ -1,0 +1,30 @@
+From 6511158d415c1a7d87b825d8975b231a96f97c65 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Wed, 18 Nov 2020 14:30:39 -0600
+Subject: [PATCH] Disable code analyzers when building from source
+
+Some analyzers are not buildable from source due to VS dependencies. We
+might as well disable all analyzers, because the analyzers seem most
+important to run against PRs in upstream. In source-build, we don't
+expect to make impactful changes to the C# code so they're unlikely to
+catch anything.
+---
+ src/Directory.Build.props | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 6c95f9d7b..63c1ce376 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -16,7 +16,7 @@
+     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+   </PropertyGroup>
+ 
+-  <ItemGroup>
++  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(DogfoodNetAnalyzersVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+     <PackageReference Include="Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers" Version="$(MicrosoftCodeAnalysisPerformanceSensitiveAnalyzersVersion)" />
+-- 
+2.25.2
+

--- a/eng/source-build-patches/0010-Build-roslyn-analyzer-tools-with-net5.0-TFM.patch
+++ b/eng/source-build-patches/0010-Build-roslyn-analyzer-tools-with-net5.0-TFM.patch
@@ -1,0 +1,52 @@
+From f1ffa381244fa08d4ba38fd6815a3dead7c3a954 Mon Sep 17 00:00:00 2001
+From: dseefeld <dseefeld@microsoft.com>
+Date: Fri, 11 Dec 2020 20:13:28 +0000
+Subject: [PATCH] Build roslyn-analyzer tools with net5.0 TFM
+
+---
+ eng/GenerateAnalyzerNuspec.targets                                      | 2 +-
+ src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj          | 1 +
+ .../GenerateDocumentationAndConfigFiles.csproj                          | 1 +
+ .../GenerateGlobalAnalyzerConfigs/GenerateGlobalAnalyzerConfigs.csproj  | 1 +
+ 4 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/eng/GenerateAnalyzerNuspec.targets b/eng/GenerateAnalyzerNuspec.targets
+index 91c6a26..f683eab 100644
+--- a/eng/GenerateAnalyzerNuspec.targets
++++ b/eng/GenerateAnalyzerNuspec.targets
+@@ -109,7 +109,7 @@
+   
+   <PropertyGroup>
+     <!-- Ideally, we would extract this from the MSBuild task, but we need this as the Target Output before that task is executed -->
+-    <_GenerateAnalyzerNuspecPath>$(ArtifactsBinDir)GenerateAnalyzerNuspec\$(Configuration)\netcoreapp3.1\GenerateAnalyzerNuspec.dll</_GenerateAnalyzerNuspecPath>
++    <_GenerateAnalyzerNuspecPath>$(ArtifactsBinDir)GenerateAnalyzerNuspec\$(Configuration)\net5.0\GenerateAnalyzerNuspec.dll</_GenerateAnalyzerNuspecPath>
+   </PropertyGroup>
+ 
+   <Target Name="BuildGenerateAnalyzerNuspecFile"
+diff --git a/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj b/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj
+index ba0a961..3a16ac4 100644
+--- a/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj
++++ b/src/Tools/GenerateAnalyzerNuspec/GenerateAnalyzerNuspec.csproj
+@@ -2,6 +2,7 @@
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+     <TargetFramework>netcoreapp3.1</TargetFramework>
++    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net5.0</TargetFramework>
+     <NonShipping>true</NonShipping>
+     <UseAppHost>false</UseAppHost>
+   </PropertyGroup>
+diff --git a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+index 0056792..181473c 100644
+--- a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
++++ b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+@@ -2,6 +2,7 @@
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+     <TargetFramework>netcoreapp3.1</TargetFramework>
++    <TargetFramework Condition="'$(DotNetBuildFromSource)' == 'true'">net5.0</TargetFramework>
+     <NonShipping>true</NonShipping>
+     <UseAppHost>false</UseAppHost>
+     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+-- 
+1.8.3.1
+

--- a/eng/source-build-patches/0011-Reference-latest-when-running-in-build.patch
+++ b/eng/source-build-patches/0011-Reference-latest-when-running-in-build.patch
@@ -1,0 +1,73 @@
+From 20eff0e62e16c49d0b02e861f2cc553d7de66061 Mon Sep 17 00:00:00 2001
+From: Davis Goodin <dagood@microsoft.com>
+Date: Mon, 28 Dec 2020 11:20:26 -0600
+Subject: [PATCH] Reference latest when running in build
+
+---
+ Directory.Build.targets                       | 35 +++++++++++++++++++
+ ...GenerateDocumentationAndConfigFiles.csproj |  3 ++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/Directory.Build.targets b/Directory.Build.targets
+index 34e0b7966..6633a023a 100644
+--- a/Directory.Build.targets
++++ b/Directory.Build.targets
+@@ -14,6 +14,41 @@
+     </Content>
+   </ItemGroup>
+ 
++  <!--
++    If this project executes during the build (a tool project, rather than a project that compiles
++    against reference assemblies for maximum compatibility), use the latest version of every package
++    rather than whatever the transitive closure happens to include. In source-build, if we use an
++    old reference-only package, it will fail to execute becuase methods are missing implementations.
++  -->
++  <ItemGroup Condition="'$(ExecutesDuringBuild)' == 'true'">
++    <ExecuteDuringBuildLatestPackageId Include="Microsoft.Bcl.AsyncInterfaces" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Collections.Immutable" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition.AttributedModel" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition.Convention" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition.Hosting" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition.Runtime" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Composition.TypedParts" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Reflection.Metadata" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Runtime.CompilerServices.Unsafe" />
++    <ExecuteDuringBuildLatestPackageId Include="System.Text.Encoding.CodePages" />
++
++    <!-- Find the name used by the PackageVersions.props infrastructure. -->
++    <ExecuteDuringBuildLatestPackageId
++      Update="@(ExecuteDuringBuildLatestPackageId)"
++      VersionPropertyName="$([System.String]::new('%(Identity)').Replace('.',''))Version" />
++
++    <!--
++      If the package version property is set (we are running in source-build or have the version in
++      eng/Versions.props), use it.
++    -->
++    <ExecuteDuringBuildLatestPackageId
++      Update="@(ExecuteDuringBuildLatestPackageId)"
++      Version="$(%(VersionPropertyName))" />
++
++    <PackageReference Include="@(ExecuteDuringBuildLatestPackageId->HasMetadata('Version'))" />
++  </ItemGroup>
++
+   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'">
+     <PackageReference Include="coverlet.msbuild" Version="$(CoverletVersion)" PrivateAssets="all" />
+   </ItemGroup>
+diff --git a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+index 181473c7f..51da76e35 100644
+--- a/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
++++ b/src/Tools/GenerateDocumentationAndConfigFiles/GenerateDocumentationAndConfigFiles.csproj
+@@ -8,6 +8,9 @@
+     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+     <MicrosoftCodeAnalysisVersion>$(MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion)</MicrosoftCodeAnalysisVersion>
+   </PropertyGroup>
++  <PropertyGroup>
++    <ExecutesDuringBuild>true</ExecutesDuringBuild>
++  </PropertyGroup>
+   <ItemGroup>
+     <Compile Include="..\..\Microsoft.CodeAnalysis.Analyzers\Core\MetaAnalyzers\ReleaseTrackingHelper.cs" Link="ReleaseTrackingHelper.cs" />
+     <Compile Include="..\..\Utilities\Compiler\Debug.cs" Link="Debug.cs" />
+-- 
+2.25.4
+

--- a/eng/source-build-patches/0012-Fix-version-for-MCVC.patch
+++ b/eng/source-build-patches/0012-Fix-version-for-MCVC.patch
@@ -1,0 +1,30 @@
+From 1839e0370d5416b45f0a8fbcc370f4984237f1ba Mon Sep 17 00:00:00 2001
+From: Omair Majid <omajid@redhat.com>
+Date: Fri, 5 Mar 2021 11:52:28 -0500
+Subject: [PATCH] Fix version for Microsoft.CodeAnalysis.VisualBasic.CodeStyle
+
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 2af360df5..066ddcaf3 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -30,6 +30,7 @@
+     <!-- Roslyn -->
+     <MicrosoftCodeAnalysisVersion>3.8.0</MicrosoftCodeAnalysisVersion>
+     <MicrosoftCodeAnalysisCommonVersion>3.8.0</MicrosoftCodeAnalysisCommonVersion>
++    <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>3.8.0</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
+     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>$(MicrosoftCodeAnalysisVersion)</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
+     <MicrosoftCodeAnalysisVersionForTests>3.8.0</MicrosoftCodeAnalysisVersionForTests>
+     <DogfoodAnalyzersVersion>3.3.2</DogfoodAnalyzersVersion>
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 40baf698c..ed66c81e6 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -34,7 +34,7 @@
+     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
+   </ItemGroup>
+   <ItemGroup Condition="'$(Language)' == 'VB'">
+-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
++    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftCodeAnalysisVisualBasicCodeStyleVersion)" />
+   </ItemGroup>
+ 
+   <!-- Setup the correct code analysis rulesets -->

--- a/eng/source-build-patches/0013-package-versions.patch
+++ b/eng/source-build-patches/0013-package-versions.patch
@@ -1,0 +1,19 @@
+diff --git a/eng/Versions.props b/eng/Versions.props
+index 605321faf..bd747b098 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -42,10 +42,10 @@
+     <!-- Roslyn Testing -->
+     <MicrosoftCodeAnalysisTestingVersion>1.0.1-beta1.21126.1</MicrosoftCodeAnalysisTestingVersion>
+     <!-- Libs -->
+-    <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+-    <SystemComponentModelCompositionVersion>4.7.0</SystemComponentModelCompositionVersion>
+-    <SystemDirectoryServicesVersion>4.7.0</SystemDirectoryServicesVersion>
+-    <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
++    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
++    <SystemComponentModelCompositionVersion>5.0.0</SystemComponentModelCompositionVersion>
++    <SystemDirectoryServicesVersion>5.0.0</SystemDirectoryServicesVersion>
++    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
+     <MicrosoftVisualBasicVersion>10.1.0</MicrosoftVisualBasicVersion>
+     <MicrosoftBuildLocatorVersion>1.1.2</MicrosoftBuildLocatorVersion>
+     <SQLitePCLRawVersion>1.1.2</SQLitePCLRawVersion>

--- a/eng/source-build-patches/0014-comment-performancesensitive.patch
+++ b/eng/source-build-patches/0014-comment-performancesensitive.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Utilities/Compiler/WellKnownTypeProvider.cs b/src/Utilities/Compiler/WellKnownTypeProvider.cs
+index b2e1b5876..7169c1500 100644
+--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
++++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
+@@ -84,7 +84,7 @@ public static WellKnownTypeProvider GetOrCreate(Compilation compilation)
+         /// <param name="fullTypeName">Namespace + type name, e.g. "System.Exception".</param>
+         /// <param name="namedTypeSymbol">Named type symbol, if any.</param>
+         /// <returns>True if found in the compilation, false otherwise.</returns>
+-        [PerformanceSensitive("https://github.com/dotnet/roslyn-analyzers/issues/4893", AllowCaptures = false)]
++        // [PerformanceSensitive("https://github.com/dotnet/roslyn-analyzers/issues/4893", AllowCaptures = false)]
+         public bool TryGetOrCreateTypeByMetadataName(
+             string fullTypeName,
+             [NotNullWhen(returnValue: true)] out INamedTypeSymbol? namedTypeSymbol)


### PR DESCRIPTION
This enables 'source-build', which makes it easier to build the entire shipping .NET SDK from source.

This is the first and second step of arcade-powered-source-build: https://github.com/dotnet/source-build/blob/master/Documentation/planning/arcade-powered-source-build/README.md

See dotnet/sourcelink#692 for a similar PR, that this is based on.