### PR TITLE
Port #4928 to release/5.0.2xx branch

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
                             var newValue = new GlobalFlowStateAnalysisValueSet(infosBuilder[i]);
-                            value = i == 0 ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
+                            value = (i == 0 || value == newValue) ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
                             var newValue = GlobalFlowStateAnalysisValueSet.Create(infosBuilder[i]);
-                            value = i == 0 ? newValue : GlobalFlowStateAnalysisValueSet.CreateWithParents(value, newValue);
+                            value = i == 0 ? newValue : GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.Instance.Merge(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -42,8 +42,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     {
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
-                            var newValue = new GlobalFlowStateAnalysisValueSet(infosBuilder[i]);
-                            value = (i == 0 || value == newValue) ? newValue : new GlobalFlowStateAnalysisValueSet(value, newValue);
+                            var newValue = GlobalFlowStateAnalysisValueSet.Create(infosBuilder[i]);
+                            value = i == 0 ? newValue : GlobalFlowStateAnalysisValueSet.CreateWithParents(value, newValue);
                         }
 
                         return value;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -2671,7 +2671,7 @@ class TestType
 
     [SupportedOSPlatform(""windows"")]
     static void Test() { }
-}";
+}" + MockAttributesCsSource;
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -2685,6 +2685,36 @@ if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Registry.GetValue("""
             }.RunAsync();
         }
 
+        [Fact, WorkItem(51652, "https://github.com/dotnet/roslyn/issues/51652")]
+        public async Task TestGuardedCheckInsideLoopWithTryCatch()
+        {
+            var source = @"
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+class TestType
+{
+    static async Task Main(string[] args) {
+	while (true)
+		try {
+			await Task.Delay(1000);
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				Test();
+		} catch {
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				Test();
+			throw;
+		}
+    }
+
+    [SupportedOSPlatform(""windows"")]
+    static void Test() { }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
         private string GetFormattedString(string resource, params string[] args) =>
             string.Format(CultureInfo.InvariantCulture, resource, args);
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -2645,46 +2645,6 @@ public class Test
             return string.Format(CultureInfo.InvariantCulture, resource, args);
         }
 
-        [Fact]
-        [WorkItem(4920, "https://github.com/dotnet/roslyn-analyzers/issues/4920")]
-        public async Task TestTimelyTermination()
-        {
-            var source = @"
-using System.Runtime.InteropServices;
-using Microsoft.Win32;
-
-if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Registry.GetValue("""", """", null) != null)
-{
-    foreach (var x in new string[0])
-    {
-        if ("""".ToString() == """")
-        {
-            try
-            {
-            }
-            catch
-            {
-            }
-        }
-    }
-}";
-
-            await new VerifyCS.Test
-            {
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50.AddPackages(
-                    ImmutableArray.Create(new PackageIdentity("Microsoft.Win32.Registry", "5.0.0"))),
-                LanguageVersion = CSharpLanguageVersion.CSharp9,
-                TestState =
-                {
-                    OutputKind = OutputKind.ConsoleApplication,
-                    Sources = { source },
-                    AnalyzerConfigFiles = { ("/.globalconfig", $@"is_global = true
-
-{s_msBuildPlatforms}") },
-                }
-            }.RunAsync();
-        }
-
         [Fact, WorkItem(51652, "https://github.com/dotnet/roslyn/issues/51652")]
         public async Task TestGuardedCheckInsideLoopWithTryCatch()
         {
@@ -2714,12 +2674,6 @@ class TestType
 }";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
-
-        private string GetFormattedString(string resource, params string[] args) =>
-            string.Format(CultureInfo.InvariantCulture, resource, args);
-
-        private string Join(string platform1, string platform2) =>
-            string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, platform1, platform2);
 
         private static VerifyCS.Test PopulateTestCs(string sourceCode, params DiagnosticResult[] expected)
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -79,12 +79,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
-                if (value1 == value2)
-                {
-                    return value1;
-                }
-
-                return new GlobalFlowStateAnalysisValueSet(value1, value2);
+                return GlobalFlowStateAnalysisValueSet.CreateWithParents(value1, value2);
             }
 
             public static GlobalFlowStateAnalysisValueSet Intersect(GlobalFlowStateAnalysisValueSet value1, GlobalFlowStateAnalysisValueSet value2)
@@ -220,7 +215,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                     }
                     else
                     {
-                        result = new GlobalFlowStateAnalysisValueSet(sets, value1.Parents, value1.Height, GlobalFlowStateAnalysisValueSetKind.Known);
+                        result = GlobalFlowStateAnalysisValueSet.Create(sets, value1.Parents, value1.Height);
                     }
 
                     return true;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -79,6 +79,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
+                if (value1 == value2)
+                {
+                    return value1;
+                }
+
                 return new GlobalFlowStateAnalysisValueSet(value1, value2);
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -79,7 +80,36 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
                 Debug.Assert(value2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
 
-                return GlobalFlowStateAnalysisValueSet.CreateWithParents(value1, value2);
+                // Perform some early bail out checks.
+                if (Equals(value1, value2))
+                {
+                    return value1;
+                }
+
+                if (value1.Height == 0 && value1.AnalysisValues.IsSubsetOf(value2.AnalysisValues))
+                {
+                    return value2;
+                }
+
+                if (value2.Height == 0 && value2.AnalysisValues.IsSubsetOf(value1.AnalysisValues))
+                {
+                    return value1;
+                }
+
+                // Check if value1 and value2 are negations of each other.
+                // If so, the analysis values nullify each other and we return an empty set.
+                if (value1.Height == value2.Height &&
+                    value1.AnalysisValues.Count == value2.AnalysisValues.Count &&
+                    Equals(value1, value2.GetNegatedValue()))
+                {
+                    return GlobalFlowStateAnalysisValueSet.Empty;
+                }
+
+                // Create a new value set with value1 and value2 as parent sets.
+                return GlobalFlowStateAnalysisValueSet.Create(
+                    ImmutableHashSet<IAbstractAnalysisValue>.Empty,
+                    ImmutableHashSet.Create(value1, value2),
+                    height: Math.Max(value1.Height, value2.Height) + 1);
             }
 
             public static GlobalFlowStateAnalysisValueSet Intersect(GlobalFlowStateAnalysisValueSet value1, GlobalFlowStateAnalysisValueSet value2)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
@@ -52,39 +52,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
         public static GlobalFlowStateAnalysisValueSet Create(IAbstractAnalysisValue analysisValue)
             => new(ImmutableHashSet.Create(analysisValue), ImmutableHashSet<GlobalFlowStateAnalysisValueSet>.Empty, height: 0, GlobalFlowStateAnalysisValueSetKind.Known);
 
-        public static GlobalFlowStateAnalysisValueSet CreateWithParents(GlobalFlowStateAnalysisValueSet parent1, GlobalFlowStateAnalysisValueSet parent2)
-        {
-            Debug.Assert(parent1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
-            Debug.Assert(parent2.Kind == GlobalFlowStateAnalysisValueSetKind.Known);
-
-            if (Equals(parent1, parent2))
-            {
-                return parent1;
-            }
-
-            if (parent1.Height == 0 && parent1.AnalysisValues.IsSubsetOf(parent2.AnalysisValues))
-            {
-                return parent2;
-            }
-
-            if (parent2.Height == 0 && parent2.AnalysisValues.IsSubsetOf(parent1.AnalysisValues))
-            {
-                return parent1;
-            }
-
-            if (parent1.Height == parent2.Height &&
-                parent1.AnalysisValues.Count == parent2.AnalysisValues.Count &&
-                Equals(parent1, parent2.GetNegatedValue()))
-            {
-                return Empty;
-            }
-
-            return new(ImmutableHashSet<IAbstractAnalysisValue>.Empty,
-                       ImmutableHashSet.Create(parent1, parent2),
-                       height: Math.Max(parent1.Height, parent2.Height) + 1,
-                       GlobalFlowStateAnalysisValueSetKind.Known);
-        }
-
         public ImmutableHashSet<IAbstractAnalysisValue> AnalysisValues { get; }
         public ImmutableHashSet<GlobalFlowStateAnalysisValueSet> Parents { get; }
         public int Height { get; }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysisValueSet.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                    height: Math.Max(parent1.Height, parent2.Height) + 1,
                    GlobalFlowStateAnalysisValueSetKind.Known)
         {
+            Debug.Assert(parent1 != parent2);
         }
 
         public ImmutableHashSet<IAbstractAnalysisValue> AnalysisValues { get; }


### PR DESCRIPTION
### Related Issues:

[dotnet build doesn't terminate in 5.0.200](https://github.com/dotnet/roslyn-analyzers/issues/4920)
[C# compiler freezes in certain platform analysis scenarios](https://github.com/dotnet/roslyn/issues/51652)

### Issue:  
In .NET 5.0.202 (for some corner cases) the build does not terminate , resulting in VS freeze.

### Description: 
The DFA for Platform Compatibility Analyzer enters an infinite loop in certain edge case code patterns, where platform checks are performed inside/outside a loop and there is a try/catch within the loop.  This untested edge case scenario was hidden under [another bug](https://github.com/dotnet/roslyn-analyzers/issues/4372) that when [fixed in 5.0.2](https://github.com/dotnet/roslyn-analyzers/pull/4393) revealed this issue.

### How found:
Customers reported this bug.

### Customer Impact:
All .NET 5.0 SDK (v5.0.200) and above customers. 
Since 5.0.2 release 2 customers reported hitting this issue. As this analyzer is enabled by default with a build warning level, it runs as part of every build with .NET5 SDK.

### Test coverage:
Unit testing and manual testing with console app having same repro.
 
### Risk: 
Low risk. The PR adds couple of bail out checks in DFA merge algorithm which prevents infinite analysis loop. This will also likely improve the overall performance of the analysis in other cases

CC @jaredpar @jeffhandley @vatsalyaagrawal @terrajobst @mikadumont @jmarolf 