### PR TITLE
OSX is alias for MacOS

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
@@ -21,6 +21,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private static readonly ImmutableArray<string> methodNames = ImmutableArray.Create("IsOSPlatform", "IsOSPlatformVersionAtLeast");
         private const string IsPrefix = "Is";
         private const string VersionSuffix = "VersionAtLeast";
+        private const string macOS = nameof(macOS);
 
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValidPlatformStringTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
         private static readonly LocalizableString s_localizableUnknownPlatform = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.UseValidPlatformStringUnknownPlatform), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));
@@ -75,6 +76,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 AddPlatformsAndVersionCountFromGuardMethods(operatingSystemType, knownPlatforms);
                 AddPlatformsFromMsBuildOptions(knownPlatforms, context.Options.GetMSBuildItemMetadataValues(
                     MSBuildItemOptionNames.SupportedPlatform, context.Compilation, context.CancellationToken));
+
+                if (knownPlatforms.TryGetValue(macOS, out var versions))
+                {
+                    knownPlatforms.Add("OSX", versions);
+                }
 
                 context.RegisterOperationAction(context => AnalyzeOperation(context.Operation, context, knownPlatforms), OperationKind.Invocation);
                 context.RegisterSymbolAction(context => AnalyzeSymbol(context.ReportDiagnostic, context.Symbol,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
@@ -376,6 +376,31 @@ public class Test
                 VerifyCS.Diagnostic(UseValidPlatformString.NoVersion).WithLocation(4).WithArguments("4.1", "Linux"));
         }
 
+        [Fact]
+        public async Task PlatformOSXIsAliasForMacOS()
+        {
+            var csSource = @"
+using System.Runtime.Versioning;
+
+public class Test
+{
+    [{|#0:SupportedOSPlatform(""MacOS1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'MacOS'. Use a version with 2-3 parts for this platform.
+    public void SupportedOSPlatformMac4PartsInvalid() { }
+
+    [SupportedOSPlatform(""MacOS1.2"")]
+    public void SupportedMacOs2PartValid() { }
+
+    [{|#1:SupportedOSPlatform(""OSX1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'OSX'. Use a version with 2-3 parts for this platform.
+    public void SupportedOSPlatformOSX4PartsInvalid() { }
+
+    [SupportedOSPlatform(""Osx1.2"")]
+    public void SupportedOsx2PartValid() { }
+}";
+            await VerifyAnalyzerAsyncCs(csSource,
+                VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(0).WithArguments("1.2.3.4", "MacOS", "-3"),
+                VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(1).WithArguments("1.2.3.4", "OSX", "-3"));
+        }
+
         private static async Task VerifyAnalyzerAsyncCs(string sourceCode, params DiagnosticResult[] expectedDiagnostics)
         {
             var test = PopulateTestCs(sourceCode);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
@@ -388,12 +388,48 @@ public class Test
     public void SupportedOSPlatformMac4PartsInvalid() { }
 
     [SupportedOSPlatform(""MacOS1.2"")]
-    public void SupportedMacOs2PartValid() { }
+    public void SupportedMacOs2PartsValid() { }
 
     [{|#1:SupportedOSPlatform(""OSX1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'OSX'. Use a version with 2-3 parts for this platform.
     public void SupportedOSPlatformOSX4PartsInvalid() { }
 
     [SupportedOSPlatform(""Osx1.2"")]
+    public void SupportedOsx2PartsValid() { }
+}";
+            await VerifyAnalyzerAsyncCs(csSource,
+                VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(0).WithArguments("1.2.3.4", "MacOS", "-3"),
+                VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(1).WithArguments("1.2.3.4", "OSX", "-3"));
+        }
+
+        [Fact]
+        public async Task APIsWithMultiplePlatformSupportUnsupport()
+        {
+            var csSource = @"
+using System.Runtime.Versioning;
+
+public class Test
+{
+    [{|#0:SupportedOSPlatform(""MacOS1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'MacOS'. Use a version with 2-3 parts for this platform.
+    [SupportedOSPlatform(""Osx2.3"")]
+    [SupportedOSPlatform(""Linux"")]
+    [[|SupportedOSPlatform(""Browser4.3"")|]] // Browser should not have a version
+    public void SupportedOSPlatformMac4PartsInvalid() { }
+
+    [SupportedOSPlatform(""MacOS1.2"")]
+    [SupportedOSPlatform(""Osx2.3"")]
+    public void SupportedMacOsOsxPartsValid() { }
+
+    [UnsupportedOSPlatform(""osx"")]
+    [{|#1:SupportedOSPlatform(""OSX1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'OSX'. Use a version with 2-3 parts for this platform.
+    [UnsupportedOSPlatform(""browser"")]
+    public void UnsupportedBrowserOSXSupportHasWarning() { }
+
+    [UnsupportedOSPlatform(""browser"")]
+    [[|UnsupportedOSPlatform(""Linux1.0"")|]] // Linux should not have a version
+    public void UnsupportedOSPlatformOSX4PartsInvalid() { }
+
+    [SupportedOSPlatform(""Osx1.2"")]
+    [[|SupportedOSPlatform(""MacOS1.2.3.4"")|]] // Version '1.2.3.4' is not valid for platform 'MacOS'. Use a version with 2-3 parts for this platform.
     public void SupportedOsx2PartValid() { }
 }";
             await VerifyAnalyzerAsyncCs(csSource,


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/49323

While testing the Known Platform names analyzer in runtime repo we discovered that runtime repo is using OSX in TFM which is  alias (old name) of MacOS. As OSX can be used instead if MacOS we should add it as known platform in case MacOS exist in the known platforms list
