### PR TITLE
Do Not consider overloads with different return types for CA2016

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
@@ -386,7 +386,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 // Overload is  valid if its return type is implicitly convertable
                 var toCompareReturnType = methodToCompareWithAllParameters.ReturnType;
                 var originalReturnType = originalMethodWithAllParameters.ReturnType;
-                if (!compilation.ClassifyCommonConversion(toCompareReturnType, originalReturnType).IsImplicit)
+                if (!toCompareReturnType.IsAssignableTo(originalReturnType, compilation))
                 {
                     // Generic Task-like types are special since awaiting them essentially erases the task-like type.
                     // If both types are Task-like we will warn if their generic arguments are convertable to each other.
@@ -431,7 +431,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     var leftTypeArgument = left.TypeArguments[0];
                     var rightTypeArgument = right.TypeArguments[0];
-                    if (!compilation.ClassifyCommonConversion(rightTypeArgument, leftTypeArgument).IsImplicit)
+                    if (!leftTypeArgument.IsAssignableTo(rightTypeArgument, compilation))
                     {
                         return false;
                     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
@@ -27,6 +27,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     ///     - The invocation method signature receives a ct and one is already being explicitly passed, or...
     ///     - The invocation method does not have an overload with the exact same arguments that also receives a ct, or...
     ///     - The invocation method only has overloads that receive more than one ct.
+    ///     - The invocation method return type differs.
     /// </summary>
     public abstract class ForwardCancellationTokenToInvocationsAnalyzer : DiagnosticAnalyzer
     {
@@ -336,6 +337,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Checks if the parameters of the two passed methods only differ in a ct.
             static bool HasSameParametersPlusCancellationToken(ITypeSymbol cancellationTokenType, IMethodSymbol originalMethod, IMethodSymbol methodToCompare)
             {
+                // Overload is not valid if it has a different return type
+                if (!originalMethod.ReturnType.Equals(methodToCompare.ReturnType))
+                {
+                    return false;
+                }
+
                 // Avoid comparing to itself, or when there are no parameters, or when the last parameter is not a ct
                 if (originalMethod.Equals(methodToCompare) ||
                     methodToCompare.Parameters.Count(p => p.Type.Equals(cancellationTokenType)) != 1 ||

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocations.Analyzer.cs
@@ -422,19 +422,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 bool TypeArgumentsAreConvertable(INamedTypeSymbol left, INamedTypeSymbol right)
                 {
-                    if (left.Arity != right.Arity)
+                    if (left.Arity != 1 ||
+                        right.Arity != 1 ||
+                        left.Arity != right.Arity)
                     {
                         return false;
                     }
 
-                    var leftTypeArguments = left.TypeArguments;
-                    var rightTypeArguments = right.TypeArguments;
-                    for (int i = 0; i < leftTypeArguments.Length; i++)
+                    var leftTypeArgument = left.TypeArguments[0];
+                    var rightTypeArgument = right.TypeArguments[0];
+                    if (!compilation.ClassifyCommonConversion(rightTypeArgument, leftTypeArgument).IsImplicit)
                     {
-                        if (!compilation.ClassifyCommonConversion(rightTypeArguments[i], leftTypeArguments[i]).IsImplicit)
-                        {
-                            return false;
-                        }
+                        return false;
                     }
 
                     return true;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
@@ -2252,6 +2252,45 @@ class C
             return CS8VerifyCodeFixAsync(originalCode, fixedCode);
         }
 
+        [Fact]
+        [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        public Task CS_NoDiagnostic_ReturnTypeIsConvertable()
+        {
+            // Local static functions are available in C# >= 8.0
+            string originalCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class P
+{
+    static void M1(string s, CancellationToken cancellationToken)
+    {
+        long result = [|M2|](s);
+    }
+
+    static long M2(string s) { throw new NotImplementedException(); }
+
+    static int M2(string s, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}";
+            string fixedCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class P
+{
+    static void M1(string s, CancellationToken cancellationToken)
+    {
+        long result = M2(s, cancellationToken);
+    }
+
+    static long M2(string s) { throw new NotImplementedException(); }
+
+    static int M2(string s, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}";
+            return VerifyCS.VerifyCodeFixAsync(originalCode, fixedCode);
+        }
         #endregion
 
         #region No Diagnostic - VB

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
@@ -437,6 +437,29 @@ class C
             ");
         }
 
+        [Fact]
+        [WorkItem(3786, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        public Task CS_NoDiagnostic_ReturnTypesDiffer()
+        {
+            return VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class P
+{
+    static void M1(string s, CancellationToken cancellationToken)
+    {
+        var result = M2(s);
+    }
+
+    static Task M2(string s) { throw new NotImplementedException(); }
+
+    static int M2(string s, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}
+            ");
+        }
+
         #endregion
 
         #region Diagnostics with no fix = C#

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ForwardCancellationTokenToInvocationsTests.cs
@@ -435,7 +435,7 @@ class C
         }
 
         [Fact]
-        [WorkItem(3786, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
         public Task CS_NoDiagnostic_ReturnTypesDiffer()
         {
             return VerifyCS.VerifyAnalyzerAsync(@"
@@ -2251,7 +2251,7 @@ class C
 
         [Fact]
         [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
-        public Task CS_NoDiagnostic_ReturnTypeIsConvertable()
+        public Task CS_Diagnostic_ReturnTypeIsConvertable()
         {
             // Local static functions are available in C# >= 8.0
             string originalCode = @"
@@ -2291,7 +2291,7 @@ class P
 
         [Fact]
         [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
-        public Task CS_NoDiagnostic_SpecialCaseTaskLikeReturnTypes()
+        public Task CS_SpecialCaseTaskLikeReturnTypes()
         {
             // Local static functions are available in C# >= 8.0
             string originalCode = @"
@@ -2728,6 +2728,31 @@ Class C
     End Sub
 End Class
             ");
+        }
+
+        [Fact]
+        [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        public Task VB_NoDiagnostic_ReturnTypesDiffer()
+        {
+            return VerifyVB.VerifyAnalyzerAsync(@"
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Program
+    Sub M1(s As String, cancellationToken As CancellationToken)
+        Dim result = M2(s)
+    End Sub
+
+    Function M2(s As String) As Task
+        Throw New NotImplementedException
+    End Function
+
+    Function M2(s As String, cancellationToken As CancellationToken) As Integer
+        Throw New NotImplementedException
+    End Function
+End Module
+");
         }
 
         #endregion
@@ -4297,6 +4322,98 @@ Class C
     End Sub
 End Class
             ";
+            return VerifyVB.VerifyCodeFixAsync(originalCode, fixedCode);
+        }
+
+        [Fact]
+        [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        public Task VB_Diagnostic_ReturnTypeIsConvertable()
+        {
+            // Local static functions are available in C# >= 8.0
+            string originalCode = @"
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Program
+    Sub M1(s As String, cancellationToken As CancellationToken)
+        Dim result As Long = [|M2|](s)
+    End Sub
+
+    Function M2(s As String) As Long
+        Throw New NotImplementedException
+    End Function
+
+    Function M2(s As String, cancellationToken As CancellationToken) As Integer
+        Throw New NotImplementedException
+    End Function
+End Module
+";
+            string fixedCode = @"
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Program
+    Sub M1(s As String, cancellationToken As CancellationToken)
+        Dim result As Long = M2(s, cancellationToken)
+    End Sub
+
+    Function M2(s As String) As Long
+        Throw New NotImplementedException
+    End Function
+
+    Function M2(s As String, cancellationToken As CancellationToken) As Integer
+        Throw New NotImplementedException
+    End Function
+End Module
+";
+            return VerifyVB.VerifyCodeFixAsync(originalCode, fixedCode);
+        }
+
+        [Fact]
+        [WorkItem(4985, "https://github.com/dotnet/roslyn-analyzers/issues/4985")]
+        public Task VB_SpecialCaseTaskLikeReturnTypes()
+        {
+            // Local static functions are available in C# >= 8.0
+            string originalCode = @"
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Program
+    Async Function M1Async(s As String, cancellationToken As CancellationToken) As Task
+        Dim result As Integer = Await [|M2|](s)
+    End Function
+
+    Function M2(s As String) As Task(Of Integer)
+        Throw New NotImplementedException
+    End Function
+
+    Function M2(s As String, cancellationToken As CancellationToken) As ValueTask(Of Integer)
+        Throw New NotImplementedException
+    End Function
+End Module
+";
+            string fixedCode = @"
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Program
+    Async Function M1Async(s As String, cancellationToken As CancellationToken) As Task
+        Dim result As Integer = Await M2(s, cancellationToken)
+    End Function
+
+    Function M2(s As String) As Task(Of Integer)
+        Throw New NotImplementedException
+    End Function
+
+    Function M2(s As String, cancellationToken As CancellationToken) As ValueTask(Of Integer)
+        Throw New NotImplementedException
+    End Function
+End Module
+";
             return VerifyVB.VerifyCodeFixAsync(originalCode, fixedCode);
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4985