### PR TITLE
CA1416 Remove unsupported attribute when allow deny list mixed

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1756,6 +1756,67 @@ namespace CallerSupportsSubsetOfTarget
         }
 
         [Fact]
+        public async Task AllowDenyListMixedApisTest()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+namespace ns
+{
+    class Caller
+    {
+        public static void CrossPlatfomr()
+        {
+            [|Target.UnsupportedBrowserSupportedOnWindowsLinux()|];
+            [|Target.SupportedOnWindowsLinuxUnsupportedBrowser()|];
+        }
+
+        [SupportedOSPlatform(""windows"")]
+        public static void SupportedWindows()
+        {
+            Target.UnsupportedBrowserSupportedOnWindowsLinux();
+            Target.SupportedOnWindowsLinuxUnsupportedBrowser();
+        }
+
+        [UnsupportedOSPlatform(""windows"")]
+        public static void UnsuportedWindows()
+        {
+            [|Target.UnsupportedBrowserSupportedOnWindowsLinux()|];
+            [|Target.SupportedOnWindowsLinuxUnsupportedBrowser()|];
+        }
+
+        [UnsupportedOSPlatform(""browser"")]
+        public static void UnsupportedBrowser()
+        {
+            [|Target.UnsupportedBrowserSupportedOnWindowsLinux()|];
+            [|Target.SupportedOnWindowsLinuxUnsupportedBrowser()|];
+        }
+
+        [SupportedOSPlatform(""browser"")]
+        public static void SupportedBrowser()
+        {
+            [|Target.UnsupportedBrowserSupportedOnWindowsLinux()|];
+            [|Target.SupportedOnWindowsLinuxUnsupportedBrowser()|];
+        }
+    }
+
+    class Target
+    {
+        [UnsupportedOSPlatform(""browser"")]
+        [SupportedOSPlatform(""windows"")]
+        [SupportedOSPlatform(""Linux"")]
+        public static void UnsupportedBrowserSupportedOnWindowsLinux() { }
+
+        [SupportedOSPlatform(""windows"")]
+        [SupportedOSPlatform(""Linux"")]
+        [UnsupportedOSPlatform(""browser"")]
+        public static void SupportedOnWindowsLinuxUnsupportedBrowser() { }
+    }
+}";
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
         public async Task UnsupportedSamePlatformMustSuppressSupported()
         {
             var source = @"


### PR DESCRIPTION
By the design, attributes applied to a member should be Allow list (supported attributes version is lowes) or Deny list (unsupported attributes version is lowest), but not both. If both applied it causes inconsistency and could lead the analyzer to malfunction., depending on which attributes first added to the collection. For example, if Supported attributes (Allow list) added to the tree first there will be no issue, but if Unsupported attributes added to the tree first it is causing an issue.  There is no better way to solve this other than removing the unneeded Unsupported attribute.

Example:      
```cs
    [UnsupportedOSPlatform(""browser"")]
    [SupportedOSPlatform(""windows"")]
    [SupportedOSPlatform(""Linux"")]
    public static void UnsupportedBrowserSupportedOnWindowsLinux() { }
```
This is an API only supported on Windows or Linux, but `[UnsupportedOSPlatform(""browser"")]` is redundant plus it could cause an issue. With this PR removing the redundant attribute(s)
