### PR TITLE
OSX needs to treated  as the same platform as MacOS, everywhere

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private const string OptionalSuffix = "VersionAtLeast";
         private const string Net = "net";
         private const string macOS = nameof(macOS);
-        private const string MacSlashOSX = "MacOS/OSX";
+        private const string MacSlashOSX = "macOS/OSX";
 
         internal static DiagnosticDescriptor OnlySupportedCsReachable = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
@@ -650,7 +650,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add(EncloseWithQuota(pName));
+                                platformNames.Add(EncloseWithQuotes(pName));
                             }
                             else
                             {
@@ -666,7 +666,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add(EncloseWithQuota(pName));
+                                platformNames.Add(EncloseWithQuotes(pName));
                             }
                             else
                             {
@@ -757,7 +757,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                         continue;
                                     }
-                                    platformNames.Add(EncloseWithQuota(pName));
+                                    platformNames.Add(EncloseWithQuotes(pName));
                                 }
                                 else
                                 {
@@ -770,7 +770,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             unsupportedRule = false;
                             if (IsEmptyVersion(supportedVersion))
                             {
-                                platformNames.Add(EncloseWithQuota(pName));
+                                platformNames.Add(EncloseWithQuotes(pName));
                             }
                             else
                             {
@@ -818,7 +818,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add(EncloseWithQuota(pName));
+                                platformNames.Add(EncloseWithQuotes(pName));
                             }
                             else
                             {
@@ -848,7 +848,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                         continue;
                                     }
-                                    platformNames.Add(EncloseWithQuota(pName));
+                                    platformNames.Add(EncloseWithQuotes(pName));
                                 }
                                 else
                                 {
@@ -873,12 +873,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             static string GetFormattedString(string resource, string platformName, object? arg1 = null, object? arg2 = null) =>
-                string.Format(CultureInfo.InvariantCulture, resource, AddOsxIfNeeded(platformName), arg1, arg2);
+                string.Format(CultureInfo.InvariantCulture, resource, AddOsxIfMacOS(platformName), arg1, arg2);
 
-            static string AddOsxIfNeeded(string platformName) =>
+            static string AddOsxIfMacOS(string platformName) =>
                 platformName.Equals(macOS, StringComparison.OrdinalIgnoreCase) ? MacSlashOSX : platformName;
 
-            static string EncloseWithQuota(string pName) => $"'{AddOsxIfNeeded(pName)}'";
+            static string EncloseWithQuotes(string pName) => $"'{AddOsxIfMacOS(pName)}'";
 
             static string JoinNames(List<string> platformNames) => string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, platformNames);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -55,6 +55,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private const string IsPrefix = "Is";
         private const string OptionalSuffix = "VersionAtLeast";
         private const string Net = "net";
+        private const string macOS = nameof(macOS);
+        private const string MacSlashOSX = "MacOS/OSX";
 
         internal static DiagnosticDescriptor OnlySupportedCsReachable = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
@@ -648,7 +650,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add($"'{pName}'");
+                                platformNames.Add(EncloseWithQuota(pName));
                             }
                             else
                             {
@@ -664,7 +666,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add($"'{pName}'");
+                                platformNames.Add(EncloseWithQuota(pName));
                             }
                             else
                             {
@@ -755,7 +757,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                         continue;
                                     }
-                                    platformNames.Add($"'{pName}'");
+                                    platformNames.Add(EncloseWithQuota(pName));
                                 }
                                 else
                                 {
@@ -768,7 +770,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             unsupportedRule = false;
                             if (IsEmptyVersion(supportedVersion))
                             {
-                                platformNames.Add($"'{pName}'");
+                                platformNames.Add(EncloseWithQuota(pName));
                             }
                             else
                             {
@@ -816,7 +818,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                     continue;
                                 }
-                                platformNames.Add($"'{pName}'");
+                                platformNames.Add(EncloseWithQuota(pName));
                             }
                             else
                             {
@@ -846,7 +848,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         platformNames.Add(GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, pName));
                                         continue;
                                     }
-                                    platformNames.Add($"'{pName}'");
+                                    platformNames.Add(EncloseWithQuota(pName));
                                 }
                                 else
                                 {
@@ -870,7 +872,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return platformNames;
             }
 
-            static string GetFormattedString(string resource, params object[] args) => string.Format(CultureInfo.InvariantCulture, resource, args);
+            static string GetFormattedString(string resource, string platformName, object? arg1 = null, object? arg2 = null) =>
+                string.Format(CultureInfo.InvariantCulture, resource, AddOsxIfNeeded(platformName), arg1, arg2);
+
+            static string AddOsxIfNeeded(string platformName) =>
+                platformName.Equals(macOS, StringComparison.OrdinalIgnoreCase) ? MacSlashOSX : platformName;
+
+            static string EncloseWithQuota(string pName) => $"'{AddOsxIfNeeded(pName)}'";
 
             static string JoinNames(List<string> platformNames) => string.Join(MicrosoftNetCoreAnalyzersResources.CommaSeparator, platformNames);
 
@@ -1592,6 +1600,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 TryParsePlatformNameAndVersion(argument.Value.ToString(), out string platformName, out Version? version))
             {
                 attributes ??= new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
+                if (platformName.Equals("OSX", StringComparison.OrdinalIgnoreCase))
+                {
+                    platformName = macOS;
+                }
+
                 if (!attributes.TryGetValue(platformName, out var _))
                 {
                     attributes[platformName] = new Versions();

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -224,8 +224,8 @@ class Test
             Api2();
         }
 
-        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
-        [|Api2()|]; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
+        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'macOS/OSX', 'Linux', 'windows'.
+        [|Api2()|]; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'macOS/OSX', 'Linux', 'windows'.
     }
 
     [SupportedOSPlatform(""macos"")]
@@ -260,7 +260,7 @@ class Test
             Api();
         }
 
-        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is unsupported on: 'MacOS/OSX', 'windows'.
+        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is unsupported on: 'macOS/OSX', 'windows'.
     }
 
     [UnsupportedOSPlatform(""windows"")]
@@ -290,7 +290,7 @@ class Test
             Api();
         }
 
-        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'MacOS/OSX' 10.1 and later, 'windows' 10.0 and later, 'Linux'.
+        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'macOS/OSX' 10.1 and later, 'windows' 10.0 and later, 'Linux'.
     }
 
     [SupportedOSPlatform(""windows10.0"")]
@@ -321,8 +321,8 @@ class Test
         }
         else
         {
-            {|#1:MacOsApi()|}; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
-            {|#2:OsxApi()|}; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
+            {|#1:MacOsApi()|}; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'macOS/OSX', 'Linux', 'windows'.
+            {|#2:OsxApi()|}; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'macOS/OSX', 'Linux', 'windows'.
             UnsupportedOsxApi();
         }
     }
@@ -339,11 +339,11 @@ class Test
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable)
-                    .WithLocation(0).WithArguments("Test.UnsupportedOsxApi()", "'MacOS/OSX'", "'MacOS/OSX'"),
+                    .WithLocation(0).WithArguments("Test.UnsupportedOsxApi()", "'macOS/OSX'", "'macOS/OSX'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms)
-                    .WithLocation(1).WithArguments("Test.MacOsApi()", "'MacOS/OSX'"),
+                    .WithLocation(1).WithArguments("Test.MacOsApi()", "'macOS/OSX'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms)
-                    .WithLocation(2).WithArguments("Test.OsxApi()", "'MacOS/OSX'"));
+                    .WithLocation(2).WithArguments("Test.OsxApi()", "'macOS/OSX'"));
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1581,7 +1581,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void TestWithMacOsSupported()
         {
             Target.SupportedOnOSXAndLinux();
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'MacOS/OSX' all versions. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
+            {|#0:Target.SupportedOnOSX14()|}; // This call site is reachable on: 'MacOS/OSX' all versions. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
             Target.SupportedOnMacOs();
         }
 
@@ -1605,21 +1605,21 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void TestWithLinuxSupported()
         {
             Target.SupportedOnOSXAndLinux();
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'Linux'. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
+            {|#1:Target.SupportedOnOSX14()|}; // This call site is reachable on: 'Linux'. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
         }
 
         public void CrossPlatform()
         {
-            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'macOS/OSX', 'linux'.
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
-            [|Target.SupportedOnMacOs()|]; // This call site is reachable on all platforms. 'Target.SupportedOnMacOs()' is only supported on: 'macos/OSX'.
+            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'MacOS/OSX', 'linux'.
+            [|Target.SupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSX14()' is only supported on: 'MacOS/OSX' 14.0 and later.
+            {|#2:Target.SupportedOnMacOs()|}; // This call site is reachable on all platforms. 'Target.SupportedOnMacOs()' is only supported on: 'Macos/OSX'.
         }
         
         [SupportedOSPlatform(""Browser"")]
         public void TestWithSupportedOnBrowserWarns()
         {
-            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'macOS/OSX', 'linux'.
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
+            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'MacOS/OSX', 'linux'.
+            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSX14()' is only supported on: 'MacOS/OSX' 14.0 and later.
         }
 
         [SupportedOSPlatform(""macos15.1"")]
@@ -1640,7 +1640,13 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void SupportedOnMacOs() { }
     }
 }";
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(0).WithArguments("Target.SupportedOnOSX14()",
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "MacOS/OSX", "14.0"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "MacOS/OSX")),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(1).WithArguments("Target.SupportedOnOSX14()",
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "MacOS/OSX", "14.0"), "'Linux'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Target.SupportedOnMacOs()", "'MacOS/OSX'"));
         }
 
         [Fact]
@@ -1656,7 +1662,7 @@ namespace ns
         [SupportedOSPlatform(""MacOS"")]
         public static void TestWithMacOsSupported()
         {
-            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on: 'MacOS/OSX'. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
+            {|#0:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'MacOS/OSX'. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
             [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on: 'MacOS/OSX' all versions. 'Target.UnsupportedOnOSX14()' is unsupported on: 'MacOS/OSX' 14.0 and later.
         }
 
@@ -1683,14 +1689,14 @@ namespace ns
 
         public void CrossPlatform()
         {
-            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
+            {|#1:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
             [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSX14()' is unsupported on: 'MacOS/OSX' 14.0 and later.
         }
         
         [UnsupportedOSPlatform(""macOs13.0"")]
         public void TestWithSupportedOnBrowserWarns()
         {
-            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on: 'MacOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX' all versions. all versions.
+            {|#2:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'MacOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX' all versions.
             Target.UnsupportedOnOSX14();
         }
     }
@@ -1702,7 +1708,12 @@ namespace ns
         public static void UnsupportedOnOSX14() { }
     }
 }";
-            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'MacOS/OSX'", "'MacOS/OSX'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(1).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'MacOS/OSX'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(2).WithArguments("Target.UnsupportedOnOSXAndLinux()",
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "MacOS/OSX"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, "MacOS/OSX", "13.0")));
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1581,7 +1581,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void TestWithMacOsSupported()
         {
             Target.SupportedOnOSXAndLinux();
-            {|#0:Target.SupportedOnOSX14()|}; // This call site is reachable on: 'MacOS/OSX' all versions. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
+            {|#0:Target.SupportedOnOSX14()|}; // This call site is reachable on: 'macOS/OSX' all versions. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
             Target.SupportedOnMacOs();
         }
 
@@ -1590,7 +1590,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void TestWithMacOsLinuxSupported()
         {
             Target.SupportedOnOSXAndLinux();
-            [|Target.SupportedOnMacOs()|]; //  This call site is reachable on: 'Linux', 'MacOS/OSX'. 'Target.SupportedOnMacOs()' is only supported on: 'macos/OSX'.
+            [|Target.SupportedOnMacOs()|]; //  This call site is reachable on: 'Linux', 'macOS/OSX'. 'Target.SupportedOnMacOs()' is only supported on: 'macos/OSX'.
         }
 
         [SupportedOSPlatform(""OSX"")]
@@ -1610,16 +1610,16 @@ namespace CallerUnsupportsNonSubsetOfTarget
 
         public void CrossPlatform()
         {
-            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'MacOS/OSX', 'linux'.
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSX14()' is only supported on: 'MacOS/OSX' 14.0 and later.
-            {|#2:Target.SupportedOnMacOs()|}; // This call site is reachable on all platforms. 'Target.SupportedOnMacOs()' is only supported on: 'Macos/OSX'.
-        }
+            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'macOS/OSX', 'linux'.
+            [|Target.SupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
+            {|#2:Target.SupportedOnMacOs()|}; // This call site is reachable on all platforms. 'Target.SupportedOnMacOs()' is only supported on: 'macOS/OSX'.
+        }0
         
         [SupportedOSPlatform(""Browser"")]
         public void TestWithSupportedOnBrowserWarns()
         {
-            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'MacOS/OSX', 'linux'.
-            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSX14()' is only supported on: 'MacOS/OSX' 14.0 and later.
+            [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'macOS/OSX', 'linux'.
+            [|Target.SupportedOnOSX14()|]; // This call site is reachable on: 'Browser'. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
         }
 
         [SupportedOSPlatform(""macos15.1"")]
@@ -1642,11 +1642,11 @@ namespace CallerUnsupportsNonSubsetOfTarget
 }";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(0).WithArguments("Target.SupportedOnOSX14()",
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "MacOS/OSX", "14.0"),
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "MacOS/OSX")),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "macOS/OSX", "14.0"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "macOS/OSX")),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(1).WithArguments("Target.SupportedOnOSX14()",
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "MacOS/OSX", "14.0"), "'Linux'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Target.SupportedOnMacOs()", "'MacOS/OSX'"));
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "macOS/OSX", "14.0"), "'Linux'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(2).WithArguments("Target.SupportedOnMacOs()", "'macOS/OSX'"));
         }
 
         [Fact]
@@ -1662,8 +1662,8 @@ namespace ns
         [SupportedOSPlatform(""MacOS"")]
         public static void TestWithMacOsSupported()
         {
-            {|#0:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'MacOS/OSX'. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
-            [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on: 'MacOS/OSX' all versions. 'Target.UnsupportedOnOSX14()' is unsupported on: 'MacOS/OSX' 14.0 and later.
+            {|#0:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'macOS/OSX'. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX'.
+            [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on: 'macOS/OSX' all versions. 'Target.UnsupportedOnOSX14()' is unsupported on: 'macOS/OSX' 14.0 and later.
         }
 
         [UnsupportedOSPlatform(""MacOS"")]
@@ -1689,14 +1689,14 @@ namespace ns
 
         public void CrossPlatform()
         {
-            {|#1:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX'.
-            [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSX14()' is unsupported on: 'MacOS/OSX' 14.0 and later.
+            {|#1:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX'.
+            [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSX14()' is unsupported on: 'macOS/OSX' 14.0 and later.
         }
         
         [UnsupportedOSPlatform(""macOs13.0"")]
         public void TestWithSupportedOnBrowserWarns()
         {
-            {|#2:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'MacOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'MacOS/OSX' all versions.
+            {|#2:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'macOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX' all versions.
             Target.UnsupportedOnOSX14();
         }
     }
@@ -1709,11 +1709,11 @@ namespace ns
     }
 }";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'MacOS/OSX'", "'MacOS/OSX'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(1).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'MacOS/OSX'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'macOS/OSX'", "'macOS/OSX'"),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(1).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'macOS/OSX'"),
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(2).WithArguments("Target.UnsupportedOnOSXAndLinux()",
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "MacOS/OSX"),
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, "MacOS/OSX", "13.0")));
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "macOS/OSX"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, "macOS/OSX", "13.0")));
         }
 
         [Fact]
@@ -2219,7 +2219,7 @@ namespace ns
             yield return new object[] { "MACOS", "10.1.2.3", "macos", "10.2.2.0", false };
             yield return new object[] { "OSX", "10.1.2.3", "Osx", "11.1.1.0", false };
             yield return new object[] { "Osx", "10.1.2.3", "osx", "10.2", false };
-            yield return new object[] { "Windows", "10.1.2.3", "MacOS/OSX", "11.1.1.4", true };
+            yield return new object[] { "Windows", "10.1.2.3", "macOS/OSX", "11.1.1.4", true };
             yield return new object[] { "Windows", "10.1.2.3", "Windows", "10.0.1.9", true };
             yield return new object[] { "Windows", "10.1.2.3", "Windows", "10.1.1.4", true };
             yield return new object[] { "Windows", "10.1.2.3", "Windows", "8.2.3.3", true };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -1590,7 +1590,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
         public static void TestWithMacOsLinuxSupported()
         {
             Target.SupportedOnOSXAndLinux();
-            [|Target.SupportedOnMacOs()|]; //  This call site is reachable on: 'Linux', 'macOS/OSX'. 'Target.SupportedOnMacOs()' is only supported on: 'macos/OSX'.
+            [|Target.SupportedOnMacOs()|]; // This call site is reachable on: 'Linux', 'macOS/OSX'. 'Target.SupportedOnMacOs()' is only supported on: 'macos/OSX'.
         }
 
         [SupportedOSPlatform(""OSX"")]
@@ -1613,7 +1613,7 @@ namespace CallerUnsupportsNonSubsetOfTarget
             [|Target.SupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSXAndLinux()' is only supported on: 'macOS/OSX', 'linux'.
             [|Target.SupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.SupportedOnOSX14()' is only supported on: 'macOS/OSX' 14.0 and later.
             {|#2:Target.SupportedOnMacOs()|}; // This call site is reachable on all platforms. 'Target.SupportedOnMacOs()' is only supported on: 'macOS/OSX'.
-        }0
+        }
         
         [SupportedOSPlatform(""Browser"")]
         public void TestWithSupportedOnBrowserWarns()


### PR DESCRIPTION
OSX needs to treated  as the same platform as MacOS, everywhere

Somehow the code handling this logic lost 🙅 (i remember had it handled in my first version, I guess it is lost in the design change refactoring result).

The brute force way for treating `OSX` as `MacOS` would add additional check for each OS platform check and platform lookup, which don't like to do. So instead:
- Whenever an OSPlatform attribute with OSX found for an API adding it as `MacOs` in the internal cache, so no need to add `OSX` specific special handling anymore
- The only issue with this solution can be seen in reporting the incompatible APIs, i.e. when there is `OSX` specific API used from an incompatible call site then developers would get a warning that the API is supported on `MacOS` instead of `OSX`. Handling this issue with reporting the platform as `MacOS/OSX` - meaning it can be `MacOS` or `OSX`

Example:
```cs
class Test
{
    public void Api_Usage()
    {
        if (OperatingSystem.IsWindows() ||
            OperatingSystem.IsLinux() ||
            OperatingSystem.IsMacOS())
        {
            Api();
            Api2(); // All supported platforms guarded
        }

        [|Api()|]; // This call site is reachable on all platforms. 'Test.Api()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
        [|Api2()|]; // This call site is reachable on all platforms. 'Test.Api2()' is only supported on: 'MacOS/OSX', 'Linux', 'windows'.
    }

    [SupportedOSPlatform("macos")]
    [SupportedOSPlatform("windows")]
    [SupportedOSPlatform("Linux")]
    void Api() { }

    [SupportedOSPlatform("windows")]
    [SupportedOSPlatform("Osx")]
    [SupportedOSPlatform("Linux")]
    void Api2() { }
}
```
