### PR TITLE
Refactor UseNameofInPlaceOfString

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
@@ -109,15 +109,12 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             var parentOperation = context.Operation.Parent;
             while (parentOperation != null)
             {
-                IMethodSymbol? methodSymbol = null;
-                if (parentOperation.Kind == OperationKind.AnonymousFunction)
+                IMethodSymbol? methodSymbol = parentOperation switch
                 {
-                    methodSymbol = ((IAnonymousFunctionOperation)parentOperation).Symbol;
-                }
-                else if (parentOperation.Kind == OperationKind.LocalFunction)
-                {
-                    methodSymbol = ((ILocalFunctionOperation)parentOperation).Symbol;
-                }
+                    IAnonymousFunctionOperation anonymousOperation => anonymousOperation.Symbol,
+                    ILocalFunctionOperation localFunctionOperation => localFunctionOperation.Symbol,
+                    _ => null;
+                };
 
                 if (methodSymbol is not null)
                 {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 {
                     IAnonymousFunctionOperation anonymousOperation => anonymousOperation.Symbol,
                     ILocalFunctionOperation localFunctionOperation => localFunctionOperation.Symbol,
-                    _ => null;
+                    _ => null
                 };
 
                 if (methodSymbol is not null)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
@@ -72,13 +72,13 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             switch (matchingParameter.Name)
             {
                 case ParamName:
-                    if (HasAParameterMatchInScope(context, stringText))
+                    if (HasAnyParameterMatchInScope(context, stringText))
                     {
                         context.ReportDiagnostic(argument.Value.CreateDiagnostic(RuleWithSuggestion, stringText));
                     }
                     return;
                 case PropertyName:
-                    if (HasAPropertyMatchInScope(context, stringText))
+                    if (HasAnyPropertyMatchInScope(context, stringText))
                     {
                         context.ReportDiagnostic(argument.Value.CreateDiagnostic(RuleWithSuggestion, stringText));
                     }
@@ -88,13 +88,13 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             }
         }
 
-        private static bool HasAPropertyMatchInScope(OperationAnalysisContext context, string stringText)
+        private static bool HasAnyPropertyMatchInScope(OperationAnalysisContext context, string stringText)
         {
             var containingType = context.ContainingSymbol.ContainingType;
             return containingType?.GetMembers(stringText).Any(m => m.Kind == SymbolKind.Property) == true;
         }
 
-        private static bool HasAParameterMatchInScope(OperationAnalysisContext context, string stringText)
+        private static bool HasAnyParameterMatchInScope(OperationAnalysisContext context, string stringText)
         {
             // get the parameters for the containing method
             foreach (var parameter in context.ContainingSymbol.GetParameters())

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/UseNameofInPlaceOfString.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -91,7 +92,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private static bool HasAPropertyMatchInScope(OperationAnalysisContext context, string stringText)
         {
             var containingType = context.ContainingSymbol.ContainingType;
-            return containingType?.GetMembers(stringText).OfType<IPropertySymbol>().Any() == true;
+            return containingType?.GetMembers(stringText).Any(m => m.Kind == SymbolKind.Property) == true;
         }
 
         private static bool HasAParameterMatchInScope(OperationAnalysisContext context, string stringText)
@@ -132,6 +133,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
                 parentOperation = parentOperation.Parent;
             }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
This avoid enumerating every parameter and property in scope.
I haven't measured performance/allocations to see if this makes any noticeable improvement, but thought it's good anyway.