### PR TITLE
Use AnalyzerConfigFiles instead of AnalyzerConfigDocument

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
@@ -925,7 +925,7 @@ public class C
     }}
 }}"
                     },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") },
                 },
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
@@ -868,7 +868,7 @@ public class C
 
 [*]
 {editorConfigText}
-") }
+") },
                 }
             }.RunAsync();
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
@@ -948,7 +948,7 @@ Public Class C
     End Sub
 End Class"
                     },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") },
                 },
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/ReviewUnusedParametersTests.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -926,14 +924,14 @@ public class C
     {{
     }}
 }}"
-                    }
+                    },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") }
                 },
-                SolutionTransforms = { WithAnalyzerConfigDocument }
             };
 
             if (expectDiagnostic)
             {
-                csTest.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithSpan(@"/Test0.cs", 4, 23, 4, 29).WithArguments("unused", "M"));
+                csTest.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithSpan(4, 23, 4, 29).WithArguments("unused", "M"));
             }
 
             await csTest.RunAsync();
@@ -950,35 +948,16 @@ Public Class C
     End Sub
 End Class"
                     },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]{Environment.NewLine}{editorConfigText}") }
                 },
-                SolutionTransforms = { WithAnalyzerConfigDocument }
             };
 
             if (expectDiagnostic)
             {
-                vbTest.ExpectedDiagnostics.Add(VerifyVB.Diagnostic().WithSpan(@"/Test0.vb", 3, 18, 3, 24).WithArguments("unused", "M"));
+                vbTest.ExpectedDiagnostics.Add(VerifyVB.Diagnostic().WithSpan(3, 18, 3, 24).WithArguments("unused", "M"));
             }
 
             await vbTest.RunAsync();
-            return;
-
-            Solution WithAnalyzerConfigDocument(Solution solution, ProjectId projectId)
-            {
-                var project = solution.GetProject(projectId)!;
-                var projectFilePath = project.Language == LanguageNames.CSharp ? @"/Test.csproj" : @"/Test.vbproj";
-                solution = solution.WithProjectFilePath(projectId, projectFilePath);
-
-                var documentId = project.DocumentIds.Single();
-                var documentExtension = project.Language == LanguageNames.CSharp ? "cs" : "vb";
-                solution = solution.WithDocumentFilePath(documentId, $@"/Test0.{documentExtension}");
-
-                return solution.GetProject(projectId)!
-                    .AddAnalyzerConfigDocument(
-                        ".editorconfig",
-                        SourceText.From($"[*.{documentExtension}]" + Environment.NewLine + editorConfigText),
-                         filePath: @"/.editorconfig")
-                    .Project.Solution;
-            }
         }
 
         [Theory]
@@ -1019,12 +998,11 @@ public class C
 {editorConfigText}
 ") }
                 },
-                SolutionTransforms = { WithAnalyzerConfigDocument }
             };
 
             if (expectDiagnostic)
             {
-                csTest.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithSpan(@"/Test0.cs", 4, 23, 4, 29).WithArguments("unused", "M"));
+                csTest.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithSpan(4, 23, 4, 29).WithArguments("unused", "M"));
             }
 
             await csTest.RunAsync();
@@ -1047,34 +1025,14 @@ End Class"
 {editorConfigText}
 ") }
                 },
-                SolutionTransforms = { WithAnalyzerConfigDocument }
             };
 
             if (expectDiagnostic)
             {
-                vbTest.ExpectedDiagnostics.Add(VerifyVB.Diagnostic().WithSpan(@"/Test0.vb", 3, 18, 3, 24).WithArguments("unused", "M"));
+                vbTest.ExpectedDiagnostics.Add(VerifyVB.Diagnostic().WithSpan(3, 18, 3, 24).WithArguments("unused", "M"));
             }
 
             await vbTest.RunAsync();
-            return;
-
-            Solution WithAnalyzerConfigDocument(Solution solution, ProjectId projectId)
-            {
-                var project = solution.GetProject(projectId)!;
-                var projectFilePath = project.Language == LanguageNames.CSharp ? @"/Test.csproj" : @"/Test.vbproj";
-                solution = solution.WithProjectFilePath(projectId, projectFilePath);
-
-                var documentId = project.DocumentIds.Single();
-                var documentExtension = project.Language == LanguageNames.CSharp ? "cs" : "vb";
-                solution = solution.WithDocumentFilePath(documentId, $@"/Test0.{documentExtension}");
-
-                return solution.GetProject(projectId)!
-                    .AddAnalyzerConfigDocument(
-                        ".editorconfig",
-                        SourceText.From($"[*.{documentExtension}]" + Environment.NewLine + editorConfigText),
-                        filePath: @"/.editorconfig")
-                    .Project.Solution;
-            }
         }
 
         [Fact, WorkItem(3106, "https://github.com/dotnet/roslyn-analyzers/issues/3106")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -862,7 +862,7 @@ public class C : System.Web.HttpApplication
             {
                 TestState =
                 {
-                    Sources = { csSource},
+                    Sources = { csSource },
                     AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") }
                 }
             }.RunAsync();
@@ -914,8 +914,11 @@ End Class
 ";
             await new VerifyVB.Test()
             {
-                TestCode = vbSource,
-                AnalyzerConfigDocument = editorConfigText,
+                TestState =
+                {
+                    Sources = { vbSource },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") }
+                }
             }.RunAsync();
         }
 
@@ -1187,8 +1190,11 @@ Public Class Test
 End Class";
             await new VerifyVB.Test()
             {
-                TestCode = vbSource,
-                AnalyzerConfigDocument = editorConfigText,
+                TestState =
+                {
+                    Sources = { vbSource },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") },
+                }
             }.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -863,7 +863,7 @@ public class C : System.Web.HttpApplication
                 TestState =
                 {
                     Sources = { csSource},
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") }
                 }
             }.RunAsync();
 
@@ -1163,7 +1163,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csSource },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") },
                 }
             }.RunAsync();
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -863,7 +863,7 @@ public class C : System.Web.HttpApplication
                 TestState =
                 {
                     Sources = { csSource },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") },
                 }
             }.RunAsync();
 
@@ -917,7 +917,7 @@ End Class
                 TestState =
                 {
                     Sources = { vbSource },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfigText}") },
                 }
             }.RunAsync();
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -860,8 +860,11 @@ public class C : System.Web.HttpApplication
 
             await new VerifyCS.Test()
             {
-                TestCode = csSource,
-                AnalyzerConfigDocument = editorConfigText,
+                TestState =
+                {
+                    Sources = { csSource},
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) }
+                }
             }.RunAsync();
 
             var vbSource = @"
@@ -1157,8 +1160,11 @@ public class Test
 }";
             await new VerifyCS.Test()
             {
-                TestCode = csSource,
-                AnalyzerConfigDocument = editorConfigText,
+                TestState =
+                {
+                    Sources = { csSource },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) },
+                }
             }.RunAsync();
 
             var vbSource = @"

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -792,8 +792,11 @@ End Class";
 
             var vbTest = new VerifyVB.Test()
             {
-                TestCode = vbCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { vbCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                }
             };
 
             if (pointsToAnalysisKind == PointsToAnalysisKind.Complete)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -742,8 +742,11 @@ public class Test
 }";
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                }
             };
 
             if (pointsToAnalysisKind == PointsToAnalysisKind.Complete)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -745,7 +745,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/ValidateArgumentsOfPublicMethodsTests.cs
@@ -745,7 +745,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 
@@ -795,7 +795,7 @@ End Class";
                 TestState =
                 {
                     Sources = { vbCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
@@ -154,7 +154,7 @@ class C
 
         private Task VerifyDiagnosticsAsync(string source, params DiagnosticResult[] expected)
         {
-            const string singleFilePublishConfig = @"[*]
+            const string singleFilePublishConfig = @"is_global = true
 build_property." + PublishSingleFile + " = true";
 
             var test = new VerifyCS.Test

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
@@ -26,7 +26,7 @@ class C
 {
     public string M() => Assembly.GetExecutingAssembly().Location;
 }";
-            string analyzerConfig = "";
+            string analyzerConfig = "[*]\r\n";
             if (publish is not null)
             {
                 analyzerConfig += $"build_property.{PublishSingleFile} = {publish}" + Environment.NewLine;
@@ -50,7 +50,7 @@ class C
             {
                 diagnostics = new DiagnosticResult[] {
                     // /0/Test0.cs(5,26): warning IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
-                    VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3000).WithSpan(5, 26, 5, 66).WithArguments("System.Reflection.Assembly.Location"),
+                    VerifyCS.Diagnostic(IL3000).WithSpan(5, 26, 5, 66).WithArguments("System.Reflection.Assembly.Location"),
                 };
             }
             else
@@ -80,7 +80,7 @@ class C
 }";
             return VerifyDiagnosticsAsync(src,
                 // /0/Test0.cs(8,13): warning IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.Assembly.Location")
+                VerifyCS.Diagnostic(IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.Assembly.Location")
             );
         }
 
@@ -100,9 +100,9 @@ class C
 }";
             return VerifyDiagnosticsAsync(src,
                 // /0/Test0.cs(8,13): warning IL3001: Assemblies embedded in a single-file app cannot have additional files in the manifest.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3001).WithSpan(8, 13, 8, 41).WithArguments("System.Reflection.Assembly.GetFile(string)"),
+                VerifyCS.Diagnostic(IL3001).WithSpan(8, 13, 8, 41).WithArguments("System.Reflection.Assembly.GetFile(string)"),
                 // /0/Test0.cs(9,13): warning IL3001: Assemblies embedded in a single-file app cannot have additional files in the manifest.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3001).WithSpan(9, 13, 9, 25).WithArguments("System.Reflection.Assembly.GetFiles()")
+                VerifyCS.Diagnostic(IL3001).WithSpan(9, 13, 9, 25).WithArguments("System.Reflection.Assembly.GetFiles()")
                 );
         }
 
@@ -122,9 +122,9 @@ class C
 }";
             return VerifyDiagnosticsAsync(src,
                 // /0/Test0.cs(8,13): warning IL3000: 'System.Reflection.AssemblyName.CodeBase' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.AssemblyName.CodeBase"),
+                VerifyCS.Diagnostic(IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.AssemblyName.CodeBase"),
                 // /0/Test0.cs(9,13): warning IL3000: 'System.Reflection.AssemblyName.EscapedCodeBase' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3000).WithSpan(9, 13, 9, 30).WithArguments("System.Reflection.AssemblyName.EscapedCodeBase")
+                VerifyCS.Diagnostic(IL3000).WithSpan(9, 13, 9, 30).WithArguments("System.Reflection.AssemblyName.EscapedCodeBase")
                 );
         }
 
@@ -146,15 +146,15 @@ class C
 }";
             return VerifyDiagnosticsAsync(src,
                 // /0/Test0.cs(8,13): warning IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.Assembly.Location"),
+                VerifyCS.Diagnostic(IL3000).WithSpan(8, 13, 8, 23).WithArguments("System.Reflection.Assembly.Location"),
                 // /0/Test0.cs(9,13): warning IL3001: Assemblies embedded in a single-file app cannot have additional files in the manifest.
-                VerifyCS.Diagnostic(AvoidAssemblyLocationInSingleFile.IL3001).WithSpan(9, 13, 9, 25).WithArguments("System.Reflection.Assembly.GetFiles()")
+                VerifyCS.Diagnostic(IL3001).WithSpan(9, 13, 9, 25).WithArguments("System.Reflection.Assembly.GetFiles()")
                 );
         }
 
         private Task VerifyDiagnosticsAsync(string source, params DiagnosticResult[] expected)
         {
-            const string singleFilePublishConfig = @"
+            const string singleFilePublishConfig = @"[*]
 build_property." + PublishSingleFile + " = true";
 
             var test = new VerifyCS.Test

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
@@ -41,7 +41,7 @@ class C
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", analyzerConfig) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", analyzerConfig) },
                 }
             };
 
@@ -162,7 +162,7 @@ build_property." + PublishSingleFile + " = true";
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", singleFilePublishConfig) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", singleFilePublishConfig) },
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Publish/AvoidAssemblyLocationInSingleFileTests.cs
@@ -38,8 +38,11 @@ class C
 
             var test = new VerifyCS.Test
             {
-                TestCode = source,
-                AnalyzerConfigDocument = analyzerConfig
+                TestState =
+                {
+                    Sources = { source },
+                    AnalyzerConfigFiles = { ("/.editorconfig", analyzerConfig) }
+                }
             };
 
             DiagnosticResult[] diagnostics;
@@ -156,8 +159,11 @@ build_property." + PublishSingleFile + " = true";
 
             var test = new VerifyCS.Test
             {
-                TestCode = source,
-                AnalyzerConfigDocument = singleFilePublishConfig
+                TestState =
+                {
+                    Sources = { source },
+                    AnalyzerConfigFiles = { ("/.editorconfig", singleFilePublishConfig) }
+                }
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -1013,7 +1013,7 @@ class C
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 
@@ -1051,7 +1051,7 @@ End Class
                 TestState =
                 {
                     Sources = { vbCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 
@@ -1103,7 +1103,7 @@ class C
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 
@@ -1140,7 +1140,7 @@ End Class
                 TestState =
                 {
                     Sources = { vbCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -1048,8 +1048,11 @@ End Class
 ";
             var vbTest = new VerifyVB.Test()
             {
-                TestCode = vbCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { vbCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                }
             };
 
             await vbTest.RunAsync();
@@ -1134,8 +1137,11 @@ End Class
 ";
             var vbTest = new VerifyVB.Test()
             {
-                TestCode = vbCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { vbCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
+                }
             };
 
             await vbTest.RunAsync();

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -1010,8 +1010,11 @@ class C
 ";
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig)}
+                }
             };
 
             await csTest.RunAsync();
@@ -1094,8 +1097,11 @@ class C
 ";
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                }
             };
 
             await csTest.RunAsync();

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -1013,7 +1013,7 @@ class C
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig)}
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
                 }
             };
 
@@ -1100,7 +1100,7 @@ class C
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}")}
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -8196,10 +8196,7 @@ End Class");
         [InlineData(PointsToAnalysisKind.Complete)]
         public async Task MemberReferenceInQueryFromClause_Disposed_NoDiagnostic(PointsToAnalysisKind? analysisKind)
         {
-            await new VerifyCS.Test()
-            {
-                AnalyzerConfigDocument = GetEditorConfigContent(analysisKind),
-                TestCode = @"
+            var source = @"
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -8237,7 +8234,14 @@ class Test
         y.Dispose();
     }
 }
-",
+";
+            await new VerifyCS.Test()
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(analysisKind)) }
+                }
             }.RunAsync();
         }
 
@@ -8877,8 +8881,11 @@ public class Test
 ";
             var test = new VerifyCS.Test()
             {
-                TestCode = source,
-                AnalyzerConfigDocument = GetEditorConfigContent(pointsToAnalysisKind)
+                TestState =
+                {
+                    Sources = { source },
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                }
             };
 
             if (pointsToAnalysisKind != PointsToAnalysisKind.None)
@@ -9015,8 +9022,11 @@ public class Test
 
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = GetEditorConfigContent(pointsToAnalysisKind)
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                }
             };
 
             if (pointsToAnalysisKind != PointsToAnalysisKind.None)
@@ -9077,8 +9087,11 @@ public class Test
 }";
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = GetEditorConfigContent(pointsToAnalysisKind)
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                }
             };
 
             if (pointsToAnalysisKind != PointsToAnalysisKind.None)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -59,17 +59,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
         private string GetEditorConfigContentToDisableInterproceduralAnalysis(DisposeAnalysisKind disposeAnalysisKind)
         {
-            var text = $@"dotnet_code_quality.interprocedural_analysis_kind = None
+            var text = $@"[*]
+                          dotnet_code_quality.interprocedural_analysis_kind = None
                           dotnet_code_quality.dispose_analysis_kind = {disposeAnalysisKind}";
             return text;
         }
 
         private string GetEditorConfigContent(DisposeAnalysisKind disposeAnalysisKind)
-            => $@"dotnet_code_quality.dispose_analysis_kind = {disposeAnalysisKind}";
+            => $@"[*]
+                  dotnet_code_quality.dispose_analysis_kind = {disposeAnalysisKind}";
 
         private string GetEditorConfigContent(PointsToAnalysisKind? pointsToAnalysisKind)
             => pointsToAnalysisKind.HasValue ?
-                $"dotnet_code_quality.CA2000.points_to_analysis_kind = {pointsToAnalysisKind}" :
+                $@"[*]
+                   dotnet_code_quality.CA2000.points_to_analysis_kind = {pointsToAnalysisKind}" :
                 string.Empty;
 
         [Fact]
@@ -9133,8 +9136,11 @@ End Class
 ";
             var vbTest = new VerifyVB.Test()
             {
-                TestCode = vbCode,
-                AnalyzerConfigDocument = GetEditorConfigContent(pointsToAnalysisKind)
+                TestState =
+                {
+                    Sources = { vbCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                }
             };
 
             if (pointsToAnalysisKind != PointsToAnalysisKind.None)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -8243,7 +8243,7 @@ class Test
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(analysisKind)) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(analysisKind)) },
                 }
             }.RunAsync();
         }
@@ -8887,7 +8887,7 @@ public class Test
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) },
                 }
             };
 
@@ -9028,7 +9028,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) },
                 }
             };
 
@@ -9093,7 +9093,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) },
                 }
             };
 
@@ -9139,7 +9139,7 @@ End Class
                 TestState =
                 {
                     Sources = { vbCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", GetEditorConfigContent(pointsToAnalysisKind)) },
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1906,8 +1906,11 @@ End Class
 ".NormalizeLineEndings();
             var vbTest = new VerifyVB.Test()
             {
-                TestCode = vbCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { vbCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                }
             };
 
             if (pointsToAnalysisKind == PointsToAnalysisKind.Complete)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1874,7 +1874,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1871,8 +1871,11 @@ public class Test
 ".NormalizeLineEndings();
             var csTest = new VerifyCS.Test()
             {
-                TestCode = csCode,
-                AnalyzerConfigDocument = editorConfig
+                TestState =
+                {
+                    Sources = { csCode },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfig) }
+                }
             };
 
             if (pointsToAnalysisKind == PointsToAnalysisKind.Complete)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotPassLiteralsAsLocalizedParametersTests.cs
@@ -1874,7 +1874,7 @@ public class Test
                 TestState =
                 {
                     Sources = { csCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 
@@ -1909,7 +1909,7 @@ End Class
                 TestState =
                 {
                     Sources = { vbCode },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{editorConfig}") },
                 }
             };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -37,7 +37,7 @@ public class CultureInfoTestClass0
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", property) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{property}") }
                 }
             }.RunAsync();
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -37,7 +37,7 @@ public class CultureInfoTestClass0
                 TestState =
                 {
                     Sources = { source },
-                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{property}") }
+                    AnalyzerConfigFiles = { ("/.editorconfig", $"[*]\r\n{property}") },
                 }
             }.RunAsync();
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureInfoTests.cs
@@ -21,9 +21,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [InlineData("build_property.InvariantGlobalization = true", @"""aaa"".ToLower()")]
         public async Task CA1304_PlainString_CSharp_InvariantGlobalization(string property, string returnExpression)
         {
-            await new VerifyCS.Test
-            {
-                TestCode = $@"
+            var source = $@"
 using System;
 using System.Globalization;
 
@@ -33,8 +31,14 @@ public class CultureInfoTestClass0
     {{
         return {returnExpression};
     }}
-}}",
-                AnalyzerConfigDocument = property,
+}}";
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AnalyzerConfigFiles = { ("/.editorconfig", property) }
+                }
             }.RunAsync();
         }
 

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -234,7 +234,7 @@ public class C
                 expectedDiagnostics = new[] { GetCSharpResultAt(2, 14, DeclarePublicApiAnalyzer.DeclareNewApiRule, "C") };
             }
 
-            await VerifyCSharpAsync(source, shippedText, unshippedText, editorconfigText, expectedDiagnostics);
+            await VerifyCSharpAsync(source, shippedText, unshippedText, $"[*]\r\n{editorconfigText}", expectedDiagnostics);
         }
 
         [Fact]

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
             await test.RunAsync();
         }
 
-        private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, string? editorConfigText, params DiagnosticResult[] expected)
+        private async Task VerifyCSharpAsync(string source, string? shippedApiText, string? unshippedApiText, string editorConfigText, params DiagnosticResult[] expected)
         {
             var test = new CSharpCodeFixVerifier<DeclarePublicApiAnalyzer, DeclarePublicApiFix>.Test
             {
@@ -212,12 +212,11 @@ public class C
         }
 
         [Theory]
-        [InlineData(null)]
         [InlineData("")]
         [InlineData("dotnet_public_api_analyzer.require_api_files = false")]
         [InlineData("dotnet_public_api_analyzer.require_api_files = true")]
         [WorkItem(2622, "https://github.com/dotnet/roslyn-analyzers/issues/2622")]
-        public async Task AnalyzerFileMissing_Both(string? editorconfigText)
+        public async Task AnalyzerFileMissing_Both(string editorconfigText)
         {
             var source = @"
 public class C
@@ -230,8 +229,7 @@ public class C
             string? unshippedText = null;
 
             var expectedDiagnostics = Array.Empty<DiagnosticResult>();
-            if (editorconfigText == null ||
-                !editorconfigText.EndsWith("true", StringComparison.OrdinalIgnoreCase))
+            if (!editorconfigText.EndsWith("true", StringComparison.OrdinalIgnoreCase))
             {
                 expectedDiagnostics = new[] { GetCSharpResultAt(2, 14, DeclarePublicApiAnalyzer.DeclareNewApiRule, "C") };
             }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                 {
                     Sources = { source },
                     AdditionalFiles = { },
-                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) }
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) },
                 },
             };
 

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -104,8 +104,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
                 {
                     Sources = { source },
                     AdditionalFiles = { },
+                    AnalyzerConfigFiles = { ("/.editorconfig", editorConfigText) }
                 },
-                AnalyzerConfigDocument = editorConfigText,
             };
 
             if (shippedApiText != null)

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Test.Utilities
 {
@@ -40,20 +39,6 @@ namespace Test.Utilities
             public Test()
             {
                 ReferenceAssemblies = AdditionalMetadataReferences.Default;
-
-                SolutionTransforms.Add((solution, projectId) =>
-                {
-                    if (AnalyzerConfigDocument is not null)
-                    {
-                        solution = solution.AddAnalyzerConfigDocument(
-                            DocumentId.CreateNewId(projectId, debugName: ".editorconfig"),
-                            ".editorconfig",
-                            SourceText.From($"is_global = true" + Environment.NewLine + AnalyzerConfigDocument),
-                            filePath: @"/.editorconfig");
-                    }
-
-                    return solution;
-                });
             }
 
             private static ImmutableDictionary<string, ReportDiagnostic> GetNullableWarningsFromCompiler()
@@ -66,8 +51,6 @@ namespace Test.Utilities
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.CSharp7_3;
-
-            public string? AnalyzerConfigDocument { get; set; }
 
             protected override CompilationOptions CreateCompilationOptions()
             {

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
@@ -20,25 +20,9 @@ namespace Test.Utilities
             public Test()
             {
                 ReferenceAssemblies = AdditionalMetadataReferences.Default;
-
-                SolutionTransforms.Add((solution, projectId) =>
-                {
-                    if (AnalyzerConfigDocument is not null)
-                    {
-                        solution = solution.AddAnalyzerConfigDocument(
-                            DocumentId.CreateNewId(projectId, debugName: ".editorconfig"),
-                            ".editorconfig",
-                            SourceText.From($"is_global = true" + Environment.NewLine + AnalyzerConfigDocument),
-                            filePath: @"/.editorconfig");
-                    }
-
-                    return solution;
-                });
             }
 
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.VisualBasic15_5;
-
-            public string? AnalyzerConfigDocument { get; set; }
 
             protected override ParseOptions CreateParseOptions()
             {


### PR DESCRIPTION
This was recently added in the testing library in https://github.com/dotnet/roslyn-sdk/pull/734.
~~The main goal of this is to (later) remove the logic of parsing editorconfig files and leave that up to the compiler (https://github.com/dotnet/roslyn-sdk/pull/734#discussion_r581165302)~~ This comment is about `AdditionalFiles`, not `AnalyzerConfigDocument`.