### PR TITLE
Fix incorrect removal of implicit property from PublicApi

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         {
                             if (sibling.IsImplicitlyDeclared)
                             {
-                                if (!sibling.IsConstructor())
+                                if (!((sibling as IMethodSymbol)?.MethodKind is MethodKind.Constructor or MethodKind.PropertyGet or MethodKind.PropertySet))
                                 {
                                     continue;
                                 }

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -536,7 +536,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                         {
                             if (sibling.IsImplicitlyDeclared)
                             {
-                                if (!((sibling as IMethodSymbol)?.MethodKind is MethodKind.Constructor or MethodKind.PropertyGet or MethodKind.PropertySet))
+                                if (sibling is not IMethodSymbol { MethodKind: MethodKind.Constructor or MethodKind.PropertyGet or MethodKind.PropertySet })
                                 {
                                     continue;
                                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4133

I'm not sure what is the best way to test `record` but I targeted `ReferenceAssemblies.Net.Net50`