### PR TITLE
Don't use PooledSortedSet that differ by compilations

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/InsecureDeserializationTypeDecider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/Helpers/InsecureDeserializationTypeDecider.cs
@@ -144,7 +144,7 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
             ITypeSymbol? Compute(ITypeSymbol typeSymbol)
             {
                 // Sort type symbols by display string so that we get consistent results.
-                using PooledSortedSet<ITypeSymbol> associatedTypeSymbols = PooledSortedSet<ITypeSymbol>.GetInstance(
+                SortedSet<ITypeSymbol> associatedTypeSymbols = new SortedSet<ITypeSymbol>(
                     this.SymbolByDisplayStringComparer);
                 GetAssociatedTypes(typeSymbol, associatedTypeSymbols);
                 foreach (ITypeSymbol t in associatedTypeSymbols)
@@ -238,8 +238,7 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
 
                 // Sort type symbols by display strings.
                 // Keep track of member types we see, and we'll recurse through those afterwards.
-                using PooledSortedSet<ITypeSymbol> typesToRecurse = PooledSortedSet<ITypeSymbol>.GetInstance(
-                    this.SymbolByDisplayStringComparer);
+                SortedSet<ITypeSymbol> typesToRecurse = new SortedSet<ITypeSymbol>(this.SymbolByDisplayStringComparer);
                 foreach (ISymbol member in typeSymbol.GetMembers())
                 {
                     switch (member)
@@ -414,7 +413,7 @@ namespace Microsoft.NetCore.Analyzers.Security.Helpers
         /// <param name="results">Set to populate with associated types.</param>
         private static void GetAssociatedTypes(
             ITypeSymbol type,
-            PooledSortedSet<ITypeSymbol> results)
+            SortedSet<ITypeSymbol> results)
         {
             if (type == null || !results.Add(type))
             {

--- a/src/Utilities/Compiler/PooledObjects/PooledSortedSet.cs
+++ b/src/Utilities/Compiler/PooledObjects/PooledSortedSet.cs
@@ -55,7 +55,7 @@ namespace Analyzer.Utilities.PooledObjects
         /// <summary>
         /// Gets a pooled instance of a <see cref="PooledSortedSet{T}"/> with an optional comparer.
         /// </summary>
-        /// <param name="comparer">Comparer to use, or null for the element type's default comparer.</param>
+        /// <param name="comparer">Singleton (or at least a bounded number) comparer to use, or null for the element type's default comparer.</param>
         /// <returns>An empty <see cref="PooledSortedSet{T}"/>.</returns>
         public static PooledSortedSet<T> GetInstance(IComparer<T>? comparer = null)
         {


### PR DESCRIPTION
Fixes #5059.

From what I can tell, there's a memory leak with using PooledSortedSet&lt;T&gt; with different instances of SymbolByDisplayStringComparer, since SymbolByDisplayStringComparer has a different instance of SymbolDisplayStringCache for each compilation. So just using SortedSets&lt;T&gt; instead.

<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
