### PR TITLE
CA1416 Fix Version comparison ambiguity

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -215,15 +215,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         {
                             return new Version(versionBuilder[0], versionBuilder[1]);
                         }
-                        else
-                        {
-                            return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2]);
-                        }
+
+                        return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2]);
                     }
-                    else
-                    {
-                        return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2], versionBuilder[3]);
-                    }
+
+                    return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2], versionBuilder[3]);
                 }
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -90,6 +90,103 @@ class Test
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
+        [Fact, WorkItem(4932, "https://github.com/dotnet/roslyn-analyzers/issues/4932")]
+        public async Task GuardMethodWith3VersionPartsEquavalentTo4PartsWithLeading0()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+public class MSAL
+{
+    [SupportedOSPlatform(""windows10.0.17763.0"")]
+    public static void UseWAMWithLeading0() { }
+
+    [SupportedOSPlatform(""windows10.0.17763"")]
+    public static void UseWAMNoLeading0() { }
+
+    static void Test()
+    {
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 17763, 0))
+        {
+            UseWAMWithLeading0();
+            UseWAMNoLeading0();
+        }
+
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0, 17763))
+        {
+            UseWAMWithLeading0();
+            UseWAMNoLeading0();
+        }
+    }
+}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
+        [Fact]
+        public async Task GuardMethodWith1VersionPartsEquavalentTo2PartsWithLeading0()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+public class MSAL
+{
+    [SupportedOSPlatform(""windows10.0"")]
+    public static void UseWAMWithLeading0() { }
+
+    static void Test()
+    {
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10))
+        {
+            UseWAMWithLeading0();
+        }
+
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10, 0))
+        {
+            UseWAMWithLeading0();
+        }
+    }
+}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
+        [Fact]
+        public async Task GuardMethodWith2VersionPartsEquavalentTo3PartsWithLeading0()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+public class MSAL
+{
+    [SupportedOSPlatform(""windows10.1.0"")]
+    public static void UseWAMWithLeading0() { }
+
+    [SupportedOSPlatform(""windows10.1"")]
+    public static void UseWAMNoLeading0() { }
+
+    static void Test()
+    {
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10, 1))
+        {
+            UseWAMWithLeading0();
+            UseWAMNoLeading0();
+        }
+
+        if (OperatingSystemHelper.IsWindowsVersionAtLeast(10, 1, 0))
+        {
+            UseWAMWithLeading0();
+            UseWAMNoLeading0();
+        }
+    }
+}" + MockAttributesCsSource + MockOperatingSystemApiSource;
+
+            await VerifyAnalyzerAsyncCs(source);
+        }
+
         [Fact]
         public async Task GuardsAroundSupported_SimpleIfElse()
         {

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DisposeMethodKind.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\OperationBlockAnalysisContextExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\StringCompatExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\VersionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Index.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\ITypeSymbolExtensions.cs" />

--- a/src/Utilities/Compiler/Extensions/VersionExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/VersionExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Analyzer.Utilities.Extensions
+{
+    internal static class VersionExtension
+    {
+        public static bool IsGreaterThanOrEqualTo(this Version? current, Version? compare)
+        {
+            if (current == null)
+            {
+                return compare == null;
+            }
+
+            if (compare == null)
+            {
+                return true;
+            }
+
+            if (current.Major != compare.Major)
+            {
+                return current.Major > compare.Major;
+            }
+
+            if (current.Minor != compare.Minor)
+            {
+                return current.Minor > compare.Minor;
+            }
+
+            // For build or revision value of 0 equals to -1
+            if (current.Build != compare.Build && (current.Build > 0 || compare.Build > 0))
+            {
+                return current.Build > compare.Build;
+            }
+
+            if (current.Revision != compare.Revision && (current.Revision > 0 || compare.Revision > 0))
+            {
+                return current.Revision > compare.Revision;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Related Issues: https://github.com/dotnet/roslyn-analyzers/issues/4932
Port of https://github.com/dotnet/roslyn-analyzers/pull/4943

### The comparison of versions having leading 0 causing CA1416 malfunction

### Context:
The comparison operations of the Version type is a bit strange:

Console.WriteLine(Version.Parse("10.0.17763.0") < Version.Parse("10.0.17763")); // False
Console.WriteLine(Version.Parse("10.0.17763.0") > Version.Parse("10.0.17763")); // True
Console.WriteLine(Version.Parse("10.0.17763.0") == Version.Parse("10.0.17763")); // False

The WinRT team wants the fix serviced in 5.0

### Risk:
No risk of causing new warnings instead suppresses warnings caused from leading 0 like above.

CC @jeffhandley @jmarolf @marcpopMSFT @mavasani