### PR TITLE
CA1416 Support custom guard members annotated with guard attributes

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -26,12 +26,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 _osPlatformType = osPlatformType;
             }
 
-            internal static bool TryParseGuardAttrbiutes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value)
+            internal static bool TryParseGuardAttributes(ImmutableArray<AttributeData> attributes, ref GlobalFlowStateAnalysisValueSet value)
             {
-                if (HasAnyGuardAttribute(symbol))
+                if (HasAnyGuardAttribute(attributes))
                 {
                     using var infosBuilder = ArrayBuilder<PlatformMethodValue>.GetInstance();
-                    if (PlatformMethodValue.TryDecode(symbol.GetAttributes(), infosBuilder))
+                    if (PlatformMethodValue.TryDecode(attributes, infosBuilder))
                     {
                         for (var i = 0; i < infosBuilder.Count; i++)
                         {
@@ -48,8 +48,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                 return false;
 
-                static bool HasAnyGuardAttribute(ISymbol symbol) =>
-                    symbol.GetAttributes().Any(a => a.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute);
+                static bool HasAnyGuardAttribute(ImmutableArray<AttributeData> attributes) =>
+                    attributes.Any(a => a.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute);
             }
 
             public override GlobalFlowStateAnalysisValueSet VisitInvocation_NonLambdaOrDelegateOrLocalFunction(
@@ -80,7 +80,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                         return GlobalFlowStateAnalysisValueSet.Unknown;
                     }
-                    else if (TryParseGuardAttrbiutes(method, ref value))
+                    else if (TryParseGuardAttributes(method.GetAttributes(), ref value))
                     {
                         return value;
                     }
@@ -94,7 +94,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 var value = base.VisitFieldReference(operation, argument);
 
                 if (operation.Type.SpecialType == SpecialType.System_Boolean &&
-                    TryParseGuardAttrbiutes(operation.Field, ref value))
+                    TryParseGuardAttributes(operation.Field.GetAttributes(), ref value))
                 {
                     return value;
                 }
@@ -106,7 +106,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 var value = base.VisitPropertyReference(operation, argument);
                 if (operation.Type.SpecialType == SpecialType.System_Boolean &&
-                    TryParseGuardAttrbiutes(operation.Property, ref value))
+                    TryParseGuardAttributes(operation.Property.GetAttributes(), ref value))
                 {
                     return value;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -112,8 +112,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 foreach (var attribute in attributes)
                 {
                     if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute &&
-                        HasNonEmptyStringArgument(attribute, out var argument) &&
-                        TryParsePlatformNameAndVersion(argument, out string platformName, out Version? version))
+                        TryParsePlatformNameAndVersion(attribute, out var platformName, out var version))
                     {
                         var info = new PlatformMethodValue(platformName, version, negated: attribute.AttributeClass.Name == UnsupportedOSPlatformGuardAttribute);
                         infosBuilder.Add(info);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -22,21 +22,19 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
     {
         private readonly struct PlatformMethodValue : IAbstractAnalysisValue, IEquatable<PlatformMethodValue>
         {
-            private PlatformMethodValue(string invokedPlatformCheckMethodName, string platformPropertyName, Version version, bool negated)
+            internal PlatformMethodValue(string platformPropertyName, Version version, bool negated)
             {
-                InvokedMethodName = invokedPlatformCheckMethodName ?? throw new ArgumentNullException(nameof(invokedPlatformCheckMethodName));
                 PlatformName = platformPropertyName ?? throw new ArgumentNullException(nameof(platformPropertyName));
                 Version = version ?? throw new ArgumentNullException(nameof(version));
                 Negated = negated;
             }
 
-            public string InvokedMethodName { get; }
             public string PlatformName { get; }
             public Version Version { get; }
             public bool Negated { get; }
 
             public IAbstractAnalysisValue GetNegatedValue()
-                => new PlatformMethodValue(InvokedMethodName, PlatformName, Version, !Negated);
+                => new PlatformMethodValue(PlatformName, Version, !Negated);
 
             public static bool TryDecode(
                 IMethodSymbol invokedPlatformCheckMethod,
@@ -50,7 +48,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     if (TryExtractPlatformName(invokedPlatformCheckMethod.Name, out var platformName))
                     {
-                        var info = new PlatformMethodValue(invokedPlatformCheckMethod.Name, platformName, new Version(0, 0), negated: false);
+                        var info = new PlatformMethodValue(platformName, EmptyVersion, negated: false);
                         infosBuilder.Add(info);
                         return true;
                     }
@@ -63,7 +61,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         Debug.Assert(osPlatformNamesBuilder.Count > 0);
                         for (var i = 0; i < osPlatformNamesBuilder.Count; i++)
                         {
-                            var info = new PlatformMethodValue(invokedPlatformCheckMethod.Name, osPlatformNamesBuilder[i], new Version(0, 0), negated: false);
+                            var info = new PlatformMethodValue(osPlatformNamesBuilder[i], EmptyVersion, negated: false);
                             infosBuilder.Add(info);
                         }
 
@@ -79,7 +77,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             if (invokedPlatformCheckMethod.Name == IsOSPlatform &&
                                 TryParsePlatformNameAndVersion(literal.ConstantValue.Value.ToString(), out string platformName, out Version? version))
                             {
-                                var info = new PlatformMethodValue(invokedPlatformCheckMethod.Name, platformName, version, negated: false);
+                                var info = new PlatformMethodValue(platformName, version, negated: false);
                                 infosBuilder.Add(info);
                                 return true;
                             }
@@ -87,7 +85,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             {
                                 // OperatingSystem.IsOSPlatformVersionAtLeast(string platform, int major, int minor = 0, int build = 0, int revision = 0)
                                 Debug.Assert(invokedPlatformCheckMethod.Name == "IsOSPlatformVersionAtLeast");
-                                var info = new PlatformMethodValue(invokedPlatformCheckMethod.Name, literal.ConstantValue.Value.ToString(), version, negated: false);
+                                var info = new PlatformMethodValue(literal.ConstantValue.Value.ToString(), version, negated: false);
                                 infosBuilder.Add(info);
                                 return true;
                             }
@@ -98,7 +96,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             if (TryExtractPlatformName(invokedPlatformCheckMethod.Name, out var platformName) &&
                                 TryDecodeOSVersion(arguments, valueContentAnalysisResult, out var version))
                             {
-                                var info = new PlatformMethodValue(invokedPlatformCheckMethod.Name, platformName, version, negated: false);
+                                var info = new PlatformMethodValue(platformName, version, negated: false);
                                 infosBuilder.Add(info);
                                 return true;
                             }
@@ -107,6 +105,26 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 return false;
+            }
+
+            public static bool TryDecode(ImmutableArray<AttributeData> attributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
+            {
+                foreach (var attribute in attributes)
+                {
+                    if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute &&
+                        HasNonEmptyStringArgument(attribute, out var argument) &&
+                        TryParsePlatformNameAndVersion(argument, out string platformName, out Version? version))
+                    {
+                        if (platformName.Equals(OSX, StringComparison.OrdinalIgnoreCase))
+                        {
+                            platformName = macOS;
+                        }
+
+                        var info = new PlatformMethodValue(platformName, version, negated: attribute.AttributeClass.Name == UnsupportedOSPlatformGuardAttribute);
+                        infosBuilder.Add(info);
+                    }
+                }
+                return infosBuilder.Any();
             }
 
             private static bool TryExtractPlatformName(string methodName, [NotNullWhen(true)] out string? platformName)
@@ -225,7 +243,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             public override string ToString()
             {
-                var result = $"{InvokedMethodName};{PlatformName};{Version}";
+                var result = $"{PlatformName};{Version}";
                 if (Negated)
                 {
                     result = $"!{result}";
@@ -235,10 +253,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             public bool Equals(PlatformMethodValue other)
-                => InvokedMethodName.Equals(other.InvokedMethodName, StringComparison.OrdinalIgnoreCase) &&
-                    PlatformName.Equals(other.PlatformName, StringComparison.OrdinalIgnoreCase) &&
-                    Version.Equals(other.Version) &&
-                    Negated == other.Negated;
+                => PlatformName.Equals(other.PlatformName, StringComparison.OrdinalIgnoreCase) &&
+                   Version.Equals(other.Version) &&
+                   Negated == other.Negated;
 
             public override bool Equals(object obj)
                 => obj is PlatformMethodValue otherInfo && Equals(otherInfo);
@@ -246,7 +263,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             public override int GetHashCode()
             {
                 return RoslynHashCode.Combine(
-                    InvokedMethodName.GetHashCode(),
                     PlatformName.GetHashCode(),
                     Version.GetHashCode(),
                     Negated.GetHashCode());

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -115,11 +115,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         HasNonEmptyStringArgument(attribute, out var argument) &&
                         TryParsePlatformNameAndVersion(argument, out string platformName, out Version? version))
                     {
-                        if (platformName.Equals(OSX, StringComparison.OrdinalIgnoreCase))
-                        {
-                            platformName = macOS;
-                        }
-
                         var info = new PlatformMethodValue(platformName, version, negated: attribute.AttributeClass.Name == UnsupportedOSPlatformGuardAttribute);
                         infosBuilder.Add(info);
                     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1677,7 +1677,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     if (i > 0 && Version.TryParse(osString[i..], out Version? parsedVersion))
                     {
-                        osPlatformName = ConsolidatePlatformName(osString.Substring(0, i));
+                        osPlatformName = GetNameAsMacOsWhenOSX(osString.Substring(0, i));
                         version = parsedVersion;
                         return true;
                     }
@@ -1686,12 +1686,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            osPlatformName = ConsolidatePlatformName(osString);
+            osPlatformName = GetNameAsMacOsWhenOSX(osString);
             version = EmptyVersion;
             return true;
         }
 
-        private static string ConsolidatePlatformName(string platformName) =>
+        private static string GetNameAsMacOsWhenOSX(string platformName) =>
             platformName.Equals(OSX, StringComparison.OrdinalIgnoreCase) ? macOS : platformName;
 
         private static void AddAttribute(string name, Version version, Versions attributes)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1437,6 +1437,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 SmallDictionary<string, Versions>? childAttributes = null;
                 foreach (AttributeData attribute in immediateAttributes)
                 {
+                    if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute)
+                    {
+                        parentAttributes = new PlatformAttributes();
+                        return;
+                    }
                     if (s_osPlatformAttributes.Contains(attribute.AttributeClass.Name))
                     {
                         TryAddValidAttribute(ref childAttributes, attribute);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1623,8 +1623,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool TryAddValidAttribute([NotNullWhen(true)] ref SmallDictionary<string, Versions>? attributes, AttributeData attribute)
         {
-            if (HasNonEmptyStringArgument(attribute, out var argument) &&
-                TryParsePlatformNameAndVersion(argument, out var platformName, out var version))
+            if (TryParsePlatformNameAndVersion(attribute, out var platformName, out var version))
             {
                 attributes ??= new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
 
@@ -1637,6 +1636,18 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return true;
             }
 
+            return false;
+        }
+
+        private static bool TryParsePlatformNameAndVersion(AttributeData attribute, out string platformName, [NotNullWhen(true)] out Version? version)
+        {
+            if (HasNonEmptyStringArgument(attribute, out var argument))
+            {
+                return TryParsePlatformNameAndVersion(argument, out platformName, out version);
+            }
+
+            version = null;
+            platformName = string.Empty;
             return false;
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1627,10 +1627,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 TryParsePlatformNameAndVersion(argument, out var platformName, out var version))
             {
                 attributes ??= new SmallDictionary<string, Versions>(StringComparer.OrdinalIgnoreCase);
-                if (platformName.Equals(OSX, StringComparison.OrdinalIgnoreCase))
-                {
-                    platformName = macOS;
-                }
 
                 if (!attributes.TryGetValue(platformName, out var _))
                 {
@@ -1670,7 +1666,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     if (i > 0 && Version.TryParse(osString[i..], out Version? parsedVersion))
                     {
-                        osPlatformName = osString.Substring(0, i);
+                        osPlatformName = ConsolidatePlatformName(osString.Substring(0, i));
                         version = parsedVersion;
                         return true;
                     }
@@ -1679,10 +1675,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
             }
 
-            osPlatformName = osString;
+            osPlatformName = ConsolidatePlatformName(osString);
             version = EmptyVersion;
             return true;
         }
+
+        private static string ConsolidatePlatformName(string platformName) =>
+            platformName.Equals(OSX, StringComparison.OrdinalIgnoreCase) ? macOS : platformName;
 
         private static void AddAttribute(string name, Version version, Versions attributes)
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4315,6 +4315,58 @@ class Test
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
+        [Fact]
+        public async Task GuardMemberWithinPlatformSpecificTypeShouldNowWarn()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+class Test
+{
+    void M1()
+    {
+        [|UnsupportedBrowserType.M1()|];
+        [|UnsupportedBrowserType.M2()|];
+        if (UnsupportedBrowserType.IsSupported)
+        {
+            UnsupportedBrowserType.M1();
+            UnsupportedBrowserType.M2();
+        }
+        var t = [|new UnsupportedBrowserType()|];
+
+        [|WindowsOnlyType.M1()|];
+        [|WindowsOnlyType.M2()|];
+        if (WindowsOnlyType.IsSupported)
+        {
+            WindowsOnlyType.M1();
+            WindowsOnlyType.M2();
+        }
+        var w = [|new WindowsOnlyType()|];
+    }
+}
+
+[UnsupportedOSPlatform(""browser"")]
+class UnsupportedBrowserType
+{
+    public static void M1() { }
+    [UnsupportedOSPlatformGuard(""browser"")]
+    public static bool IsSupported { get; }
+    public static void M2() { }
+}
+[SupportedOSPlatform(""windows"")]
+class WindowsOnlyType
+{
+    public static void M1() { }
+    [SupportedOSPlatformGuard(""windows"")]
+    public static bool IsSupported { get; }
+    public static void M2() { }
+}
+" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
         private readonly string MockAttributesCsSource = @"
 namespace System.Runtime.Versioning
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3989,8 +3989,8 @@ class Test
 
         if (_http3Enabled)
         {
-            //SupportedOnWindowsLinuxOsx();  
-            [|SupportedOnLinux()|]; // only supported on linux but call site is reachable on 3, linus, windows, macos
+            SupportedOnWindowsLinuxOsx();  
+            [|SupportedOnLinux()|]; // only supported on linux but call site is reachable on 3, linux, windows, macos
         }
         else
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3945,6 +3945,402 @@ class Test
             await VerifyAnalyzerAsyncCs(source, "dotnet_code_quality.interprocedural_analysis_kind = ContextSensitive");
         }
 
+        [Fact]
+        public async Task GuardMembersWithSupportedGuardAttributes()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""linux"")]
+    private bool IsLunuxSupported() => true;
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""Windows"")]
+    internal bool LinuxAndWindowsSupported { get; set; }
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""macOS"")]
+    [SupportedOSPlatformGuard(""Windows"")]
+    private readonly bool _http3Enabled;
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""macOS"")]
+    [SupportedOSPlatformGuard(""Windows"")]
+    [SupportedOSPlatformGuard(""Android"")]
+    private bool IsHttp3PlusAndroidEnabled() => false;
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""macOS"")]
+    [SupportedOSPlatformGuard(""Windows"")]
+    [UnsupportedOSPlatformGuard(""Android"")]
+    private readonly bool _http3EnabledNotAndroid;
+
+    void M1()
+    {
+        if (IsLunuxSupported()) // one of the support guarded, so no warning
+        {
+            SupportedOnWindowsLinuxOsx();    
+            SupportedOnLinux();
+        }
+
+        if (_http3Enabled)
+        {
+            //SupportedOnWindowsLinuxOsx();  
+            [|SupportedOnLinux()|]; // only supported on linux but call site is reachable on 3, linus, windows, macos
+        }
+        else
+        {
+            [|SupportedOnWindowsLinuxOsx()|]; // This call site is reachable on all platforms. 'Test.SupportedOnWindowsLinuxOsx()' is only supported on: 'macOS/OSX', 'Linux', 'windows'.
+            {|#0:SupportedOnLinux()|}; // This call site is reachable on all platforms. 'Test.SupportedOnLinux()' is only supported on: 'linux'.
+        }
+
+        if (IsHttp3PlusAndroidEnabled()) // Android is not in the support list
+        {
+            [|SupportedOnWindowsLinuxOsx()|]; // This call site is reachable on: 'Android'. 'Test.M2()' is only supported on: 'windows', 'macOS/OSX', 'Linux'.           
+        }
+
+        if (_http3EnabledNotAndroid)
+        {
+            SupportedOnWindowsLinuxOsx();  
+            [|SupportedOnLinux()|];
+        }
+        
+        [|SupportedOnWindowsLinuxOsx()|];
+        Debug.Assert(LinuxAndWindowsSupported);
+        SupportedOnWindowsLinuxOsx();    
+        [|SupportedOnLinux()|];
+    }
+
+    [SupportedOSPlatform(""windows"")]
+    [SupportedOSPlatform(""Linux"")]
+    [SupportedOSPlatform(""OSX"")]
+    void SupportedOnWindowsLinuxOsx() { }
+
+    [SupportedOSPlatform(""linux"")]
+    void SupportedOnLinux() { }
+}" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).
+                WithArguments("Test.SupportedOnLinux()", "'linux'"));
+        }
+
+        [Fact]
+        public async Task GuardMembersWithUnsupportedGuardAttributes()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [UnsupportedOSPlatformGuard(""linux"")]
+    private readonly bool _linuxNotSupported;
+
+    [UnsupportedOSPlatformGuard(""linux"")]
+    [UnsupportedOSPlatformGuard(""Windows"")]
+    public bool LinuxAndWindowsNotSupported { get; }
+
+    [UnsupportedOSPlatformGuard(""linux"")]
+    [UnsupportedOSPlatformGuard(""ios"")]
+    [UnsupportedOSPlatformGuard(""Windows"")]
+    private bool IsLinuxWindowsIosNotSupported() => true;
+
+    [UnsupportedOSPlatformGuard(""linux"")]
+    [UnsupportedOSPlatformGuard(""ios"")]
+    [UnsupportedOSPlatformGuard(""Windows"")]
+    [UnsupportedOSPlatformGuard(""Android"")]
+    private readonly bool _linuxWindowsIosAndroidNotSupported;
+
+    void M1()
+    {
+        if (_linuxNotSupported)
+        {
+            UnsupportedOnLinux();
+            [|UnsupportedOnLinuxWindowsIos()|]; // This call site is reachable on all platforms. 'Test.UnsupportedOnLinuxWindowsIos()' is unsupported on: 'windows', 'ios'.
+        }
+
+        if (LinuxAndWindowsNotSupported)
+        {
+            UnsupportedOnLinux();
+            {|#0:UnsupportedOnLinuxWindowsIos()|}; // This call site is reachable on all platforms. 'Test.UnsupportedOnLinuxWindowsIos()' is unsupported on: 'ios'.
+        }
+
+        if (_linuxWindowsIosAndroidNotSupported)
+        {
+            UnsupportedOnLinux();
+            UnsupportedOnLinuxWindowsIos();
+        }
+        else
+        {
+            [|UnsupportedOnLinux()|]; // This call site is reachable on: 'Windows', 'linux', 'Android'. 'Test.UnsupportedOnLinux()' is unsupported on: 'Linux'.
+            [|UnsupportedOnLinuxWindowsIos()|]; // This call site is reachable on: 'Android', 'Windows'. 'Test.UnsupportedOnLinuxWindowsIos()' is unsupported on: 'Linux', 'ios', 'windows'.
+        }
+
+        Debug.Assert(IsLinuxWindowsIosNotSupported());
+        UnsupportedOnLinux();
+        UnsupportedOnLinuxWindowsIos();
+    }
+
+
+    [UnsupportedOSPlatform(""Linux"")]
+    void UnsupportedOnLinux() { }
+
+    [UnsupportedOSPlatform(""windows"")]
+    [UnsupportedOSPlatform(""Linux"")]
+    [UnsupportedOSPlatform(""ios"")]
+    void UnsupportedOnLinuxWindowsIos() { }
+}" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(0).
+                WithArguments("Test.UnsupportedOnLinuxWindowsIos()", "'ios'"));
+        }
+
+        [Fact]
+        public async Task GuardMembersWithVersionedSupportedUnsupportedGuardAttributes()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""Windows10.0"")]
+    private bool IsWindow10Supported() => true;
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""Windows10.0"")]
+    [SupportedOSPlatformGuard(""Osx14.1"")]
+    private readonly bool _linuxAndWindows10MacOS14Supported;
+
+    [UnsupportedOSPlatformGuard(""linux"")]
+    [UnsupportedOSPlatformGuard(""ios9.0"")]
+    [UnsupportedOSPlatformGuard(""Windows8.0"")]
+    private bool LinuxWindows8Ios9NotSupported { get; }
+
+    void M1()
+    {
+        if (IsWindow10Supported())
+        {
+            {|#0:UnsupportedOnLinuxWindows10Ios91()|}; // This call site is reachable on: 'Windows' 10.0 and later. 'Test.UnsupportedOnLinuxWindows10Ios91()' is unsupported on: 'windows' 10.0 and later.
+            SupportedOnWindows10LinuxMacOS14();
+            SupportedOnWindows8();
+        }
+
+        if (_linuxAndWindows10MacOS14Supported)
+        {
+            [|UnsupportedOnLinuxWindows10Ios91()|]; // This call site is reachable on: 'Windows' 10.0 and later. 'Test.UnsupportedOnLinuxWindows10Ios91()' is unsupported on: 'windows' 10.0 and later, 'Linux', 'ios' 9.1 and later.
+            SupportedOnWindows10LinuxMacOS14();
+            [|SupportedOnWindows8()|]; // This call site is reachable on: 'linux'. 'Test.SupportedOnWindows8()' is only supported on: 'windows' 8.0 and later.
+        }
+
+        if (LinuxWindows8Ios9NotSupported)
+        {
+            UnsupportedOnLinuxWindows10Ios91();
+            [|SupportedOnWindows10LinuxMacOS14()|]; // This call site is reachable on all platforms. 'Test.SupportedOnWindows10LinuxMacOS14()' is only supported on: 'windows' 10.0 and later, 'Linux', 'macOS' 14.0 and later.
+            {|#1:SupportedOnWindows8()|}; // This call site is reachable on all platforms. 'Test.SupportedOnWindows8()' is only supported on: 'windows' 8.0 and later.      
+        }
+    }
+
+    [UnsupportedOSPlatform(""windows10.0"")]
+    [UnsupportedOSPlatform(""Linux"")]
+    [UnsupportedOSPlatform(""ios9.1"")]
+    void UnsupportedOnLinuxWindows10Ios91() { }
+
+    [SupportedOSPlatform(""windows10.0"")]
+    [SupportedOSPlatform(""Linux"")]
+    [SupportedOSPlatform(""macOS14.0"")]
+    void SupportedOnWindows10LinuxMacOS14() { }
+
+    [SupportedOSPlatform(""windows8.0"")]
+    void SupportedOnWindows8() { }
+}" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).
+                WithArguments("Test.UnsupportedOnLinuxWindows10Ios91()", GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "windows", "10.0"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "Windows", "10.0")),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(1).WithArguments("Test.SupportedOnWindows8()",
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "windows", "8.0")));
+        }
+
+        [Fact]
+        public async Task GuardMembersWithSupportedUnsupportedVersionRangeGuardAttributes()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""Windows"")]
+    [UnsupportedOSPlatformGuard(""Windows10.0"")]
+    public bool SupportedUntilWindow10 => true;
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""Windows"")]
+    [UnsupportedOSPlatformGuard(""Windows10.0"")]
+    private bool IsSupportedUntilWindow10AndLinux() => false;
+
+    [UnsupportedOSPlatformGuard(""ios"")]
+    [SupportedOSPlatformGuard(""ios14.0"")]
+    [UnsupportedOSPlatformGuard(""ios18.0"")]
+    [UnsupportedOSPlatformGuard(""Windows8.0"")]
+    private readonly bool _windows8IosNotSupportedSupportedIos14_18;
+
+    void M1()
+    {
+        if (SupportedUntilWindow10)
+        {
+            {|#0:UnsupportedOnWindows8IosSupportsIos14_19()|}; // This call site is reachable on: 'Windows' 10.0 and before. 'Test.UnsupportedOnWindows8IosSupportsIos14_19()' is unsupported on: 'Windows' 8.0 and later.
+            SupportedOnWindowsUntil10AndLinux();
+            SupportedOnWindowsUntil10();
+        }
+
+        if (IsSupportedUntilWindow10AndLinux())
+        {
+            [|UnsupportedOnWindows8IosSupportsIos14_19()|]; // This call site is reachable on: 'linux', 'Windows' 10.0 and before. 'Test.UnsupportedOnWindows8IosSupportsIos14_19()' is supported on: 'ios' from version 14.0 to 19.0, 'Windows' 8.0 and later.
+            SupportedOnWindowsUntil10AndLinux();
+            {|#1:SupportedOnWindowsUntil10()|}; // This call site is reachable on: 'linux'. 'Test.SupportedOnWindowsUntil10()' is only supported on: 'Windows'.
+        }
+        else
+        {
+            [|UnsupportedOnWindows8IosSupportsIos14_19()|]; // This call site is reachable on all platforms. 'Test.UnsupportedOnWindows8IosSupportsIos14_19()' is supported on: 'ios' from version 14.0 to 19.0, 'Windows' 8.0 and later.
+            [|SupportedOnWindowsUntil10AndLinux()|]; // This call site is reachable on all platforms. 'Test.SupportedOnWindowsUntil10AndLinux()' is only supported on: 'linux', 'Windows' 10.0 and before.
+            [|SupportedOnWindowsUntil10()|]; // This call site is reachable on all platforms. 'Test.SupportedOnWindowsUntil10()' is only supported on: 'Windows' 10.0 and before.
+        }
+
+        if (_windows8IosNotSupportedSupportedIos14_18)
+        {
+            UnsupportedOnWindows8IosSupportsIos14_19();
+            [|SupportedOnWindowsUntil10AndLinux()|]; // This call site is reachable on: 'ios' 14.0 and later. 'Test.SupportedOnWindowsUntil10AndLinux()' is only supported on: 'linux', 'Windows'.
+            [|SupportedOnWindowsUntil10()|]; // This call site is reachable on: 'ios' 14.0 and later. 'Test.SupportedOnWindowsUntil10()' is only supported on: 'Windows'.      
+        }
+    }
+
+    [UnsupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""ios14.0"")]
+    [UnsupportedOSPlatform(""ios19.0"")]
+    [UnsupportedOSPlatform(""Windows8.0"")]
+    void UnsupportedOnWindows8IosSupportsIos14_19() { }
+
+    [SupportedOSPlatform(""linux"")]
+    [SupportedOSPlatform(""Windows"")]
+    [UnsupportedOSPlatform(""Windows10.0"")]
+    void SupportedOnWindowsUntil10AndLinux() { }
+
+    [SupportedOSPlatform(""Windows"")]
+    [UnsupportedOSPlatform(""Windows10.0"")]
+    void SupportedOnWindowsUntil10() { }
+}" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Test.UnsupportedOnWindows8IosSupportsIos14_19()",
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndLater, "Windows", "8.0"),
+                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, "Windows", "10.0")),
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsReachable).WithLocation(1).WithArguments("Test.SupportedOnWindowsUntil10()", "'Windows'", "'linux'"));
+        }
+
+        [Fact]
+        public async Task GuardAttributesFalsePositives()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""Windows10.0"")]
+    private string IsWindow10Supported() => ""true"";
+
+    [SupportedOSPlatformGuard(""linux"")]
+    [SupportedOSPlatformGuard(""Windows10.0"")]
+    private bool _linuxAndWindows10Supported;
+
+    [UnsupportedOSPlatformGuard(""linux"")]
+    [UnsupportedOSPlatformGuard(""ios9.0"")]
+    private bool LinuxIos9NotSupported { get; set;}
+
+    void M1()
+    {
+        if (IsWindow10Supported() == ""true"") // return type string, no effect
+        {
+            [|SupportedOnWindows10Linux()|];
+            [|SupportedOnWindows8()|];
+        }
+        _linuxAndWindows10Supported = true; // normal statements no effect
+        IsWindow10Supported();
+        [|SupportedOnWindows10Linux()|];
+        var value = _linuxAndWindows10Supported;
+        if (value)
+        {
+            IsWindow10Supported();
+            [|SupportedOnWindows8()|];
+            SupportedOnWindows10Linux();
+        }
+        if (_linuxAndWindows10Supported == true)
+        {
+            [|SupportedOnWindows8()|];
+            [|SupportedOnWindows10Linux()|]; // 39
+        }
+        var result = LinuxIos9NotSupported == true;  // not a guarding a block
+        [|UnsupportedOnLinuxIos91()|];
+
+        Debug.Assert(LinuxIos9NotSupported == false); // no effect when there is expression
+        [|UnsupportedOnLinuxIos91()|];
+
+        Debug.Assert(LinuxIos9NotSupported); // Assert should work
+        UnsupportedOnLinuxIos91();
+    }
+
+    [UnsupportedOSPlatform(""Linux"")]
+    [UnsupportedOSPlatform(""ios9.1"")]
+    void UnsupportedOnLinuxIos91() { }
+
+    [SupportedOSPlatform(""windows10.0"")]
+    [SupportedOSPlatform(""Linux"")]
+    void SupportedOnWindows10Linux() { }
+
+    [SupportedOSPlatform(""windows8.0"")]
+    void SupportedOnWindows8() { }
+}" + MockAttributesCsSource;
+
+            await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
+        }
+
+        private readonly string MockAttributesCsSource = @"
+namespace System.Runtime.Versioning
+{
+    [AttributeUsage(AttributeTargets.Class |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property |
+                    AttributeTargets.Field |
+                    AttributeTargets.Struct,
+                    AllowMultiple = true, Inherited = false)]
+    public sealed class SupportedOSPlatformGuardAttribute : Attribute
+    {
+        public SupportedOSPlatformGuardAttribute(string platformName) { }
+    }
+
+    [AttributeUsage(AttributeTargets.Class |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property |
+                    AttributeTargets.Field |
+                    AttributeTargets.Struct,
+                    AllowMultiple = true, Inherited = false)]
+    public sealed class UnsupportedOSPlatformGuardAttribute : Attribute
+    {
+        public UnsupportedOSPlatformGuardAttribute(string platformName) { }
+    }
+}";
+
         private readonly string TargetTypesForTest = @"
 namespace PlatformCompatDemo.SupportedUnupported
 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 {
     public partial class PlatformCompatabilityAnalyzerTests
     {
-        private const string s_msBuildPlatforms = "build_property._SupportedPlatformList=windows,browser,macOS, ios;\nbuild_property.TargetFramework=net5.0";
+        private const string s_msBuildPlatforms = "build_property._SupportedPlatformList=windows,browser,macOS, ios, linux;\nbuild_property.TargetFramework=net5.0";
 
         [Fact(Skip = "TODO need to be fixed: Test for for wrong arguments, not sure how to report the Compiler error diagnostic")]
         public async Task TestOsPlatformAttributesWithNonStringArgument()
@@ -1671,14 +1671,14 @@ namespace ns
         [UnsupportedOSPlatform(""MacOS"")]
         public static void TestWithMacOsLinuxSupported()
         {
-            Target.UnsupportedOnOSXAndLinux();
+            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'linux'.
             Target.UnsupportedOnOSX14();
         }
 
         [UnsupportedOSPlatform(""OSX"")]
         public static void TestWithOsxSupported()
         {
-            Target.UnsupportedOnOSXAndLinux();
+            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'linux'.
             Target.UnsupportedOnOSX14();
         }
 
@@ -1691,14 +1691,14 @@ namespace ns
 
         public void CrossPlatform()
         {
-            {|#1:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX'.
+            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX'.
             [|Target.UnsupportedOnOSX14()|]; // This call site is reachable on all platforms. 'Target.UnsupportedOnOSX14()' is unsupported on: 'macOS/OSX' 14.0 and later.
         }
         
         [UnsupportedOSPlatform(""macOs13.0"")]
         public void TestWithSupportedOnBrowserWarns()
         {
-            {|#2:Target.UnsupportedOnOSXAndLinux()|}; // This call site is reachable on: 'macOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX' all versions.
+            [|Target.UnsupportedOnOSXAndLinux()|]; // This call site is reachable on: 'macOS/OSX' 13.0 and before. 'Target.UnsupportedOnOSXAndLinux()' is unsupported on: 'macOS/OSX' all versions.
             Target.UnsupportedOnOSX14();
         }
     }
@@ -1711,11 +1711,7 @@ namespace ns
     }
 }";
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'macOS/OSX'", "'macOS/OSX'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsAllPlatforms).WithLocation(1).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'macOS/OSX'"),
-                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(2).WithArguments("Target.UnsupportedOnOSXAndLinux()",
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityAllVersions, "macOS/OSX"),
-                    GetFormattedString(MicrosoftNetCoreAnalyzersResources.PlatformCompatibilityVersionAndBefore, "macOS/OSX", "13.0")));
+                VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Target.UnsupportedOnOSXAndLinux()", "'macOS/OSX'", "'macOS/OSX'"));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/4428 Related to https://github.com/dotnet/runtime/issues/51541 and https://github.com/dotnet/runtime/issues/44922#issuecomment-789212369

The CA1416 Platform Compatibility analyzer already recognizes platform guards using the methods on OperatingSystem/RuntimeInformation, such as OperatingSystem.IsWindows and OperatingSystem.IsWindowsVersionAtLeast. However, the analyzer does not recognize other guard options like when a field, property, or helper methods cached the platform check result and used as platform guards. 

Expanding this support involved adding new attributes `SupportedOSPlatformGuard` and `UnsupportedOSPlatformGuard` and annotated the custom guards with those attributes with the corresponding platform and/or version. Now this annotation needs to be recognized and respected in the Platform Compatibility analyzer flow analysis

## Usage Examples
`Thread.IsThreadStartSupported` indicates whether or not the current platform supports calls to `Thread.Start()`, which is not supported on `browser`. So in this `[UnsupportedOSPlatformGuard]` attributes can be used for this field and the analyzer will recognize it as a platform guard.

```cs 
#if !TARGET_BROWSER
    [UnsupportedOSPlatformGuard("browser")] // The platform guard atribute
    internal const bool IsThreadStartSupported = true;
#endif

protected internal override void QueueTask(Task task)
{
    if (Thread.IsThreadStartSupported) // This will be evaluated same as `!OperatingSystem.IsBrowser()`
    {
        new Thread(s_longRunningThreadWork)
        {
            IsBackground = true,
            Name = ".NET Long Running Task"
        }.UnsafeStart(task);      // Call unsupported on browser APIs safely (without the attribute it would warn here)
    }
}
```

Example with helper method:

```cs
[SupportedOSPlatformGuard("windows10.0")]
public bool  IsWindows10OrAbove()
{ 
     return OperatingSystem.IsWindowsVersionAtLeast(10);
}

[SupportedOSPlatform("windows10.0")]
public bool  Windows10OnlyAPI() { }

void Sample ()
{
    if (IsWindows10OrAbove()) // work same as OperatingSystem.IsWindowsVersionAtLeast(10)
    {
        Windows10OnlyAPI();
    }
}
```
For guarding multiple platforms need to apply the attribute for each platform
```cs
class Test
{
    [SupportedOSPlatformGuard(""linux"")]
    [SupportedOSPlatformGuard(""macOS"")]
    [SupportedOSPlatformGuard(""Windows"")]
    private readonly bool _http3Enabled = OperatingSystem.IsLinux() || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();

    void M1()
    {
        if (_http3Enabled)
        {
            ApiWorkOnWindowsLinuxMac();  // Not warn
        }
        else
        {
            ApiWorkOnWindowsLinuxMac();  // Warns 
        }
    }

    [SupportedOSPlatform("windows")]
    [SupportedOSPlatform("Linux")]
    [SupportedOSPlatform("macos")]
    void ApiWorkOnWindowsLinuxMac() { }
}
```