### PR TITLE
#4775 Use case-insensitive identifier comparisons in VB

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
@@ -144,7 +144,7 @@ Class C
     Private Shared Sub SomeMethod2(s As String)
     End Sub
 
-    <{|CA2101:DllImport(""user32.dll"", CharSet:=CharSet.Unicode)|}>
+    <DllImport(""user32.dll"", CharSet:=CharSet.Unicode)>
     Private Shared Sub SomeMethod3(s As String)
     End Sub
 End Class

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
@@ -126,6 +126,10 @@ Class C
     <{|CA2101:DllImport(""user32.dll"", CharSet:=CharSet.Ansi)|}>
     Private Shared Sub SomeMethod2(s As String)
     End Sub
+
+    <{|CA2101:DllImport(""user32.dll"", CHARSET:=CharSet.Ansi)|}>
+    Private Shared Sub SomeMethod3(s As String)
+    End Sub
 End Class
 ", @"
 Imports System.Runtime.InteropServices
@@ -138,6 +142,10 @@ Class C
 
     <DllImport(""user32.dll"", CharSet:=CharSet.Unicode)>
     Private Shared Sub SomeMethod2(s As String)
+    End Sub
+
+    <{|CA2101:DllImport(""user32.dll"", CHARSET:=CharSet.Unicode)|}>
+    Private Shared Sub SomeMethod3(s As String)
     End Sub
 End Class
 ");

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/SpecifyMarshalingForPInvokeStringArgumentsTests.Fixer.cs
@@ -144,7 +144,7 @@ Class C
     Private Shared Sub SomeMethod2(s As String)
     End Sub
 
-    <{|CA2101:DllImport(""user32.dll"", CHARSET:=CharSet.Unicode)|}>
+    <{|CA2101:DllImport(""user32.dll"", CharSet:=CharSet.Unicode)|}>
     Private Shared Sub SomeMethod3(s As String)
     End Sub
 End Class

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamAsyncMemoryOverloadsTestBase.cs
@@ -485,5 +485,19 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             yield return new object[] { "cancellationToken:=CancellationToken.None, offset:=0, count:=buffer.Length, buffer:=buffer",
                                         "buffer:=buffer, cancellationToken:=CancellationToken.None" };
         }
+
+        public static IEnumerable<object[]> VisualBasicNamedArgumentsWrongCaseTestData()
+        {
+            yield return new object[] { "cOUnt:=buffer.Length, BUFFER:=buffer, offSET:=1",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length)" };
+            yield return new object[] { "OffSet:=0, cOUNT:=buffer.Length, BuFfEr:=buffer",
+                                        "buffer:=buffer" };
+            yield return new object[] { "COUNT:=buffer.Length, oFFSeT:=1, bUffEr:=buffer, CANCELlationtOKEN:=New CancellationToken()",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "CANCELLATIONTOKEN:=New CancellationToken(), OffsEt:=1, BUFFEr:=buffer, cOUnt:=buffer.Length",
+                                        "buffer:=buffer.AsMemory(start:=1, length:=buffer.Length), cancellationToken:=New CancellationToken()" };
+            yield return new object[] { "COUNT:=buffer.Length, BUFFER:=buffer, CANCELLATIONTOKEN:=CancellationToken.None, OFFSET:=0",
+                                        "buffer:=buffer, cancellationToken:=CancellationToken.None" };
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -923,6 +923,44 @@ End Class
         }
 
         [Theory]
+        [InlineData("System")]
+        [InlineData("system")]
+        [InlineData("SYSTEM")]
+        [InlineData("systEM")]
+        public Task VB_Fixer_Diagnostic_EnsureSystemNamespaceNotAddedWhenAlreadyPresent(string systemNamespace)
+        {
+            string originalCode = $@"
+Imports System.IO
+Imports System.Threading
+Imports {systemNamespace}
+
+Class C
+    Public Async Sub M()
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Dim buffer As Byte() = New Byte(s.Length - 1) {{}}
+            Await s.ReadAsync(New Byte(s.Length - 1) {{}}, 0, s.Length)
+        End Using
+    End Sub
+End Class
+";
+            string fixedCode = $@"
+Imports System.IO
+Imports System.Threading
+Imports {systemNamespace}
+
+Class C
+    Public Async Sub M()
+        Using s As FileStream = New FileStream(""path.txt"", FileMode.Create)
+            Dim buffer As Byte() = New Byte(s.Length - 1) {{}}
+            Await s.ReadAsync((New Byte(s.Length - 1) {{}}).AsMemory(0, s.Length))
+        End Using
+    End Sub
+End Class
+";
+            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(10, 19, 10, 70));
+        }
+
+        [Theory]
         [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamReadAsyncMemoryOverloadsTests.cs
@@ -929,6 +929,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
@@ -939,6 +940,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
@@ -959,6 +961,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument(string originalArgs, string fixedArgs) =>
             VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: true);
 
@@ -969,6 +972,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VB_Fixer_Diagnostic_AwaitInvocationPassedAsArgument_Internal(originalArgs, fixedArgs, isEmptyConfigureAwait: false);
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -883,6 +883,45 @@ End Class
         }
 
         [Theory]
+        [InlineData("System")]
+        [InlineData("system")]
+        [InlineData("SYSTEM")]
+        [InlineData("sYSTEm")]
+        public Task VB_Fixer_Diagnostic_EnsureSystemNamespaceNotAddedWhenAlreadyPresent(string systemNamespace)
+        {
+            string originalCode = $@"
+Imports System.IO
+Imports System.Threading
+Imports {systemNamespace}
+
+Class C
+    Public Async Sub M()
+        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
+            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
+            Await s.WriteAsync(buffer, 1, buffer.Length)
+        End Using
+    End Sub
+End Class
+";
+            string fixedCode = $@"
+Imports System.IO
+Imports System.Threading
+Imports {systemNamespace}
+
+Class C
+    Public Async Sub M()
+        Using s As FileStream = File.Open(""path.txt"", FileMode.Open)
+            Dim buffer As Byte() = {{&HBA, &H5E, &HBA, &H11, &HF0, &H07, &HBA, &H11}}
+            Await s.WriteAsync(buffer.AsMemory(1, buffer.Length))
+        End Using
+    End Sub
+End Class
+";
+
+            return VisualBasicVerifyExpectedCodeFixDiagnosticsAsync(originalCode, fixedCode, GetVisualBasicResult(10, 19, 10, 57));
+        }
+
+        [Theory]
         [MemberData(nameof(VisualBasicUnnamedArgumentsFullBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsFullBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenFullBufferTestData))]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStreamWriteAsyncMemoryOverloadsTests.cs
@@ -889,6 +889,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: true);
 
@@ -899,6 +900,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_ArgumentNaming_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "FileStream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 
@@ -916,6 +918,7 @@ End Class
         [MemberData(nameof(VisualBasicUnnamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsPartialBufferTestData))]
         [MemberData(nameof(VisualBasicNamedArgumentsWithCancellationTokenPartialBufferTestData))]
+        [MemberData(nameof(VisualBasicNamedArgumentsWrongCaseTestData))]
         public Task VB_Fixer_Diagnostic_AsStream_WithConfigureAwait(string originalArgs, string fixedArgs) =>
             VisualBasicVerifyCodeFixAsync(originalArgs, fixedArgs, streamTypeName: "Stream", isEmptyByteDeclaration: false, isEmptyConfigureAwait: false);
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/InteropServices/BasicSpecifyMarshalingForPInvokeStringArguments.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/InteropServices/BasicSpecifyMarshalingForPInvokeStringArguments.Fixer.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.InteropServices
         Protected Overrides Function FindNamedArgument(arguments As IReadOnlyList(Of SyntaxNode), argumentName As String) As SyntaxNode
             Return Aggregate arg In arguments.OfType(Of SimpleArgumentSyntax)
                    Where arg.IsNamed
-                   Into FirstOrDefault(arg.NameColonEquals.Name.Identifier.Text = argumentName)
+                   Into FirstOrDefault(String.Equals(arg.NameColonEquals.Name.Identifier.Text, argumentName, StringComparison.OrdinalIgnoreCase))
         End Function
 
         Protected Overrides Function IsDeclareStatement(node As SyntaxNode) As Boolean

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                     Dim operation = args.FirstOrDefault(
                         Function(argOperation)
                             argNode = TryCast(argOperation.Syntax, SimpleArgumentSyntax)
-                            Return argNode.NameColonEquals?.Name?.Identifier.ValueText = name
+                            Return String.Equals(argNode.NameColonEquals?.Name?.Identifier.ValueText, name, StringComparison.OrdinalIgnoreCase)
                         End Function)
                     If operation IsNot Nothing Then
                         isNamed = True
@@ -46,7 +46,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
                         Dim simpleClause = TryCast(clause, SimpleImportsClauseSyntax)
                         If simpleClause IsNot Nothing Then
                             Dim identifier = TryCast(simpleClause.Name, IdentifierNameSyntax)
-                            If identifier IsNot Nothing AndAlso identifier.Identifier.Text = "System" Then
+                            If identifier IsNot Nothing AndAlso String.Equals(identifier.Identifier.Text, "System", StringComparison.OrdinalIgnoreCase) Then
                                 Return True
                             End If
                         End If

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicPreferStreamAsyncMemoryOverloads.Fixer.vb
@@ -96,8 +96,8 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             ' whose identifier is an identifier name node, and its value is the same as the value of first argument, and the member name is `Length`
             Dim thirdArgumentIdentifierName = TryCast(thirdArgumentMemberAccessExpression.Expression, IdentifierNameSyntax)
             If thirdArgumentIdentifierName IsNot Nothing And
-                thirdArgumentIdentifierName.Identifier.Text = firstArgumentIdentifierName.Identifier.Text And
-                thirdArgumentMemberAccessExpression.Name.Identifier.Text = WellKnownMemberNames.LengthPropertyName Then
+                String.Equals(thirdArgumentIdentifierName.Identifier.Text, firstArgumentIdentifierName.Identifier.Text, StringComparison.OrdinalIgnoreCase) And
+                String.Equals(thirdArgumentMemberAccessExpression.Name.Identifier.Text, WellKnownMemberNames.LengthPropertyName, StringComparison.OrdinalIgnoreCase) Then
                 Return True
             End If
             Return False


### PR DESCRIPTION
Fix #4775