### PR TITLE
Add .NET Core taint tracking

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForCommandExecutionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForCommandExecutionVulnerabilitiesTests.cs
@@ -148,5 +148,25 @@ public partial class WebForm : System.Web.UI.Page
 }",
                 GetCSharpResultAt(14, 13, 11, 24, "string ProcessStartInfo.Arguments", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)"));
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_Process_Start_fileName_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        Process p = Process.Start(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(10, 21, 9, 24, "Process Process.Start(string fileName)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForDllInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForDllInjectionVulnerabilitiesTests.cs
@@ -130,5 +130,25 @@ public partial class WebForm : System.Web.UI.Page
 }",
                 GetCSharpResultAt(15, 9, 14, 24, "int AppDomain.ExecuteAssembly(string assemblyFile)", "void WebForm.Page_Load(object sender, EventArgs e)", "NameValueCollection HttpRequest.Form", "void WebForm.Page_Load(object sender, EventArgs e)"));
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_AppDomain_ExecuteAssembly_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        AppDomain.CurrentDomain.ExecuteAssembly(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(10, 9, 9, 24, "int AppDomain.ExecuteAssembly(string assemblyFile)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForFileCanonicalizationVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForFileCanonicalizationVulnerabilitiesTests.cs
@@ -135,5 +135,25 @@ public partial class WebForm : System.Web.UI.Page
     }
 }");
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_FileInfo_Constructor_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.IO;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        new FileInfo(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(10, 9, 9, 24, "FileInfo.FileInfo(string fileName)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForLdapInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForLdapInjectionVulnerabilitiesTests.cs
@@ -184,5 +184,25 @@ public partial class WebForm : System.Web.UI.Page
     }
 }");
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_DirectoryEntry_Path_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.DirectoryServices;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        new DirectoryEntry(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(10, 9, 9, 24, "DirectoryEntry.DirectoryEntry(string path)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForRegexInjectionVulnerabilitiesTests.cs
@@ -171,5 +171,25 @@ public partial class WebForm : System.Web.UI.Page
     }
 }");
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_Process_Start_fileName_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        new Regex(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(10, 9, 9, 24, "Regex.Regex(string pattern)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForSqlInjectionVulnerabilitiesTests.cs
@@ -3849,5 +3849,30 @@ public class MyController
                 },
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_Form_Direct_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.Data;
+using System.Data.SqlClient;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        var sqlCommand = new SqlCommand()
+        {
+            CommandText = input,
+            CommandType = CommandType.Text,
+        };
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(13, 13, 10, 24, "string SqlCommand.CommandText", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForXmlInjectionVulnerabilitiesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/ReviewCodeForXmlInjectionVulnerabilitiesTests.cs
@@ -312,5 +312,28 @@ public partial class WebForm : System.Web.UI.Page
     }
 }");
         }
+
+        [Fact]
+        public async Task AspNetCoreHttpRequest_XmlTextWriter_WriteRaw_Diagnostic()
+        {
+            await VerifyCSharpWithDependenciesAsync(@"
+using System.IO;
+using System.Text;
+using System.Xml;
+using Microsoft.AspNetCore.Mvc;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        string input = Request.Form[""in""];
+        var xtw = new XmlTextWriter(new MemoryStream(), Encoding.UTF8);
+        xtw.WriteRaw(input);
+
+        return View();
+    }
+}",
+                GetCSharpResultAt(13, 9, 11, 24, "void XmlTextWriter.WriteRaw(string data)", "IActionResult HomeController.Index()", "IFormCollection HttpRequest.Form", "IActionResult HomeController.Index()"));
+        }
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -6,6 +6,7 @@ namespace Analyzer.Utilities
     {
         public const string MicrosoftAspNetCoreAntiforgeryIAntiforgery = "Microsoft.AspNetCore.Antiforgery.IAntiforgery";
         public const string MicrosoftAspNetCoreHttpCookieOptions = "Microsoft.AspNetCore.Http.CookieOptions";
+        public const string MicrosoftAspNetCoreHttpHttpRequest = "Microsoft.AspNetCore.Http.HttpRequest";
         public const string MicrosoftAspNetCoreHttpIResponseCookies = "Microsoft.AspNetCore.Http.IResponseCookies";
         public const string MicrosoftAspNetCoreHttpInternalResponseCookies = "Microsoft.AspNetCore.Http.Internal.ResponseCookies";
         public const string MicrosoftAspNetCoreMvcController = "Microsoft.AspNetCore.Mvc.Controller";

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/WebInputSources.cs
@@ -34,6 +34,29 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
             var sourceInfosBuilder = PooledHashSet<SourceInfo>.GetInstance();
 
+            sourceInfosBuilder.AddSourceInfo(
+                WellKnownTypeNames.MicrosoftAspNetCoreHttpHttpRequest,
+                isInterface: false,
+                taintedProperties: new string[] {
+                    "Body",
+                    "ContentType",
+                    "Cookies",
+                    "Form",
+                    "Headers",
+                    "Host",
+                    "Method",
+                    "Path",
+                    "PathBase",
+                    "Protocol",
+                    "Query",
+                    "QueryString",
+                    "RouteValues",
+                    "Scheme",
+                },
+                taintedMethods: new string[] {
+                    "ReadFormAsync",
+                });
+
             sourceInfosBuilder.AddSourceInfoSpecifyingTaintedTargets(
                 WellKnownTypeNames.SystemWebHttpServerUtility,
                 isInterface: false,


### PR DESCRIPTION
Fixes #5095

Adds unit tests for CA3001, CA3003, CA3005, CA3006, CA3009, CA3011 and CA3012 security rules.
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
