### PR TITLE
Tiny Refactoring CA1824

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Resources/CSharpMarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Resources/CSharpMarkAssembliesWithNeutralResourcesLanguage.cs
@@ -15,16 +15,17 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Resources
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpMarkAssembliesWithNeutralResourcesLanguageAnalyzer : MarkAssembliesWithNeutralResourcesLanguageAnalyzer
     {
-        protected override void RegisterAttributeAnalyzer(CompilationStartAnalysisContext context, Action onResourceFound)
+        protected override void RegisterAttributeAnalyzer(CompilationStartAnalysisContext context, Action onResourceFound, INamedTypeSymbol generatedCode)
         {
-            context.RegisterSyntaxNodeAction(nc =>
+            context.RegisterSyntaxNodeAction(context =>
             {
-                if (!CheckAttribute(nc.Node))
+                var attributeSyntax = (AttributeSyntax)context.Node;
+                if (!CheckAttribute(attributeSyntax))
                 {
                     return;
                 }
 
-                if (!CheckResxGeneratedFile(nc.SemanticModel, nc.Node, ((AttributeSyntax)nc.Node).ArgumentList.Arguments[0].Expression, nc.CancellationToken))
+                if (!CheckResxGeneratedFile(context.SemanticModel, attributeSyntax, attributeSyntax.ArgumentList.Arguments[0].Expression, generatedCode, context.CancellationToken))
                 {
                     return;
                 }
@@ -33,9 +34,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Resources
             }, SyntaxKind.Attribute);
         }
 
-        private static bool CheckAttribute(SyntaxNode node)
+        private static bool CheckAttribute(AttributeSyntax attribute)
         {
-            var attribute = node as AttributeSyntax;
             return attribute?.Name?.GetLastToken().Text?.Equals(GeneratedCodeAttribute, StringComparison.Ordinal) == true &&
                 attribute.ArgumentList.Arguments.Count > 0;
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguage.cs
@@ -82,7 +82,6 @@ namespace Microsoft.NetCore.Analyzers.Resources
                         return;
                     }
 
-
                     if (data != null)
                     {
                         // we have the attribute but its doing it wrong.

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Resources/BasicMarkAssembliesWithNeutralResourcesLanguage.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Resources/BasicMarkAssembliesWithNeutralResourcesLanguage.vb
@@ -13,14 +13,15 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Resources
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicMarkAssembliesWithNeutralResourcesLanguageAnalyzer
         Inherits MarkAssembliesWithNeutralResourcesLanguageAnalyzer
-        Protected Overrides Sub RegisterAttributeAnalyzer(context As CompilationStartAnalysisContext, onResourceFound As Action)
+        Protected Overrides Sub RegisterAttributeAnalyzer(context As CompilationStartAnalysisContext, onResourceFound As Action, generatedCode As INamedTypeSymbol)
             context.RegisterSyntaxNodeAction(
                 Sub(nc)
-                    If Not CheckBasicAttribute(nc.Node) Then
+                    Dim attributeSyntax = DirectCast(nc.Node, AttributeSyntax)
+                    If Not CheckBasicAttribute(attributeSyntax) Then
                         Return
                     End If
 
-                    If Not CheckResxGeneratedFile(nc.SemanticModel, nc.Node, DirectCast(nc.Node, AttributeSyntax).ArgumentList.Arguments(0).GetExpression(), nc.CancellationToken) Then
+                    If Not CheckResxGeneratedFile(nc.SemanticModel, attributeSyntax, attributeSyntax.ArgumentList.Arguments(0).GetExpression(), generatedCode, nc.CancellationToken) Then
                         Return
                     End If
 
@@ -28,8 +29,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Resources
                 End Sub, SyntaxKind.Attribute)
         End Sub
 
-        Private Shared Function CheckBasicAttribute(node As SyntaxNode) As Boolean
-            Dim attribute = TryCast(node, AttributeSyntax)
+        Private Shared Function CheckBasicAttribute(attribute As AttributeSyntax) As Boolean
             Return (attribute?.Name?.GetLastToken().Text.Equals(GeneratedCodeAttribute, StringComparison.Ordinal) = True AndAlso
                 attribute.ArgumentList.Arguments.Count > 0).GetValueOrDefault()
         End Function


### PR DESCRIPTION
Closes #5123

**First commit**:

Main idea is to move the line:

```csharp
            INamedTypeSymbol? generatedCode = model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCodeDomCompilerGeneratedCodeAttribute);
```

from `CheckResxGeneratedFile` to `RegisterCompilationStartAction` and bail-out early if needed.

Extra cleanups:

- Avoid unneeded type checking and cast the node directly to AttributeSyntax. The cast can't fail because the registered node action is for `SyntaxKind.Attribute`.
- Rename `nc` to `context`


---

**Second commit**:

Move `TryCheckNeutralResourcesLanguageAttribute` to compilation start to avoid unnecessary callbacks when we're sure there is no diagnostics to be produced.