### PR TITLE
Fix detection of duplicate symbols with oblivious markers

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -86,8 +86,6 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private sealed class Impl
         {
-            private const char ObliviousMarker = '~';
-
             private static readonly ImmutableArray<MethodKind> s_ignorableMethodKinds
                 = ImmutableArray.Create(MethodKind.EventAdd, MethodKind.EventRemove);
 

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -32,6 +32,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         internal const string InvalidReasonMisplacedNullableEnable = "The '#nullable enable' marker can only appear as the first line in the shipped API file";
         internal const string PublicApiIsShippedPropertyBagKey = "PublicAPIIsShipped";
 
+        private const char ObliviousMarker = '~';
+
         /// <summary>
         /// Boolean option to configure if public API analyzer should bail out silently if public API files are missing.
         /// </summary>
@@ -448,7 +450,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         {
             foreach (ApiLine cur in apiList)
             {
-                if (publicApiMap.TryGetValue(cur.Text, out ApiLine existingLine))
+                string textWithoutOblivious = cur.Text.TrimStart(ObliviousMarker);
+                if (publicApiMap.TryGetValue(textWithoutOblivious, out ApiLine existingLine))
                 {
                     LinePositionSpan existingLinePositionSpan = existingLine.SourceText.Lines.GetLinePositionSpan(existingLine.Span);
                     Location existingLocation = Location.Create(existingLine.Path, existingLine.Span, existingLinePositionSpan);
@@ -459,7 +462,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 }
                 else
                 {
-                    publicApiMap.Add(cur.Text, cur);
+                    publicApiMap.Add(textWithoutOblivious, cur);
                 }
             }
         }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -763,6 +763,32 @@ C.Property.get -> int";
 
         [Fact]
         [WorkItem(4584, "https://github.com/dotnet/roslyn-analyzers/issues/4584")]
+        public async Task DuplicateObliviousSymbolsInSameApiFile()
+        {
+            var source = @"
+public class C
+{
+    public int Field;
+    public int Property { get; set; }
+}
+";
+
+            var shippedText = @"#nullable enable
+C
+C.C() -> void
+C.Field -> int
+C.Property.set -> void
+~C.Property.get -> int
+{|RS0025:~C.Property.get -> int|}
+";
+
+            var unshippedText = @"";
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
+        [Fact]
+        [WorkItem(4584, "https://github.com/dotnet/roslyn-analyzers/issues/4584")]
         public async Task DuplicateSymbolUsingObliviousInSameApiFiles()
         {
             var source = @"

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicApiAnalyzerTests.cs
@@ -779,19 +779,12 @@ C.C() -> void
 C.Field -> int
 C.Property.get -> int
 C.Property.set -> void
-~C.Property.get -> int
+{|RS0025:~C.Property.get -> int|}
 ";
 
             var unshippedText = @"";
 
-#pragma warning disable RS0030 // Do not used banned APIs
-            var expected = new DiagnosticResult(DeclarePublicApiAnalyzer.DuplicateSymbolInApiFiles)
-                           .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 7, 1)
-                           .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 5, 1)
-                           .WithArguments("~C.Property.get -> int");
-#pragma warning restore RS0030 // Do not used banned APIs
-
-            await VerifyCSharpAsync(source, shippedText, unshippedText, expected);
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
         }
 
         [Fact]
@@ -815,16 +808,9 @@ C.Property.set -> void
 ";
 
             var unshippedText = @"#nullable enable
-C.Property.get -> int";
+{|RS0025:C.Property.get -> int|}";
 
-#pragma warning disable RS0030 // Do not used banned APIs
-            var expected = new DiagnosticResult(DeclarePublicApiAnalyzer.DuplicateSymbolInApiFiles)
-#pragma warning restore RS0030 // Do not used banned APIs
-                           .WithLocation(DeclarePublicApiAnalyzer.UnshippedFileName, 2, 1)
-                           .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 5, 1)
-                           .WithArguments("C.Property.get -> int");
-
-            await VerifyCSharpAsync(source, shippedText, unshippedText, expected);
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
         }
 
         [Fact]
@@ -848,29 +834,11 @@ C.Property.set -> void
 ";
 
             var unshippedText = @"#nullable enable
-~C.Property.get -> int
-C.Property.get -> int
-~C.Property.set -> void";
+{|RS0025:~C.Property.get -> int|}
+{|RS0025:C.Property.get -> int|}
+{|RS0025:~C.Property.set -> void|}";
 
-#pragma warning disable RS0030 // Do not used banned APIs
-            var expectedResults = new[]
-            {
-                new DiagnosticResult(DeclarePublicApiAnalyzer.DuplicateSymbolInApiFiles)
-                    .WithLocation(DeclarePublicApiAnalyzer.UnshippedFileName, 2, 1)
-                    .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 5, 1)
-                    .WithArguments("~C.Property.get -> int"),
-                new DiagnosticResult(DeclarePublicApiAnalyzer.DuplicateSymbolInApiFiles)
-                    .WithLocation(DeclarePublicApiAnalyzer.UnshippedFileName, 3, 1)
-                    .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 5, 1)
-                    .WithArguments("C.Property.get -> int"),
-                new DiagnosticResult(DeclarePublicApiAnalyzer.DuplicateSymbolInApiFiles)
-                    .WithLocation(DeclarePublicApiAnalyzer.UnshippedFileName, 4, 1)
-                    .WithLocation(DeclarePublicApiAnalyzer.ShippedFileName, 6, 1)
-                    .WithArguments("~C.Property.set -> void"),
-            };
-#pragma warning restore RS0030 // Do not used banned APIs
-
-            await VerifyCSharpAsync(source, shippedText, unshippedText, expectedResults);
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
         }
 
         [Fact, WorkItem(773, "https://github.com/dotnet/roslyn-analyzers/issues/773")]


### PR DESCRIPTION
Previously, api file validation would only check for exact matches of symbols.
The addition of the oblivious marker for nullable and non-nullable annotations broke the duplication validation.
The change is to ignore the oblivious marker on duplicate comparison to prevent duplicates going unnoticed when adding the nullable reference type support.

Fixes: #4584 

<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
