### PR TITLE
Allow multiple input files for SymbolIsBannedAnalyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 .vs/
 .vscode/
+.idea/
 
 # Build results
 artifacts/

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -1,8 +1,9 @@
 # How to use Microsoft.CodeAnalysis.BannedApiAnalyzers
 
-The following file have to be added to any project referencing this package to enable analysis:
+The following file or files have to be added to any project referencing this package to enable analysis:
 
 - BannedSymbols.txt
+- BannedSymbols.\*.txt
 
 This can be done by:
 
@@ -15,7 +16,7 @@ This can be done by:
   </ItemGroup>
   ```
 
-To add a symbol to banned list, just add an entry in the format below to the BannedSymbols.txt (Description Text will be displayed as description in diagnostics, which is optional):
+To add a symbol to the banned list, just add an entry in the format below to one of the configuration files (Description Text will be displayed as description in diagnostics, which is optional):
 
 ```txt
 {Documentation Comment ID string for the symbol}[;Description Text]

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -181,6 +181,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                     from additionalFile in compilationContext.Options.AdditionalFiles
                     let fileName = Path.GetFileName(additionalFile.Path)
                     where fileName != null && fileName.StartsWith("BannedSymbols.", StringComparison.Ordinal) && fileName.EndsWith(".txt", StringComparison.Ordinal)
+                    orderby additionalFile.Path // Additional files are sorted by DocumentId (which is a GUID), make the file order deterministic
                     let sourceText = additionalFile.GetText(compilationContext.CancellationToken)
                     where sourceText != null
                     from line in sourceText.Lines

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -18,8 +18,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 {
     internal static class SymbolIsBannedAnalyzer
     {
-        public const string BannedSymbolsFileName = "BannedSymbols.txt";
-
         public static readonly DiagnosticDescriptor SymbolIsBannedRule = new(
             id: DiagnosticIds.SymbolIsBannedRuleId,
             title: new LocalizableResourceString(nameof(BannedApiAnalyzerResources.SymbolIsBannedTitle), BannedApiAnalyzerResources.ResourceManager, typeof(BannedApiAnalyzerResources)),
@@ -181,7 +179,8 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             {
                 var query =
                     from additionalFile in compilationContext.Options.AdditionalFiles
-                    where StringComparer.Ordinal.Equals(Path.GetFileName(additionalFile.Path), SymbolIsBannedAnalyzer.BannedSymbolsFileName)
+                    let fileName = Path.GetFileName(additionalFile.Path)
+                    where fileName != null && fileName.StartsWith("BannedSymbols.", StringComparison.Ordinal) && fileName.EndsWith(".txt", StringComparison.Ordinal)
                     let sourceText = additionalFile.GetText(compilationContext.CancellationToken)
                     where sourceText != null
                     from line in sourceText.Lines

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -126,6 +126,32 @@ End Class");
         }
 
         [Fact]
+        public async Task DiagnosticReportedForDuplicateBannedApiLinesInDifferentFiles()
+        {
+            var test = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { @"" },
+                    AdditionalFiles =
+                    {
+                        ("BannedSymbols.txt", @"{|#0:T:System.Console|}") ,
+                        ("BannedSymbols.Other.txt", @"{|#1:T:System.Console|}")
+                    },
+                },
+                ExpectedDiagnostics =
+                {
+                    new DiagnosticResult(SymbolIsBannedAnalyzer.DuplicateBannedSymbolRule)
+                        .WithLocation(0)
+                        .WithLocation(1)
+                        .WithArguments("System.Console")
+                }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task CSharp_BannedApiFile_MessageIncludedInDiagnostic()
         {
             var source = @"
@@ -242,10 +268,12 @@ namespace N
                         ("OtherFile.txt", @"T:N.NotBanned")
                     },
                 },
+                ExpectedDiagnostics =
+                {
+                    GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedA", ""),
+                    GetCSharpResultAt(1, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedB", "")
+                }
             };
-
-            test.ExpectedDiagnostics.Add(GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedA", ""));
-            test.ExpectedDiagnostics.Add(GetCSharpResultAt(1, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedB", ""));
 
             await test.RunAsync();
         }
@@ -1117,10 +1145,12 @@ End Namespace";
                         ("OtherFile.txt", @"T:N.NotBanned")
                     },
                 },
+                ExpectedDiagnostics =
+                {
+                    GetBasicResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedA", ""),
+                    GetBasicResultAt(1, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedB", "")
+                }
             };
-
-            test.ExpectedDiagnostics.Add(GetBasicResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedA", ""));
-            test.ExpectedDiagnostics.Add(GetBasicResultAt(1, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "BannedB", ""));
 
             await test.RunAsync();
         }


### PR DESCRIPTION
Fixes #5143.

`SymbolIsBannedAnalyzer` will now accept the following file patterns: `BannedSymbols.txt` and `BannedSymbols.*.txt`.

Note that a duplicate pattern in different files will still generate RS0031. I'm not sure if we should allow that or not, but that can go into a separate issue.
