### PR TITLE
Delete IDE dispose analyzer rules from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -80,11 +80,6 @@ dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 
-# Dispose rules (CA2000 and CA2213) ported to IDE analyzers. We already execute the CA rules on the repo, so disable the IDE ones.
-dotnet_diagnostic.IDE0067.severity = none
-dotnet_diagnostic.IDE0068.severity = none
-dotnet_diagnostic.IDE0069.severity = none
-
 ### CSharp code style settings ###
 [*.cs]
 


### PR DESCRIPTION
The IDE dispose analyzer rules have been deleted from Roslyn:

https://github.com/dotnet/roslyn/commit/eeba499ecf839ec35bca25062d69d2fc5c4885b9
