### PR TITLE
CA1416 MacCatalyst is a superset of iOS

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 using var infosBuilder = ArrayBuilder<PlatformMethodValue>.GetInstance();
-                if (TryDecodeGuardAttribute(guardAttributes, infosBuilder))
+                if (TryDecodeGuardAttributes(guardAttributes, infosBuilder))
                 {
                     for (var i = 0; i < infosBuilder.Count; i++)
                     {
@@ -95,7 +95,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return mappedAttributes != null;
             }
 
-            public bool TryDecodeGuardAttribute(SmallDictionary<string, Versions> mappedAttributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
+            public bool TryDecodeGuardAttributes(SmallDictionary<string, Versions> mappedAttributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
             {
                 foreach (var (name, versions) in mappedAttributes)
                 {
@@ -168,7 +168,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                         infosBuilder.Clear();
                         var attributes = method.GetAttributes();
-                        if (HasAnyGuardAttribute(attributes, out var mappedAttributes) && TryDecodeGuardAttribute(mappedAttributes, infosBuilder))
+                        if (HasAnyGuardAttribute(attributes, out var mappedAttributes) && TryDecodeGuardAttributes(mappedAttributes, infosBuilder))
                         {
                             for (var i = 0; i < infosBuilder.Count; i++)
                             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
+using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
@@ -16,29 +18,32 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             private readonly ImmutableArray<IMethodSymbol> _platformCheckMethods;
             private readonly INamedTypeSymbol? _osPlatformType;
+            private SmallDictionary<string, (string relatedPlatform, bool isSubset)> _relatedPlatforms;
 
             public OperationVisitor(
                 ImmutableArray<IMethodSymbol> platformCheckMethods,
                 INamedTypeSymbol? osPlatformType,
+                SmallDictionary<string, (string relatedPlatform, bool isSubset)> relatedPlatforms,
                 GlobalFlowStateAnalysisContext analysisContext)
                 : base(analysisContext, hasPredicatedGlobalState: true)
             {
                 _platformCheckMethods = platformCheckMethods;
                 _osPlatformType = osPlatformType;
+                _relatedPlatforms = relatedPlatforms;
             }
 
-            internal static bool TryParseGuardAttributes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value)
+            internal bool TryParseGuardAttributes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value)
             {
                 var attributes = symbol.GetAttributes();
 
                 if (symbol.GetMemberType()!.SpecialType != SpecialType.System_Boolean ||
-                    !HasAnyGuardAttribute(attributes))
+                    !HasAnyGuardAttribute(attributes, out var guardAttributes))
                 {
                     return false;
                 }
 
                 using var infosBuilder = ArrayBuilder<PlatformMethodValue>.GetInstance();
-                if (PlatformMethodValue.TryDecode(attributes, infosBuilder))
+                if (TryDecodeGuardAttribute(guardAttributes, infosBuilder))
                 {
                     for (var i = 0; i < infosBuilder.Count; i++)
                     {
@@ -56,8 +61,89 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return false;
             }
 
-            private static bool HasAnyGuardAttribute(ImmutableArray<AttributeData> attributes) =>
-                    attributes.Any(a => a.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute);
+            private static bool HasAnyGuardAttribute(ImmutableArray<AttributeData> attributes, [NotNullWhen(true)] out SmallDictionary<string, Versions>? mappedAttributes)
+            {
+                mappedAttributes = null;
+
+                foreach (var attribute in attributes)
+                {
+                    if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute &&
+                        TryParsePlatformNameAndVersion(attribute, out var platformName, out var version))
+                    {
+                        mappedAttributes ??= new(StringComparer.OrdinalIgnoreCase);
+                        if (!mappedAttributes.TryGetValue(platformName, out var versions))
+                        {
+                            versions = new Versions();
+                            mappedAttributes.Add(platformName, versions);
+                        }
+
+                        if (attribute.AttributeClass.Name == SupportedOSPlatformGuardAttribute)
+                        {
+                            versions.SupportedFirst = version;
+                        }
+                        else if (versions.UnsupportedFirst == null)
+                        {
+                            versions.UnsupportedFirst = version;
+                        }
+                        else
+                        {
+                            versions.UnsupportedSecond = version;
+                        }
+                    }
+                }
+
+                return mappedAttributes != null;
+            }
+
+            public bool TryDecodeGuardAttribute(SmallDictionary<string, Versions> mappedAttributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
+            {
+                foreach (var (name, versions) in mappedAttributes)
+                {
+                    AddValue(infosBuilder, name, versions);
+
+                    if (_relatedPlatforms.TryGetValue(name, out var relation) && relation.isSubset)
+                    {
+                        if (mappedAttributes.TryGetValue(relation.relatedPlatform, out var v))
+                        {
+                            if (v.UnsupportedFirst != null && versions.SupportedFirst == v.UnsupportedFirst && AllowList(versions))
+                            {
+                                var index = infosBuilder.FindIndex(v => v.PlatformName == relation.relatedPlatform);
+                                if (index > -1)
+                                {
+                                    infosBuilder.RemoveAt(index);
+                                }
+                                v.SupportedFirst = null;
+                                v.UnsupportedFirst = null;
+                            }
+                        }
+                        else
+                        {
+                            AddValue(infosBuilder, relation.relatedPlatform, versions);
+                        }
+                    }
+                }
+                return infosBuilder.Any();
+            }
+
+            private static void AddValue(ArrayBuilder<PlatformMethodValue> infosBuilder, string name, Versions versions)
+            {
+                if (versions.IsSet())
+                {
+                    if (versions.SupportedFirst != null)
+                    {
+                        infosBuilder.Add(new PlatformMethodValue(name, versions.SupportedFirst, negated: false));
+                    }
+
+                    if (versions.UnsupportedFirst != null)
+                    {
+                        infosBuilder.Add(new PlatformMethodValue(name, versions.UnsupportedFirst, negated: true));
+                        if (versions.UnsupportedSecond != null)
+                        {
+                            infosBuilder.Add(new PlatformMethodValue(name, versions.UnsupportedSecond, negated: true));
+                        }
+                    }
+                }
+            }
 
             public override GlobalFlowStateAnalysisValueSet VisitInvocation_NonLambdaOrDelegateOrLocalFunction(
                 IMethodSymbol method,
@@ -82,7 +168,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                         infosBuilder.Clear();
                         var attributes = method.GetAttributes();
-                        if (HasAnyGuardAttribute(attributes) && PlatformMethodValue.TryDecode(attributes, infosBuilder))
+                        if (HasAnyGuardAttribute(attributes, out var mappedAttributes) && TryDecodeGuardAttribute(mappedAttributes, infosBuilder))
                         {
                             for (var i = 0; i < infosBuilder.Count; i++)
                             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             private readonly ImmutableArray<IMethodSymbol> _platformCheckMethods;
             private readonly INamedTypeSymbol? _osPlatformType;
-            private SmallDictionary<string, (string relatedPlatform, bool isSubset)> _relatedPlatforms;
+            private readonly SmallDictionary<string, (string relatedPlatform, bool isSubset)> _relatedPlatforms;
 
             public OperationVisitor(
                 ImmutableArray<IMethodSymbol> platformCheckMethods,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -121,24 +121,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return infosBuilder.Any();
             }
 
-            private static bool TryExtractPlatformName(string methodName, [NotNullWhen(true)] out string? platformName)
-            {
-                if (!methodName.StartsWith(IsPrefix, StringComparison.Ordinal))
-                {
-                    platformName = null;
-                    return false;
-                }
-
-                if (methodName.EndsWith(OptionalSuffix, StringComparison.Ordinal))
-                {
-                    platformName = methodName.Substring(2, methodName.Length - 2 - OptionalSuffix.Length);
-                    return true;
-                }
-
-                platformName = methodName[2..];
-                return true;
-            }
-
             private static bool TryDecodeRuntimeInformationIsOSPlatform(
                 IOperation argumentValue,
                 INamedTypeSymbol? osPlatformType,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -107,20 +107,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return false;
             }
 
-            public static bool TryDecode(ImmutableArray<AttributeData> attributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
-            {
-                foreach (var attribute in attributes)
-                {
-                    if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute &&
-                        TryParsePlatformNameAndVersion(attribute, out var platformName, out var version))
-                    {
-                        var info = new PlatformMethodValue(platformName, version, negated: attribute.AttributeClass.Name == UnsupportedOSPlatformGuardAttribute);
-                        infosBuilder.Add(info);
-                    }
-                }
-                return infosBuilder.Any();
-            }
-
             private static bool TryDecodeRuntimeInformationIsOSPlatform(
                 IOperation argumentValue,
                 INamedTypeSymbol? osPlatformType,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4380,6 +4380,7 @@ class WindowsOnlyType
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
+#if DEBUG
         [Fact]
         public async Task IosGuardsMacCatalyst()
         {
@@ -4446,6 +4447,7 @@ class Test
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
+#endif
 
         private readonly string MockApisCsSource = @"
 namespace System.Runtime.Versioning

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4051,13 +4051,11 @@ class Test
 
     [UnsupportedOSPlatformGuard(""linux"")]
     [UnsupportedOSPlatformGuard(""ios"")]
-    [UnsupportedOSPlatformGuard(""maccatalyst"")]
     [UnsupportedOSPlatformGuard(""Windows"")]
     private bool IsLinuxWindowsIosNotSupported() => true;
 
     [UnsupportedOSPlatformGuard(""linux"")]
     [UnsupportedOSPlatformGuard(""ios"")]
-    [UnsupportedOSPlatformGuard(""maccatalyst"")]
     [UnsupportedOSPlatformGuard(""Windows"")]
     [UnsupportedOSPlatformGuard(""Android"")]
     private readonly bool _linuxWindowsIosAndroidNotSupported;
@@ -4123,7 +4121,6 @@ class Test
     private readonly bool _linuxAndWindows10MacOS14Supported;
 
     [UnsupportedOSPlatformGuard(""linux"")]
-    [UnsupportedOSPlatformGuard(""maccatalyst9.0"")]
     [UnsupportedOSPlatformGuard(""ios9.0"")]
     [UnsupportedOSPlatformGuard(""Windows8.0"")]
     private bool LinuxWindows8Ios9NotSupported { get; }
@@ -4199,9 +4196,6 @@ class Test
     [UnsupportedOSPlatformGuard(""ios"")]
     [SupportedOSPlatformGuard(""ios14.0"")]
     [UnsupportedOSPlatformGuard(""ios18.0"")]
-    [UnsupportedOSPlatformGuard(""maccatalyst"")]
-    [SupportedOSPlatformGuard(""maccatalyst14.0"")]
-    [UnsupportedOSPlatformGuard(""maccatalyst18.0"")]
     [UnsupportedOSPlatformGuard(""Windows8.0"")]
     private readonly bool _windows8IosNotSupportedSupportedIos14_18;
 
@@ -4277,7 +4271,6 @@ class Test
 
     [UnsupportedOSPlatformGuard(""linux"")]
     [UnsupportedOSPlatformGuard(""ios9.0"")]
-    [UnsupportedOSPlatformGuard(""MacCatalyst9.0"")]
     private bool LinuxIos9NotSupported { get; set;}
 
     void M1()
@@ -4448,7 +4441,7 @@ class Test
         }
 
         [Fact]
-        public async Task SupporetedIosGuardAttrbiutesInferMacCatalyst()
+        public async Task IOSSupportGuardAttributesInferMacCatalyst()
         {
             var source = @"
 using System;
@@ -4539,7 +4532,7 @@ class Test
         }
 
         [Fact]
-        public async Task UnsupporetedIosGuardAttrbiutesInferMacCatalyst()
+        public async Task IOSUnsupportGuardAttributesInferMacCatalyst()
         {
             var source = @"
 using System;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4447,7 +4447,6 @@ class Test
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
-#endif
 
         private readonly string MockApisCsSource = @"
 namespace System
@@ -4463,6 +4462,7 @@ namespace System
     }
 }
 ";
+#endif
 
         private readonly string TargetTypesForTest = @"
 namespace PlatformCompatDemo.SupportedUnupported

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4022,7 +4022,7 @@ class Test
 
     [SupportedOSPlatform(""linux"")]
     void SupportedOnLinux() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.OnlySupportedCsAllPlatforms).WithLocation(0).
@@ -4101,7 +4101,7 @@ class Test
     [UnsupportedOSPlatform(""Linux"")]
     [UnsupportedOSPlatform(""ios"")]
     void UnsupportedOnLinuxWindowsIos() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -4165,7 +4165,7 @@ class Test
 
     [SupportedOSPlatform(""windows8.0"")]
     void SupportedOnWindows8() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Test.UnsupportedOnLinuxWindows10Ios91()",
@@ -4250,7 +4250,7 @@ class Test
     [SupportedOSPlatform(""Windows"")]
     [UnsupportedOSPlatform(""Windows10.0"")]
     void SupportedOnWindowsUntil10() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms,
                 VerifyCS.Diagnostic(PlatformCompatibilityAnalyzer.UnsupportedCsReachable).WithLocation(0).WithArguments("Test.UnsupportedOnWindows8IosSupportsIos14_19()",
@@ -4323,7 +4323,7 @@ class Test
 
     [SupportedOSPlatform(""windows8.0"")]
     void SupportedOnWindows8() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -4375,7 +4375,7 @@ class WindowsOnlyType
     public static bool IsSupported { get; }
     public static void M2() { }
 }
-" + MockApisCsSource;
+";
 
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
@@ -4450,31 +4450,6 @@ class Test
 #endif
 
         private readonly string MockApisCsSource = @"
-namespace System.Runtime.Versioning
-{
-    [AttributeUsage(AttributeTargets.Class |
-                    AttributeTargets.Method |
-                    AttributeTargets.Property |
-                    AttributeTargets.Field |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
-    public sealed class SupportedOSPlatformGuardAttribute : Attribute
-    {
-        public SupportedOSPlatformGuardAttribute(string platformName) { }
-    }
-
-    [AttributeUsage(AttributeTargets.Class |
-                    AttributeTargets.Method |
-                    AttributeTargets.Property |
-                    AttributeTargets.Field |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
-    public sealed class UnsupportedOSPlatformGuardAttribute : Attribute
-    {
-        public UnsupportedOSPlatformGuardAttribute(string platformName) { }
-    }
-}
-
 namespace System
 {
     public class MockOperatingSystem

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3797,47 +3797,55 @@ class TestType
     [UnsupportedOSPlatform(""MacCatalyst"")]
     static void SupportsIOSNotMacCatalyst() { }
 
-    void M1()
+    [UnsupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""maccatalyst"")]
+    public void WorksOnMacCatalystNotIOS() { }
+
+    void CrossPlatformMethod()
     {
         [|SupportsIOSLinuxMacCatalyst()|]; // This call site is reachable on all platforms. 'TestType.SupportsIOSLinuxMacCatalyst()' is only supported on: 'ios', 'Linux', 'maccatalyst'.
         [|SupportsMacCatalyst()|];         // This call site is reachable on all platforms. 'TestType.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.
         [|SupportsIOS()|];                 // This call site is reachable on all platforms. 'TestType.SupportsIOS()' is only supported on: 'ios', 'maccatalyst'.
         [|SupportsIOSNotMacCatalyst()|];   // This call site is reachable on all platforms. 'TestType.SupportsIOSNotMacCatalyst()' is only supported on: 'ios'.
+        [|WorksOnMacCatalystNotIOS()|];    // This call site is reachable on all platforms. 'TestType.WorksOnMacCatalystNotIOS()' is only supported on: 'maccatalyst'.
         UnsupportsIos();                   // no warning because not in the MSBuild default list
         UnsupportsMacCatalyst();
     }
 
     [SupportedOSPlatform(""iOS"")]
-    void IOSMethod()
+    void MethodReachableOnIOS()
     {
         SupportsIOSLinuxMacCatalyst();
         [|SupportsMacCatalyst()|];       // This call site is reachable on: 'iOS', 'maccatalyst'. 'TestType.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.
         SupportsIOS();
         [|SupportsIOSNotMacCatalyst()|]; // This call site is reachable on: 'iOS', 'maccatalyst'. 'TestType.SupportsIOSNotMacCatalyst()' is only supported on: 'ios'.
+        [|WorksOnMacCatalystNotIOS()|];  // This call site is reachable on: 'iOS', 'maccatalyst'. 'TestType.WorksOnMacCatalystNotIOS()' is only supported on: 'maccatalyst'.
         [|UnsupportsIos()|];             // This call site is reachable on: 'iOS', 'maccatalyst'. 'TestType.UnsupportsIos()' is unsupported on: 'ios', 'maccatalyst'.
         [|UnsupportsMacCatalyst()|];     // This call site is reachable on: 'iOS', 'maccatalyst'. 'TestType.UnsupportsMacCatalyst()' is unsupported on: 'maccatalyst'.
     }
 
     [SupportedOSPlatform(""MacCatalyst"")]
-    void MacCatalystMethod()
+    void MethodReachableOnMacCatalyst()
     {
         SupportsIOSLinuxMacCatalyst();
         SupportsMacCatalyst();
         SupportsIOS();
         [|SupportsIOSNotMacCatalyst()|]; // This call site is reachable on: 'MacCatalyst'. 'TestType.SupportsIOSNotMacCatalyst()' is only supported on: 'ios'.
+        WorksOnMacCatalystNotIOS();
         [|UnsupportsIos()|];             // This call site is reachable on: 'MacCatalyst'. 'TestType.UnsupportsIos()' is unsupported on: 'maccatalyst'.
         [|UnsupportsMacCatalyst()|];     // This call site is reachable on: 'MacCatalyst'. 'TestType.UnsupportsMacCatalyst()' is unsupported on: 'maccatalyst'.
     }
 
     [SupportedOSPlatform(""ios"")]
     [UnsupportedOSPlatform(""MacCatalyst"")]
-    void IOSButNotMacCatalystMethod()
+    void MethodReachableOnIOSButNotMacCatalyst()
     {
-        SupportsIOSLinuxMacCatalyst();     
-        [|SupportsMacCatalyst()|];   // This call site is reachable on: 'ios'. 'TestType.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.    
+        SupportsIOSLinuxMacCatalyst();
+        [|SupportsMacCatalyst()|];     // This call site is reachable on: 'ios'. 'TestType.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.    
         SupportsIOS();
         SupportsIOSNotMacCatalyst();
-        [|UnsupportsIos()|];         // This call site is reachable on: 'ios'. 'TestType.UnsupportsIos()' is unsupported on: 'ios'.
+        [|WorksOnMacCatalystNotIOS()|]; // This call site is unreachable on: 'ios', 'maccatalyst'. 'TestType.WorksOnMacCatalystNotIOS()' is only supported on: 'maccatalyst'.
+        [|UnsupportsIos()|];            // This call site is reachable on: 'ios'. 'TestType.UnsupportsIos()' is unsupported on: 'ios'.
         UnsupportsMacCatalyst();    
     }
 }" + MockApisCsSource;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3975,7 +3975,7 @@ class TestType
             var test = new VerifyCS.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { }
             };
@@ -4027,7 +4027,7 @@ class TestType
             var test = new VerifyVB.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
+                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { },
             };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3766,6 +3766,7 @@ class TestType
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
 
+#if DEBUG
         [Fact]
         public async Task IosSupportedOnMacCatalyst()
         {
@@ -3961,6 +3962,7 @@ class TestType
 }" + MockApisCsSource;
             await VerifyAnalyzerAsyncCs(source, s_msBuildPlatforms);
         }
+#endif
 
         private string GetFormattedString(string resource, params string[] args) =>
             string.Format(CultureInfo.InvariantCulture, resource, args);


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/53084
## MacCatalyst is a superset of iOS

## Acceptance Criteria

To consider the proposal of using `SupportedOSPlatformGuard` attributes on the `OperatingSystem` methods to achieve a relationship of MacCatalyst as a superset of IOS, we will utilize the following acceptance criteria.

1. APIs annotated as supported on IOS are available on MacCatalyst without warning
    * This allows existing APIs annotated as supported on IOS to be automatically supported on MacCatalyst
2. Guarding those calls only requires checking a single platform
    * `OperatingSystem.IsIOS()` matches both IOS and MacCatalyst
3. APIs can still be annotated as being supported on one but not both IOS and MacCatalyst
    * `OperatingSystem.IsIOS() && !OperatingSystem.IsMacCatalyst()` matches only IOS but not MacCatalyst
    * `OperatingSystem.IsMacCatalyst()` matches only MacCatalyst but not IOS
4. New usage of `[SupportedOSPlatformGuard]` attributes is consistent with existing behavior
5. `[UnsupportedOSPlatform]` and `[UnsupportedOSPlatformGuard]` attributes must continue to work as expected
    * `[UnsupportedOSPlatform]` attributes must respect the platform relationship defined
    * This allows existing APIs annotated as unsupported on IOS to be automatically unsupported on MacCatalyst
6. The performance impact of the change must be negligible

## Proposal Summary

1. Update `OperatingSystem.IsIOS` to return `true` when the platform is "ios" *OR* "maccatalyst"
2. Update the Platform Compatibility Analyzer to respect `[SupportedOSPlatformGuard]` attributes on `System.OperatingSystem`
    * Load these into a map during analyzer initialization
    * Use fallback logic of inferring the method's platform guard from the method name if no attributes exist
3. Annotate `OperatingSystem.IsIOS` with [`SupportedOSPlatformGuard("maccatalyst")]`
4. Update the Platform Compatibility Analyzer such that when identifying an API's supported/unsupported platforms, the platform set is expanded to include all platforms indicated through `[SupportedOSPlatformGuard]` attributes on that platform's `Is{Platform}` method

### Illustration of Acceptance Criteria
```csharp
public class OperatingSystem
{
    // Guard methods that simulate the OperatingSystem members
    // [SupportedOSPlatformGuard("ios")] this annotation is not needed as the method name express that it is iOS guard 
    [SupportedOSPlatformGuard("maccatalyst")]
    public static bool IsIOS() => IsIOS() || IsMacCatalyst();

    // [SupportedOSPlatformGuard("maccatalyst")] for same reason annotation doesn't need
    public static bool IsMacCatalyst() => IsMacCatalyst();
    ...
}

public class AnnotationScenarios    // APIs for the scenarios
{
    // The [SupportedOSPlatform("maccatalyst")] attribute would not exist in the code
    // but it would be inferred by the analyzer.
    [SupportedOSPlatform("ios")]
    void SupportedOnIOSAndMacCatalyst() { }

    // Having the [SupportedOSPlatform("maccatalyst")] explicitly
    // has no effect, it is same as above annotation
    [SupportedOSPlatform("maccatalyst")]
    [SupportedOSPlatform("ios")]
    void SupportedOnIOSAndMacCatalyst() { }

    [SupportedOSPlatform("ios")]
    // The following attribute could be used
    // to cancel the inferred "maccatalyst" support
    [UnsupportedOSPlatform("maccatalyst")]
    void SupportedOnIOS_ButNotMacCatalyst() { }

    // Unlike the [SupportedOSPlatform("ios")] 
    // this will not infer iOS support, only support  maccatalyst
    [SupportedOSPlatform("maccatalyst")]
    void SupportedOnMacCatalyst() { }

    [UnsupportedOSPlatform("ios")]
    // The following attribute would not exist in the code
    // but it would be inferred by the analyzer.
    // that also [UnsupportedOSPlatform("maccatalyst")]
    void UnsupportedOnIOSAndMacCatalyst() { }

    // only unsupported on maccatalyst
    [UnsupportedOSPlatform("maccatalyst")]
    void UnsupportedOnMacCatalyst() { }

    void Main()
    {
        // This block is reachable on both IOS and MacCatalyst
        if (OperatingSystem.IsIOS())
        {
            SupportedOnIOSAndMacCatalyst();      // Scenario 1a - No warning
            SupportedOnMacCatalyst();           // Scenario 1b - Warning
            SupportedOnIOS();                   // Scenario 1c - No warning
            SupportedOnIOS_ButNotMacCatalyst(); // Scenario 1d - Warning
            UnsupportedOnIOS();                 // Scenario 1e - Warning
            UnsupportedOnMacCatalyst();         // Scenario 1f - Warning
        }

        // This block is reachable on MacCatalyst but not IOS
        if (OperatingSystem.IsMacCatalyst())
        {
            SupportedOnIOSAndMacCatalyst();      // Scenario 2a - No warning
            SupportedOnMacCatalyst();           // Scenario 2b - No warning
            SupportedOnIOS();                   // Scenario 2c - No warning
            SupportedOnIOS_ButNotMacCatalyst(); // Scenario 2d - Warning
            UnsupportedOnIOS();                 // Scenario 2e - Warning
            UnsupportedOnMacCatalyst();         // Scenario 2f - Warning
        }

        // This code block is reachable on IOS but not MacCatalyst
        if (OperatingSystem.IsIOS() && !OperatingSystem.IsMacCatalyst())
        {
            SupportedOnIOSAndMacCatalyst();      // Scenario 3a - No warning
            SupportedOnMacCatalyst();           // Scenario 3b - Warning
            SupportedOnIOS();                   // Scenario 3c - No warning
            SupportedOnIOS_ButNotMacCatalyst(); // Scenario 3d - UPDATE: NO WARNING
            UnsupportedOnIOS();                 // Scenario 3e - Warning
            UnsupportedOnMacCatalyst();         // Scenario 3f - No warning
        }
    }
}
```