### PR TITLE
Adding RichNav indexing

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,8 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <!-- Used for Rich Navigation indexing task -->
+    <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -26,7 +26,7 @@ stages:
       jobs:
       - job: Debug_Build
         pool:
-          name: NetCoreInternal-Pool
+          name: NetCorePublic-Pool
           queue: BuildPool.Windows.10.Amd64.VS2019.Pre
         variables:
           - group: DotNet-Blob-Feed

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -3,12 +3,6 @@ trigger:
   - main
   - release/*
 
-variables:
-  - name: _TeamName
-    value: Roslyn
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
-
 stages:
 - stage: build
   displayName: Build
@@ -31,4 +25,4 @@ stages:
         clean: true
       - script: eng\common\CIBuild.cmd 
                   -configuration $(_BuildConfig)
-        displayName: Build and Test
+        displayName: Build and Index

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -13,29 +13,22 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableRichCodeNavigation: true
-      richCodeNavigationEnvironment: "production"
-      richCodeNavigationLanguage: "csharp"
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
-      enableTelemetry: true
-      enableSourceBuild: true
-      jobs:
-      - job: Debug_Build
-        pool:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
-        variables:
-          - group: DotNet-Blob-Feed
-          - group: Publish-Build-Assets
-          - name: _BuildConfig
-            value: Debug
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\common\CIBuild.cmd 
-                    -configuration $(_BuildConfig)
-          displayName: Build and Test
+- template: /eng/common/templates/jobs/jobs.yml
+  parameters:
+    enableRichCodeNavigation: true
+    richCodeNavigationEnvironment: "production"
+    richCodeNavigationLanguage: "csharp"
+    jobs:
+    - job: Debug_Build
+      pool:
+        name: NetCorePublic-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+      variables:
+        - name: _BuildConfig
+          value: Debug
+      steps:
+      - checkout: self
+        clean: true
+      - script: eng\common\CIBuild.cmd 
+                  -configuration $(_BuildConfig)
+        displayName: Build and Test

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -1,0 +1,41 @@
+# Branches that trigger a build on commit
+trigger:
+  - main
+  - release/*
+
+variables:
+  - name: _TeamName
+    value: Roslyn
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+
+stages:
+- stage: build
+  displayName: Build
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableRichCodeNavigation: true
+      richCodeNavigationEnvironment: "production"
+      richCodeNavigationLanguage: "csharp"
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enableTelemetry: true
+      enableSourceBuild: true
+      jobs:
+      - job: Debug_Build
+        pool:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+        variables:
+          - group: DotNet-Blob-Feed
+          - group: Publish-Build-Assets
+          - name: _BuildConfig
+            value: Debug
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng\common\CIBuild.cmd 
+                    -configuration $(_BuildConfig)
+          displayName: Build and Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,19 +18,12 @@ jobs:
     enableRichCodeNavigation: true
     richCodeNavigationEnvironment: "production"
     richCodeNavigationLanguage: "csharp"
-    enableMicrobuild: true
-    enablePublishBuildArtifacts: true
-    enablePublishTestResults: true
-    enableTelemetry: true
-    enableSourceBuild: true
     jobs:
     - job: Debug_Build
       pool:
         name: NetCoreInternal-Pool
         queue: BuildPool.Windows.10.Amd64.VS2019.Pre
       variables:
-        - group: DotNet-Blob-Feed
-        - group: Publish-Build-Assets
         - name: _BuildConfig
           value: Debug
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
     - job: Debug_Build
       pool:
         name: NetCorePublic-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
       variables:
         - name: _BuildConfig
           value: Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,32 +13,32 @@ pr:
 - 2.9.x
 
 jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableRichCodeNavigation: true
-      richCodeNavigationEnvironment: "production"
-      richCodeNavigationLanguage: "csharp"
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishTestResults: true
-      enableTelemetry: true
-      enableSourceBuild: true
-      jobs:
-      - job: Debug_Build
-        pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
-        variables:
-          - group: DotNet-Blob-Feed
-          - group: Publish-Build-Assets
-          - name: _BuildConfig
-            value: Debug
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng\common\CIBuild.cmd 
-                    -configuration $(_BuildConfig)
-          displayName: Build and Test
+- template: /eng/common/templates/jobs/jobs.yml
+  parameters:
+    enableRichCodeNavigation: true
+    richCodeNavigationEnvironment: "production"
+    richCodeNavigationLanguage: "csharp"
+    enableMicrobuild: true
+    enablePublishBuildArtifacts: true
+    enablePublishTestResults: true
+    enableTelemetry: true
+    enableSourceBuild: true
+    jobs:
+    - job: Debug_Build
+      pool:
+        name: NetCoreInternal-Pool
+        queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+      variables:
+        - group: DotNet-Blob-Feed
+        - group: Publish-Build-Assets
+        - name: _BuildConfig
+          value: Debug
+      steps:
+      - checkout: self
+        clean: true
+      - script: eng\common\CIBuild.cmd 
+                  -configuration $(_BuildConfig)
+        displayName: Build and Test
           
 - job: Windows
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
     jobs:
     - job: Debug_Build
       pool:
-        name: NetCoreInternal-Pool
+        name: NetCorePublic-Pool
         queue: BuildPool.Windows.10.Amd64.VS2019.Pre
       variables:
         - name: _BuildConfig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,33 @@ pr:
 - 2.9.x
 
 jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableRichCodeNavigation: true
+      richCodeNavigationEnvironment: "production"
+      richCodeNavigationLanguage: "csharp"
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishTestResults: true
+      enableTelemetry: true
+      enableSourceBuild: true
+      jobs:
+      - job: Debug_Build
+        pool:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+        variables:
+          - group: DotNet-Blob-Feed
+          - group: Publish-Build-Assets
+          - name: _BuildConfig
+            value: Debug
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng\common\CIBuild.cmd 
+                    -configuration $(_BuildConfig)
+          displayName: Build and Test
+          
 - job: Windows
   strategy:
     maxParallel: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,27 +12,7 @@ pr:
 - features/*
 - 2.9.x
 
-jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableRichCodeNavigation: true
-    richCodeNavigationEnvironment: "production"
-    richCodeNavigationLanguage: "csharp"
-    jobs:
-    - job: Debug_Build
-      pool:
-        name: NetCorePublic-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-      variables:
-        - name: _BuildConfig
-          value: Debug
-      steps:
-      - checkout: self
-        clean: true
-      - script: eng\common\CIBuild.cmd 
-                  -configuration $(_BuildConfig)
-        displayName: Build and Test
-          
+jobs:        
 - job: Windows
   strategy:
     maxParallel: 4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
 - features/*
 - 2.9.x
 
-jobs:        
+jobs:
 - job: Windows
   strategy:
     maxParallel: 4


### PR DESCRIPTION
This PR adds a new build pipeline yml which runs RichNav indexing. A new pipeline from this yml will need to be created manually on Azure DevOps.

This was validated by copying the step to the PR build yml and having it run there:
[RichNav run in PR build pipeline](https://dev.azure.com/dnceng/public/_build/results?buildId=1253791&view=logs&j=fc533387-d81d-5071-290a-b060f31dec76&t=1b420e69-e7e9-5794-165e-c8f61678a3fb)