### PR TITLE
Bug fix: Only tag types implementing empty Preview interfacees

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -112,7 +112,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             foreach (INamedTypeSymbol anInterface in interfaces)
             {
                 var interfaceMembers = anInterface.GetMembers();
-                if (interfaceMembers.Length == 0)
+                if (interfaceMembers.Length == 0 && ProcessPreviewAttribute(anInterface, requiresPreviewFeaturesSymbols))
                 {
                     // Only tag empty interfaces to prevent breaking changes in the future
                     requiresPreviewFeaturesSymbolsToUsageType.GetOrAdd(symbol, PreviewFeatureUsageType.EmptyInterface);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
@@ -584,6 +584,33 @@ namespace Preview_Feature_Scratch
         }
 
         [Fact]
+        public async Task TestNonPreviewEmptyInterface()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{" +
+@"
+
+    class Program : IProgram
+    {
+        static void Main(string[] args)
+        {
+            new Program();
+        }
+    }
+
+    public interface IProgram
+    {
+    }
+}
+
+    ";
+
+            await TestCS(csInput);
+        }
+
+        [Fact]
         public async Task TestInterfaceMethodInvocation()
         {
             var csInput = @" 


### PR DESCRIPTION
Just a small change. Currently the DetectPreviewFeatures analyzer tags all types implementing empty interfaces with a diagnostic. This is a bug. We should only tag types implementing empty Preview interfaces. 