### PR TITLE
Update test dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -30,7 +30,7 @@
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.7.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
-    <MicrosoftCodeAnalysisVersionForTests>3.9.0-3.final</MicrosoftCodeAnalysisVersionForTests>
+    <MicrosoftCodeAnalysisVersionForTests>4.0.0-2.final</MicrosoftCodeAnalysisVersionForTests>
     <DogfoodAnalyzersVersion>3.3.2</DogfoodAnalyzersVersion>
     <DogfoodNetAnalyzersVersion>5.0.4-preview1.21126.5</DogfoodNetAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(DogfoodAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexerTests.cs
@@ -847,7 +847,7 @@ public class TestClass
             {
                 TestCode = source,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersion.CSharp9,
                 FixedCode = corrected,
             };
 
@@ -861,7 +861,7 @@ public class TestClass
             {
                 TestCode = source,
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-                LanguageVersion = LanguageVersion.Preview,
+                LanguageVersion = LanguageVersion.CSharp9,
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
@@ -29,6 +29,23 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             }.RunAsync();
         }
 
+        private static async Task TestCSPreview(string csInput)
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
+                TestState =
+                {
+                    Sources =
+                    {
+                        csInput
+                    }
+                },
+                MarkupOptions = MarkupOptions.UseFirstDescriptor,
+                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+            }.RunAsync();
+        }
+
         [Fact]
         public async Task TestPreviewMethodUnaryOperator()
         {
@@ -457,7 +474,7 @@ namespace Preview_Feature_Scratch
 
         }
 
-        [Fact(Skip = "The following test cannot be activated yet because it requires preview roslyn bits")]
+        [Fact(Skip = "Not yet working")]
         public async Task TestPreviewLanguageFeatures()
         {
             var csInput = @" 
@@ -472,6 +489,9 @@ namespace Preview_Feature_Scratch
                 {
                     new Program();
                 }
+
+                public static bool StaticMethod() => throw null;
+                public static bool AProperty => throw null;
             }
 
             public interface IProgram
@@ -483,7 +503,7 @@ namespace Preview_Feature_Scratch
 
             ";
 
-            await TestCS(csInput);
+            await TestCSPreview(csInput);
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
@@ -9,62 +10,24 @@ using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
-    public partial class DetectPreviewFeatureUnitTests
+    public class DetectPreviewFeatureUnitTests
     {
         private static async Task TestCS(string csInput)
         {
             await new VerifyCS.Test
             {
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
                 TestState =
                 {
                     Sources =
                     {
-                        csInput, requiresPreviewFeaturesAttribute
+                        csInput
                     }
                 },
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
+                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
             }.RunAsync();
         }
-
-        private static async Task TestCSNet50(string csInput)
-        {
-            await new VerifyCS.Test
-            {
-                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
-                TestState =
-                {
-                    Sources =
-                    {
-                        csInput, requiresPreviewFeaturesAttribute
-                    }
-                },
-                MarkupOptions = MarkupOptions.UseFirstDescriptor,
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net50,
-            }.RunAsync();
-        }
-
-        private const string requiresPreviewFeaturesAttribute = $@"
-namespace System.Runtime.Versioning
-{{
-    [AttributeUsage(AttributeTargets.Assembly |
-                AttributeTargets.Module |
-                AttributeTargets.Class |
-                AttributeTargets.Interface |
-                AttributeTargets.Delegate |
-                AttributeTargets.Struct |
-                AttributeTargets.Enum |
-                AttributeTargets.Constructor |
-                AttributeTargets.Method |
-                AttributeTargets.Property |
-                AttributeTargets.Field |
-                AttributeTargets.Event, Inherited = false)]
-    public sealed class RequiresPreviewFeaturesAttribute : Attribute
-    {{
-        public RequiresPreviewFeaturesAttribute() {{ }}
-    }}
-}}
-";
 
         [Fact]
         public async Task TestPreviewMethodUnaryOperator()
@@ -552,7 +515,7 @@ namespace Preview_Feature_Scratch
 
     ";
 
-            await TestCSNet50(csInput);
+            await TestCS(csInput);
         }
 
         [Fact]
@@ -637,7 +600,7 @@ namespace Preview_Feature_Scratch
 
     ";
 
-            await TestCSNet50(csInput);
+            await TestCS(csInput);
         }
 
         [Fact]

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
@@ -80,6 +82,19 @@ namespace Test.Utilities
         public static MetadataReference SystemWebExtensions { get; } = MetadataReference.CreateFromFile(typeof(System.Web.Script.Serialization.JavaScriptSerializer).Assembly.Location);
         public static MetadataReference SystemServiceModel { get; } = MetadataReference.CreateFromFile(typeof(System.ServiceModel.OperationContractAttribute).Assembly.Location);
 #endif
+
+        private static readonly Lazy<ReferenceAssemblies> _lazyNet60 =
+            new(() =>
+            {
+                return new ReferenceAssemblies(
+                    "net6.0",
+                    new PackageIdentity(
+                        "Microsoft.NETCore.App.Ref",
+                        "6.0.0-preview.6.21352.12"),
+                    Path.Combine("ref", "net6.0"));
+            });
+
+        public static ReferenceAssemblies Net60 => _lazyNet60.Value;
 
         private static ReferenceAssemblies CreateDefaultReferenceAssemblies()
         {


### PR DESCRIPTION
* Update MicrosoftCodeAnalysisVersionForTests to 4.0.0-2.final
* Add Net60 reference assemblies
* Use Net60 reference assemblies in `DetectPreviewFeatureUnitTests`