### PR TITLE
Fix a bunch of RS1024 on Equals

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpRegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpRegisterActionAnalyzer.cs
@@ -77,10 +77,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers
             }
 
             protected override bool IsSyntaxKind(ITypeSymbol type)
-            {
-                return (_csharpSyntaxKind != null && SymbolEqualityComparer.Default.Equals(type, _csharpSyntaxKind)) ||
-                    (_basicSyntaxKind != null && SymbolEqualityComparer.Default.Equals(type, _basicSyntaxKind));
-            }
+                => SymbolEqualityComparer.Default.Equals(type, _csharpSyntaxKind)
+                    || SymbolEqualityComparer.Default.Equals(type, _basicSyntaxKind);
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpRegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpRegisterActionAnalyzer.cs
@@ -78,8 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers
 
             protected override bool IsSyntaxKind(ITypeSymbol type)
             {
-                return (_csharpSyntaxKind != null && type.Equals(_csharpSyntaxKind)) ||
-                    (_basicSyntaxKind != null && type.Equals(_basicSyntaxKind));
+                return (_csharpSyntaxKind != null && SymbolEqualityComparer.Default.Equals(type, _csharpSyntaxKind)) ||
+                    (_basicSyntaxKind != null && SymbolEqualityComparer.Default.Equals(type, _basicSyntaxKind));
             }
         }
     }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     {
                         AnalyzeFixerWithFixAll(fixer, context);
                     }
-                    else if (fixer.BaseType != null && fixer.BaseType.Equals(_codeFixProviderSymbol))
+                    else if (fixer.BaseType != null && SymbolEqualityComparer.Default.Equals(fixer.BaseType, _codeFixProviderSymbol))
                     {
                         Diagnostic diagnostic = fixer.CreateDiagnostic(OverrideGetFixAllProviderRule, fixer.Name);
                         context.ReportDiagnostic(diagnostic);
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                 {
                     foreach (INamedTypeSymbol type in fixer.GetBaseTypesAndThis())
                     {
-                        if (!type.Equals(_codeFixProviderSymbol))
+                        if (!SymbolEqualityComparer.Default.Equals(type, _codeFixProviderSymbol))
                         {
                             IMethodSymbol getFixAllProviderMethod = type.GetMembers(GetFixAllProviderMethodName).OfType<IMethodSymbol>().FirstOrDefault();
                             if (getFixAllProviderMethod != null && getFixAllProviderMethod.IsOverride)
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
 
                     foreach (var argument in invocation.Arguments)
                     {
-                        if (argument.Parameter.Equals(param))
+                        if (SymbolEqualityComparer.Default.Equals(argument.Parameter, param))
                         {
                             return argument.Value.ConstantValue.HasValue && argument.Value.ConstantValue.Value == null;
                         }
@@ -323,13 +323,13 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     // Local functions
                     bool IsCodeActionWithOverriddenEquivalenceKey(INamedTypeSymbol namedType)
                     {
-                        if (namedType == null || namedType.Equals(_codeActionSymbol))
+                        if (namedType == null || SymbolEqualityComparer.Default.Equals(namedType, _codeActionSymbol))
                         {
                             return false;
                         }
 
                         // We are already tracking CodeActions with equivalence key in this compilation.
-                        if (namedType.ContainingAssembly.Equals(_sourceAssembly))
+                        if (SymbolEqualityComparer.Default.Equals(namedType.ContainingAssembly, _sourceAssembly))
                         {
                             return _codeActionsWithEquivalenceKey != null && _codeActionsWithEquivalenceKey.Contains(namedType);
                         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     {
                         AnalyzeFixerWithFixAll(fixer, context);
                     }
-                    else if (fixer.BaseType != null && SymbolEqualityComparer.Default.Equals(fixer.BaseType, _codeFixProviderSymbol))
+                    else if (SymbolEqualityComparer.Default.Equals(fixer.BaseType, _codeFixProviderSymbol))
                     {
                         Diagnostic diagnostic = fixer.CreateDiagnostic(OverrideGetFixAllProviderRule, fixer.Name);
                         context.ReportDiagnostic(diagnostic);
@@ -323,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                     // Local functions
                     bool IsCodeActionWithOverriddenEquivalenceKey(INamedTypeSymbol namedType)
                     {
-                        if (namedType == null || SymbolEqualityComparer.Default.Equals(namedType, _codeActionSymbol))
+                        if (SymbolEqualityComparer.Default.Equals(namedType, _codeActionSymbol))
                         {
                             return false;
                         }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
@@ -260,24 +260,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
         }
 
         private static bool IsSymbolType(ITypeSymbol typeSymbol, INamedTypeSymbol symbolType)
-        {
-            if (typeSymbol == null)
-            {
-                return false;
-            }
-
-            if (SymbolEqualityComparer.Default.Equals(typeSymbol, symbolType))
-            {
-                return true;
-            }
-
-            if (typeSymbol.AllInterfaces.Contains(symbolType))
-            {
-                return true;
-            }
-
-            return false;
-        }
+            => typeSymbol != null
+                && (SymbolEqualityComparer.Default.Equals(typeSymbol, symbolType)
+                    || typeSymbol.AllInterfaces.Contains(symbolType));
 
         private static bool IsSymbolClassType(IOperation operation)
         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
                 if (symbolEqualityComparerType != null)
                 {
-                    var collectionTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>();
+                    var collectionTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
                     collectionTypesBuilder.AddIfNotNull(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsGenericDictionary2));
                     collectionTypesBuilder.AddIfNotNull(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsGenericHashSet1));
                     collectionTypesBuilder.AddIfNotNull(compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsConcurrentConcurrentDictionary2));
@@ -266,7 +266,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 return false;
             }
 
-            if (typeSymbol.Equals(symbolType))
+            if (SymbolEqualityComparer.Default.Equals(typeSymbol, symbolType))
             {
                 return true;
             }
@@ -352,7 +352,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             {
                 if (!builder.ContainsKey(methodName))
                 {
-                    builder.Add(methodName, ImmutableHashSet.CreateBuilder<INamedTypeSymbol>());
+                    builder.Add(methodName, ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default));
                 }
 
                 builder[methodName].Add(typeSymbol);

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ConfigureGeneratedCodeAnalysisAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ConfigureGeneratedCodeAnalysisAnalyzer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 IParameterSymbol? analysisContextParameter = null;
                 foreach (var parameter in method.Parameters)
                 {
-                    if (!Equals(parameter.Type, analysisContext))
+                    if (!SymbolEqualityComparer.Default.Equals(parameter.Type, analysisContext))
                     {
                         continue;
                     }
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 }
 
                 var parameterReference = (IParameterReferenceOperation)invocation.Instance;
-                if (!Equals(parameterReference.Parameter, _analysisContextParameter))
+                if (!SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, _analysisContextParameter))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerAPIUsageAnalyzer.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                         do
                         {
                             var typeToProcess = typesToProcess.Dequeue();
-                            Debug.Assert(typeToProcess.ContainingAssembly.Equals(declaredType.ContainingAssembly));
+                            Debug.Assert(SymbolEqualityComparer.Default.Equals(typeToProcess.ContainingAssembly, declaredType.ContainingAssembly));
                             Debug.Assert(namedTypesToAccessedTypesMap.ContainsKey(typeToProcess));
 
                             foreach (INamedTypeSymbol usedType in namedTypesToAccessedTypesMap[typeToProcess])

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerCorrectnessAnalyzer.DiagnosticAnalyzerSymbolAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerCorrectnessAnalyzer.DiagnosticAnalyzerSymbolAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
             protected bool IsDiagnosticAnalyzer(INamedTypeSymbol type)
             {
-                return type.Equals(DiagnosticAnalyzer);
+                return SymbolEqualityComparer.Default.Equals(type, DiagnosticAnalyzer);
             }
 
             internal void AnalyzeSymbol(SymbolAnalysisContext symbolContext)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerFieldsAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticAnalyzerFieldsAnalyzer.cs
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     {
                         foreach (ITypeSymbol innerType in type.GetBaseTypesAndThis())
                         {
-                            if (innerType.Equals(_compilationType))
+                            if (SymbolEqualityComparer.Default.Equals(innerType, _compilationType))
                             {
                                 ReportDiagnostic(type, typeNode, symbolContext);
                                 return;
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
                         foreach (INamedTypeSymbol iface in type.AllInterfaces)
                         {
-                            if (iface.Equals(_symbolType) || iface.Equals(_operationType))
+                            if (SymbolEqualityComparer.Default.Equals(iface, _symbolType) || SymbolEqualityComparer.Default.Equals(iface, _operationType))
                             {
                                 ReportDiagnostic(type, typeNode, symbolContext);
                                 return;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DiagnosticDescriptorCreationAnalyzer.cs
@@ -405,12 +405,12 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             return creationMethod != null;
 
             bool IsDescriptorConstructor(IMethodSymbol method)
-                => method.ContainingType.Equals(diagnosticDescriptorType);
+                => SymbolEqualityComparer.Default.Equals(method.ContainingType, diagnosticDescriptorType);
 
             // Heuristic to identify helper methods to create DiagnosticDescriptor:
             //  "A method invocation that returns 'DiagnosticDescriptor' and has a first string parameter named 'id'"
             bool IsCreateHelper(IMethodSymbol method)
-                => method.ReturnType.Equals(diagnosticDescriptorType) &&
+                => SymbolEqualityComparer.Default.Equals(method.ReturnType, diagnosticDescriptorType) &&
                     !method.Parameters.IsEmpty &&
                     method.Parameters[0].Name == DiagnosticIdParameterName &&
                     method.Parameters[0].Type.SpecialType == SpecialType.System_String;
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             bool TryGetConstructorCreation([NotNullWhen(true)] out string? nameOfLocalizableResource, [NotNullWhen(true)] out string? resourceFileName)
             {
                 if (operation.WalkDownConversion() is IObjectCreationOperation objectCreation &&
-                    objectCreation.Constructor.ContainingType.Equals(localizableResourceStringType) &&
+                    SymbolEqualityComparer.Default.Equals(objectCreation.Constructor.ContainingType, localizableResourceStringType) &&
                     objectCreation.Arguments.Length >= 3 &&
                     objectCreation.Arguments.GetArgumentForParameterAtIndex(0) is { } firstParamArgument &&
                     firstParamArgument.Parameter.Type.SpecialType == SpecialType.System_String &&
@@ -680,7 +680,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 analyzeStringValueCore(argumentValue, argument, argumentValueLocation, operationAnalysisContext.ReportDiagnostic);
             }
             else if (localizableStringsMap != null &&
-                argument.Parameter.Type.Equals(localizableStringType))
+                SymbolEqualityComparer.Default.Equals(argument.Parameter.Type, localizableStringType))
             {
                 RoslynDebug.Assert(resourceDataValueMap != null);
 
@@ -966,7 +966,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
                     case DefaultSeverityParameterName:
                         if (argument.Value is IFieldReferenceOperation fieldReference &&
-                            fieldReference.Field.ContainingType.Equals(diagnosticSeverityType) &&
+                            SymbolEqualityComparer.Default.Equals(fieldReference.Field.ContainingType, diagnosticSeverityType) &&
                             Enum.TryParse(fieldReference.Field.Name, out DiagnosticSeverity parsedSeverity))
                         {
                             defaultSeverity = parsedSeverity;
@@ -977,7 +977,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     case RuleLevelParameterName:
                         if (ruleLevelType != null &&
                             argument.Value is IFieldReferenceOperation fieldReference2 &&
-                            fieldReference2.Field.ContainingType.Equals(ruleLevelType) &&
+                            SymbolEqualityComparer.Default.Equals(fieldReference2.Field.ContainingType, ruleLevelType) &&
                             Enum.TryParse(fieldReference2.Field.Name, out RuleLevel parsedRuleLevel))
                         {
                             switch (parsedRuleLevel)

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseCompilationGetSemanticModelAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseCompilationGetSemanticModelAnalyzer.cs
@@ -55,9 +55,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
                             if (invocation.TargetMethod.Name.Equals("GetSemanticModel", StringComparison.Ordinal) &&
                                 (
-                                    invocation.TargetMethod.ContainingType.Equals(compilationType) ||
-                                    invocation.TargetMethod.ContainingType.Equals(csharpCompilation) ||
-                                    invocation.TargetMethod.ContainingType.Equals(visualBasicCompilation)
+                                    SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, compilationType) ||
+                                    SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, csharpCompilation) ||
+                                    SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, visualBasicCompilation)
                                 ))
                             {
                                 operationContext.ReportDiagnostic(invocation.Syntax.CreateDiagnostic(Rule));

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/EnableConcurrentExecutionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/EnableConcurrentExecutionAnalyzer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 IParameterSymbol? analysisContextParameter = null;
                 foreach (var parameter in method.Parameters)
                 {
-                    if (!Equals(parameter.Type, analysisContext))
+                    if (!SymbolEqualityComparer.Default.Equals(parameter.Type, analysisContext))
                     {
                         continue;
                     }
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 }
 
                 var parameterReference = (IParameterReferenceOperation)invocation.Instance;
-                if (!Equals(parameterReference.Parameter, _analysisContextParameter))
+                if (!SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, _analysisContextParameter))
                 {
                     return;
                 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/RegisterActionAnalyzer.cs
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                 {
                     foreach (INamedTypeSymbol contextType in allowedContextTypes)
                     {
-                        if (namedType.Equals(contextType))
+                        if (SymbolEqualityComparer.Default.Equals(namedType, contextType))
                         {
                             return true;
                         }
@@ -354,9 +354,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                                         symbol = semanticModel.GetSymbolInfo(argument, context.CancellationToken).Symbol;
                                         if (symbol != null &&
 #pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/4519
-                                                symbol.Kind == SymbolKind.Field &&
+                                            symbol.Kind == SymbolKind.Field &&
 #pragma warning restore CA1508 // Avoid dead conditional code
-                                                _symbolKind.Equals(symbol.ContainingType) &&
+                                            SymbolEqualityComparer.Default.Equals(_symbolKind, symbol.ContainingType) &&
                                             !s_supportedSymbolKinds.Contains(symbol.Name))
                                         {
                                             Diagnostic diagnostic = argument.CreateDiagnostic(UnsupportedSymbolKindArgumentRule, symbol.Name);
@@ -448,7 +448,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
 
             private void NoteRegisterActionInvocation(IMethodSymbol method, TInvocationExpressionSyntax invocation, SemanticModel model, CancellationToken cancellationToken)
             {
-                if (method.ContainingType.Equals(_analysisContext))
+                if (SymbolEqualityComparer.Default.Equals(method.ContainingType, _analysisContext))
                 {
                     // Not a nested action.
                     return;
@@ -531,8 +531,8 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             private void ReportDiagnostic(CodeBlockAnalysisContext codeBlockContext, IParameterSymbol contextParameter, bool hasEndAction)
             {
                 Debug.Assert(IsContextType(contextParameter.Type, _codeBlockStartAnalysisContext, _compilationStartAnalysisContext, _operationBlockStartAnalysisContext));
-                bool isCompilationStartAction = contextParameter.Type.OriginalDefinition.Equals(_compilationStartAnalysisContext.OriginalDefinition);
-                bool isOperationBlockStartAction = !isCompilationStartAction && contextParameter.Type.OriginalDefinition.Equals(_operationBlockStartAnalysisContext.OriginalDefinition);
+                bool isCompilationStartAction = SymbolEqualityComparer.Default.Equals(contextParameter.Type.OriginalDefinition, _compilationStartAnalysisContext.OriginalDefinition);
+                bool isOperationBlockStartAction = !isCompilationStartAction && SymbolEqualityComparer.Default.Equals(contextParameter.Type.OriginalDefinition, _operationBlockStartAnalysisContext.OriginalDefinition);
 
                 Location location = contextParameter.DeclaringSyntaxReferences.First()
                         .GetSyntax(codeBlockContext.CancellationToken).GetLocation();

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CancellationTokenParametersMustComeLast.cs
@@ -97,13 +97,13 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     // Skip optional parameters, UNLESS one of them is a CancellationToken
                     // AND it's not the last one.
                     if (last >= 0 && methodSymbol.Parameters[last].IsOptional
-                        && !methodSymbol.Parameters[last].Type.Equals(cancellationTokenType))
+                        && !SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[last].Type, cancellationTokenType))
                     {
                         last--;
 
                         while (last >= 0 && methodSymbol.Parameters[last].IsOptional)
                         {
-                            if (methodSymbol.Parameters[last].Type.Equals(cancellationTokenType))
+                            if (SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[last].Type, cancellationTokenType))
                             {
                                 symbolContext.ReportDiagnostic(methodSymbol.CreateDiagnostic(Rule, methodSymbol.ToDisplayString()));
                             }
@@ -113,7 +113,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     }
 
                     // Ignore multiple cancellation token parameters at the end of the parameter list.
-                    while (last >= 0 && methodSymbol.Parameters[last].Type.Equals(cancellationTokenType))
+                    while (last >= 0 && SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[last].Type, cancellationTokenType))
                     {
                         last--;
                     }
@@ -127,7 +127,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     // Ignore IProgress<T> when last
                     if (last >= 0
                         && iprogressType != null
-                        && methodSymbol.Parameters[last].Type.OriginalDefinition.Equals(iprogressType))
+                        && SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[last].Type.OriginalDefinition, iprogressType))
                     {
                         last--;
                     }
@@ -135,7 +135,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     for (int i = last - 1; i >= 0; i--)
                     {
                         ITypeSymbol parameterType = methodSymbol.Parameters[i].Type;
-                        if (!parameterType.Equals(cancellationTokenType))
+                        if (!SymbolEqualityComparer.Default.Equals(parameterType, cancellationTokenType))
                         {
                             continue;
                         }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -118,9 +118,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             // exclude readonly collections
-            if (property.Type.OriginalDefinition.Equals(knownTypes.ReadonlyCollection) ||
-                property.Type.OriginalDefinition.Equals(knownTypes.ReadonlyDictionary) ||
-                property.Type.OriginalDefinition.Equals(knownTypes.ReadonlyObservableCollection))
+            if (SymbolEqualityComparer.Default.Equals(property.Type.OriginalDefinition, knownTypes.ReadonlyCollection) ||
+                SymbolEqualityComparer.Default.Equals(property.Type.OriginalDefinition, knownTypes.ReadonlyDictionary) ||
+                SymbolEqualityComparer.Default.Equals(property.Type.OriginalDefinition, knownTypes.ReadonlyObservableCollection))
             {
                 return;
             }
@@ -136,7 +136,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static bool Inherits(ITypeSymbol symbol, ITypeSymbol baseType)
         {
-            Debug.Assert(baseType.Equals(baseType.OriginalDefinition));
+            Debug.Assert(SymbolEqualityComparer.Default.Equals(baseType, baseType.OriginalDefinition));
             return symbol?.OriginalDefinition.Inherits(baseType) ?? false;
         }
 

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -128,6 +128,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)SymbolDisplayStringCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SymbolByDisplayStringComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FxCopWellKnownDiagnosticTags.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SymbolEqualityComparer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UnusedValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WellKnownTypeNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WellKnownTypeProvider.cs" />

--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -18,7 +18,7 @@ using Microsoft.CodeAnalysis.Operations;
 
 namespace Analyzer.Utilities.Extensions
 {
-    internal static partial class IMethodSymbolExtensions
+    internal static class IMethodSymbolExtensions
     {
         /// <summary>
         /// Checks if the given method overrides <see cref="object.Equals(object)"/>.
@@ -214,8 +214,7 @@ namespace Analyzer.Utilities.Extensions
 
             // Identify the implementor of IAsyncDisposable.Dispose in the given method's containing type and check
             // if it is the given method.
-            return method.ReturnType != null &&
-                SymbolEqualityComparer.Default.Equals(method.ReturnType, valueTaskType) &&
+            return SymbolEqualityComparer.Default.Equals(method.ReturnType, valueTaskType) &&
                 method.Parameters.IsEmpty &&
                 method.IsImplementationOfInterfaceMethod(null, iAsyncDisposable, "DisposeAsync");
         }

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -379,14 +379,14 @@ namespace Analyzer.Utilities.Extensions
 
             // this doesn't account for type conversion but FxCop implementation seems doesn't either
             // so this should match FxCop implementation.
-            return type2.Equals(type1);
+            return SymbolEqualityComparer.Default.Equals(type2, type1);
         }
 
         /// <summary>
         /// Check whether return type, parameters count and parameter types are same for the given methods.
         /// </summary>
         public static bool ReturnTypeAndParametersAreSame(this IMethodSymbol method, IMethodSymbol otherMethod)
-            => method.ReturnType.Equals(otherMethod.ReturnType) &&
+            => SymbolEqualityComparer.Default.Equals(method.ReturnType, otherMethod.ReturnType) &&
                method.ParametersAreSame(otherMethod);
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsFromMscorlib(this ISymbol symbol, Compilation compilation)
         {
             var @object = compilation.GetSpecialType(SpecialType.System_Object);
-            return symbol.ContainingAssembly?.Equals(@object.ContainingAssembly) == true;
+            return SymbolEqualityComparer.Default.Equals(symbol.ContainingAssembly, @object.ContainingAssembly);
         }
 
         /// <summary>
@@ -408,7 +408,7 @@ namespace Analyzer.Utilities.Extensions
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // does not account for method with optional parameters
-                if (method.Equals(overload) || overload.Parameters.Length != method.Parameters.Length)
+                if (SymbolEqualityComparer.Default.Equals(method, overload) || overload.Parameters.Length != method.Parameters.Length)
                 {
                     // either itself, or signature is not same
                     continue;
@@ -420,7 +420,7 @@ namespace Analyzer.Utilities.Extensions
                     continue;
                 }
 
-                if (overload.Parameters[parameterIndex].Type.Equals(type))
+                if (SymbolEqualityComparer.Default.Equals(overload.Parameters[parameterIndex].Type, type))
                 {
                     // we no longer interested in this overload. there can be only 1 match
                     return overload;
@@ -494,7 +494,7 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsImplementationOfInterfaceMember(this ISymbol symbol, [NotNullWhen(returnValue: true)] ISymbol? interfaceMember)
         {
             return interfaceMember != null &&
-                   symbol.Equals(symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember));
+                SymbolEqualityComparer.Default.Equals(symbol, symbol.ContainingType.FindImplementationForInterfaceMember(interfaceMember));
         }
 
         /// <summary>
@@ -645,7 +645,7 @@ namespace Analyzer.Utilities.Extensions
 
             while (symbol != null)
             {
-                if (symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute)))
+                if (symbol.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attribute)))
                 {
                     return true;
                 }
@@ -684,7 +684,7 @@ namespace Analyzer.Utilities.Extensions
 
             while (symbol != null)
             {
-                if (symbol.GetAttributes().Any(attr => attr.AttributeClass.Equals(attribute)))
+                if (symbol.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attribute)))
                 {
                     return true;
                 }
@@ -714,7 +714,7 @@ namespace Analyzer.Utilities.Extensions
             {
                 for (int i = 0; i < attributes.Length; i++)
                 {
-                    if (attributeData.AttributeClass.Equals(attributes[i]))
+                    if (SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, attributes[i]))
                     {
                         isAttributePresent[i] = true;
                     }
@@ -738,7 +738,7 @@ namespace Analyzer.Utilities.Extensions
                 return Enumerable.Empty<AttributeData>();
             }
 
-            return symbol.GetAttributes().Where(attr => attr.AttributeClass.Equals(attributeType));
+            return symbol.GetAttributes().Where(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
         }
 
         /// <summary>

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -97,7 +97,7 @@ namespace Analyzer.Utilities.Extensions
             if (!baseTypesOnly && candidateBaseType.TypeKind == TypeKind.Interface)
             {
                 var allInterfaces = symbol.AllInterfaces.OfType<ITypeSymbol>();
-                if (candidateBaseType.OriginalDefinition.Equals(candidateBaseType))
+                if (SymbolEqualityComparer.Default.Equals(candidateBaseType.OriginalDefinition, candidateBaseType))
                 {
                     // Candidate base type is not a constructed generic type, so use original definition for interfaces.
                     allInterfaces = allInterfaces.Select(i => i.OriginalDefinition);
@@ -123,7 +123,7 @@ namespace Analyzer.Utilities.Extensions
 
             while (symbol != null)
             {
-                if (symbol.Equals(candidateBaseType))
+                if (SymbolEqualityComparer.Default.Equals(symbol, candidateBaseType))
                 {
                     return true;
                 }
@@ -160,7 +160,7 @@ namespace Analyzer.Utilities.Extensions
 
             static bool IsInterfaceOrImplementsInterface(ITypeSymbol type, INamedTypeSymbol? interfaceType)
                 => interfaceType != null &&
-                   (Equals(type, interfaceType) || type.AllInterfaces.Contains(interfaceType));
+                   (SymbolEqualityComparer.Default.Equals(type, interfaceType) || type.AllInterfaces.Contains(interfaceType));
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Analyzer.Utilities.Extensions
                 {
                     foreach (var attributeClassData in currentAttributeClass.GetAttributes())
                     {
-                        if (!Equals(attributeClassData.AttributeClass, attributeUsageAttribute))
+                        if (!SymbolEqualityComparer.Default.Equals(attributeClassData.AttributeClass, attributeUsageAttribute))
                         {
                             continue;
                         }
@@ -369,9 +369,9 @@ namespace Analyzer.Utilities.Extensions
                 RoslynDebug.Assert(iReadOnlyCollectionOfT != null);
 
                 return type.OriginalDefinition is INamedTypeSymbol originalDefinition &&
-                    (iCollection.Equals(originalDefinition) ||
-                     iCollectionOfT.Equals(originalDefinition) ||
-                     iReadOnlyCollectionOfT.Equals(originalDefinition));
+                    (SymbolEqualityComparer.Default.Equals(iCollection, originalDefinition) ||
+                     SymbolEqualityComparer.Default.Equals(iCollectionOfT, originalDefinition) ||
+                     SymbolEqualityComparer.Default.Equals(iReadOnlyCollectionOfT, originalDefinition));
             }
         }
     }

--- a/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
+++ b/src/Utilities/Compiler/Extensions/OperationBlockAnalysisContextExtension.cs
@@ -53,10 +53,16 @@ namespace Analyzer.Utilities.Extensions
                     descendants[0] is IThrowOperation throwOperation &&
                     throwOperation.GetThrownExceptionType() is ITypeSymbol createdExceptionType)
                 {
-                    if (Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException), createdExceptionType.OriginalDefinition) ||
-                        Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotSupportedException), createdExceptionType.OriginalDefinition) ||
+                    if (SymbolEqualityComparer.Default.Equals(
+                            context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException),
+                            createdExceptionType.OriginalDefinition) ||
+                        SymbolEqualityComparer.Default.Equals(
+                            context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotSupportedException),
+                            createdExceptionType.OriginalDefinition) ||
                         (checkPlatformNotSupported &&
-                        Equals(context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemPlatformNotSupportedException), createdExceptionType.OriginalDefinition)))
+                        SymbolEqualityComparer.Default.Equals(
+                            context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemPlatformNotSupportedException),
+                            createdExceptionType.OriginalDefinition)))
                     {
                         return true;
                     }

--- a/src/Utilities/Compiler/SymbolEqualityComparer.cs
+++ b/src/Utilities/Compiler/SymbolEqualityComparer.cs
@@ -1,21 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#if !CODEANALYSIS_V3_OR_BETTER
 namespace Microsoft.CodeAnalysis
 {
-#if !CODEANALYSIS_V3_OR_BETTER
-    internal class SymbolEqualityComparer
+    using System.Collections.Generic;
+
+    internal sealed class SymbolEqualityComparer : IEqualityComparer<ISymbol?>
     {
         private SymbolEqualityComparer()
         {
 
         }
 
-#pragma warning disable CA1822 // Mark members as static
-        public bool Equals(ISymbol? symbol1, ISymbol? symbol2) =>
-#pragma warning restore CA1822 // Mark members as static
-            object.Equals(symbol1, symbol2);
+        public bool Equals(ISymbol? x, ISymbol? y)
+            => x is null
+                ? y is null
+                : x.Equals(y);
+
+        public int GetHashCode(ISymbol? obj)
+            => obj?.GetHashCode() ?? 0;
 
         public static SymbolEqualityComparer Default { get; } = new();
     }
-#endif
 }
+#endif

--- a/src/Utilities/Compiler/SymbolEqualityComparer.cs
+++ b/src/Utilities/Compiler/SymbolEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 #if !CODEANALYSIS_V3_OR_BETTER
 namespace Microsoft.CodeAnalysis

--- a/src/Utilities/Compiler/SymbolEqualityComparer.cs
+++ b/src/Utilities/Compiler/SymbolEqualityComparer.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+#if !CODEANALYSIS_V3_OR_BETTER
+    internal class SymbolEqualityComparer
+    {
+        private SymbolEqualityComparer()
+        {
+
+        }
+
+#pragma warning disable CA1822 // Mark members as static
+        public bool Equals(ISymbol? symbol1, ISymbol? symbol2) =>
+#pragma warning restore CA1822 // Mark members as static
+            object.Equals(symbol1, symbol2);
+
+        public static SymbolEqualityComparer Default { get; } = new();
+    }
+#endif
+}

--- a/src/Utilities/Compiler/SymbolEqualityComparer.cs
+++ b/src/Utilities/Compiler/SymbolEqualityComparer.cs
@@ -9,7 +9,6 @@ namespace Microsoft.CodeAnalysis
     {
         private SymbolEqualityComparer()
         {
-
         }
 
         public bool Equals(ISymbol? x, ISymbol? y)

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -30,9 +30,7 @@ namespace Analyzer.Utilities
                 () =>
                 {
                     return ImmutableHashSet.Create<IAssemblySymbol>(
-#if CODEANALYSIS_V3_OR_BETTER
                         SymbolEqualityComparer.Default,
-#endif
                         Compilation.Assembly.Modules
                             .SelectMany(m => m.ReferencedAssemblySymbols)
                             .ToArray());
@@ -203,11 +201,8 @@ namespace Analyzer.Utilities
         {
             return typeSymbol != null
                 && typeSymbol.OriginalDefinition != null
-                &&
-#if CODEANALYSIS_V3_OR_BETTER
-                    SymbolEqualityComparer.Default.
-#endif
-                    Equals(typeSymbol.OriginalDefinition, GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1))
+                && SymbolEqualityComparer.Default.Equals(typeSymbol.OriginalDefinition,
+                    GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1))
                 && typeSymbol is INamedTypeSymbol namedTypeSymbol
                 && namedTypeSymbol.TypeArguments.Length == 1
                 && typeArgumentPredicate(namedTypeSymbol.TypeArguments[0]);

--- a/src/Utilities/Compiler/WellKnownTypeProvider.cs
+++ b/src/Utilities/Compiler/WellKnownTypeProvider.cs
@@ -30,6 +30,9 @@ namespace Analyzer.Utilities
                 () =>
                 {
                     return ImmutableHashSet.Create<IAssemblySymbol>(
+#if CODEANALYSIS_V3_OR_BETTER
+                        SymbolEqualityComparer.Default,
+#endif
                         Compilation.Assembly.Modules
                             .SelectMany(m => m.ReferencedAssemblySymbols)
                             .ToArray());
@@ -200,7 +203,11 @@ namespace Analyzer.Utilities
         {
             return typeSymbol != null
                 && typeSymbol.OriginalDefinition != null
-                && typeSymbol.OriginalDefinition.Equals(GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1))
+                &&
+#if CODEANALYSIS_V3_OR_BETTER
+                    SymbolEqualityComparer.Default.
+#endif
+                    Equals(typeSymbol.OriginalDefinition, GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1))
                 && typeSymbol is INamedTypeSymbol namedTypeSymbol
                 && namedTypeSymbol.TypeArguments.Length == 1
                 && typeArgumentPredicate(namedTypeSymbol.TypeArguments[0]);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.CopyDataFlowOperationVisitor.cs
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                 if (throwBranchWithExceptionType.IsDefaultExceptionForExceptionsPathAnalysis)
                 {
                     // Only tracking non-child analysis entities for exceptions path analysis for now.
-                    Debug.Assert(throwBranchWithExceptionType.ExceptionType.Equals(ExceptionNamedType));
+                    Debug.Assert(SymbolEqualityComparer.Default.Equals(throwBranchWithExceptionType.ExceptionType, ExceptionNamedType));
                     predicate = e => !e.IsChildOrInstanceMember;
                 }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractLocationDataFlowOperationVisitor.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected override void EscapeValueForParameterOnExit(IParameterSymbol parameter, AnalysisEntity analysisEntity)
         {
-            Debug.Assert(Equals(analysisEntity.Symbol, parameter));
+            Debug.Assert(SymbolEqualityComparer.Default.Equals(analysisEntity.Symbol, parameter));
             var escapedLocationsForParameter = GetEscapedLocations(analysisEntity);
             if (!escapedLocationsForParameter.IsEmpty)
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityDataFlowOperationVisitor.cs
@@ -290,7 +290,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected override void SetValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity, ArgumentInfo<TAbstractAnalysisValue>? assignedValue)
         {
-            Debug.Assert(Equals(analysisEntity.Symbol, parameter));
+            Debug.Assert(SymbolEqualityComparer.Default.Equals(analysisEntity.Symbol, parameter));
             if (assignedValue != null)
             {
                 SetAbstractValueForAssignment(analysisEntity, assignedValue.Operation, assignedValue.Value);
@@ -801,13 +801,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 {
                     // Root tuple entity, compare the underlying tuple types.
                     return childEntity.Parent == null &&
-                        tupleElementEntity.Type.OriginalDefinition.Equals(childEntity.Type.OriginalDefinition);
+                        SymbolEqualityComparer.Default.Equals(tupleElementEntity.Type.OriginalDefinition, childEntity.Type.OriginalDefinition);
                 }
 
                 // Must be a tuple element field entity.
                 return tupleElementEntity.Symbol is IFieldSymbol tupleElementField &&
                     childEntity.Symbol is IFieldSymbol childEntityField &&
-                    tupleElementField.OriginalDefinition.Equals(childEntityField.OriginalDefinition) &&
+                    SymbolEqualityComparer.Default.Equals(tupleElementField.OriginalDefinition, childEntityField.OriginalDefinition) &&
                     IsMatchingAssignedEntity(tupleElementEntity.Parent, childEntity.Parent);
             }
         }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityMapAbstractDomain.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         }
                         else
                         {
-                            if (key1.Symbol == null || !Equals(key1.Symbol, key2.Symbol))
+                            if (key1.Symbol == null || !SymbolEqualityComparer.Default.Equals(key1.Symbol, key2.Symbol))
                             {
                                 // PERF: Do not add a new key-value pair to the resultMap for unrelated entities or non-symbol based entities.
                                 continue;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -827,8 +827,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             // If so, we return the abstract value for the task wrapping the underlying return value.
             if (OwningSymbol is IMethodSymbol method &&
                 method.IsAsync &&
-                method.ReturnType.OriginalDefinition.Equals(GenericTaskNamedType) &&
-                !method.ReturnType.Equals(returnValueOperation.Type))
+                SymbolEqualityComparer.Default.Equals(method.ReturnType.OriginalDefinition, GenericTaskNamedType) &&
+                !SymbolEqualityComparer.Default.Equals(method.ReturnType, returnValueOperation.Type))
             {
                 var location = AbstractLocation.CreateAllocationLocation(returnValueOperation, method.ReturnType, DataFlowAnalysisContext.InterproceduralAnalysisData?.CallStack);
                 implicitTaskPointsToValue = PointsToAbstractValue.Create(location, mayBeNull: false);
@@ -1737,7 +1737,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 foreach (var interfaceType in methodSymbol.ContainingType.AllInterfaces)
                 {
-                    if (interfaceType.OriginalDefinition.Equals(GenericIEquatableNamedType))
+                    if (SymbolEqualityComparer.Default.Equals(interfaceType.OriginalDefinition, GenericIEquatableNamedType))
                     {
                         var equalsMember = interfaceType.GetMembers("Equals").OfType<IMethodSymbol>().FirstOrDefault();
                         if (equalsMember != null && methodSymbol.IsOverrideOrImplementationOfInterfaceMember(equalsMember))
@@ -3137,7 +3137,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     HandleEnterLockOperation(arguments[0].Value);
                 }
                 else if (InterlockedNamedType != null &&
-                    targetMethod.ContainingType.OriginalDefinition.Equals(InterlockedNamedType))
+                    SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType.OriginalDefinition, InterlockedNamedType))
                 {
                     ProcessInterlockedOperation(targetMethod, arguments, InterlockedNamedType);
                 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ThrownExceptionInfo.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/ThrownExceptionInfo.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 BasicBlockOrdinal == other.BasicBlockOrdinal &&
                 HandlingCatchRegion == other.HandlingCatchRegion &&
                 ContainingFinallyRegion == other.ContainingFinallyRegion &&
-                Equals(ExceptionType, other.ExceptionType) &&
+                SymbolEqualityComparer.Default.Equals(ExceptionType, other.ExceptionType) &&
                 InterproceduralCallStack.SequenceEqual(other.InterproceduralCallStack) &&
                 IsDefaultExceptionForExceptionsPathAnalysis == other.IsDefaultExceptionForExceptionsPathAnalysis;
         }


### PR DESCRIPTION
Not sure why but I have started to get hundreds of warning related to `RS1024` in the codebase so I decided to start tackling them.

In this PR, I am focusing on the `Equals` because for some reason most of the complains on collections don't get fixed after applying the comparer.