### PR TITLE
Remove un-needed interface declaration

### DIFF
--- a/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
+++ b/src/Utilities/Compiler/PooledObjects/ArrayBuilder.cs
@@ -12,7 +12,7 @@ namespace Analyzer.Utilities.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
     [DebuggerTypeProxy(typeof(ArrayBuilder<>.DebuggerProxy))]
-    internal sealed partial class ArrayBuilder<T> : IReadOnlyCollection<T>, IReadOnlyList<T>, IDisposable
+    internal sealed partial class ArrayBuilder<T> : IReadOnlyList<T>, IDisposable
     {
         #region DebuggerProxy
 #pragma warning disable CA1812 // ArrayBuilder<T>.DebuggerProxy is an internal class that is apparently never instantiated - used in DebuggerTypeProxy attribute above.


### PR DESCRIPTION
`IReadonlyCollection` is inherited by `IReadonlyLsit` so there is no need for the extra declaration.