### PR TITLE
Move ExportCodeFixProvider attribute onto the concrete type

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseStringContainsCharOverloadWithSingleCharactersFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseStringContainsCharOverloadWithSingleCharactersFixer.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Composition;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.NetCore.Analyzers.Performance;
 
 namespace Microsoft.NetCore.CSharp.Analyzers.Performance
 {
 
+    [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpUseStringContainsCharOverloadWithSingleCharactersFixer : UseStringContainsCharOverloadWithSingleCharactersCodeFix
     {
         protected override bool TryGetArgumentName(SyntaxNode violatingNode, out string argumentName)

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseStringContainsCharOverloadWithSingleCharacters.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseStringContainsCharOverloadWithSingleCharacters.Fixer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -11,7 +10,6 @@ using Microsoft.CodeAnalysis.Editing;
 
 namespace Microsoft.NetCore.Analyzers.Performance
 {
-    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic), Shared]
     public abstract class UseStringContainsCharOverloadWithSingleCharactersCodeFix : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUseStringContainsCharOverloadWithSingleCharactersFixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicUseStringContainsCharOverloadWithSingleCharactersFixer.vb
@@ -1,11 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Composition
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.NetCore.Analyzers.Performance
 
 Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
+    <ExportCodeFixProvider(LanguageNames.VisualBasic), [Shared]>
     Public NotInheritable Class BasicUseStringContainsCharOverloadWithSingleCharactersFixer
         Inherits UseStringContainsCharOverloadWithSingleCharactersCodeFix
 


### PR DESCRIPTION
Doesn't make sense to propagate an abstract type for registration as a code fix provider

Resolves #5335

