### PR TITLE
Replace bitwise operator to boolean

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 {
                     if (!attributeInstance.ConstructorArguments.IsEmpty &&
                         attributeInstance.ConstructorArguments[0].Kind == TypedConstantKind.Primitive &&
-                        attributeInstance.ConstructorArguments[0].Value != null &
+                        attributeInstance.ConstructorArguments[0].Value != null &&
                         attributeInstance.ConstructorArguments[0].Value.Equals(true))
                     {
                         // Has the attribute, with the value 'true'.

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/MarkAssembliesWithComVisible.cs
@@ -67,8 +67,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 {
                     if (!attributeInstance.ConstructorArguments.IsEmpty &&
                         attributeInstance.ConstructorArguments[0].Kind == TypedConstantKind.Primitive &&
-                        attributeInstance.ConstructorArguments[0].Value != null &&
-                        attributeInstance.ConstructorArguments[0].Value.Equals(true))
+                        Equals(attributeInstance.ConstructorArguments[0].Value, true))
                     {
                         // Has the attribute, with the value 'true'.
                         context.ReportNoLocationDiagnostic(RuleChangeComVisible, context.Compilation.Assembly.Name);


### PR DESCRIPTION
With the bitwise operator, it's possible to get `NullReferenceException`, because the right-hand operand will execute.
With the boolean operator if the `attributeInstance.ConstructorArguments[0].Value != null` will false the next operand will  not run.