### PR TITLE
[BannedApiAnalyzers] Add typeof() argument's analyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -175,7 +175,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 OperationKind.Decrement,
                 OperationKind.TypeOf);
 
-
             compilationContext.RegisterSyntaxNodeAction(
                 context => VerifyDocumentationSyntax(context.ReportDiagnostic, GetReferenceSyntaxNodeFromXmlCref(context.Node), context),
                 XmlCrefSyntaxKind);

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -155,6 +155,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                                 VerifyType(context.ReportDiagnostic, incrementOrDecrement.OperatorMethod.ContainingType, context.Operation.Syntax);
                             }
                             break;
+                        case ITypeOfOperation typeOfOperation:
+                            VerifyType(context.ReportDiagnostic, typeOfOperation.TypeOperand, context.Operation.Syntax);
+                            break;
                     }
                 },
                 OperationKind.ObjectCreation,
@@ -169,7 +172,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 OperationKind.UnaryOperator,
                 OperationKind.BinaryOperator,
                 OperationKind.Increment,
-                OperationKind.Decrement);
+                OperationKind.Decrement,
+                OperationKind.TypeOf);
+
 
             compilationContext.RegisterSyntaxNodeAction(
                 context => VerifyDocumentationSyntax(context.ReportDiagnostic, GetReferenceSyntaxNodeFromXmlCref(context.Node), context),

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -752,13 +752,46 @@ namespace N
         }
     }
 }";
-
             var bannedText = @"M:N.C.Banned";
 
             await VerifyCSharpAnalyzerAsync(
                 source,
                 bannedText,
                 GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "C.Banned()", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_NoDiagnosticClass_TypeOfArgument()
+        {
+            var source = @"
+class Banned {  }
+class C
+{
+    void M()
+    {
+        var type = {|#0:typeof(C)|};
+    }
+}
+";
+            var bannedText = @"T:Banned";
+            await VerifyCSharpAnalyzerAsync(source, bannedText);
+        }
+
+        [Fact]
+        public async Task CSharp_BannedClass_TypeOfArgument()
+        {
+            var source = @"
+class Banned {  }
+class C
+{
+    void M()
+    {
+        var type = {|#0:typeof(Banned)|};
+    }
+}
+";
+            var bannedText = @"T:Banned";
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "Banned", ""));
         }
 
         [Fact, WorkItem(3295, "https://github.com/dotnet/roslyn-analyzers/issues/3295")]


### PR DESCRIPTION
I added a feature to warn Analyzer when a BannedText's target is specified in the argument of typeof().

# sample code
```cs
class Banned {  }
class C
{
    void M()
    {
        var type = typeof(Banned);
    }
}
```

## Current implementation for sample code

It does not give any warning at all.
I think the BannedApiAnalyzer should create a Diagnostic for this case.

## Implementations I've added

If a BannedText target is specified in the argument of typeof(), the BannedApiAnalyzer will create and report a Diagnostic.