### PR TITLE
Detect missing .ConfigureAwait in 'await foreach'

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
     public sealed class DoNotDirectlyAwaitATaskAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2007";
-
+        private const string ConfigureAwait = "ConfigureAwait";
         public static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
             RuleId,
             CreateLocalizableResourceString(nameof(DoNotDirectlyAwaitATaskTitle)),
@@ -53,6 +53,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 }
 
                 var configuredAsyncDisposable = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesConfiguredAsyncDisposable);
+                var configuredCancelableAsyncEnumerable = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesConfiguredCancelableAsyncEnumerable);
 
                 context.RegisterOperationBlockStartAction(context =>
                 {
@@ -77,6 +78,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                             context.RegisterOperationAction(context => AnalyzeUsingOperation(context, configuredAsyncDisposable), OperationKind.Using);
                             context.RegisterOperationAction(context => AnalyzeUsingDeclarationOperation(context, configuredAsyncDisposable), OperationKindEx.UsingDeclaration);
                         }
+                        if (configuredCancelableAsyncEnumerable is not null)
+                        {
+                            context.RegisterOperationAction(context => AnalyzeForEachOperation(context, configuredCancelableAsyncEnumerable), OperationKind.Loop);
+                        }
                     }
                 });
             });
@@ -92,6 +97,70 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 context.ReportDiagnostic(awaitExpression.Operation.Syntax.CreateDiagnostic(Rule));
             }
+        }
+
+        private static void AnalyzeForEachOperation(OperationAnalysisContext context,
+            INamedTypeSymbol configuredCancelableAsyncEnumerable)
+        {
+            if (context.Operation is not IForEachLoopOperation operation)
+                return;
+
+            if (!operation.IsAsynchronous())
+            {
+                return;
+            }
+
+            // Get the type of the expression being iterated over.
+            IOperation collectionOperation = operation.Collection;
+            ITypeSymbol? typeOfCollection = collectionOperation.Type;
+            if (typeOfCollection.OriginalDefinition == configuredCancelableAsyncEnumerable)
+            {
+                // Operation should be conversion to IAsyncEnumerable
+                if (collectionOperation is IConversionOperation conversionOperation)
+                {
+                    if (conversionOperation.Operand is ILocalReferenceOperation localReferenceOperation)
+                    {
+                        // Can we find the initializer of this local?
+                        var location = localReferenceOperation.Local.Locations.First();
+                        SyntaxNode? node = location.SourceTree?.GetRoot(context.CancellationToken)
+                                                               .FindNode(location.SourceSpan);
+                        if (node is not null)
+                        {
+                            // Checking VariableDeclaratorSyntax.Initializer is CSharp specific
+                            // Do we need to move rule to CSharp.NetAnalyzers?
+                            if (node.ToString().Contains(ConfigureAwait))
+                            {
+                                return;
+                            }
+                        }
+                    }
+                    else if (conversionOperation.Operand is IInvocationOperation)
+                    {
+                        // Cannot use pattern matching as we want a nullable declaration.
+#pragma warning disable IDE0020 // Use pattern matching
+                        IInvocationOperation? invocationOperation = (IInvocationOperation)conversionOperation.Operand;
+#pragma warning restore IDE0020 // Use pattern matching
+
+                        // Differentiate between
+                        // .WithCancellation(...).ConfigureAwait(...)
+                        // and .ConfigureAwait(...).WithCancellation(...)
+                        // Fall back to just string comparison as it could be either
+                        // the ConfiguredCancelableAsyncEnumerable member method or
+                        // the TaskAsyncEnumerableExtensions extension method.
+                        if (invocationOperation.TargetMethod.Name == "WithCancellation")
+                        {
+                            invocationOperation = invocationOperation.Instance as IInvocationOperation;
+                        }
+
+                        if (invocationOperation?.TargetMethod.Name == ConfigureAwait)
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+
+            context.ReportDiagnostic(collectionOperation.Syntax.CreateDiagnostic(Rule));
         }
 
         private static void AnalyzeUsingOperation(OperationAnalysisContext context, INamedTypeSymbol configuredAsyncDisposable)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATask.cs
@@ -113,7 +113,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             // Get the type of the expression being iterated over.
             IOperation collectionOperation = operation.Collection;
             ITypeSymbol? typeOfCollection = collectionOperation.Type;
-            if (typeOfCollection.OriginalDefinition == configuredCancelableAsyncEnumerable)
+            if (Equals(typeOfCollection.OriginalDefinition, configuredCancelableAsyncEnumerable))
             {
                 // Operation should be conversion to IAsyncEnumerable
                 if (collectionOperation is IConversionOperation conversionOperation)

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotDirectlyAwaitATaskTests.cs
@@ -741,5 +741,202 @@ public class C
 
             await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
         }
+
+        [Fact, WorkItem(3703, "https://github.com/dotnet/roslyn-analyzers/issues/3703")]
+        public async Task CSharpAwaitForEach()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items)
+    {
+        int sum = 0;
+        await foreach (var item in [|items|])
+            sum += item;
+        return sum;
+    }
+}
+";
+            var fixedCode = @"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items)
+    {
+        int sum = 0;
+        await foreach (var item in items.ConfigureAwait(false))
+            sum += item;
+        return sum;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                    ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "5.0.0"))),
+                LanguageVersion = CSharpLanguageVersion.CSharp8,
+                TestCode = code,
+                FixedCode = fixedCode,
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3703, "https://github.com/dotnet/roslyn-analyzers/issues/3703")]
+        public async Task CSharpAwaitForEachUsingLocal()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items)
+    {
+        var local = items.ConfigureAwait(false);
+        int sum = 0;
+        await foreach (var item in local)
+            sum += item;
+        return sum;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                    ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "5.0.0"))),
+                LanguageVersion = CSharpLanguageVersion.CSharp8,
+                TestCode = code,
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3703, "https://github.com/dotnet/roslyn-analyzers/issues/3703")]
+        public async Task CSharpAwaitForEachUsingLocalWithCancellation()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items, CancellationToken cancellationToken)
+    {
+        var local = items.WithCancellation(cancellationToken);
+        int sum = 0;
+        await foreach (var item in [|local|])
+            sum += item;
+        return sum;
+    }
+}
+";
+            var fixedCode = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items, CancellationToken cancellationToken)
+    {
+        var local = items.WithCancellation(cancellationToken);
+        int sum = 0;
+        await foreach (var item in local.ConfigureAwait(false))
+            sum += item;
+        return sum;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                    ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "5.0.0"))),
+                LanguageVersion = CSharpLanguageVersion.CSharp8,
+                TestCode = code,
+                FixedCode = fixedCode,
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3703, "https://github.com/dotnet/roslyn-analyzers/issues/3703")]
+        public async Task CSharpAwaitForEachWithCancellation()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items, CancellationToken cancellationToken)
+    {
+        int sum = 0;
+        await foreach (var item in [|items.WithCancellation(cancellationToken)|])
+            sum += item;
+        return sum;
+    }
+}
+";
+            var fixedCode = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items, CancellationToken cancellationToken)
+    {
+        int sum = 0;
+        await foreach (var item in items.WithCancellation(cancellationToken).ConfigureAwait(false))
+            sum += item;
+        return sum;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                    ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "5.0.0"))),
+                LanguageVersion = CSharpLanguageVersion.CSharp8,
+                TestCode = code,
+                FixedCode = fixedCode,
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(3703, "https://github.com/dotnet/roslyn-analyzers/issues/3703")]
+        public async Task CSharpAwaitForEachConfigureAwaitWithCancellation()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public static class AsyncExtensions
+{
+    public static async Task<int> Sum(this IAsyncEnumerable<int> items, CancellationToken cancellationToken)
+    {
+        int sum = 0;
+        // ConfigureAwait/WithCancellation can be in either order.
+        await foreach (var item in items.ConfigureAwait(false).WithCancellation(cancellationToken))
+            sum += item;
+        return sum;
+    }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                    ImmutableArray.Create(new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "5.0.0"))),
+                LanguageVersion = CSharpLanguageVersion.CSharp8,
+                TestCode = code,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -64,6 +64,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Index.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsExternalInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Lightup\IForEachLoopOperationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\IMethodSymbolExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\IOperationWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\ITypeSymbolExtensions.cs" />

--- a/src/Utilities/Compiler/Lightup/IForEachLoopOperationExtensions.cs
+++ b/src/Utilities/Compiler/Lightup/IForEachLoopOperationExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+#if HAS_IOPERATION
+
+using System;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Analyzer.Utilities.Lightup
+{
+    internal static class IForEachLoopOperationExtensions
+    {
+        private static readonly Func<IForEachLoopOperation, bool> s_isAsynchronous
+            = LightupHelpers.CreateOperationPropertyAccessor<IForEachLoopOperation, bool>(typeof(IForEachLoopOperation), nameof(IsAsynchronous), fallbackResult: false);
+
+        public static bool IsAsynchronous(this IForEachLoopOperation forEachLoopOperation)
+            => s_isAsynchronous(forEachLoopOperation);
+    }
+}
+
+#endif

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -270,6 +270,7 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeCompilerServicesCallerMemberNameAttribute = "System.Runtime.CompilerServices.CallerMemberNameAttribute";
         public const string SystemRuntimeCompilerServicesCompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string SystemRuntimeCompilerServicesConfiguredAsyncDisposable = "System.Runtime.CompilerServices.ConfiguredAsyncDisposable";
+        public const string SystemRuntimeCompilerServicesConfiguredCancelableAsyncEnumerable = "System.Runtime.CompilerServices.ConfiguredCancelableAsyncEnumerable`1";
         public const string SystemRuntimeCompilerServicesConfiguredValueTaskAwaitable1 = "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1";
         public const string SystemRuntimeCompilerServicesICriticalNotifyCompletion = "System.Runtime.CompilerServices.ICriticalNotifyCompletion";
         public const string SystemRuntimeCompilerServicesINotifyCompletion = "System.Runtime.CompilerServices.INotifyCompletion";


### PR DESCRIPTION
Fixes #3703 

Added detection of missing `.ConfigureAwait` when using `await foreach`

