### PR TITLE
Fixes exception on LoggerMessageAnalyzer for missing named placeholder

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     context.ReportDiagnostic(formatExpression.CreateDiagnostic(CA2253Rule));
                 }
-                else if (char.IsLower(valueName[0]))
+                else if (valueName.Length > 0 && char.IsLower(valueName[0]))
                 {
                     context.ReportDiagnostic(formatExpression.CreateDiagnostic(CA1727Rule));
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     context.ReportDiagnostic(formatExpression.CreateDiagnostic(CA2253Rule));
                 }
-                else if (valueName.Length > 0 && char.IsLower(valueName[0]))
+                else if (!string.IsNullOrEmpty(valueName) && char.IsLower(valueName[0]))
                 {
                     context.ReportDiagnostic(formatExpression.CreateDiagnostic(CA1727Rule));
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.Logging.Analyzer
         }
 
         [Theory]
+        [MemberData(nameof(GenerateTemplateUsages), @"{|CA2254:$""{new System.Exception().Message}""|}", "11", false)]
         [MemberData(nameof(GenerateTemplateUsages), @"{|CA2254:$""{string.Empty}""|}", "11", false)]
         [MemberData(nameof(GenerateTemplateUsages), @"{|CA2254:""string"" + 2|}", "11", false)]
         public async Task CA2254IsProducedForDynamicFormatArgument(string format)
@@ -77,6 +78,7 @@ namespace Microsoft.Extensions.Logging.Analyzer
         [Theory]
         [InlineData(@"LoggerMessage.Define(LogLevel.Information, 42, {|CA2017:""{One} {Two} {Three}""|});")]
         [InlineData(@"LoggerMessage.Define<int>(LogLevel.Information, 42, {|CA2017:""{One} {Two} {Three}""|});")]
+        [InlineData(@"LoggerMessage.Define<int>(LogLevel.Information, 42, {|CA2017:""{One} {}""|});")]
         [InlineData(@"LoggerMessage.Define<int, int>(LogLevel.Information, 42, {|CA2017:""{One} {Two} {Three}""|});")]
         [InlineData(@"LoggerMessage.Define<int, int, int>(LogLevel.Information, 42, {|CA2017:""{One} {Two}""|});")]
         [InlineData(@"LoggerMessage.Define<int, int, int, int>(LogLevel.Information, 42, {|CA2017:""{One} {Two} {Three}""|});")]


### PR DESCRIPTION
Fixes exception on LoggerMessageAnalyzer for missing named placeholder.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/5362
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
