### PR TITLE
Fix RichNav yaml formatting

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -7,22 +7,22 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableRichCodeNavigation: true
-    richCodeNavigationEnvironment: "production"
-    richCodeNavigationLanguage: "csharp"
-    jobs:
-    - job: Debug_Build
-      pool:
-        name: NetCorePublic-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
-      variables:
-        - name: _BuildConfig
-          value: Debug
-      steps:
-      - checkout: self
-        clean: true
-      - script: eng\common\CIBuild.cmd 
-                  -configuration $(_BuildConfig)
-        displayName: Build and Index
+    - template: /eng/common/templates/jobs/jobs.yml
+      parameters:
+        enableRichCodeNavigation: true
+        richCodeNavigationEnvironment: "production"
+        richCodeNavigationLanguage: "csharp"
+        jobs:
+        - job: Debug_Build
+          pool:
+            name: NetCorePublic-Pool
+            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+          variables:
+            - name: _BuildConfig
+              value: Debug
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng\common\CIBuild.cmd 
+                      -configuration $(_BuildConfig)
+            displayName: Build and Index


### PR DESCRIPTION
The richnav build pipeline yml had some incorrect indentation, making AzDo unable to parse it. 

This PR fixes the indentation, you can see it now running successfully [here](https://dev.azure.com/dnceng/public/_build/results?buildId=1299775&view=results).