### PR TITLE
Clarify instructions for running msbuild /t:Pack

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,9 @@ If your Pull Request is doing one of the following:
 
 Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.
 
+- This command must be run from a Visual Studio Developer Command Prompt
+- Alternatively, `dotnet msbuild /t:Pack /v:m` can be used from a standard terminal window
+
 Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.
 
 -->


### PR DESCRIPTION
It wasn't clear how to run this command or that `dotnet msbuild /t:Pack /v:m` could be used as an alternative command.