### PR TITLE
Update ref for the unit tests

### DIFF
--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -93,7 +93,7 @@ namespace Test.Utilities
                     "net6.0",
                     new PackageIdentity(
                         "Microsoft.NETCore.App.Ref",
-                        "6.0.0-preview.6.21352.12"),
+                        "6.0.100-rc.2.21420.21"),
                     Path.Combine("ref", "net6.0"));
             });
 


### PR DESCRIPTION
I need to be able to access `RequiresPreviewFeaturesAttribute.Message` (https://source.dot.net/#System.Private.CoreLib/RequiresPreviewFeaturesAttribute.cs,37). It was merged in RC1. This change didn't succeed for me locally, so I'm trying it in CI to see if it's a local environment issue. 
