### PR TITLE
Better diagnostic location for types

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.NetCore.Analyzers.Runtime;
+
+namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
+{
+    public class CSharpDetectPreviewFeatureAnalyzer : DetectPreviewFeatureAnalyzer
+    {
+        protected override SyntaxNode? GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(ISymbol typeSymbol, ISymbol previewInterfaceSymbol)
+        {
+            SyntaxNode? ret = null;
+            ImmutableArray<SyntaxReference> typeSymbolDeclaringReferences = typeSymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? syntaxReference in typeSymbolDeclaringReferences)
+            {
+                SyntaxNode typeSymbolDefinition = syntaxReference.GetSyntax();
+                if (typeSymbolDefinition is ClassDeclarationSyntax classDeclaration)
+                {
+                    SeparatedSyntaxList<BaseTypeSyntax> baseListTypes = classDeclaration.BaseList.Types;
+                    ret = GetPreviewInterfaceNodeForClassOrStructImplementingPreviewInterface(baseListTypes, previewInterfaceSymbol);
+                    if (ret != null)
+                    {
+                        return ret;
+                    }
+                }
+                else if (typeSymbolDefinition is StructDeclarationSyntax structDeclaration)
+                {
+                    SeparatedSyntaxList<BaseTypeSyntax> baseListTypes = structDeclaration.BaseList.Types;
+                    ret = GetPreviewInterfaceNodeForClassOrStructImplementingPreviewInterface(baseListTypes, previewInterfaceSymbol);
+                    if (ret != null)
+                    {
+                        return ret;
+                    }
+                }
+            }
+
+            return ret;
+        }
+
+        private SyntaxNode? GetPreviewInterfaceNodeForClassOrStructImplementingPreviewInterface(SeparatedSyntaxList<BaseTypeSyntax> baseListTypes, ISymbol previewInterfaceSymbol)
+        {
+            foreach (BaseTypeSyntax baseTypeSyntax in baseListTypes)
+            {
+                if (baseTypeSyntax is SimpleBaseTypeSyntax simpleBaseTypeSyntax)
+                {
+                    TypeSyntax type = simpleBaseTypeSyntax.Type;
+                    if (type is IdentifierNameSyntax identifier)
+                    {
+                        if (identifier.Identifier.ValueText == previewInterfaceSymbol.Name)
+                        {
+                            return simpleBaseTypeSyntax;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -15,8 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     /// <summary>
     /// Detect the use of [RequiresPreviewFeatures] in assemblies that have not opted into preview features
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class DetectPreviewFeatureAnalyzer : DiagnosticAnalyzer
+    public abstract class DetectPreviewFeatureAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA2252";
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(MicrosoftNetCoreAnalyzersResources.DetectPreviewFeaturesTitle), MicrosoftNetCoreAnalyzersResources.ResourceManager, typeof(MicrosoftNetCoreAnalyzersResources));

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -304,6 +304,25 @@
             ]
           }
         },
+        "CA2252": {
+          "id": "CA2252",
+          "shortDescription": "This API requires opting into preview features",
+          "fullDescription": "An assembly has to opt into preview features before using them.",
+          "defaultLevel": "note",
+          "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252",
+          "properties": {
+            "category": "Usage",
+            "isEnabledByDefault": true,
+            "typeName": "CSharpDetectPreviewFeatureAnalyzer",
+            "languages": [
+              "C#"
+            ],
+            "tags": [
+              "Telemetry",
+              "EnabledRuleInAggressiveMode"
+            ]
+          }
+        },
         "CA2352": {
           "id": "CA2352",
           "shortDescription": "Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks",
@@ -3610,26 +3629,6 @@
             ]
           }
         },
-        "CA2252": {
-          "id": "CA2252",
-          "shortDescription": "This API requires opting into preview features",
-          "fullDescription": "An assembly has to opt into preview features before using them.",
-          "defaultLevel": "note",
-          "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252",
-          "properties": {
-            "category": "Usage",
-            "isEnabledByDefault": true,
-            "typeName": "DetectPreviewFeatureAnalyzer",
-            "languages": [
-              "C#",
-              "Visual Basic"
-            ],
-            "tags": [
-              "Telemetry",
-              "EnabledRuleInAggressiveMode"
-            ]
-          }
-        },
         "CA2253": {
           "id": "CA2253",
           "shortDescription": "Named placeholders should not be numeric values",
@@ -5795,6 +5794,25 @@
             ],
             "tags": [
               "PortedFromFxCop",
+              "Telemetry",
+              "EnabledRuleInAggressiveMode"
+            ]
+          }
+        },
+        "CA2252": {
+          "id": "CA2252",
+          "shortDescription": "This API requires opting into preview features",
+          "fullDescription": "An assembly has to opt into preview features before using them.",
+          "defaultLevel": "note",
+          "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252",
+          "properties": {
+            "category": "Usage",
+            "isEnabledByDefault": true,
+            "typeName": "BasicDetectPreviewFeatureAnalyzer",
+            "languages": [
+              "Visual Basic"
+            ],
+            "tags": [
               "Telemetry",
               "EnabledRuleInAggressiveMode"
             ]

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -11,7 +11,6 @@ CA1842 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-r
 CA1843 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1843> | Do not use 'WaitAll' with a single task |
 CA1848 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848> | Use the LoggerMessage delegates |
 CA2017 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017> | Parameter count mismatch |
-CA2018 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018> | 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument |
 CA2252 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252> | This API requires opting into preview features |
 CA2253 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253> | Named placeholders should not be numeric values |
 CA2254 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254> | Template should be a static expression |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
@@ -156,6 +156,168 @@ namespace Preview_Feature_Scratch
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(1).WithArguments("FooBar"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(2).WithArguments("BarImplemented"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.OverridesPreviewMethodRule).WithLocation(3).WithArguments("Bar", "AbClass.Bar"));
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPartialClassOrStructDeclaration(string classOrStruct)
+        {
+            var csInput = @$" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{{
+    public partial {classOrStruct} Zoo"; // Zoo: IFoo
+
+            csInput += @": {|#0:IFoo|}
+    {
+        public void {|#1:Foo|}() { }
+    }
+";
+            csInput += $@"
+    public partial {classOrStruct} Zoo : NonPreviewInterface";
+
+            csInput += @"
+    {
+        public void Bar() { }
+    }
+
+    [RequiresPreviewFeatures]
+    interface IFoo
+    {
+        void Foo();
+    }
+
+    interface NonPreviewInterface
+    {
+        void Bar();
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(0).WithArguments("Zoo", "IFoo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(1).WithArguments("Foo", "IFoo.Foo"));
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPartialClassOrStructDeclarationEndOfList(string classOrStruct)
+        {
+            var csInput = @$" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{{
+    public partial {classOrStruct} Zoo";
+
+            csInput += @": NonPreviewInterface, {|#0:IFoo|}
+    {
+        public void {|#1:Foo|}() { }
+        public void Bar() { }
+    }
+
+    [RequiresPreviewFeatures]
+    interface IFoo
+    {
+        void Foo();
+    }
+
+    interface NonPreviewInterface
+    {
+        void Bar();
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(0).WithArguments("Zoo", "IFoo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(1).WithArguments("Foo", "IFoo.Foo"));
+            await test.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPartialClassOrStructImplementsMultiplePreviewInterfaces(string classOrStruct)
+        {
+            var csInput = @$" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{{
+    public partial {classOrStruct} Zoo";
+
+            csInput += @": {|#3:PreviewInterface|}, NonPreviewInterface, {|#0:IFoo|}
+    {
+        public void {|#1:Foo|}() { }
+        public void {|#2:Bar|}() { }
+        public void NonPreviewInterfaceMethod() { }
+    }
+
+    [RequiresPreviewFeatures]
+    interface IFoo
+    {
+        void Foo();
+    }
+
+    [RequiresPreviewFeatures]
+    interface PreviewInterface
+    {
+        void Bar();
+    }
+
+    interface NonPreviewInterface
+    {
+        void NonPreviewInterfaceMethod();
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(0).WithArguments("Zoo", "IFoo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(3).WithArguments("Zoo", "PreviewInterface"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(1).WithArguments("Foo", "IFoo.Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(2).WithArguments("Bar", "PreviewInterface.Bar"));
+            await test.RunAsync();
+        }
+
+        [Fact(Skip = "Not implemented yet. Update DetectPreviewFeatureAnalyzer to support better diagnostic locations for base classes")]
+        public async Task TestPartialClassDeclarationInterfacesAndAbstractClass()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+    public partial class Zoo : NonPreviewInterface, {|#0:IFoo|}
+    {
+        public void {|#1:Foo|}() { }
+        public void Bar() { }
+    }
+
+    public partial class Zoo : {|#2:AbClass|}
+    {
+    }
+
+    [RequiresPreviewFeatures]
+    interface IFoo
+    {
+        void Foo();
+    }
+
+    interface NonPreviewInterface
+    {
+        void Bar();
+    }
+
+    [RequiresPreviewFeatures]
+    public abstract class AbClass
+    {
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(0).WithArguments("Zoo", "IFoo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(1).WithArguments("Foo", "IFoo.Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.DerivesFromPreviewClassRule).WithLocation(2).WithArguments("Zoo", "AbClass"));
             await test.RunAsync();
         }
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Dependencies.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Dependencies.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Enums.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Enums.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
@@ -211,7 +211,7 @@ class {|#1:A|}<T> where T : IFoo, new()
     }
 }
 
-class {|#2:Foo|} : IFoo
+class Foo : {|#2:IFoo|}
 {
     public void {|#3:Bar|}() { }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Interfaces.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Interfaces.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
@@ -53,7 +53,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         namespace Preview_Feature_Scratch
         {
 
-            class {|#1:Program|} : IProgram
+            class Program : {|#1:IProgram|}
             {
                 static void Main(string[] args)
                 {
@@ -87,7 +87,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         namespace Preview_Feature_Scratch
         {
 
-            class {|#0:Program|} : IProgram
+            class Program : {|#0:IProgram|}
             {
                 static void Main(string[] args)
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Operators.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Operators.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -3,7 +3,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
@@ -194,7 +194,7 @@ namespace Preview_Feature_Scratch
 using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
-    public class {|#0:Foo|} : IFoo
+    public class Foo : {|#0:IFoo|}
     {
         [RequiresPreviewFeatures]
         public decimal Value => 1.1m;
@@ -219,7 +219,7 @@ namespace Preview_Feature_Scratch
 using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
-    public class {|#0:Foo|} : IFoo
+    public class Foo : {|#0:IFoo|}
     {
         [RequiresPreviewFeatures]
         decimal IFoo.Value => 1.1m;
@@ -244,7 +244,7 @@ namespace Preview_Feature_Scratch
 using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
-    public class {|#0:Foo|} : IFoo
+    public class Foo : {|#0:IFoo|}
     {
         [RequiresPreviewFeatures]
         decimal IFoo.Value

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer,
+    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
@@ -1,0 +1,19 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.NetCore.Analyzers.Runtime
+
+Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
+
+    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
+    Public NotInheritable Class BasicDetectPreviewFeatureAnalyzer
+
+        Inherits DetectPreviewFeatureAnalyzer
+
+        Protected Overrides Function GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(typeSymbol As ISymbol, previewInterfaceSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
+    End Class
+
+End Namespace


### PR DESCRIPTION
I've implemented better diagnostic locations for types implementing preview interfaces. Instead of the diagnostic appearing on the type itself, it now appears on the interface in the interface list. I think this is a good starting point to get feedback first, and if I get sign off here, I can merge this PR and work on improving the diagnostic location for methods and other types with the same approach.