### PR TITLE
Follow up diagnostic location for types/methods/properties

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -11,6 +11,208 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpDetectPreviewFeatureAnalyzer : DetectPreviewFeatureAnalyzer
     {
+        protected override SyntaxNode? GetPreviewTypeArgumentSyntaxNodeForMethod(IMethodSymbol methodSymbol, ISymbol parameterSymbol)
+        {
+            ImmutableArray<SyntaxReference> methodReferences = methodSymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? methodReference in methodReferences)
+            {
+                SyntaxNode definition = methodReference.GetSyntax();
+                if (definition is MethodDeclarationSyntax methodDeclaration)
+                {
+                    TypeParameterListSyntax? parameterList = methodDeclaration.TypeParameterList;
+                    foreach (TypeParameterSyntax? parameter in parameterList.Parameters)
+                    {
+                        if (IsSyntaxToken(parameter.Identifier, parameterSymbol))
+                        {
+                            return parameter;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        protected override SyntaxNode? GetPreviewSyntaxNodeForFieldsOrEvents(ISymbol fieldOrEventSymbol, ISymbol previewSymbol)
+        {
+            ImmutableArray<SyntaxReference> fieldOrEventReferences = fieldOrEventSymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? fieldOrEventReference in fieldOrEventReferences)
+            {
+                SyntaxNode definition = fieldOrEventReference.GetSyntax();
+
+                while (definition is VariableDeclaratorSyntax)
+                {
+                    definition = definition.Parent;
+                }
+                if (definition is VariableDeclarationSyntax fieldDeclaration)
+                {
+                    TypeSyntax parameterType = fieldDeclaration.Type;
+                    while (parameterType is ArrayTypeSyntax arrayType)
+                    {
+                        parameterType = arrayType.ElementType;
+                    }
+
+                    if (IsIdentifierNameSyntax(parameterType, previewSymbol))
+                    {
+                        return parameterType;
+                    }
+                    else if (parameterType is GenericNameSyntax genericName)
+                    {
+                        SyntaxNode? previewNode = MatchGenericSyntaxNodeWithGivenSymbol(genericName, previewSymbol);
+                        if (previewNode != null)
+                        {
+                            return previewNode;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        protected override SyntaxNode? GetPreviewParameterSyntaxNodeForMethod(IMethodSymbol methodSymbol, ISymbol parameterSymbol)
+        {
+            ImmutableArray<SyntaxReference> methodSymbolDeclaringReferences = methodSymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? syntaxReference in methodSymbolDeclaringReferences)
+            {
+                SyntaxNode methodDefinition = syntaxReference.GetSyntax();
+                if (methodDefinition is MethodDeclarationSyntax methodDeclaration)
+                {
+                    ParameterListSyntax? parameters = methodDeclaration.ParameterList;
+                    foreach (ParameterSyntax? parameter in parameters.Parameters)
+                    {
+                        TypeSyntax parameterType = parameter.Type;
+                        if (IsIdentifierNameSyntax(parameterType, parameterSymbol))
+                        {
+                            return parameterType;
+                        }
+                        else if (parameterType is GenericNameSyntax genericName)
+                        {
+                            SyntaxNode? previewNode = MatchGenericSyntaxNodeWithGivenSymbol(genericName, parameterSymbol);
+                            if (previewNode != null)
+                            {
+                                return previewNode;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        // Handles both generic and non-generic return types
+        protected override SyntaxNode? GetPreviewReturnTypeSyntaxNodeForMethodOrProperty(ISymbol methodOrPropertySymbol, ISymbol previewReturnTypeSymbol)
+        {
+            ImmutableArray<SyntaxReference> methodOrPropertySymbolDeclaringReferences = methodOrPropertySymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? syntaxReference in methodOrPropertySymbolDeclaringReferences)
+            {
+                SyntaxNode methodOrPropertyDefinition = syntaxReference.GetSyntax();
+                if (methodOrPropertyDefinition is PropertyDeclarationSyntax propertyDeclaration)
+                {
+                    TypeSyntax returnType = propertyDeclaration.Type;
+                    if (IsIdentifierNameSyntax(returnType, previewReturnTypeSymbol))
+                    {
+                        return returnType;
+                    }
+                }
+                else if (methodOrPropertyDefinition is MethodDeclarationSyntax methodDeclaration)
+                {
+                    TypeSyntax returnType = methodDeclaration.ReturnType;
+                    if (IsIdentifierNameSyntax(returnType, previewReturnTypeSymbol))
+                    {
+                        return returnType;
+                    }
+                    else if (returnType is GenericNameSyntax genericName)
+                    {
+                        SyntaxNode? previewNode = MatchGenericSyntaxNodeWithGivenSymbol(genericName, previewReturnTypeSymbol);
+                        if (previewNode != null)
+                        {
+                            return previewNode;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private SyntaxNode? MatchGenericSyntaxNodeWithGivenSymbol(GenericNameSyntax genericName, ISymbol previewReturnTypeSymbol)
+        {
+            TypeArgumentListSyntax typeArgumentList = genericName.TypeArgumentList;
+            foreach (TypeSyntax typeArgument in typeArgumentList.Arguments)
+            {
+                if (typeArgument is GenericNameSyntax innerGenericName)
+                {
+                    return MatchGenericSyntaxNodeWithGivenSymbol(innerGenericName, previewReturnTypeSymbol);
+                }
+                if (IsIdentifierNameSyntax(typeArgument, previewReturnTypeSymbol))
+                {
+                    return typeArgument;
+                }
+            }
+
+            return null;
+        }
+
+        protected override SyntaxNode? GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(ISymbol typeOrMethodSymbol, ISymbol previewInterfaceConstraintSymbol)
+        {
+            SyntaxNode? ret = null;
+            ImmutableArray<SyntaxReference> typeSymbolDeclaringReferences = typeOrMethodSymbol.DeclaringSyntaxReferences;
+
+            foreach (SyntaxReference? syntaxReference in typeSymbolDeclaringReferences)
+            {
+                SyntaxNode typeOrMethodDefinition = syntaxReference.GetSyntax();
+                if (typeOrMethodDefinition is ClassDeclarationSyntax classDeclaration)
+                {
+                    // For ex: class A<T> where T : IFoo, new() // where IFoo is preview
+                    SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses = classDeclaration.ConstraintClauses;
+                    ret = HandleConstraintClauses(constraintClauses, previewInterfaceConstraintSymbol);
+                    if (ret != null)
+                    {
+                        return ret;
+                    }
+                }
+                else if (typeOrMethodDefinition is MethodDeclarationSyntax methodDeclaration)
+                {
+                    SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses = methodDeclaration.ConstraintClauses;
+                    ret = HandleConstraintClauses(constraintClauses, previewInterfaceConstraintSymbol);
+                    if (ret != null)
+                    {
+                        return ret;
+                    }
+                }
+            }
+            return ret;
+        }
+
+        private SyntaxNode? HandleConstraintClauses(SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, ISymbol previewInterfaceConstraintSymbol)
+        {
+            foreach (TypeParameterConstraintClauseSyntax constraintClause in constraintClauses)
+            {
+                SeparatedSyntaxList<TypeParameterConstraintSyntax> constraints = constraintClause.Constraints;
+                foreach (TypeParameterConstraintSyntax? constraint in constraints)
+                {
+                    if (constraint is TypeConstraintSyntax typeConstraintSyntax)
+                    {
+                        if (typeConstraintSyntax.Type is IdentifierNameSyntax identifier)
+                        {
+                            if (identifier.Identifier.ValueText == previewInterfaceConstraintSymbol.Name)
+                            {
+                                return constraint;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
         protected override SyntaxNode? GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(ISymbol typeSymbol, ISymbol previewInterfaceSymbol)
         {
             SyntaxNode? ret = null;
@@ -56,6 +258,29 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
             }
 
             previewInterfaceNode = null;
+            return false;
+        }
+
+        private bool IsSyntaxToken(SyntaxToken identifier, ISymbol previewInterfaceSymbol)
+        {
+            if (identifier.ValueText == previewInterfaceSymbol.Name)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsIdentifierNameSyntax(TypeSyntax identifier, ISymbol previewInterfaceSymbol)
+        {
+            if (identifier is IdentifierNameSyntax identifierName)
+            {
+                if (identifierName.Identifier.ValueText == previewInterfaceSymbol.Name)
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
     }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 {
                     TypeSyntax type = simpleBaseTypeSyntax.Type;
                     if (type is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == previewInterfaceSymbol.Name)
-                    {
+                        {
                         previewInterfaceNode = simpleBaseTypeSyntax;
                         return true;
                     }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -119,6 +119,13 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                     {
                         return returnType;
                     }
+                    else if (returnType is GenericNameSyntax genericName)
+                    {
+                        if (TryMatchGenericSyntaxNodeWithGivenSymbol(genericName, previewReturnTypeSymbol, out SyntaxNode? previewNode))
+                        {
+                            return previewNode;
+                        }
+                    }
                 }
                 else if (methodOrPropertyDefinition is MethodDeclarationSyntax methodDeclaration)
                 {

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                 {
                     TypeSyntax type = simpleBaseTypeSyntax.Type;
                     if (type is IdentifierNameSyntax identifier && identifier.Identifier.ValueText == previewInterfaceSymbol.Name)
-                        {
+                    {
                         previewInterfaceNode = simpleBaseTypeSyntax;
                         return true;
                     }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDetectPreviewFeatureAnalyzer.cs
@@ -63,10 +63,6 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                     foreach (ParameterSyntax? parameter in parameters.Parameters)
                     {
                         TypeSyntax parameterType = parameter.Type;
-                        if (parameterType.ToString() == parameterSymbol.Name)
-                        {
-                            return parameterType;
-                        }
 
                         if (IsIdentifierNameSyntax(parameterType, parameterSymbol))
                         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -132,30 +132,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             FieldOrEventIsPreviewTypeRule,
             StaticAbstractIsPreviewFeatureRule);
 
-        protected virtual SyntaxNode? GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(ISymbol typeSymbol, ISymbol previewInterfaceSymbol)
-        {
-            return null;
-        }
+        protected abstract SyntaxNode? GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(ISymbol typeSymbol, ISymbol previewInterfaceSymbol);
 
-        protected virtual SyntaxNode? GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(ISymbol typeOrMethodSymbol, ISymbol previewInterfaceConstraintSymbol)
-        {
-            return null;
-        }
+        protected abstract SyntaxNode? GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(ISymbol typeOrMethodSymbol, ISymbol previewInterfaceConstraintSymbol);
 
-        protected virtual SyntaxNode? GetPreviewReturnTypeSyntaxNodeForMethodOrProperty(ISymbol methodOrPropertySymbol, ISymbol previewReturnTypeSymbol)
-        {
-            return null;
-        }
+        protected abstract SyntaxNode? GetPreviewReturnTypeSyntaxNodeForMethodOrProperty(ISymbol methodOrPropertySymbol, ISymbol previewReturnTypeSymbol);
 
-        protected virtual SyntaxNode? GetPreviewParameterSyntaxNodeForMethod(IMethodSymbol methodSymbol, ISymbol parameterSymbol)
-        {
-            return null;
-        }
+        protected abstract SyntaxNode? GetPreviewParameterSyntaxNodeForMethod(IMethodSymbol methodSymbol, ISymbol parameterSymbol);
 
-        protected virtual SyntaxNode? GetPreviewSyntaxNodeForFieldsOrEvents(ISymbol fieldOrEventSymbol, ISymbol previewSymbol)
-        {
-            return null;
-        }
+        protected abstract SyntaxNode? GetPreviewSyntaxNodeForFieldsOrEvents(ISymbol fieldOrEventSymbol, ISymbol previewSymbol);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -258,17 +258,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 symbolType = arrayType.ElementType;
             }
 
-            // continue from here. Test TEstPreviewTypeArrayOfGeneric... unit test. Also, create another unit test with a preview generic type taking a non preview type. Does this change still work?
             ProcessFieldOrEventSymbolAttributes(context, symbol, symbolType, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol);
-
-            //if (symbolType is INamedTypeSymbol outerNamedType)
-            //{
-            //    ISymbol? innerSymbolType = GetPreviewSymbolForGenericTypesFromTypeArguments(outerNamedType.TypeArguments, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol);
-            //    if (innerSymbolType != null)
-            //    {
-            //        ProcessFieldOrEventSymbolAttributes(context, symbol, innerSymbolType, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol);
-            //    }
-            //}
         }
 
         private void ProcessFieldOrEventSymbolAttributes(SymbolAnalysisContext context, ISymbol symbol, ISymbol symbolType,
@@ -287,6 +277,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     context.ReportDiagnostic(symbol.CreateDiagnostic(FieldOrEventIsPreviewTypeRule, symbol.Name, symbolType.Name));
                 }
             }
+
             if (SymbolContainsGenericTypesWithPreviewAttributes(symbolType, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out ISymbol? previewSymbol, out SyntaxNode? syntaxNode, fieldSymbolForGenericParameterSyntaxNode: symbol is IFieldSymbol fieldSymbol ? fieldSymbol : null, eventSymbolForGenericParameterSyntaxNode: symbol is IEventSymbol eventSymbol ? eventSymbol : null))
             {
                 if (syntaxNode != null)
@@ -400,7 +391,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 case IEventSymbol:
                     return GetPreviewSyntaxNodeForFieldsOrEvents(symbol, previewType);
                 case IMethodSymbol methodSymbol:
-                    // symbol is not really a method symbol. It is a parameter to a method
                     return GetPreviewParameterSyntaxNodeForMethod(methodSymbol, previewType);
                 case IPropertySymbol:
                 case ITypeSymbol: // Methods/Properties/Types cannot have a type argument that is Preview. Only type parameters can be Preview

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -311,7 +311,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 if (SymbolIsAnnotatedAsPreview(baseType, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol))
                 {
-                    context.ReportDiagnostic(symbol.CreateDiagnostic(DerivesFromPreviewClassRule, symbol.Name, baseType.Name));
+                    SyntaxNode? baseTypeNode = GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(symbol, baseType);
+                    if (baseTypeNode != null)
+                    {
+                        context.ReportDiagnostic(baseTypeNode.CreateDiagnostic(DerivesFromPreviewClassRule, symbol.Name, baseType.Name));
+                    }
+                    else
+                    {
+                        context.ReportDiagnostic(symbol.CreateDiagnostic(DerivesFromPreviewClassRule, symbol.Name, baseType.Name));
+                    }
                 }
             }
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -152,11 +152,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             return null;
         }
 
-        protected virtual SyntaxNode? GetPreviewTypeArgumentSyntaxNodeForMethod(IMethodSymbol methodSymbol, ISymbol parameterSymbol)
-        {
-            return null;
-        }
-
         protected virtual SyntaxNode? GetPreviewSyntaxNodeForFieldsOrEvents(ISymbol fieldOrEventSymbol, ISymbol previewSymbol)
         {
             return null;
@@ -278,7 +273,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
 
-            if (SymbolContainsGenericTypesWithPreviewAttributes(symbolType, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out ISymbol? previewSymbol, out SyntaxNode? syntaxNode, fieldSymbolForGenericParameterSyntaxNode: symbol is IFieldSymbol fieldSymbol ? fieldSymbol : null, eventSymbolForGenericParameterSyntaxNode: symbol is IEventSymbol eventSymbol ? eventSymbol : null))
+            if (SymbolContainsGenericTypesWithPreviewAttributes(symbolType,
+                                                                requiresPreviewFeaturesSymbols,
+                                                                previewFeatureAttributeSymbol,
+                                                                out ISymbol? previewSymbol,
+                                                                out SyntaxNode? syntaxNode,
+                                                                methodOrFieldOrEventSymbolForGenericParameterSyntaxNode: symbol))
             {
                 if (syntaxNode != null)
                 {
@@ -326,7 +326,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
 
-            if (SymbolContainsGenericTypesWithPreviewAttributes(symbol, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out ISymbol? previewSymbol, out SyntaxNode? syntaxNode))
+            if (SymbolContainsGenericTypesWithPreviewAttributes(symbol,
+                                                                requiresPreviewFeaturesSymbols,
+                                                                previewFeatureAttributeSymbol,
+                                                                out ISymbol? previewSymbol,
+                                                                out SyntaxNode? syntaxNode))
             {
                 if (syntaxNode != null)
                 {
@@ -392,37 +396,28 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return GetPreviewSyntaxNodeForFieldsOrEvents(symbol, previewType);
                 case IMethodSymbol methodSymbol:
                     return GetPreviewParameterSyntaxNodeForMethod(methodSymbol, previewType);
-                case IPropertySymbol:
-                case ITypeSymbol: // Methods/Properties/Types cannot have a type argument that is Preview. Only type parameters can be Preview
                 default:
                     return null;
             }
         }
 
         private bool SymbolContainsGenericTypesWithPreviewAttributes(ISymbol symbol,
-            ConcurrentDictionary<ISymbol, bool> requiresPreviewFeaturesSymbols,
-            INamedTypeSymbol previewFeatureAttribute, [NotNullWhen(true)] out ISymbol? previewSymbol,
-            out SyntaxNode? previewSyntaxNode, bool checkTypeParametersForPreviewFeatures = true,
-            IMethodSymbol? methodSymbolForGenericParameterSyntaxNode = null,
-            IFieldSymbol? fieldSymbolForGenericParameterSyntaxNode = null,
-            IEventSymbol? eventSymbolForGenericParameterSyntaxNode = null)
+                                                                     ConcurrentDictionary<ISymbol, bool> requiresPreviewFeaturesSymbols,
+                                                                     INamedTypeSymbol previewFeatureAttribute,
+                                                                     [NotNullWhen(true)] out ISymbol? previewSymbol,
+                                                                     out SyntaxNode? previewSyntaxNode,
+                                                                     bool checkTypeParametersForPreviewFeatures = true,
+                                                                     ISymbol? methodOrFieldOrEventSymbolForGenericParameterSyntaxNode = null)
         {
             if (symbol is INamedTypeSymbol typeSymbol && typeSymbol.Arity > 0)
             {
                 ISymbol? previewTypeArgument = GetPreviewSymbolForGenericTypesFromTypeArguments(typeSymbol.TypeArguments, requiresPreviewFeaturesSymbols, previewFeatureAttribute);
                 if (previewTypeArgument != null)
                 {
-                    if (fieldSymbolForGenericParameterSyntaxNode != null)
+                    if (methodOrFieldOrEventSymbolForGenericParameterSyntaxNode != null)
                     {
-                        previewSyntaxNode = GetPreviewSyntaxNodeFromSymbols(fieldSymbolForGenericParameterSyntaxNode, previewTypeArgument);
-                    }
-                    else if (eventSymbolForGenericParameterSyntaxNode != null)
-                    {
-                        previewSyntaxNode = GetPreviewSyntaxNodeFromSymbols(eventSymbolForGenericParameterSyntaxNode, previewTypeArgument);
-                    }
-                    else if (methodSymbolForGenericParameterSyntaxNode != null)
-                    {
-                        previewSyntaxNode = GetPreviewSyntaxNodeFromSymbols(methodSymbolForGenericParameterSyntaxNode, previewTypeArgument);
+
+                        previewSyntaxNode = GetPreviewSyntaxNodeFromSymbols(methodOrFieldOrEventSymbolForGenericParameterSyntaxNode, previewTypeArgument);
                     }
                     else
                     {
@@ -554,7 +549,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         }
                     }
 
-                    if (SymbolContainsGenericTypesWithPreviewAttributes(parameter.Type, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out ISymbol? referencedPreviewSymbol, out SyntaxNode? syntaxNode, methodSymbolForGenericParameterSyntaxNode: method))
+                    if (SymbolContainsGenericTypesWithPreviewAttributes(parameter.Type,
+                                                                        requiresPreviewFeaturesSymbols,
+                                                                        previewFeatureAttributeSymbol,
+                                                                        out ISymbol? referencedPreviewSymbol,
+                                                                        out SyntaxNode? syntaxNode,
+                                                                        methodOrFieldOrEventSymbolForGenericParameterSyntaxNode: method))
                     {
                         if (syntaxNode != null)
                         {
@@ -568,7 +568,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
 
-            if (SymbolContainsGenericTypesWithPreviewAttributes(propertyOrMethodSymbol, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out ISymbol? previewSymbol, out SyntaxNode? referencedPreviewTypeSyntaxNode))
+            if (SymbolContainsGenericTypesWithPreviewAttributes(propertyOrMethodSymbol,
+                                                                requiresPreviewFeaturesSymbols,
+                                                                previewFeatureAttributeSymbol,
+                                                                out ISymbol? previewSymbol,
+                                                                out SyntaxNode? referencedPreviewTypeSyntaxNode))
             {
                 if (referencedPreviewTypeSyntaxNode != null)
                 {
@@ -634,7 +638,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return true;
             }
 
-            if (SymbolContainsGenericTypesWithPreviewAttributes(symbol, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol, out referencedPreviewSymbol, out SyntaxNode? _, checkTypeParametersForPreviewFeatures: false))
+            if (SymbolContainsGenericTypesWithPreviewAttributes(symbol,
+                                                                requiresPreviewFeaturesSymbols,
+                                                                previewFeatureAttributeSymbol,
+                                                                out referencedPreviewSymbol,
+                                                                out SyntaxNode? _,
+                                                                checkTypeParametersForPreviewFeatures: false))
             {
                 return true;
             }
@@ -735,7 +744,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             return ret;
         }
 
-        private bool TypeParametersHavePreviewAttribute(ISymbol namedTypeSymbolOrMethodSymbol, ImmutableArray<ITypeParameterSymbol> typeParameters, ConcurrentDictionary<ISymbol, bool> requiresPreviewFeaturesSymbols, INamedTypeSymbol previewFeatureAttribute, [NotNullWhen(true)] out ISymbol? previewSymbol, out SyntaxNode? previewSyntaxNode)
+        private bool TypeParametersHavePreviewAttribute(ISymbol namedTypeSymbolOrMethodSymbol,
+                                                        ImmutableArray<ITypeParameterSymbol> typeParameters,
+                                                        ConcurrentDictionary<ISymbol, bool> requiresPreviewFeaturesSymbols,
+                                                        INamedTypeSymbol previewFeatureAttribute,
+                                                        [NotNullWhen(true)] out ISymbol? previewSymbol,
+                                                        out SyntaxNode? previewSyntaxNode)
         {
             foreach (ITypeParameterSymbol typeParameter in typeParameters)
             {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
@@ -115,7 +115,7 @@ namespace Preview_Feature_Scratch
         namespace Preview_Feature_Scratch
         {
 
-            class {|#0:Program|} : AbClass
+            class Program : {|#0:AbClass|}
             {
                 static void Main(string[] args)
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Classes.cs
@@ -280,7 +280,7 @@ namespace Preview_Feature_Scratch
             await test.RunAsync();
         }
 
-        [Fact(Skip = "Not implemented yet. Update DetectPreviewFeatureAnalyzer to support better diagnostic locations for base classes")]
+        [Fact]
         public async Task TestPartialClassDeclarationInterfacesAndAbstractClass()
         {
             var csInput = @" 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
@@ -230,7 +230,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             {
                 public event EventHandler<{|#0:PreviewEventArgs|}> RaiseCustomEvent;
 #nullable enable
-                public event EventHandler<{|#4:PreviewEventArgs?|}>? RaiseCustomEventNullable;
+                public event EventHandler<{|#4:PreviewEventArgs|}?>? RaiseCustomEventNullable;
 #nullable disable
          
                 public void DoSomething()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
@@ -229,6 +229,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             class Publisher
             {
                 public event EventHandler<{|#0:PreviewEventArgs|}> RaiseCustomEvent;
+#nullable enable
+                public event EventHandler<{|#4:PreviewEventArgs?|}>? RaiseCustomEventNullable;
+#nullable disable
          
                 public void DoSomething()
                 {
@@ -282,6 +285,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             var test = TestCS(csInput);
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(0).WithArguments("RaiseCustomEvent", "PreviewEventArgs"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(4).WithArguments("RaiseCustomEventNullable", "PreviewEventArgs"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(1).WithArguments("PreviewEventArgs"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(2).WithArguments("PreviewEventArgs"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(3).WithArguments("PreviewEventArgs"));

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Events.cs
@@ -228,7 +228,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         {
             class Publisher
             {
-                public event EventHandler<PreviewEventArgs> {|#0:RaiseCustomEvent|};
+                public event EventHandler<{|#0:PreviewEventArgs|}> RaiseCustomEvent;
          
                 public void DoSomething()
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
@@ -22,6 +22,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             class Program
             {
                 private Dictionary<int, {|#0:PreviewType|}> _genericPreviewFieldDictionary;
+#nullable enable
+                private Dictionary<int, {|#3:PreviewType?|}>? _genericPreviewFieldDictionaryWithNullable;
+#nullable disable
                 private List<List<List<List<{|#1:PreviewType|}>>>> _genericPreviewField;
                 private List<List<AGenericClass<Int32>>> _genericClassField;
                 private List<List<AGenericPreviewClass<Int32>>> {|#2:_genericPreviewClassField|};
@@ -55,6 +58,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             var test = TestCS(csInput);
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(0).WithArguments("_genericPreviewFieldDictionary", "PreviewType"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(3).WithArguments("_genericPreviewFieldDictionaryWithNullable", "PreviewType"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(1).WithArguments("_genericPreviewField", "PreviewType"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(2).WithArguments("_genericPreviewClassField", "AGenericPreviewClass"));
             await test.RunAsync();
@@ -139,6 +143,16 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             {
 
             }
+
+#nullable enable
+            public class AGenericClassWithNullable<T>
+                where T : {|#6:PreviewType?|}
+            {
+                private {|#7:PreviewType|}? _fieldNullable;
+                private {|#8:PreviewType|}[]? _fieldArrayNullable;
+                private {|#9:PreviewType|}[][]? _fieldArrayOfArrayNullable;
+            }
+#nullable disable
         }";
 
             var test = TestCS(csInput);
@@ -148,6 +162,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(3).WithArguments("AGenericClass", "PreviewType"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(4).WithArguments("_fieldArray", "PreviewType"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(5).WithArguments("_fieldArrayOfArray", "PreviewType"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(6).WithArguments("AGenericClassWithNullable", "PreviewType"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(7).WithArguments("_fieldNullable", "PreviewType"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(8).WithArguments("_fieldArrayNullable", "PreviewType"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(9).WithArguments("_fieldArrayOfArrayNullable", "PreviewType"));
             await test.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
@@ -23,11 +23,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             {
                 private Dictionary<int, {|#0:PreviewType|}> _genericPreviewFieldDictionary;
 #nullable enable
-                private Dictionary<int, {|#3:PreviewType?|}>? _genericPreviewFieldDictionaryWithNullable;
+                private Dictionary<int, {|#3:PreviewType|}?>? _genericPreviewFieldDictionaryWithNullable;
 #nullable disable
                 private List<List<List<List<{|#1:PreviewType|}>>>> _genericPreviewField;
                 private List<List<AGenericClass<Int32>>> _genericClassField;
-                private List<List<AGenericPreviewClass<Int32>>> {|#2:_genericPreviewClassField|};
+                private List<List<{|#2:AGenericPreviewClass<Int32>|}>> _genericPreviewClassField;
 
 
                 public Program()
@@ -180,7 +180,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             public class Program
             {
                 private {|#0:PreviewType|} _field;
-                private AGenericClass<{|#2:PreviewType|}>[] {|#3:_genericPreviewField|};
+                private {|#3:AGenericClass<{|#2:PreviewType|}>|}[] _genericPreviewField;
 
                 public Program()
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
@@ -21,8 +21,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             class Program
             {
-                private Dictionary<int, PreviewType> {|#0:_genericPreviewFieldDictionary|};
-                private List<List<List<List<PreviewType>>>> {|#1:_genericPreviewField|};
+                private Dictionary<int, {|#0:PreviewType|}> _genericPreviewFieldDictionary;
+                private List<List<List<List<{|#1:PreviewType|}>>>> _genericPreviewField;
                 private List<List<AGenericClass<Int32>>> _genericClassField;
                 private List<List<AGenericPreviewClass<Int32>>> {|#2:_genericPreviewClassField|};
 
@@ -70,8 +70,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             class Program
             {
-                private PreviewType {|#0:_field|};
-                private AGenericClass<PreviewType> {|#2:_genericPreviewField|};
+                private {|#0:PreviewType|} _field;
+                private AGenericClass<{|#2:PreviewType|}> _genericPreviewField;
                 private AGenericClass<bool> _noDiagnosticField;
 
                 public Program()
@@ -113,10 +113,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             public class Program
             {
-                private PreviewType {|#0:_field|};
-                private PreviewType[] {|#4:_fieldArray|};
-                private PreviewType[][] {|#5:_fieldArrayOfArray|};
-                private AGenericClass<PreviewType>[] {|#2:_genericPreviewField|};
+                private {|#0:PreviewType|} _field;
+                private {|#4:PreviewType|}[] _fieldArray;
+                private {|#5:PreviewType|}[][] _fieldArrayOfArray;
+                private AGenericClass<{|#2:PreviewType|}>[] _genericPreviewField;
 
                 public Program()
                 {
@@ -134,8 +134,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             }
 
-            public class {|#3:AGenericClass|}<T>
-                where T : PreviewType
+            public class AGenericClass<T>
+                where T : {|#3:PreviewType|}
             {
 
             }
@@ -161,8 +161,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             public class Program
             {
-                private PreviewType {|#0:_field|};
-                private AGenericClass<PreviewType>[] {|#3:{|#2:_genericPreviewField|}|};
+                private {|#0:PreviewType|} _field;
+                private AGenericClass<{|#2:PreviewType|}>[] {|#3:_genericPreviewField|};
 
                 public Program()
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
@@ -297,6 +297,61 @@ interface IFoo
         }
 
         [Fact]
+        public async Task TestClassImplementsGenericInterface()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+class A : {|#0:IFoo<PreviewClass>|}
+{
+    static void Main(string[] args)
+    {
+    }
+}
+
+[RequiresPreviewFeatures]
+interface IFoo<T>
+{
+}
+
+[RequiresPreviewFeatures]
+class PreviewClass
+{
+}
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewInterfaceRule).WithLocation(0).WithArguments("A", "IFoo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestClassExtendsGenericPreviewClass()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+class A : {|#0:PreviewClass<int>|}
+{
+    static void Main(string[] args)
+    {
+    }
+}
+
+[RequiresPreviewFeatures]
+class PreviewClass<T>
+{
+}
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.DerivesFromPreviewClassRule).WithLocation(0).WithArguments("A", "PreviewClass"));
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestGenericClassWithPreviewDependency()
         {
             var csInput = @" 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
@@ -78,6 +78,70 @@ namespace Preview_Feature_Scratch
         }
 
         [Fact]
+        public async Task TestGenericMethodWithNullablePreviewClass()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+
+    class Program
+    {
+#nullable enable
+        public bool GenericMethod<T>()
+            where T : {|#0:Foo?|}
+        {
+            return true;
+        }
+#nullable disable
+
+        static void Main(string[] args)
+        {
+        }
+    }
+
+    [RequiresPreviewFeatures]
+    public class Foo
+    {
+    }
+
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(0).WithArguments("GenericMethod", "Foo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestGenericClassWithNullablePreviewClass()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+
+#nullable enable
+    class Program<T>
+        where T : {|#0:Foo?|}
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+#nullable disable
+
+    [RequiresPreviewFeatures]
+    public class Foo
+    {
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(0).WithArguments("Program", "Foo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestGenericMethodInsidePreviewClass()
         {
             var csInput = @" 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
@@ -26,6 +26,19 @@ namespace Preview_Feature_Scratch
             return foo;
         }
 
+#nullable enable
+        public Dictionary<int, {|#2:Foo?|}> GetterNullable(Dictionary<int, {|#3:Foo?|}> foo)
+        {
+            return foo;
+        }
+
+        public Dictionary<int, {|#4:Foo?[]|}> GetterNullableArray(Dictionary<int, {|#5:Foo?[]|}> foo)
+        {
+            return foo;
+        }
+
+#nullable disable
+
         static void Main(string[] args)
         {
         }
@@ -40,6 +53,10 @@ namespace Preview_Feature_Scratch
             var test = TestCS(csInput);
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(0).WithArguments("Getter", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(1).WithArguments("Getter", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(2).WithArguments("GetterNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(3).WithArguments("GetterNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(4).WithArguments("GetterNullableArray", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(5).WithArguments("GetterNullableArray", "Foo"));
             await test.RunAsync();
         }
 
@@ -124,6 +141,13 @@ namespace Preview_Feature_Scratch
             return foo;
         }
 
+#nullable enable
+        public {|#4:Foo?|} GetterNullable({|#3:Foo?|} foo)
+        {
+            return foo;
+        }
+#nullable disable
+
         static void Main(string[] args)
         {
             Program prog = new Program();
@@ -141,6 +165,8 @@ namespace Preview_Feature_Scratch
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(0).WithArguments("Getter", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(1).WithArguments("Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(2).WithArguments("Getter", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(3).WithArguments("GetterNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(4).WithArguments("GetterNullable", "Foo"));
             await test.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
@@ -176,6 +176,34 @@ namespace Preview_Feature_Scratch
         }
 
         [Fact]
+        public async Task TestSyntaxNodeNameComparison()
+        {
+            var csInput = @" 
+        using System.Runtime.Versioning; using System;
+        namespace Preview_Feature_Scratch
+        {
+            [RequiresPreviewFeatures]
+            public class T { }
+
+            public class C
+            {
+                public void M1<T>(Preview_Feature_Scratch.T {|#0:t|}) // Doesn't use the type parameter. The location detection logic for syntax node doesn't work here.
+                {
+                }
+
+                public void M2<T>(T t) // Uses the type parameter.
+                {
+                }
+            }
+        }
+        ";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(0).WithArguments("M1", "T"));
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestPreviewMethodCallingPreviewMethod()
         {
             var csInput = @" 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
@@ -27,12 +27,12 @@ namespace Preview_Feature_Scratch
         }
 
 #nullable enable
-        public Dictionary<int, {|#2:Foo?|}> GetterNullable(Dictionary<int, {|#3:Foo?|}> foo)
+        public Dictionary<int, {|#2:Foo|}?> GetterNullable(Dictionary<int, {|#3:Foo|}?> foo)
         {
             return foo;
         }
 
-        public Dictionary<int, {|#4:Foo?[]|}> GetterNullableArray(Dictionary<int, {|#5:Foo?[]|}> foo)
+        public Dictionary<int, {|#4:Foo?|}[]> GetterNullableArray(Dictionary<int, {|#5:Foo?|}[]> foo)
         {
             return foo;
         }
@@ -142,7 +142,7 @@ namespace Preview_Feature_Scratch
         }
 
 #nullable enable
-        public {|#4:Foo?|} GetterNullable({|#3:Foo?|} foo)
+        public {|#4:Foo|}? GetterNullable({|#3:Foo|}? foo)
         {
             return foo;
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Methods.cs
@@ -21,7 +21,40 @@ namespace Preview_Feature_Scratch
 
     class Program
     {
-        public Dictionary<int, Foo> {|#1:Getter|}(Dictionary<int, Foo> {|#0:foo|}) // Highlight Foo in the parameter list and return type here
+        public Dictionary<int, {|#1:Foo|}> Getter(Dictionary<int, {|#0:Foo|}> foo)
+        {
+            return foo;
+        }
+
+        static void Main(string[] args)
+        {
+        }
+    }
+
+    [RequiresPreviewFeatures]
+    public class Foo
+    {
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(0).WithArguments("Getter", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(1).WithArguments("Getter", "Foo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task TestNestedGenericPreviewParametersToPreviewMethod()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+using System.Collections.Generic;
+namespace Preview_Feature_Scratch
+{
+
+    class Program
+    {
+        public List<List<List<{|#1:Foo|}>>> Getter(List<List<List<{|#0:Foo|}>>> foo)
         {
             return foo;
         }
@@ -86,7 +119,7 @@ namespace Preview_Feature_Scratch
 
     class Program
     {
-        public Foo {|#2:Getter|}(Foo {|#0:foo|})
+        public {|#2:Foo|} Getter({|#0:Foo|} foo)
         {
             return foo;
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -88,9 +88,9 @@ namespace Preview_Feature_Scratch
             }
         }
 #nullable enable
-        private List<{|#6:Foo?|}>? _valueNullable;
+        private List<{|#6:Foo|}?>? _valueNullable;
 
-        public List<{|#4:Foo?|}>? ValueNullable
+        public List<{|#4:Foo|}?>? ValueNullable
         {
             get
             {
@@ -204,6 +204,56 @@ namespace Preview_Feature_Scratch
         }
 
         [Fact]
+        public async Task TestNullablePropertyReturnTypePreviewGetterAndSetters()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+
+    class AFoo
+    {
+#nullable enable
+        private {|#5:Foo|}[]? _valueNullable;
+        private {|#8:Foo?|}[]? _valueNullableArray;
+        private {|#9:Foo?|}[] _valueNullableArrayInitialized;
+
+        public {|#6:Foo|}[]? ValueNullable
+        {
+            get
+            {
+                return _valueNullable;
+            }
+            {|#7:set|}
+            {
+                _valueNullable = value;
+            }
+        }
+
+        public AFoo()
+        {
+            _valueNullableArrayInitialized = {|#10:new Foo?[0]|};
+        }
+#nullable disable
+    }
+
+    [RequiresPreviewFeatures]
+    public class Foo
+    {
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(5).WithArguments("_valueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(6).WithArguments("get_ValueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(7).WithArguments("set_ValueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(8).WithArguments("_valueNullableArray", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(9).WithArguments("_valueNullableArrayInitialized", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.GeneralPreviewFeatureAttributeRule).WithLocation(10).WithArguments("Foo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestPropertyReturnTypePreviewGetterAndSetters()
         {
             var csInput = @" 
@@ -226,21 +276,6 @@ namespace Preview_Feature_Scratch
                 _value = value;
             }
         }
-#nullable enable
-        private {|#5:Foo[]?|} _valueNullable;
-
-        public {|#6:Foo[]?|} ValueNullable
-        {
-            get
-            {
-                return _valueNullable;
-            }
-            {|#7:set|}
-            {
-                _valueNullable = value;
-            }
-        }
-#nullable disable
 
         public {|#4:Foo|} AnotherGetter => _value;
     }
@@ -257,9 +292,6 @@ namespace Preview_Feature_Scratch
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(2).WithArguments("get_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(3).WithArguments("set_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(4).WithArguments("get_AnotherGetter", "Foo"));
-            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(5).WithArguments("_valueNullable", "Foo"));
-            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(6).WithArguments("get_ValueNullable", "Foo"));
-            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(7).WithArguments("set_ValueNullable", "Foo"));
             await test.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -18,14 +18,14 @@ using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
 
-    class {|#2:AFoo|}<T> where T : Foo, new() // Highlight Foo
+    class AFoo<T> where T : {|#2:Foo|}, new()
     {
         [RequiresPreviewFeatures]
         private Foo _value;
 
-        public Foo Value // Highlight Foo. Nice to have to collapse 0 and 1 into Value itself
+        public {|#0:Foo|} Value
         {
-            {|#0:get|}
+            get
             {
                 return {|#4:_value|};
             }
@@ -35,7 +35,7 @@ namespace Preview_Feature_Scratch
             }
         }
 
-        public Foo AnotherGetter => {|#6:{|#3:_value|}|};
+        public {|#3:Foo|} AnotherGetter => {|#6:_value|};
     }
 
     class Program
@@ -153,13 +153,13 @@ using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
 
-    class {|#0:AFoo|}<T> where T : Foo, new()
+    class AFoo<T> where T : {|#0:Foo|}, new()
     {
-        private Foo {|#1:_value|};
+        private {|#1:Foo|} _value;
 
-        public Foo Value // Highlight Foo. Nice to have: Collapse 0 and 1 into Value itself, though this might lead to 2 diagnostics on Value.
+        public {|#2:Foo|} Value // Highlight Foo. Nice to have: Collapse 0 and 1 into Value itself, though this might lead to 2 diagnostics on Value.
         {
-            {|#2:get|}
+            get
             {
                 return _value;
             }
@@ -169,7 +169,7 @@ namespace Preview_Feature_Scratch
             }
         }
 
-        public Foo AnotherGetter => {|#4:_value|};
+        public {|#4:Foo|} AnotherGetter => _value;
     }
 
     [RequiresPreviewFeatures]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -64,6 +64,54 @@ namespace Preview_Feature_Scratch
         }
 
         [Fact]
+        public async Task TestGenericPreviewPropertyGetterAndSetters()
+        {
+            var csInput = @" 
+using System.Runtime.Versioning; using System;
+using System.Collections.Generic;
+namespace Preview_Feature_Scratch
+{
+
+    class AFoo<T> where T : {|#2:Foo|}, new()
+    {
+        private List<{|#6:Foo|}> _value;
+
+        public List<{|#0:Foo|}> Value
+        {
+            get
+            {
+                return _value;
+            }
+            {|#1:set|}
+            {
+                _value = value;
+            }
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Program prog = new Program();
+        }
+    }
+
+    [RequiresPreviewFeatures]
+    public class Foo
+    {
+    }
+}";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(0).WithArguments("get_Value", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(1).WithArguments("set_Value", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(2).WithArguments("AFoo", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(6).WithArguments("_value", "Foo"));
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestPreviewPropertySetter()
         {
             var csInput = @" 
@@ -157,7 +205,7 @@ namespace Preview_Feature_Scratch
     {
         private {|#1:Foo|} _value;
 
-        public {|#2:Foo|} Value // Highlight Foo. Nice to have: Collapse 0 and 1 into Value itself, though this might lead to 2 diagnostics on Value.
+        public {|#2:Foo|} Value
         {
             get
             {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -74,7 +74,7 @@ namespace Preview_Feature_Scratch
 
     class AFoo<T> where T : {|#2:Foo|}, new()
     {
-        private List<{|#6:Foo|}> _value;
+        private List<{|#3:Foo|}> _value;
 
         public List<{|#0:Foo|}> Value
         {
@@ -87,6 +87,21 @@ namespace Preview_Feature_Scratch
                 _value = value;
             }
         }
+#nullable enable
+        private List<{|#6:Foo?|}>? _valueNullable;
+
+        public List<{|#4:Foo?|}>? ValueNullable
+        {
+            get
+            {
+                return _valueNullable;
+            }
+            {|#5:set|}
+            {
+                _valueNullable = value;
+            }
+        }
+#nullable disable
     }
 
     [RequiresPreviewFeatures]
@@ -99,7 +114,10 @@ namespace Preview_Feature_Scratch
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(0).WithArguments("get_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(1).WithArguments("set_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(2).WithArguments("AFoo", "Foo"));
-            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(6).WithArguments("_value", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(3).WithArguments("_value", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(6).WithArguments("_valueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(4).WithArguments("get_ValueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.UsesPreviewTypeParameterRule).WithLocation(5).WithArguments("set_ValueNullable", "Foo"));
             await test.RunAsync();
         }
 
@@ -208,6 +226,21 @@ namespace Preview_Feature_Scratch
                 _value = value;
             }
         }
+#nullable enable
+        private {|#5:Foo[]?|} _valueNullable;
+
+        public {|#6:Foo[]?|} ValueNullable
+        {
+            get
+            {
+                return _valueNullable;
+            }
+            {|#7:set|}
+            {
+                _valueNullable = value;
+            }
+        }
+#nullable disable
 
         public {|#4:Foo|} AnotherGetter => _value;
     }
@@ -224,6 +257,9 @@ namespace Preview_Feature_Scratch
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(2).WithArguments("get_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(3).WithArguments("set_Value", "Foo"));
             test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(4).WithArguments("get_AnotherGetter", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.FieldOrEventIsPreviewTypeRule).WithLocation(5).WithArguments("_valueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodReturnsPreviewTypeRule).WithLocation(6).WithArguments("get_ValueNullable", "Foo"));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.MethodUsesPreviewTypeAsParameterRule).WithLocation(7).WithArguments("set_ValueNullable", "Foo"));
             await test.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -89,14 +89,6 @@ namespace Preview_Feature_Scratch
         }
     }
 
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Program prog = new Program();
-        }
-    }
-
     [RequiresPreviewFeatures]
     public class Foo
     {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
@@ -598,11 +598,11 @@ namespace Preview_Feature_Scratch
 {" +
     @"
 
-    class {|#2:AFoo|}<T> where T : Foo, new()
+    class AFoo<T> where T : {|#2:Foo|}, new()
     {
-        public Foo[] {|#1:_fooArray|};
+        public {|#1:Foo|}[] _fooArray;
 
-        public void CallBackMethod(Action<Foo> {|#5:action|})
+        public void CallBackMethod(Action<{|#5:Foo|}> action)
         {
             foreach (var foo in _fooArray)
             {

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
@@ -14,6 +14,26 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Protected Overrides Function GetPreviewInterfaceNodeForTypeImplementingPreviewInterface(typeSymbol As ISymbol, previewInterfaceSymbol As ISymbol) As SyntaxNode
             Return Nothing
         End Function
+
+        Protected Overrides Function GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(typeOrMethodSymbol As ISymbol, previewInterfaceConstraintSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
+
+        Protected Overrides Function GetPreviewReturnTypeSyntaxNodeForMethodOrProperty(methodOrPropertySymbol As ISymbol, previewReturnTypeSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
+
+        Protected Overrides Function GetPreviewParameterSyntaxNodeForMethod(methodSymbol As IMethodSymbol, parameterSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
+
+        Protected Overrides Function GetPreviewTypeArgumentSyntaxNodeForMethod(methodSymbol As IMethodSymbol, parameterSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
+
+        Protected Overrides Function GetPreviewSyntaxNodeForFieldsOrEvents(fieldOrEventSymbol As ISymbol, previewSymbol As ISymbol) As SyntaxNode
+            Return Nothing
+        End Function
     End Class
 
 End Namespace

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
@@ -27,10 +27,6 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             Return Nothing
         End Function
 
-        Protected Overrides Function GetPreviewTypeArgumentSyntaxNodeForMethod(methodSymbol As IMethodSymbol, parameterSymbol As ISymbol) As SyntaxNode
-            Return Nothing
-        End Function
-
         Protected Overrides Function GetPreviewSyntaxNodeForFieldsOrEvents(fieldOrEventSymbol As ISymbol, previewSymbol As ISymbol) As SyntaxNode
             Return Nothing
         End Function


### PR DESCRIPTION
Follow up to https://github.com/dotnet/roslyn-analyzers/pull/5402. This improves the diagnostic location for:

1. Type constrained by preview types
2. Method or Properties returning a preview type
3. Methods taking in a preview parameter
4. Fields or Events with a preview type. Also fixes #5428 