### PR TITLE
don't specify a ubuntu version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,7 @@ jobs:
 
 - job: Markdownlint
   pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-latest
   steps:
     - script: sudo npm install -g markdownlint-cli
       displayName: Install markdownlint-cli

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -118,7 +118,8 @@ jobs:
 
 - job: Markdownlint
   pool:
-      vmImage: ubuntu-latest
+      name: NetCorePublic-Pool
+      queue: BuildPool.Ubuntu.1804.amd64.Open
   steps:
     - script: sudo npm install -g markdownlint-cli
       displayName: Install markdownlint-cli


### PR DESCRIPTION
We only need a machine capable of running npm which should be all of them.
Instead use 'ubuntu-latest' so we are running in the pool with the most machines.

<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
