### PR TITLE
Fix crash when querying auto properties

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -677,17 +677,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         symbol = propertySymbol.SetMethod;
                     }
-
-                    if (symbol == null)
-                    {
-                        referencedPreviewSymbol = null;
-                        return false;
-                    }
                 }
 
                 if (operation is IEventAssignmentOperation eventAssignment && symbol is IEventSymbol eventSymbol)
                 {
                     symbol = eventAssignment.Adds ? eventSymbol.AddMethod : eventSymbol.RemoveMethod;
+                }
+
+                if (symbol == null)
+                {
+                    referencedPreviewSymbol = null;
+                    return false;
                 }
 
                 if (symbol is IMethodSymbol methodSymbol && methodSymbol.IsConstructor())

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -677,6 +677,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         symbol = propertySymbol.SetMethod;
                     }
+
+                    if (symbol == null)
+                    {
+                        referencedPreviewSymbol = null;
+                        return false;
+                    }
                 }
 
                 if (operation is IEventAssignmentOperation eventAssignment && symbol is IEventSymbol eventSymbol)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -20,9 +20,13 @@ namespace Preview_Feature_Scratch
     class Program
     {
         public int Value { get; }
-        static void Main(string[] args)
+        public Program()
         {
             Value = 1;
+        }
+
+        static void Main(string[] args)
+        {
         }
     }
 }";

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -11,6 +11,26 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
     public partial class DetectPreviewFeatureUnitTests
     {
         [Fact]
+        public async Task TestPropertyGetterSetInConstructor()
+        {
+            var csInput = @"
+using System.Runtime.Versioning; using System;
+namespace Preview_Feature_Scratch
+{
+    class Program
+    {
+        public int Value { get; }
+        static void Main(string[] args)
+        {
+            Value = 1;
+        }
+    }
+}";
+            var test = TestCS(csInput);
+            await test.RunAsync();
+        }
+
+        [Fact]
         public async Task TestPreviewPropertyGetterAndSetters()
         {
             var csInput = @" 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5450

Currently, the analyzer assumes that a property.UsageInfo == Write implies that a `Set` method exists. This leads to a crash when dealing with auto properties where they are not backed by explicit fields. This PR fixes that.