### PR TITLE
Skipping CA2254 diagnostic when message template references constant values

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -229,30 +229,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             switch (argumentExpression)
             {
-                case ILiteralOperation { ConstantValue: { HasValue: true, Value: string constantValue } }:
-                    return constantValue;
-                case IInterpolatedStringOperation interpolated:
-                    var text = "";
-                    foreach (var interpolatedStringContent in interpolated.Parts)
-                    {
-                        if (interpolatedStringContent is IInterpolatedStringTextOperation textSyntax)
-                        {
-                            text += textSyntax.Text;
-                        }
-                        else if (interpolatedStringContent is IInterpolationOperation { ConstantValue: { HasValue: true, Value: string constantValue } })
-                        {
-                            text += constantValue; // works for e.g. nameof
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    }
-                    return text;
-                case INameOfOperation { ConstantValue: { HasValue: true, Value: string constantValue } }:
+                case IOperation { ConstantValue: { HasValue: true, Value: string constantValue } }:
                     return constantValue;
                 case INameOfOperation:
-                    // return placeholder from here because actual value is not required for analysis and is hard to get
                     return "NAMEOF";
                 case IParenthesizedOperation parenthesized:
                     return TryGetFormatText(parenthesized.Operand);
@@ -267,11 +246,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     return null;
                 default:
-                    var constant = argumentExpression.ConstantValue;
-                    if (constant.HasValue && constant.Value is string constantString)
-                    {
-                        return constantString;
-                    }
                     return null;
             }
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -231,10 +231,6 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 case IOperation { ConstantValue: { HasValue: true, Value: string constantValue } }:
                     return constantValue;
-                case INameOfOperation:
-                    return "NAMEOF";
-                case IParenthesizedOperation parenthesized:
-                    return TryGetFormatText(parenthesized.Operand);
                 case IBinaryOperation { OperatorKind: BinaryOperatorKind.Add } binary:
                     var leftText = TryGetFormatText(binary.LeftOperand);
                     var rightText = TryGetFormatText(binary.RightOperand);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -229,7 +229,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             switch (argumentExpression)
             {
-                case ILiteralOperation { ConstantValue: { HasValue: false, Value: string constantValue } }:
+                case ILiteralOperation { ConstantValue: { HasValue: true, Value: string constantValue } }:
                     return constantValue;
                 case IInterpolatedStringOperation interpolated:
                     var text = "";
@@ -238,6 +238,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         if (interpolatedStringContent is IInterpolatedStringTextOperation textSyntax)
                         {
                             text += textSyntax.Text;
+                        }
+                        else if (interpolatedStringContent is IInterpolationOperation { ConstantValue: { HasValue: true, Value: string constantValue } })
+                        {
+                            text += constantValue; // works for e.g. nameof
                         }
                         else
                         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineTests.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Extensions.Logging.Analyzer
             await TriggerCodeAsync(format);
         }
 
+        [Fact]
+        public async Task CA2254ShouldNotApplyForConstantValues()
+        {
+            await TriggerCodeAsync("{|CA1848:logger.LogDebug($\"{nameof(System.Collections.Generic.IList<object>)}<{{Arg1}}> could not be resovled from DI container, using default JSON binder.\", typeof(string).Assembly)|};");
+        }
+
         [Theory]
         [MemberData(nameof(GenerateTemplateUsages), @"{|CA2254:$""{new System.Exception().Message}""|}", "11", false)]
         [MemberData(nameof(GenerateTemplateUsages), @"{|CA2254:$""{string.Empty}""|}", "11", false)]


### PR DESCRIPTION
Skipping CA2254 diagnostic when message template references constant values

Fixes https://github.com/dotnet/roslyn-analyzers/issues/5415

/cc: @sharwell @jmarolf @333fred

TODO:

- [x] Add test