### PR TITLE
Fix RuntimeInformaiton.IsOSPlatform(OSPlatform.OSX) guard

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -121,7 +121,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 if ((argumentValue is IPropertyReferenceOperation propertyReference) &&
                     propertyReference.Property.ContainingType.Equals(osPlatformType))
                 {
-                    decodedOsPlatformNamesBuilder.Add(propertyReference.Property.Name);
+                    if (propertyReference.Property.Name.Equals(OSX, StringComparison.OrdinalIgnoreCase))
+                    {
+                        decodedOsPlatformNamesBuilder.Add(macOS);
+                    }
+                    else
+                    {
+                        decodedOsPlatformNamesBuilder.Add(propertyReference.Property.Name);
+                    }
                     return true;
                 }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -1131,6 +1131,49 @@ class Test
             await VerifyAnalyzerCSAsync(source);
         }
 
+        [Fact]
+        public async Task GuardedWith_RuntimeInformation_IsOSPlatform_OSX_GuardsMacOS()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System.Runtime.InteropServices;
+
+class Test
+{
+    void M1()
+    {
+        if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            SupportsMacOS();
+            [|UnsupportsMacOS()|];
+            SupportsOSX();
+            [|UnsupportsOSX()|];
+        }
+        else
+        {
+            [|SupportsMacOS()|];
+            UnsupportsMacOS();
+            [|SupportsOSX()|];
+            UnsupportsOSX();
+        }
+    }
+
+    [SupportedOSPlatform(""macos"")]
+    void SupportsMacOS() { }
+
+    [UnsupportedOSPlatform(""MacOS"")]
+    void UnsupportsMacOS() { }
+
+    [SupportedOSPlatform(""OSX"")]
+    void SupportsOSX() { }
+
+    [UnsupportedOSPlatform(""osx"")]
+    void UnsupportsOSX() { }
+}";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
         [Fact, WorkItem(4119, "https://github.com/dotnet/roslyn-analyzers/issues/4119")]
         public async Task GuardedWith_RuntimeInformation_IsOSPlatform_OSPlatformCreate_SimpleIfElseAsync()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5205

Because `OSX` is the alias of `MacOS` we are replacing the `OSX` with `MacOS` while parsing the OS platform attributes

https://github.com/dotnet/roslyn-analyzers/blob/c5c6a7df6452524557baaa28c47da1d4828c1687/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs#L1815-L1816

There is no guard for OSX in `OperatingSystem` type and the guard `OperatingSystem.IsMacOS()` is working just fine with the above change, though we forgot about `RuntimeInformaiton.IsOSPlatform(OSPlatform.OSX)` can be used as a guard for `macOS/OSX`. This PR is fixing that gap.

Not sure if 6.0 is already closed, but it is good to have in 6.0 if possible @jmarolf @jeffhandley 