### PR TITLE
[release/7.0.1xx] Migrate to 1ES hosted pools

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -40,8 +40,8 @@ stages:
       jobs:
       - job: Signed_Build
         pool:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
         variables:
           - group: DotNet-Blob-Feed
           - group: Publish-Build-Assets

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -15,8 +15,8 @@ stages:
         jobs:
         - job: Debug_Build
           pool:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
           variables:
             - name: _BuildConfig
               value: Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,8 @@ jobs:
         _configuration: Release
         _codeCoverage: False
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
   timeoutInMinutes: 40
 
   steps:
@@ -56,8 +56,8 @@ jobs:
   strategy:
     maxParallel: 4
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.Amd64.VS2019.Pre.ES.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.ES.Open
   timeoutInMinutes: 40
 
   steps:
@@ -90,8 +90,8 @@ jobs:
       Release:
         _configuration: Release
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Ubuntu.1804.amd64.Open
+    name: NetCore1ESPool-Svc-Public
+    demands: ImageOverride -equals Build.Ubuntu.1804.amd64.Open
   timeoutInMinutes: 40
   steps:
     - checkout: self


### PR DESCRIPTION
We need to migrate pools to 1ES hosted pools. Only the yamls have to be changed. The supported functionality stays the same.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276
/CC: @jonfortescue 