### PR TITLE
Update messages for symbol comparison diagnostic and codefix

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -341,13 +341,13 @@
     <value>Symbols should be compared for equality, not identity. Use an overload accepting an 'IEqualityComparer' and pass 'SymbolEqualityComparer'.</value>
   </data>
   <data name="CompareSymbolsCorrectlyMessage" xml:space="preserve">
-    <value>Compare symbols correctly</value>
+    <value>Use `SymbolEqualityComparer` when comparing symbols</value>
   </data>
   <data name="CompareSymbolsCorrectlyTitle" xml:space="preserve">
-    <value>Compare symbols correctly</value>
+    <value>Symbols should be compared for equality</value>
   </data>
   <data name="CompareSymbolsCorrectlyCodeFix" xml:space="preserve">
-    <value>Compare symbols correctly</value>
+    <value>Use a `SymbolEqualityComparer` for symbol comparison</value>
   </data>
   <data name="ConfigureGeneratedCodeAnalysisMessage" xml:space="preserve">
     <value>Configure generated code analysis</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -341,13 +341,13 @@
     <value>Symbols should be compared for equality, not identity. Use an overload accepting an 'IEqualityComparer' and pass 'SymbolEqualityComparer'.</value>
   </data>
   <data name="CompareSymbolsCorrectlyMessage" xml:space="preserve">
-    <value>Use `SymbolEqualityComparer` when comparing symbols</value>
+    <value>Use 'SymbolEqualityComparer' when comparing symbols</value>
   </data>
   <data name="CompareSymbolsCorrectlyTitle" xml:space="preserve">
     <value>Symbols should be compared for equality</value>
   </data>
   <data name="CompareSymbolsCorrectlyCodeFix" xml:space="preserve">
-    <value>Use a `SymbolEqualityComparer` for symbol comparison</value>
+    <value>Use a 'SymbolEqualityComparer' for symbol comparison</value>
   </data>
   <data name="ConfigureGeneratedCodeAnalysisMessage" xml:space="preserve">
     <value>Configure generated code analysis</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Porovnat symboly správně</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Porovnat symboly správně</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porovnat symboly správně</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Porovnat symboly správně</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porovnat symboly správně</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Porovnat symboly správně</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porovnat symboly správně</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Porovnat symboly správně</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Symbole ordnungsgemäß vergleichen</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Symbole ordnungsgemäß vergleichen</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Symbole ordnungsgemäß vergleichen</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Symbole ordnungsgemäß vergleichen</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Symbole ordnungsgemäß vergleichen</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Symbole ordnungsgemäß vergleichen</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Symbole ordnungsgemäß vergleichen</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Symbole ordnungsgemäß vergleichen</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar los símbolos correctamente</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Comparar los símbolos correctamente</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar los símbolos correctamente</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Comparar los símbolos correctamente</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar los símbolos correctamente</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Comparar los símbolos correctamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Comparar los símbolos correctamente</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Comparar los símbolos correctamente</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Comparer les symboles correctement</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Comparer les symboles correctement</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparer les symboles correctement</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Comparer les symboles correctement</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparer les symboles correctement</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Comparer les symboles correctement</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparer les symboles correctement</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Comparer les symboles correctement</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Confrontare i simboli nel modo corretto</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Confrontare i simboli nel modo corretto</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Confrontare i simboli nel modo corretto</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Confrontare i simboli nel modo corretto</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Confrontare i simboli nel modo corretto</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Confrontare i simboli nel modo corretto</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Confrontare i simboli nel modo corretto</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Confrontare i simboli nel modo corretto</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">シンボルを正しく比較する</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">シンボルを正しく比較する</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">シンボルを正しく比較する</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">シンボルを正しく比較する</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">シンボルを正しく比較する</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">シンボルを正しく比較する</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">シンボルを正しく比較する</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">シンボルを正しく比較する</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">기호를 올바르게 비교</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">기호를 올바르게 비교</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">기호를 올바르게 비교</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">기호를 올바르게 비교</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">기호를 올바르게 비교</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">기호를 올바르게 비교</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">기호를 올바르게 비교</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">기호를 올바르게 비교</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porównaj symbole poprawnie</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Porównaj symbole poprawnie</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porównaj symbole poprawnie</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Porównaj symbole poprawnie</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Porównaj symbole poprawnie</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Porównaj symbole poprawnie</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Porównaj symbole poprawnie</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Porównaj symbole poprawnie</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar símbolos corretamente</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Comparar símbolos corretamente</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar símbolos corretamente</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Comparar símbolos corretamente</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Comparar símbolos corretamente</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Comparar símbolos corretamente</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Comparar símbolos corretamente</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Comparar símbolos corretamente</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Сравнивайте символы правильно</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Сравнивайте символы правильно</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Сравнивайте символы правильно</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Сравнивайте символы правильно</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Сравнивайте символы правильно</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Сравнивайте символы правильно</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Сравнивайте символы правильно</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Сравнивайте символы правильно</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">Simgeleri doğru karşılaştır</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">Simgeleri doğru karşılaştır</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Simgeleri doğru karşılaştır</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">Simgeleri doğru karşılaştır</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Simgeleri doğru karşılaştır</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">Simgeleri doğru karşılaştır</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">Simgeleri doğru karşılaştır</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">Simgeleri doğru karşılaştır</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">正确比较符号</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">正确比较符号</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正确比较符号</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">正确比较符号</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正确比较符号</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">正确比较符号</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正确比较符号</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">正确比较符号</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正確比較符號</target>
+        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <target state="needs-review-translation">正確比較符號</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyDescription">
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正確比較符號</target>
+        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <target state="needs-review-translation">正確比較符號</target>
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyTitle">
-        <source>Compare symbols correctly</source>
-        <target state="translated">正確比較符號</target>
+        <source>Symbols should be compared for equality</source>
+        <target state="needs-review-translation">正確比較符號</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -18,7 +18,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyCodeFix">
-        <source>Use a `SymbolEqualityComparer` for symbol comparison</source>
+        <source>Use a 'SymbolEqualityComparer' for symbol comparison</source>
         <target state="needs-review-translation">正確比較符號</target>
         <note />
       </trans-unit>
@@ -33,7 +33,7 @@
         <note />
       </trans-unit>
       <trans-unit id="CompareSymbolsCorrectlyMessage">
-        <source>Use `SymbolEqualityComparer` when comparing symbols</source>
+        <source>Use 'SymbolEqualityComparer' when comparing symbols</source>
         <target state="needs-review-translation">正確比較符號</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
@@ -292,7 +292,7 @@ MSBuildWorkspace has moved to the Microsoft.CodeAnalysis.Workspaces.MSBuild NuGe
 |CodeFix|False|
 ---
 
-## RS1024: Compare symbols correctly
+## RS1024: Symbols should be compared for equality
 
 Symbols should be compared for equality, not identity. Use an overload accepting an 'IEqualityComparer' and pass 'SymbolEqualityComparer'.
 

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -246,7 +246,7 @@
         },
         "RS1024": {
           "id": "RS1024",
-          "shortDescription": "Compare symbols correctly",
+          "shortDescription": "Symbols should be compared for equality",
           "fullDescription": "Symbols should be compared for equality, not identity. Use an overload accepting an 'IEqualityComparer' and pass 'SymbolEqualityComparer'.",
           "defaultLevel": "warning",
           "properties": {

--- a/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
@@ -24,7 +24,7 @@ RS1019 |  | DiagnosticId must be unique across analyzers |
 RS1020 |  | Category for analyzers must be from the specified values |
 RS1021 |  | Invalid entry in analyzer category and diagnostic ID range specification file |
 RS1022 |  | Do not use types from Workspaces assembly in an analyzer |
-RS1024 |  | Compare symbols correctly |
+RS1024 |  | Symbols should be compared for equality |
 RS1025 |  | Configure generated code analysis |
 RS1026 |  | Enable concurrent execution |
 RS1027 |  | Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -11,7 +11,6 @@ CA1843 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-r
 CA1848 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848> | Use the LoggerMessage delegates |
 CA1849 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1849> | Call async methods when in an async method |
 CA2017 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2017> | Parameter count mismatch |
-CA2252 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252> | This API requires opting into preview features |
 CA2253 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253> | Named placeholders should not be numeric values |
 CA2254 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254> | Template should be a static expression |
 CA2255 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255> | The 'ModuleInitializer' attribute should not be used in libraries |


### PR DESCRIPTION
Fixes #3427

New messages: 

Title: `Symbols should be compared for equality`
Message: `Use 'SymbolEqualityComparer' when comparing symbols` 
Description: `Symbols should be compared for equality, not identity. Use an overload accepting an 'IEqualityComparer' and pass 'SymbolEqualityComparer'.`