### PR TITLE
Enable auto-merge for OneLoc pull requests

### DIFF
--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Enable auto merge
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  add_milestone:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'dotnet/roslyn-analyzers' && github.event.pull_request.author.login == 'dotnet-bot' && startsWith(github.event.pull_request.title, 'Localized file check-in') }}
+    steps:
+    - name: Enable pull request auto-merge
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
+      run: |
+        gh api graphql -f query='
+          mutation($pull: ID!) {
+            enablePullRequestAutoMerge(input: {pullRequestId: $pull}) {
+              pullRequest {
+                id
+                number
+                autoMergeRequest {
+                  mergeMethod
+                }
+              }
+            }
+          }' -f pull=$PULL_REQUEST_ID


### PR DESCRIPTION
Implements the following rule using GitHub Actions automation:

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/1408396/135365646-ba156b30-f3a7-4d26-9042-964469777c20.png)
