### PR TITLE
Update the flow analysis result evaluation to account the call site reachability

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -347,9 +347,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         var value = analysisResult[platformSpecificOperation.Key.Kind, platformSpecificOperation.Key.Syntax];
                         var csAttributes = pair.csAttributes != null ? CopyAttributes(pair.csAttributes) : null;
 
-                        if ((value.Kind == GlobalFlowStateAnalysisValueSetKind.Known && IsKnownValueGuarded(pair.attributes, ref csAttributes, value)) ||
+                        if ((value.Kind == GlobalFlowStateAnalysisValueSetKind.Known && IsKnownValueGuarded(pair.attributes, ref csAttributes, value, pair.csAttributes)) ||
                            (value.Kind == GlobalFlowStateAnalysisValueSetKind.Unknown && HasGuardedLambdaOrLocalFunctionResult(platformSpecificOperation.Key,
-                           pair.attributes, ref csAttributes, analysisResult)))
+                           pair.attributes, ref csAttributes, analysisResult, pair.csAttributes)))
                         {
                             continue;
                         }
@@ -386,7 +386,8 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         }
 
         private static bool HasGuardedLambdaOrLocalFunctionResult(IOperation platformSpecificOperation, SmallDictionary<string, Versions> attributes,
-            ref SmallDictionary<string, Versions>? csAttributes, DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult, GlobalFlowStateAnalysisValueSet> analysisResult)
+            ref SmallDictionary<string, Versions>? csAttributes, DataFlowAnalysisResult<GlobalFlowStateBlockAnalysisResult,
+                GlobalFlowStateAnalysisValueSet> analysisResult, SmallDictionary<string, Versions>? originalCsAttributes)
         {
             if (!platformSpecificOperation.IsWithinLambdaOrLocalFunction(out var containingLambdaOrLocalFunctionOperation))
             {
@@ -406,7 +407,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 // NOTE: IsKnownValueGuarded mutates the input values, so we pass in cloned values
                 // to ensure that evaluation of each result is independent of evaluation of other parts.
                 if (localValue.Kind != GlobalFlowStateAnalysisValueSetKind.Known ||
-                    !IsKnownValueGuarded(CopyAttributes(attributes), ref csAttributes, localValue))
+                    !IsKnownValueGuarded(CopyAttributes(attributes), ref csAttributes, localValue, originalCsAttributes))
                 {
                     return false;
                 }
@@ -454,16 +455,17 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         }
 
         private static bool IsKnownValueGuarded(SmallDictionary<string, Versions> attributes,
-                ref SmallDictionary<string, Versions>? csAttributes, GlobalFlowStateAnalysisValueSet value)
+                ref SmallDictionary<string, Versions>? csAttributes, GlobalFlowStateAnalysisValueSet value, SmallDictionary<string, Versions>? originalCsAttributes)
         {
             using var capturedVersions = PooledDictionary<string, Version>.GetInstance(StringComparer.OrdinalIgnoreCase);
-            return IsKnownValueGuarded(attributes, ref csAttributes, value, capturedVersions);
+            return IsKnownValueGuarded(attributes, ref csAttributes, value, capturedVersions, originalCsAttributes);
 
             static bool IsKnownValueGuarded(
                 SmallDictionary<string, Versions> attributes,
                 ref SmallDictionary<string, Versions>? csAttributes,
                 GlobalFlowStateAnalysisValueSet value,
-                PooledDictionary<string, Version> capturedVersions)
+                PooledDictionary<string, Version> capturedVersions,
+                SmallDictionary<string, Versions>? originalCsAttributes)
             {
                 // 'GlobalFlowStateAnalysisValueSet.AnalysisValues' represent the && of values.
                 foreach (var analysisValue in value.AnalysisValues)
@@ -487,9 +489,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                 }
                                 else
                                 {
-                                    if (csAttributes != null &&
+                                    if (originalCsAttributes != null &&
                                         AllowList(attribute) &&
-                                        IsOnlySupportNeedsGuard(info.PlatformName, attributes, csAttributes))
+                                        IsOnlySupportNeedsGuard(info.PlatformName, attributes, originalCsAttributes))
                                     {
                                         attribute.SupportedFirst = null;
                                         attribute.SupportedSecond = null;
@@ -587,7 +589,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             }
                         }
 
-                        if (!IsKnownValueGuarded(parentAttributes, ref csAttributes, parent, parentCapturedVersions))
+                        if (!IsKnownValueGuarded(parentAttributes, ref csAttributes, parent, parentCapturedVersions, originalCsAttributes))
                         {
                             return false;
                         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -160,6 +160,171 @@ class Test
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [Fact]
+        public async Task OneOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+[UnsupportedOSPlatform(""MacCatalyst13.0"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|]; // This call site is reachable on: 'android' 23.0 and later, 'ios' 13.0 and later, 'windows' 8.1 and later. 'MyType' is only supported on: 'windows' 10.0.10240 and later.
+
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = new MyType();
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+    }
+}
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+[UnsupportedOSPlatform(""MacCatalyst13.0"")]
+class MyType { }
+" + MockApisCsSource;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task TwoOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""tvos13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+class MyUsage
+{
+    public void M()
+    {
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            var t = [|new MyType()|];
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var t = [|new MyType()|];
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            var t = new MyType();
+        }
+    }
+}
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""tvos15.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+class MyType { }";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task OneOfSupportsNeedsGuard_OneNotSuppressedByCallSite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|];
+
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = [|new MyType()|];
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = [|new MyType()|];
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+    }
+}
+
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+class MyType { }";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task OneOfUnsupportsNeedsGuard()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[UnsupportedOSPlatform(""android23.0"")]
+[UnsupportedOSPlatform(""ios13.0"")]
+[UnsupportedOSPlatform(""windows10.0.10240"")]
+[SupportedOSPlatform(""MacCatalyst13.0"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|]; // This call site is reachable on: 'windows' 10.0.10240 and before. 'MyType' is unsupported on: 'windows' 8.1 and later.
+        if (!OperatingSystem.IsWindows() || !OperatingSystem.IsWindowsVersionAtLeast(8, 1))
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindowsVersionAtLeast(8, 1))
+        {
+            t = new MyType();
+        }
+    }
+}
+[UnsupportedOSPlatform(""android23.0"")]
+[UnsupportedOSPlatform(""ios13.0"")]
+[UnsupportedOSPlatform(""windows8.1"")]
+[SupportedOSPlatform(""MacCatalyst13.0"")]
+class MyType { }
+" + MockApisCsSource;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
         [Fact, WorkItem(4932, "https://github.com/dotnet/roslyn-analyzers/issues/4932")]
         public async Task GuardMethodWith3VersionPartsEquavalentTo4PartsWithLeading0Async()
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -160,171 +160,6 @@ class Test
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
-        [Fact]
-        public async Task OneOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
-        {
-            var source = @"
-using System.Runtime.Versioning;
-using System;
-
-[SupportedOSPlatform(""android23.0"")]
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""windows8.1"")]
-[UnsupportedOSPlatform(""MacCatalyst13.0"")]
-class MyUsage
-{
-    public void M()
-    {
-        var t = [|new MyType()|]; // This call site is reachable on: 'android' 23.0 and later, 'ios' 13.0 and later, 'windows' 8.1 and later. 'MyType' is only supported on: 'windows' 10.0.10240 and later.
-
-        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            t = new MyType();
-        }
-
-        if (!OperatingSystem.IsWindows())
-        {
-            t = new MyType();
-        }
-
-        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            t = new MyType();
-        }
-    }
-}
-[SupportedOSPlatform(""android23.0"")]
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""windows10.0.10240"")]
-[UnsupportedOSPlatform(""MacCatalyst13.0"")]
-class MyType { }
-" + MockApisCsSource;
-
-            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
-        }
-
-        [Fact]
-        public async Task TwoOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
-        {
-            var source = @"
-using System.Runtime.Versioning;
-using System;
-
-[SupportedOSPlatform(""android23.0"")]
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""tvos13.0"")]
-[SupportedOSPlatform(""windows8.1"")]
-class MyUsage
-{
-    public void M()
-    {
-        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            var t = [|new MyType()|];
-        }
-
-        if (!OperatingSystem.IsWindows())
-        {
-            var t = [|new MyType()|];
-        }
-
-        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            var t = new MyType();
-        }
-    }
-}
-[SupportedOSPlatform(""android23.0"")]
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""tvos15.0"")]
-[SupportedOSPlatform(""windows10.0.10240"")]
-class MyType { }";
-
-            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
-        }
-
-        [Fact]
-        public async Task OneOfSupportsNeedsGuard_OneNotSuppressedByCallSite()
-        {
-            var source = @"
-using System.Runtime.Versioning;
-using System;
-
-[SupportedOSPlatform(""android23.0"")]
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""windows8.1"")]
-class MyUsage
-{
-    public void M()
-    {
-        var t = [|new MyType()|];
-
-        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            t = [|new MyType()|];
-        }
-
-        if (!OperatingSystem.IsWindows())
-        {
-            t = [|new MyType()|];
-        }
-
-        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
-        {
-            t = new MyType();
-        }
-    }
-}
-
-[SupportedOSPlatform(""ios13.0"")]
-[SupportedOSPlatform(""windows10.0.10240"")]
-class MyType { }";
-
-            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
-        }
-
-        [Fact]
-        public async Task OneOfUnsupportsNeedsGuard()
-        {
-            var source = @"
-using System.Runtime.Versioning;
-using System;
-
-[UnsupportedOSPlatform(""android23.0"")]
-[UnsupportedOSPlatform(""ios13.0"")]
-[UnsupportedOSPlatform(""windows10.0.10240"")]
-[SupportedOSPlatform(""MacCatalyst13.0"")]
-class MyUsage
-{
-    public void M()
-    {
-        var t = [|new MyType()|]; // This call site is reachable on: 'windows' 10.0.10240 and before. 'MyType' is unsupported on: 'windows' 8.1 and later.
-        if (!OperatingSystem.IsWindows() || !OperatingSystem.IsWindowsVersionAtLeast(8, 1))
-        {
-            t = new MyType();
-        }
-
-        if (!OperatingSystem.IsWindows())
-        {
-            t = new MyType();
-        }
-
-        if (!OperatingSystem.IsWindowsVersionAtLeast(8, 1))
-        {
-            t = new MyType();
-        }
-    }
-}
-[UnsupportedOSPlatform(""android23.0"")]
-[UnsupportedOSPlatform(""ios13.0"")]
-[UnsupportedOSPlatform(""windows8.1"")]
-[SupportedOSPlatform(""MacCatalyst13.0"")]
-class MyType { }
-" + MockApisCsSource;
-
-            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
-        }
-
         [Fact, WorkItem(4932, "https://github.com/dotnet/roslyn-analyzers/issues/4932")]
         public async Task GuardMethodWith3VersionPartsEquavalentTo4PartsWithLeading0Async()
         {
@@ -4768,6 +4603,171 @@ class Test
         }
     }
 }" + MockApisCsSource;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task OneOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+[UnsupportedOSPlatform(""MacCatalyst13.0"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|]; // This call site is reachable on: 'android' 23.0 and later, 'ios' 13.0 and later, 'windows' 8.1 and later. 'MyType' is only supported on: 'windows' 10.0.10240 and later.
+
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = new MyType();
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+    }
+}
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+[UnsupportedOSPlatform(""MacCatalyst13.0"")]
+class MyType { }
+" + MockApisCsSource;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task TwoOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""tvos13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+class MyUsage
+{
+    public void M()
+    {
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            var t = [|new MyType()|];
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var t = [|new MyType()|];
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            var t = new MyType();
+        }
+    }
+}
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""tvos15.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+class MyType { }";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task OneOfSupportsNeedsGuard_OneNotSuppressedByCallSite()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[SupportedOSPlatform(""android23.0"")]
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows8.1"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|];
+
+        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = [|new MyType()|];
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = [|new MyType()|];
+        }
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            t = new MyType();
+        }
+    }
+}
+
+[SupportedOSPlatform(""ios13.0"")]
+[SupportedOSPlatform(""windows10.0.10240"")]
+class MyType { }";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task OneOfUnsupportsNeedsGuard()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+using System;
+
+[UnsupportedOSPlatform(""android23.0"")]
+[UnsupportedOSPlatform(""ios13.0"")]
+[UnsupportedOSPlatform(""windows10.0.10240"")]
+[SupportedOSPlatform(""MacCatalyst13.0"")]
+class MyUsage
+{
+    public void M()
+    {
+        var t = [|new MyType()|]; // This call site is reachable on: 'windows' 10.0.10240 and before. 'MyType' is unsupported on: 'windows' 8.1 and later.
+        if (!OperatingSystem.IsWindows() || !OperatingSystem.IsWindowsVersionAtLeast(8, 1))
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindows())
+        {
+            t = new MyType();
+        }
+
+        if (!OperatingSystem.IsWindowsVersionAtLeast(8, 1))
+        {
+            t = new MyType();
+        }
+    }
+}
+[UnsupportedOSPlatform(""android23.0"")]
+[UnsupportedOSPlatform(""ios13.0"")]
+[UnsupportedOSPlatform(""windows8.1"")]
+[SupportedOSPlatform(""MacCatalyst13.0"")]
+class MyType { }
+" + MockApisCsSource;
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }


### PR DESCRIPTION
## Customer Impact

This fixes a customer-reported issue related to a combination of `SupportedOSPlatform` attributes along with flow analysis handling of `OperatingSystem` guard methods. With this edge case bug, we report a false-positive diagnostic on a call site, indicating that the call site is reachable on a version of the platform that differs from what is actually reachable.

Here is the specific scenario that was reported:

```cs
using System.Runtime.Versioning;

[SupportedOSPlatform("android23.0")]
[SupportedOSPlatform("ios13.0")]
[SupportedOSPlatform("windows8.1")]
[UnsupportedOSPlatform("MacCatalyst")]
class MyUsage
{
    public void M()
    {
        if (!OperatingSystem.IsWindows() || OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
        {
            // FALSE POSITIVE DIAGNOSTIC REPORTED
            // CA1416: This call site is reachable on: 'android' 23.0 and later, 'ios' 13.0 and later,
            // 'windows' 8.1 and later. 'MyType' is only supported on: 'windows' 10.0.10240 and later.
            var t = new MyType();
        }
    }
}
[SupportedOSPlatform("android23.0")]
[SupportedOSPlatform("ios13.0")]
[SupportedOSPlatform("windows10.0.10240")]
class MyType { }
```

It is caused by the logic we use for evaluating the flow analysis result, we suppress warnings with 2 steps:

 1. Call site attributes -> with this one the `[SupportedOSPlatform("android23.0")] [SupportedOSPlatform("ios13.0")]` attributes are suppressed (removed), therefore only unmatching `[SupportedOSPlatform("windows10.0.10240")]` will be left for MyType
 2. Check if the flow analysis result `!Windows() || Windows10OrLater()` is guarding the API call, from the OR conditionals the  `!Windows()` is not guarding the API for the remaining attribute `[SupportedOSPlatform("windows10.0.10240")]` therefore there is a warning

The issue is we are not accounting for the call site reachability when evaluating the flow analysis result. The fix here is now accounting for that in the flow analysis result evaluation.

## Testing

We have thorough unit test coverage for related scenarios, and new tests were added for these edge cases.

## Risk

Low. Minimal performance implications of adding additional code during flow analysis evaluation of which platforms/versions can reach the call site.