### PR TITLE
Avoid applying Community PR label to dotnet-bot and dotnet-maestro

### DIFF
--- a/.github/workflows/community-pr.yml
+++ b/.github/workflows/community-pr.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   add_community_label:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'dotnet/roslyn-analyzers' }}
+    if: ${{ github.repository == 'dotnet/roslyn-analyzers' && github.event.pull_request.user.login != 'dotnet-bot' && github.event.pull_request.user.login != 'dotnet-maestro[bot]' }}
     steps:
     - name: Get data
       env:


### PR DESCRIPTION
The API appears to occasionally return the wrong authorAssociation for pull requests submitted by these users. Excluding them by name is the easiest way to avoid applying the Community label to these pull requests.

Part of #5565