### PR TITLE
PreviewFeatures - Handle an error case where GetOverriddenMembers() returns null for an indexer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -769,6 +769,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static bool SymbolIsAnnotatedAsPreview(ISymbol symbol, ConcurrentDictionary<ISymbol, bool> requiresPreviewFeaturesSymbols, INamedTypeSymbol previewFeatureAttribute)
         {
+            if (symbol is null)
+            {
+                // We are sometimes null, such as for IPropertySymbol.GetOverriddenMember()
+                // when the property symbol represents an indexer, so return false as a precaution
+                return false;
+            }
+
             if (!requiresPreviewFeaturesSymbols.TryGetValue(symbol, out bool existing))
             {
                 if (symbol.HasAttribute(previewFeatureAttribute))


### PR DESCRIPTION
## Customer Impact

The Requires Preview Features Analyzer (CA2252) encounters an unhandled exception in some scenarios when `null` symbols are evaluated. This was discovered while @tannergooding was consuming preview features in the [TerraFX](https://github.com/terrafx/terrafx) project and an indexer property was evaluated.

```
Severity Code Description Project File Line Suppression State Detail Description
Error AD0001 Analyzer 'Microsoft.NetCore.Analyzers.Runtime.DetectPreviewFeatureAnalyzer' threw an exception of type 'System.ArgumentNullException' with message 'Value cannot be null.
Parameter name: key'.
Exception occurred with following context:
Compilation: TerraFX.Samples.DirectX
IOperation: PropertyReference
SyntaxTree: C:\Users\tagoo\Source\repos\terrafx.interop.windows\samples\DirectX\D3D12\HelloTriangle12.cs
SyntaxNode: psoDesc.RTVFormats[0] [ElementAccessExpressionSyntax]@[5006..5027) (110,12)-(110,33)
```

## Fix

Defensive code was added to bail from symbol analysis if the symbol is `null`.

## Testing

Additional test coverage was added for indexer properties. Another test gap of `ref T` properties was identified during this testing, and another test was added for that scenario; the test passed without the fix herein. The fix was also validated against the TerraFX project scenarios.

## Risks

Very low. Addition of defensive code to prevent an unhandled exception. The code path could never have resulted in a diagnostic being reported for a null symbol, so behavior is otherwise unchanged.