### PR TITLE
Update Getting Started page's branch list

### DIFF
--- a/docs/NetCore_GettingStarted.md
+++ b/docs/NetCore_GettingStarted.md
@@ -16,7 +16,6 @@
 |[main](https://github.com/dotnet/roslyn-analyzers/tree/main)| .NET SDK 7.0.0xx  | Currently active branch. All work should target this branch unless it is a bugfix for a previous release
 |[release/5.0.3xx](https://github.com/dotnet/roslyn-analyzers/tree/release/5.0.3xx)| .NET SDK 5.0.3xx | Servicing branch for the .NET 5 SDK.
 |[release/6.0.1xx](https://github.com/dotnet/roslyn-analyzers/tree/release/6.0.1xx)| .NET SDK 6.0.0xx | Servicing branch for the .NET 6 SDK. Currently accepting targeting fixes until the .NET 6 SDK ships
-|[release/7.0.1xx](https://github.com/dotnet/roslyn-analyzers/tree/release/7.0.1xx)| .NET SDK 7.0.0xx | Currently active release branch. New SDK analyzer should target this branch.
 
 ## Definition of done
 


### PR DESCRIPTION
### Summary

The `release/7.0.1xx` branch was removed in favor of using the main branch for .NET 7.x releases. If appears that docs for the main branch were updated, but that docs for the .NET 7 release branch were not.