### PR TITLE
Mark CA2252 as Error severity

### DIFF
--- a/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md
+++ b/src/NetAnalyzers/Core/AnalyzerReleases.Shipped.md
@@ -272,7 +272,7 @@ CA2017 | Reliability | Warning | LoggerMessageDefineAnalyzer, [Documentation](ht
 CA2018 | Reliability | Warning | BufferBlockCopyLengthAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2018)
 CA2250 | Usage | Info | UseCancellationTokenThrowIfCancellationRequested, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2250)
 CA2251 | Usage | Hidden | UseStringEqualsOverStringCompare, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2251)
-CA2252 | Usage | Info | DetectPreviewFeatureAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252)
+CA2252 | Usage | Error | DetectPreviewFeatureAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2252)
 CA2253 | Usage | Info | LoggerMessageDefineAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2253)
 CA2254 | Usage | Info | LoggerMessageDefineAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2254)
 CA2255 | Usage | Warning | ModuleInitializerAttributeShouldNotBeUsedInLibraries, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2255)


### PR DESCRIPTION
Fixes #5636 by setting CA2252 to Error severity.

## Customer Impact

We intended for the CA2252 Preview Feature analyzer to produce build **errors** by default, forcing customers to opt into using preview features. We had validated the experience across our own repos and other existing projects, and that error behavior was experienced. In new projects however, the analyzer was being treated as info-level by default.

The net result is that using APIs marked with `[RequiresPreviewFeatures]` was not yielding build errors by default, even if the customer had not opted in. This means customers are able to unknowingly use preview features. This is a blocker for 6.0 GA that needs to be fixed.

## Testing

This issue had been missed because we had not conducted end-to-end testing of this analyzer through the .NET CLI or in Visual Studio while working in a brand new project. Instead, all prior testing had been conducted while working in projects that already had the projects configured such that this analyzer's diagnostics would be reported as errors. Therefore the behavior of the analyzer itself had been validated, but its default analysis level of Error had not been validated properly.

Using a private build of the analyzers package, we've now validated that the analyzer has the Error severity as the effective default. This has been validated using both command-line and Visual Studio.

## Mitigation of Similar Oversights

* #5640
* #5639

## Risks

This will surface as a build breaking change for someone who consumed preview APIs in Preview 7, RC1, and RC2 in a new project where they had not opted into using preview features. This is very unfortunate, but it's a necessary effect to ensure we have the expected experience in 6.0 GA.

The following APIs are marked as preview:

* All APIs related to Generic Math exposed through the `System.Runtime.Experimental` package
* `System.Runtime.Intrinsics.X86.AvxVnni`
* `Microsoft.AspNetCore.Server.Kestrel.Core.Http3`
* `Microsoft.AspNetCore.Server.Kestrel.Core.Http1AndHttp2AndHttp3`
* `Microsoft.AspNetCore.Hosting.WebHostBuilderQuicExtensions.UseQuic`