### PR TITLE
Add end-to-end testing to the definition of done for .NET Analyzers

### DIFF
--- a/docs/NetCore_GettingStarted.md
+++ b/docs/NetCore_GettingStarted.md
@@ -45,8 +45,8 @@
 - Create the appropriate documentation for [docs.microsoft.com](https://github.com/dotnet/docs/tree/main/docs/fundamentals/code-analysis/quality-rules) within **ONE WEEK**, instructions available on [Contribute docs for .NET code analysis rules to the .NET docs repository](https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis).
 - PR merged into `dotnet/roslyn-analyzers`.
 - Validate the analyzer's behavior with end-to-end testing using the command-line and Visual Studio:
-    - Use `dotnet new console` and `dotnet build` from the command-line, updating the code to introduce diagnostics and ensuring warnings/errors are reported at the command-line
-    - Use Visual Studio to create a new project, introduce diagnostics, and observe the warnings/errors/info messages without invoking a build
+  - Use `dotnet new console` and `dotnet build` from the command-line, updating the code to introduce diagnostics and ensuring warnings/errors are reported at the command-line
+  - Use Visual Studio to create a new project, introduce diagnostics, and observe the warnings/errors/info messages without invoking a build
 
 ## Testing against the Runtime and Roslyn-analyzers repo
 


### PR DESCRIPTION
To help address issues like #5636, this adds end-to-end testing notes into the definition of done for .NET Analyzers. This captures how that specific issue was discovered, reproduced, and narrowed down.