### PR TITLE
Fix CS2014 handling of stackalloc in a foreach expression

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseStackallocInLoops.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseStackallocInLoops.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 using Microsoft.NetCore.Analyzers.Runtime;
@@ -34,10 +35,19 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                         case SyntaxKind.AnonymousMethodExpression:
                             return;
 
+                        // foreach loops are special, in that as with other loops we don't want stackallocs
+                        // in the body of the loop, but in the expression of a foreach is ok.
+                        case SyntaxKind.ForEachStatement:
+                            ForEachStatementSyntax foreachStatement = (ForEachStatementSyntax)node;
+                            if (foreachStatement.Expression.Contains(ctx.Node))
+                            {
+                                return;
+                            }
+                            goto case SyntaxKind.WhileStatement; // fall through
+
                         // Look for loops.  We don't bother with ad-hoc loops via gotos as we're
                         // too likely to incur false positives.
                         case SyntaxKind.ForStatement:
-                        case SyntaxKind.ForEachStatement:
                         case SyntaxKind.WhileStatement:
                         case SyntaxKind.DoStatement:
 

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseStackallocInLoops.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Runtime/CSharpDoNotUseStackallocInLoops.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
                             ForEachStatementSyntax foreachStatement = (ForEachStatementSyntax)node;
                             if (foreachStatement.Expression.Contains(ctx.Node))
                             {
-                                return;
+                                continue;
                             }
                             goto case SyntaxKind.WhileStatement; // fall through
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -266,5 +266,24 @@ class TestClass {
                     }
                 }");
         }
+
+        [Fact]
+        public async Task Diagnostics_StackallocAsSourceOfForeachLoopButInAnotherLoop()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+                using System;
+                unsafe class TestClass {
+                    private static void SourceOfForeachLoopInAnotherLoop() {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            foreach (char c in {|CA2014:stackalloc char[] { 'a', 'b', 'c' }|}) { }
+                        }
+                    }
+                }"
+            }.RunAsync();
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotUseStackallocInLoopsTests.cs
@@ -29,6 +29,22 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [Fact]
+        public async Task NoDiagnostics_StackallocAsSourceOfForeachLoop()
+        {
+            await new VerifyCS.Test
+            {
+                LanguageVersion = LanguageVersion.CSharp8,
+                TestCode = @"
+                using System;
+                unsafe class TestClass {
+                    private static void SourceOfForeachLoop() {
+                        foreach (char c in stackalloc char[] { 'a', 'b', 'c' }) { }
+                    }
+                }"
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task NoDiagnostics_StackallocInLoopWithBreakAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5693