### PR TITLE
No more noisy pragmas needed for 'new System.IO.MemoryStream'

### DIFF
--- a/src/Microsoft.CodeAnalysis.AnalyzerUtilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.AnalyzerUtilities/PublicAPI.Unshipped.txt
@@ -258,6 +258,7 @@ Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisD
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.WellKnownTypeProvider.get -> Analyzer.Utilities.WellKnownTypeProvider!
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ExceptionNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.TaskNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
+Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.MemoryStreamNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.InterlockedNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ContractNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
 Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.IDisposableNamedType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -12599,5 +12599,22 @@ class Program
     }
 }");
         }
+
+        [Fact, WorkItem(4147, "https://github.com/dotnet/roslyn-analyzers/issues/4147")]
+        public async Task Dispose_ValueIsObviouslyMemoryStream_NoDiagnosticAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+    using System;
+    using System.IO;
+
+    class Program
+    {
+        public void TestCa2000()
+        {
+            var ms = new MemoryStream();
+            return;
+        }
+    }");
+        }
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -224,6 +224,7 @@ namespace Analyzer.Utilities
         public const string SystemIOFileInfo = "System.IO.FileInfo";
         public const string SystemIOFileStream = "System.IO.FileStream";
         public const string SystemIOLogLogStore = "System.IO.Log.LogStore";
+        public const string SystemIOMemoryStream = "System.IO.MemoryStream";
         public const string SystemIOPath = "System.IO.Path";
         public const string SystemIOStream = "System.IO.Stream";
         public const string SystemIOStringReader = "System.IO.StringReader";

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/DisposeAnalysis/DisposeAnalysis.DisposeDataFlowOperationVisitor.cs
@@ -104,6 +104,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DisposeAnalysis
                     return defaultValue;
                 }
 
+                // Special case: MemoryStream doesn't need to be disposed. Subclasses *might* need to be disposed, but that is the less common case, and the common case is a huge source of noisy warnings.
+                if (MemoryStreamNamedType != null &&
+                    instanceType.Equals(MemoryStreamNamedType))
+                {
+                    return defaultValue;
+                }
+
                 // Handle user option for additional excluded types
                 if (DataFlowAnalysisContext.IsConfiguredToSkipAnalysis(instanceType))
                 {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -250,6 +250,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             IDisposableNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable);
             IAsyncDisposableNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIAsyncDisposable);
             TaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
+            MemoryStreamNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIOMemoryStream);
             ValueTaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksValueTask);
             GenericTaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1);
             MonitorNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingMonitor);
@@ -4007,6 +4008,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Tasks.Task"/>
         /// </summary>
         protected INamedTypeSymbol? TaskNamedType { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.IO.MemoryStream"/>
+        /// </summary>
+        protected INamedTypeSymbol? MemoryStreamNamedType { get; }
 
         /// <summary>
         /// <see cref="INamedTypeSymbol"/> for System.Threading.Tasks.ValueTask/>


### PR DESCRIPTION
Fixes #4147.

We all never want to see this code again right!:
```
#pragma warning disable CA2000 // Dispose objects before losing scope
            var stream = new MemoryStream();
#pragma warning restore CA2000 // Dispose objects before losing scope
```