### PR TITLE
Use a property initializer to guarantee one-time array allocation

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
             ["ToImmutableSortedSet"] = "System.Collections.Immutable.ImmutableSortedSet`1",
         }.ToImmutableDictionary();
 
-        public static ImmutableArray<string> ToImmutableMethodNames => ImmutableCollectionMetadataNames.Keys.ToImmutableArray();
+        public static ImmutableArray<string> ToImmutableMethodNames { get; } = ImmutableCollectionMetadataNames.Keys.ToImmutableArray();
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.cs
@@ -54,7 +54,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         internal const string NonStaticMemberIsMethodKey = nameof(NonStaticMemberIsMethodKey);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
             DynamicInterfaceCastableImplementationUnsupported,
             InterfaceMembersMissingImplementation,
             MembersDeclaredOnImplementationTypeMustBeStatic);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                         isPortedFxCopRule: false,
                                                         isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                               isPortedFxCopRule: false,
                                                                               isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UnknownPlatform, InvalidVersion, NoVersion);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(UnknownPlatform, InvalidVersion, NoVersion);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseStringContainsCharOverloadWithSingleCharactersAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseStringContainsCharOverloadWithSingleCharactersAnalyzer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule_CA1847);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s_rule_CA1847);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/BufferBlockCopyLengthAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/BufferBlockCopyLengthAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -189,7 +189,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                     isPortedFxCopRule: false,
                                                                                                                     isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
             GeneralPreviewFeatureAttributeRule,
             ImplementsPreviewInterfaceRule,
             ImplementsPreviewMethodRule,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          isDataflowRule: false,
                                                                          isReportedAtCompilationEnd: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(CA1727Rule, CA1848Rule, CA2253Rule, CA2254Rule, CA2017Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(CA1727Rule, CA1848Rule, CA2253Rule, CA2254Rule, CA2017Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ModuleInitializerAttributeShouldNotBeUsedInLibraries.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ModuleInitializerAttributeShouldNotBeUsedInLibraries.cs
@@ -36,7 +36,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                     isPortedFxCopRule: false,
                                                                     isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferAsSpanOverSubstring.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferAsSpanOverSubstring.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferDictionaryContainsMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferDictionaryContainsMethods.cs
@@ -44,7 +44,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         internal const string KeysPropertyName = "Keys";
         internal const string ValuesPropertyName = "Values";
 
-        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ContainsKeyRule, ContainsValueRule);
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ContainsKeyRule, ContainsValueRule);
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideStreamMemoryBasedAsyncOverrides.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideStreamMemoryBasedAsyncOverrides.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         private const string ReadAsyncName = nameof(System.IO.Stream.ReadAsync);
         private const string WriteAsyncName = nameof(System.IO.Stream.WriteAsync);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -47,7 +47,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                               isPortedFxCopRule: false,
                                                                               isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor, DescriptorNoAlternativeMethod);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptor, DescriptorNoAlternativeMethod);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseEnvironmentMembers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseEnvironmentMembers.cs
@@ -50,7 +50,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(UseEnvironmentProcessIdRule, UseEnvironmentProcessPathRule, UseEnvironmentCurrentManagedThreadIdRule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(UseEnvironmentProcessIdRule, UseEnvironmentProcessPathRule, UseEnvironmentCurrentManagedThreadIdRule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseSpanBasedStringConcat.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseSpanBasedStringConcat.cs
@@ -42,7 +42,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         /// </summary>
         private protected abstract IOperation WalkDownBuiltInImplicitConversionOnConcatOperand(IOperation operand);
 
-        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseStringEqualsOverStringCompare.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseStringEqualsOverStringCompare.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAlwaysSkipTokenValidationInDelegates.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAlwaysSkipTokenValidationInDelegates.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 isPortedFxCopRule: false,
                 isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
@@ -33,7 +33,7 @@ namespace Microsoft.NetCore.Analyzers.Security
                 isPortedFxCopRule: false,
                 isDataflowRule: false);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotUseWhenAllOrWaitAllWithSingleArgument.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/DoNotUseWhenAllOrWaitAllWithSingleArgument.cs
@@ -38,7 +38,7 @@ namespace Microsoft.NetCore.Analyzers.Tasks
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
-        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(WhenAllRule, WaitAllRule);
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(WhenAllRule, WaitAllRule);
 
         public sealed override void Initialize(AnalysisContext context)
         {

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ParamsParameterRule, ValueTypeNonOverridenCallRule);
 
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(SyntaxKind.InvocationExpression);
+        protected override ImmutableArray<SyntaxKind> Expressions { get; } = ImmutableArray.Create(SyntaxKind.InvocationExpression);
 
         protected override void AnalyzeNode(SyntaxNodeAnalysisContext context, in PerformanceSensitiveInfo info)
         {

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/ConcatenationAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/ConcatenationAllocationAnalyzer.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(StringConcatenationAllocationRule, ValueTypeToReferenceTypeInAStringConcatenationRule);
 
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression);
+        protected override ImmutableArray<SyntaxKind> Expressions { get; } = ImmutableArray.Create(SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression);
 
         private static readonly object[] EmptyMessageArgs = Array.Empty<object>();
 

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/DisplayClassAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/DisplayClassAllocationAnalyzer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ClosureCaptureRule, ClosureDriverRule, LambaOrAnonymousMethodInGenericMethodRule);
 
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.AnonymousMethodExpression);
+        protected override ImmutableArray<SyntaxKind> Expressions { get; } = ImmutableArray.Create(SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression, SyntaxKind.AnonymousMethodExpression);
 
         private static readonly object[] EmptyMessageArgs = Array.Empty<object>();
 

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/EnumeratorAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/EnumeratorAllocationAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ReferenceTypeEnumeratorRule);
 
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(SyntaxKind.ForEachStatement, SyntaxKind.InvocationExpression);
+        protected override ImmutableArray<SyntaxKind> Expressions { get; } = ImmutableArray.Create(SyntaxKind.ForEachStatement, SyntaxKind.InvocationExpression);
 
         private static readonly object[] EmptyMessageArgs = Array.Empty<object>();
 

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/TypeConversionAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/TypeConversionAllocationAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ValueTypeToReferenceTypeConversionRule, DelegateOnStructInstanceRule, MethodGroupAllocationRule, ReadonlyMethodGroupAllocationRule);
 
-        protected override ImmutableArray<SyntaxKind> Expressions => ImmutableArray.Create(
+        protected override ImmutableArray<SyntaxKind> Expressions { get; } = ImmutableArray.Create(
             SyntaxKind.SimpleAssignmentExpression,
             SyntaxKind.ReturnStatement,
             SyntaxKind.YieldReturnStatement,

--- a/src/PerformanceSensitiveAnalyzers/Core/ExplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/Core/ExplicitAllocationAnalyzer.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             AnonymousObjectCreationRule,
             LetCauseRule);
 
-        protected override ImmutableArray<OperationKind> Operations => ImmutableArray.Create(
+        protected override ImmutableArray<OperationKind> Operations { get; } = ImmutableArray.Create(
             OperationKind.ArrayCreation,
             OperationKind.ObjectCreation,
             OperationKind.AnonymousObjectCreation,

--- a/src/PerformanceTests/Utilities/Common/EmptyAnalyzer.cs
+++ b/src/PerformanceTests/Utilities/Common/EmptyAnalyzer.cs
@@ -9,7 +9,7 @@ namespace PerfUtilities
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class EmptyAnalyzer : DiagnosticAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray<DiagnosticDescriptor>.Empty;
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray<DiagnosticDescriptor>.Empty;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -153,7 +153,7 @@ namespace Analyzer.Utilities.Extensions
             {
                 IMethodSymbol m => m.Parameters,
                 IPropertySymbol p => p.Parameters,
-                _ => ImmutableArray<IParameterSymbol>.Empty
+                _ => ImmutableArray<IParameterSymbol>.Empty,
             };
         }
 

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -153,7 +153,7 @@ namespace Analyzer.Utilities.Extensions
             {
                 IMethodSymbol m => m.Parameters,
                 IPropertySymbol p => p.Parameters,
-                _ => ImmutableArray.Create<IParameterSymbol>()
+                _ => ImmutableArray<IParameterSymbol>.Empty
             };
         }
 


### PR DESCRIPTION
`ImmutableArray.Create` calls does an array allocation:

https://github.com/dotnet/runtime/blob/d9afc1ecd6f22d836e1d7665847917aa09f580e9/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs#L30-L53

With the previous code, `ImmutableArray.Create` will be called EVERY time `SupportedDiagnostics` is accessed. With an initializer, the call to `ImmutableArray.Create` will only be done once. See [SharpLab](https://sharplab.io/#v2:EYLgtghglgdgNAExAagD4AEDMACdAmbAYQFgAoAbzO2tx3QEYAGAbQF1sBle7AXgD5sMAKYB3XE2YBWVgG4qNLOJbsOBctgDmQgC4zsAX16DRSqbLL6gA===).