### PR TITLE
Make DiagnosticDescriptors readonly

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/PreferIsKindAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/PreferIsKindAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class PreferIsKindAnalyzer : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             DiagnosticIds.PreferIsKindRuleId,
             CreateLocalizableResourceString(nameof(PreferIsKindTitle)),
             CreateLocalizableResourceString(nameof(PreferIsKindMessage)),

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
     {
         internal const string RuleId = "CA1419";
 
-        internal static DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
                                                         RuleId,
                                                         CreateLocalizableResourceString(nameof(ProvidePublicParameterlessSafeHandleConstructorTitle)),
                                                         CreateLocalizableResourceString(nameof(ProvidePublicParameterlessSafeHandleConstructorMessage)),

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(UseValidPlatformStringTitle));
         private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(UseValidPlatformStringDescription));
 
-        internal static DiagnosticDescriptor UnknownPlatform = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor UnknownPlatform = DiagnosticDescriptorHelper.Create(RuleId,
                                                                               s_localizableTitle,
                                                                               CreateLocalizableResourceString(nameof(UseValidPlatformStringUnknownPlatform)),
                                                                               DiagnosticCategory.Interoperability,
@@ -37,7 +37,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                               isPortedFxCopRule: false,
                                                                               isDataflowRule: false);
 
-        internal static DiagnosticDescriptor InvalidVersion = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor InvalidVersion = DiagnosticDescriptorHelper.Create(RuleId,
                                                                               s_localizableTitle,
                                                                               CreateLocalizableResourceString(nameof(UseValidPlatformStringInvalidVersion)),
                                                                               DiagnosticCategory.Interoperability,
@@ -46,7 +46,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                                                               isPortedFxCopRule: false,
                                                                               isDataflowRule: false);
 
-        internal static DiagnosticDescriptor NoVersion = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor NoVersion = DiagnosticDescriptorHelper.Create(RuleId,
                                                                               s_localizableTitle,
                                                                               CreateLocalizableResourceString(nameof(UseValidPlatformStringNoVersion)),
                                                                               DiagnosticCategory.Interoperability,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/BufferBlockCopyLengthAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/BufferBlockCopyLengthAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     {
         internal const string RuleId = "CA2018";
 
-        internal static DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       CreateLocalizableResourceString(nameof(BufferBlockCopyLengthTitle)),
                                                                                       CreateLocalizableResourceString(nameof(BufferBlockCopyLengthMessage)),
                                                                                       DiagnosticCategory.Reliability,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(DetectPreviewFeaturesDescription));
         private static readonly ImmutableArray<SymbolKind> s_symbols = ImmutableArray.Create(SymbolKind.NamedType, SymbolKind.Method, SymbolKind.Property, SymbolKind.Field, SymbolKind.Event);
 
-        internal static DiagnosticDescriptor GeneralPreviewFeatureAttributeRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor GeneralPreviewFeatureAttributeRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                     s_localizableTitle,
                                                                                                                     CreateLocalizableResourceString(nameof(DetectPreviewFeaturesMessage)),
                                                                                                                     DiagnosticCategory.Usage,
@@ -36,7 +36,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                     s_localizableDescription,
                                                                                                                     isPortedFxCopRule: false,
                                                                                                                     isDataflowRule: false);
-        internal static DiagnosticDescriptor GeneralPreviewFeatureAttributeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor GeneralPreviewFeatureAttributeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                     s_localizableTitle,
                                                                                                                     CreateLocalizableResourceString(nameof(DetectPreviewFeaturesMessageWithCustomMessagePlaceholder)),
                                                                                                                     DiagnosticCategory.Usage,
@@ -45,7 +45,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                     isPortedFxCopRule: false,
                                                                                                                     isDataflowRule: false);
 
-        internal static DiagnosticDescriptor ImplementsPreviewInterfaceRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor ImplementsPreviewInterfaceRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(ImplementsPreviewInterfaceMessage)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -53,7 +53,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 s_localizableDescription,
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
-        internal static DiagnosticDescriptor ImplementsPreviewInterfaceRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor ImplementsPreviewInterfaceRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(ImplementsPreviewInterfaceMessageWithCustomMessagePlaceholder)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -62,7 +62,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
 
-        internal static DiagnosticDescriptor ImplementsPreviewMethodRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor ImplementsPreviewMethodRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(ImplementsPreviewMethodMessage)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -70,7 +70,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 s_localizableDescription,
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
-        internal static DiagnosticDescriptor ImplementsPreviewMethodRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor ImplementsPreviewMethodRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(ImplementsPreviewMethodMessageWithCustomMessagePlaceholder)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -79,7 +79,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
 
-        internal static DiagnosticDescriptor OverridesPreviewMethodRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor OverridesPreviewMethodRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(OverridesPreviewMethodMessage)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -87,7 +87,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 s_localizableDescription,
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
-        internal static DiagnosticDescriptor OverridesPreviewMethodRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor OverridesPreviewMethodRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                 s_localizableTitle,
                                                                                                                 CreateLocalizableResourceString(nameof(OverridesPreviewMethodMessageWithCustomMessagePlaceholder)),
                                                                                                                 DiagnosticCategory.Usage,
@@ -96,7 +96,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                 isPortedFxCopRule: false,
                                                                                                                 isDataflowRule: false);
 
-        internal static DiagnosticDescriptor DerivesFromPreviewClassRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor DerivesFromPreviewClassRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                              s_localizableTitle,
                                                                                                              CreateLocalizableResourceString(nameof(DerivesFromPreviewClassMessage)),
                                                                                                              DiagnosticCategory.Usage,
@@ -104,7 +104,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                              s_localizableDescription,
                                                                                                              isPortedFxCopRule: false,
                                                                                                              isDataflowRule: false);
-        internal static DiagnosticDescriptor DerivesFromPreviewClassRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor DerivesFromPreviewClassRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                              s_localizableTitle,
                                                                                                              CreateLocalizableResourceString(nameof(DerivesFromPreviewClassMessageWithCustomMessagePlaceholder)),
                                                                                                              DiagnosticCategory.Usage,
@@ -113,7 +113,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                              isPortedFxCopRule: false,
                                                                                                              isDataflowRule: false);
 
-        internal static DiagnosticDescriptor UsesPreviewTypeParameterRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor UsesPreviewTypeParameterRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                               s_localizableTitle,
                                                                                                               CreateLocalizableResourceString(nameof(UsesPreviewTypeParameterMessage)),
                                                                                                               DiagnosticCategory.Usage,
@@ -121,7 +121,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                               s_localizableDescription,
                                                                                                               isPortedFxCopRule: false,
                                                                                                               isDataflowRule: false);
-        internal static DiagnosticDescriptor UsesPreviewTypeParameterRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor UsesPreviewTypeParameterRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                               s_localizableTitle,
                                                                                                               CreateLocalizableResourceString(nameof(UsesPreviewTypeParameterMessageWithCustomMessagePlaceholder)),
                                                                                                               DiagnosticCategory.Usage,
@@ -130,7 +130,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                               isPortedFxCopRule: false,
                                                                                                               isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MethodReturnsPreviewTypeRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor MethodReturnsPreviewTypeRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                               s_localizableTitle,
                                                                                                               CreateLocalizableResourceString(nameof(MethodReturnsPreviewTypeMessage)),
                                                                                                               DiagnosticCategory.Usage,
@@ -138,7 +138,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                               s_localizableDescription,
                                                                                                               isPortedFxCopRule: false,
                                                                                                               isDataflowRule: false);
-        internal static DiagnosticDescriptor MethodReturnsPreviewTypeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor MethodReturnsPreviewTypeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                               s_localizableTitle,
                                                                                                               CreateLocalizableResourceString(nameof(MethodReturnsPreviewTypeMessageWithCustomMessagePlaceholder)),
                                                                                                               DiagnosticCategory.Usage,
@@ -147,7 +147,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                               isPortedFxCopRule: false,
                                                                                                               isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MethodUsesPreviewTypeAsParameterRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor MethodUsesPreviewTypeAsParameterRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                       s_localizableTitle,
                                                                                                                       CreateLocalizableResourceString(nameof(MethodUsesPreviewTypeAsParameterMessage)),
                                                                                                                       DiagnosticCategory.Usage,
@@ -155,7 +155,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                       s_localizableDescription,
                                                                                                                       isPortedFxCopRule: false,
                                                                                                                       isDataflowRule: false);
-        internal static DiagnosticDescriptor MethodUsesPreviewTypeAsParameterRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor MethodUsesPreviewTypeAsParameterRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                       s_localizableTitle,
                                                                                                                       CreateLocalizableResourceString(nameof(MethodUsesPreviewTypeAsParameterMessageWithCustomMessagePlaceholder)),
                                                                                                                       DiagnosticCategory.Usage,
@@ -163,7 +163,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                                       s_localizableDescription,
                                                                                                                       isPortedFxCopRule: false,
                                                                                                                       isDataflowRule: false);
-        internal static DiagnosticDescriptor FieldOrEventIsPreviewTypeRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor FieldOrEventIsPreviewTypeRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                         s_localizableTitle,
                                                                                                         CreateLocalizableResourceString(nameof(FieldIsPreviewTypeMessage)),
                                                                                                         DiagnosticCategory.Usage,
@@ -171,7 +171,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                         s_localizableDescription,
                                                                                                         isPortedFxCopRule: false,
                                                                                                         isDataflowRule: false);
-        internal static DiagnosticDescriptor FieldOrEventIsPreviewTypeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor FieldOrEventIsPreviewTypeRuleWithCustomMessage = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                         s_localizableTitle,
                                                                                                         CreateLocalizableResourceString(nameof(FieldIsPreviewTypeMessageWithCustomMessagePlaceholder)),
                                                                                                         DiagnosticCategory.Usage,
@@ -180,7 +180,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                                         isPortedFxCopRule: false,
                                                                                                         isDataflowRule: false);
 
-        internal static DiagnosticDescriptor StaticAbstractIsPreviewFeatureRule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor StaticAbstractIsPreviewFeatureRule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                                                     s_localizableTitle,
                                                                                                                     CreateLocalizableResourceString(nameof(StaticAndAbstractRequiresPreviewFeatures)),
                                                                                                                     DiagnosticCategory.Usage,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         internal const string CA2254RuleId = "CA2254";
         internal const string CA2017RuleId = "CA2017";
 
-        internal static DiagnosticDescriptor CA1727Rule = DiagnosticDescriptorHelper.Create(CA1727RuleId,
+        internal static readonly DiagnosticDescriptor CA1727Rule = DiagnosticDescriptorHelper.Create(CA1727RuleId,
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticUsePascalCasedLogMessageTokensTitle)),
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticUsePascalCasedLogMessageTokensMessage)),
                                                                          DiagnosticCategory.Naming,
@@ -35,7 +35,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          isDataflowRule: false,
                                                                          isReportedAtCompilationEnd: false);
 
-        internal static DiagnosticDescriptor CA1848Rule = DiagnosticDescriptorHelper.Create(CA1848RuleId,
+        internal static readonly DiagnosticDescriptor CA1848Rule = DiagnosticDescriptorHelper.Create(CA1848RuleId,
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticUseCompiledLogMessagesTitle)),
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticUseCompiledLogMessagesMessage)),
                                                                          DiagnosticCategory.Performance,
@@ -45,7 +45,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          isDataflowRule: false,
                                                                          isReportedAtCompilationEnd: false);
 
-        internal static DiagnosticDescriptor CA2253Rule = DiagnosticDescriptorHelper.Create(CA2253RuleId,
+        internal static readonly DiagnosticDescriptor CA2253Rule = DiagnosticDescriptorHelper.Create(CA2253RuleId,
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticNumericsInFormatStringTitle)),
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticNumericsInFormatStringMessage)),
                                                                          DiagnosticCategory.Usage,
@@ -55,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          isDataflowRule: false,
                                                                          isReportedAtCompilationEnd: false);
 
-        internal static DiagnosticDescriptor CA2254Rule = DiagnosticDescriptorHelper.Create(CA2254RuleId,
+        internal static readonly DiagnosticDescriptor CA2254Rule = DiagnosticDescriptorHelper.Create(CA2254RuleId,
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticConcatenationInFormatStringTitle)),
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticConcatenationInFormatStringMessage)),
                                                                          DiagnosticCategory.Usage,
@@ -65,7 +65,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                          isDataflowRule: false,
                                                                          isReportedAtCompilationEnd: false);
 
-        internal static DiagnosticDescriptor CA2017Rule = DiagnosticDescriptorHelper.Create(CA2017RuleId,
+        internal static readonly DiagnosticDescriptor CA2017Rule = DiagnosticDescriptorHelper.Create(CA2017RuleId,
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticFormatParameterCountMismatchTitle)),
                                                                          CreateLocalizableResourceString(nameof(LoggerMessageDiagnosticFormatParameterCountMismatchMessage)),
                                                                          DiagnosticCategory.Reliability,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ModuleInitializerAttributeShouldNotBeUsedInLibraries.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ModuleInitializerAttributeShouldNotBeUsedInLibraries.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
     {
         internal const string RuleId = "CA2255";
 
-        internal static DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(RuleId,
                                                                     CreateLocalizableResourceString(nameof(ModuleInitializerAttributeShouldNotBeUsedInLibrariesTitle)),
                                                                     CreateLocalizableResourceString(nameof(ModuleInitializerAttributeShouldNotBeUsedInLibrariesMessage)),
                                                                     DiagnosticCategory.Usage,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(UseAsyncMethodInAsyncContextTitle));
         private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(UseAsyncMethodInAsyncContextDescription));
 
-        internal static DiagnosticDescriptor Descriptor = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor Descriptor = DiagnosticDescriptorHelper.Create(RuleId,
                                                                                       s_localizableTitle,
                                                                                       CreateLocalizableResourceString(nameof(UseAsyncMethodInAsyncContextMessage)),
                                                                                       DiagnosticCategory.Performance,
@@ -38,7 +38,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                                       isPortedFxCopRule: false,
                                                                                       isDataflowRule: false);
 
-        internal static DiagnosticDescriptor DescriptorNoAlternativeMethod = DiagnosticDescriptorHelper.Create(RuleId,
+        internal static readonly DiagnosticDescriptor DescriptorNoAlternativeMethod = DiagnosticDescriptorHelper.Create(RuleId,
                                                                               s_localizableTitle,
                                                                               CreateLocalizableResourceString(nameof(UseAsyncMethodInAsyncContextMessage_NoAlternative)),
                                                                               DiagnosticCategory.Performance,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAlwaysSkipTokenValidationInDelegates.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAlwaysSkipTokenValidationInDelegates.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     {
         internal const string DiagnosticId = "CA5405";
 
-        internal static DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
                 DiagnosticId,
                 CreateLocalizableResourceString(nameof(DoNotAlwaysSkipTokenValidationInDelegatesTitle)),
                 CreateLocalizableResourceString(nameof(DoNotAlwaysSkipTokenValidationInDelegatesMessage)),

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Security
 
         internal const string DiagnosticId = "CA5404";
 
-        internal static DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
                 DiagnosticId,
                 CreateLocalizableResourceString(nameof(DoNotDisableTokenValidationChecksTitle)),
                 CreateLocalizableResourceString(nameof(DoNotDisableTokenValidationChecksMessage)),

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/CallSiteImplicitAllocationAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         public const string ParamsParameterRuleId = "HAA0101";
         public const string ValueTypeNonOverridenCallRuleId = "HAA0102";
 
-        internal static DiagnosticDescriptor ParamsParameterRule = new(
+        internal static readonly DiagnosticDescriptor ParamsParameterRule = new(
             ParamsParameterRuleId,
             CreateLocalizableResourceString(nameof(ParamsParameterRuleTitle)),
             CreateLocalizableResourceString(nameof(ParamsParameterRuleMessage)),
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor ValueTypeNonOverridenCallRule = new(
+        internal static readonly DiagnosticDescriptor ValueTypeNonOverridenCallRule = new(
             ValueTypeNonOverridenCallRuleId,
             CreateLocalizableResourceString(nameof(ValueTypeNonOverridenCallRuleTitle)),
             CreateLocalizableResourceString(nameof(ValueTypeNonOverridenCallRuleMessage)),

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/ConcatenationAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/ConcatenationAllocationAnalyzer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         public const string StringConcatenationAllocationRuleId = "HAA0201";
         public const string ValueTypeToReferenceTypeInAStringConcatenationRuleId = "HAA0202";
 
-        internal static DiagnosticDescriptor StringConcatenationAllocationRule = new(
+        internal static readonly DiagnosticDescriptor StringConcatenationAllocationRule = new(
             StringConcatenationAllocationRuleId,
             CreateLocalizableResourceString(nameof(StringConcatenationAllocationRuleTitle)),
             CreateLocalizableResourceString(nameof(StringConcatenationAllocationRuleMessage)),
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             isEnabledByDefault: true,
             helpLinkUri: "http://msdn.microsoft.com/en-us/library/2839d5h5(v=vs.110).aspx");
 
-        internal static DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new(
+        internal static readonly DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new(
             ValueTypeToReferenceTypeInAStringConcatenationRuleId,
             CreateLocalizableResourceString(nameof(ValueTypeToReferenceTypeInAStringConcatenationRuleTitle)),
             CreateLocalizableResourceString(nameof(ValueTypeToReferenceTypeInAStringConcatenationRuleMessage)),

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/DisplayClassAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/DisplayClassAllocationAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         public const string ClosureCaptureRuleId = "HAA0302";
         public const string LambaOrAnonymousMethodInGenericMethodRuleId = "HAA0303";
 
-        internal static DiagnosticDescriptor ClosureDriverRule = new(
+        internal static readonly DiagnosticDescriptor ClosureDriverRule = new(
             ClosureDriverRuleId,
             CreateLocalizableResourceString(nameof(ClosureDriverRuleTitle)),
             CreateLocalizableResourceString(nameof(ClosureDriverRuleMessage)),
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor ClosureCaptureRule = new(
+        internal static readonly DiagnosticDescriptor ClosureCaptureRule = new(
             ClosureCaptureRuleId,
             CreateLocalizableResourceString(nameof(ClosureCaptureRuleTitle)),
             CreateLocalizableResourceString(nameof(ClosureCaptureRuleMessage)),
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor LambaOrAnonymousMethodInGenericMethodRule = new(
+        internal static readonly DiagnosticDescriptor LambaOrAnonymousMethodInGenericMethodRule = new(
             LambaOrAnonymousMethodInGenericMethodRuleId,
             CreateLocalizableResourceString(nameof(LambaOrAnonymousMethodInGenericMethodRuleTitle)),
             CreateLocalizableResourceString(nameof(LambaOrAnonymousMethodInGenericMethodRuleMessage)),

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/EnumeratorAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/EnumeratorAllocationAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
     {
         public const string ReferenceTypeEnumeratorRuleId = "HAA0401";
 
-        internal static DiagnosticDescriptor ReferenceTypeEnumeratorRule = new(
+        internal static readonly DiagnosticDescriptor ReferenceTypeEnumeratorRule = new(
             ReferenceTypeEnumeratorRuleId,
             CreateLocalizableResourceString(nameof(ReferenceTypeEnumeratorRuleTitle)),
             CreateLocalizableResourceString(nameof(ReferenceTypeEnumeratorRuleMessage)),

--- a/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/TypeConversionAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/CSharp/Analyzers/TypeConversionAllocationAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
         public const string MethodGroupAllocationRuleId = "HAA0603";
         public const string ReadonlyMethodGroupAllocationRuleId = "HAA0604";
 
-        internal static DiagnosticDescriptor ValueTypeToReferenceTypeConversionRule = new(
+        internal static readonly DiagnosticDescriptor ValueTypeToReferenceTypeConversionRule = new(
             ValueTypeToReferenceTypeConversionRuleId,
             CreateLocalizableResourceString(nameof(ValueTypeToReferenceTypeConversionRuleTitle)),
             CreateLocalizableResourceString(nameof(ValueTypeToReferenceTypeConversionRuleMessage)),
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor DelegateOnStructInstanceRule = new(
+        internal static readonly DiagnosticDescriptor DelegateOnStructInstanceRule = new(
             DelegateOnStructInstanceRuleId,
             CreateLocalizableResourceString(nameof(DelegateOnStructInstanceRuleTitle)),
             CreateLocalizableResourceString(nameof(DelegateOnStructInstanceRuleMessage)),
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor MethodGroupAllocationRule = new(
+        internal static readonly DiagnosticDescriptor MethodGroupAllocationRule = new(
             MethodGroupAllocationRuleId,
             CreateLocalizableResourceString(nameof(MethodGroupAllocationRuleTitle)),
             CreateLocalizableResourceString(nameof(MethodGroupAllocationRuleMessage)),
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new(
+        internal static readonly DiagnosticDescriptor ReadonlyMethodGroupAllocationRule = new(
             ReadonlyMethodGroupAllocationRuleId,
             CreateLocalizableResourceString(nameof(ReadonlyMethodGroupAllocationRuleTitle)),
             CreateLocalizableResourceString(nameof(ReadonlyMethodGroupAllocationRuleMessage)),

--- a/src/PerformanceSensitiveAnalyzers/Core/ExplicitAllocationAnalyzer.cs
+++ b/src/PerformanceSensitiveAnalyzers/Core/ExplicitAllocationAnalyzer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
         private static readonly LocalizableString s_localizablAnonymousObjectCreationRuleTitleAndMessage = CreateLocalizableResourceString(nameof(AnonymousNewObjectRuleTitleAndMessage));
         private static readonly LocalizableString s_localizableLetCauseRuleTitleAndMessage = CreateLocalizableResourceString(nameof(LetCauseRuleTitleAndMessage));
 
-        internal static DiagnosticDescriptor ArrayCreationRule = new(
+        internal static readonly DiagnosticDescriptor ArrayCreationRule = new(
             ArrayCreationRuleId,
             s_localizableArrayCreationRuleTitleAndMessage,
             s_localizableArrayCreationRuleTitleAndMessage,
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor ObjectCreationRule = new(
+        internal static readonly DiagnosticDescriptor ObjectCreationRule = new(
             ObjectCreationRuleId,
             s_localizableObjectCreationRuleTitleAndMessage,
             s_localizableObjectCreationRuleTitleAndMessage,
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             DiagnosticSeverity.Info,
             isEnabledByDefault: true);
 
-        internal static DiagnosticDescriptor AnonymousObjectCreationRule = new(
+        internal static readonly DiagnosticDescriptor AnonymousObjectCreationRule = new(
             AnonymousObjectCreationRuleId,
             s_localizablAnonymousObjectCreationRuleTitleAndMessage,
             s_localizablAnonymousObjectCreationRuleTitleAndMessage,
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers
             isEnabledByDefault: true,
             helpLinkUri: "http://msdn.microsoft.com/en-us/library/bb397696.aspx");
 
-        internal static DiagnosticDescriptor LetCauseRule = new(
+        internal static readonly DiagnosticDescriptor LetCauseRule = new(
             LetCauseRuleId,
             s_localizableLetCauseRuleTitleAndMessage,
             s_localizableLetCauseRuleTitleAndMessage,

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpAvoidOptSuffixForNullableEnableCode.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpAvoidOptSuffixForNullableEnableCode.cs
@@ -26,7 +26,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
     {
         internal const string OptSuffix = "Opt";
 
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.AvoidOptSuffixForNullableEnableCodeRuleId,
             CreateLocalizableResourceString(nameof(AvoidOptSuffixForNullableEnableCodeTitle)),
             CreateLocalizableResourceString(nameof(AvoidOptSuffixForNullableEnableCodeMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/PreferNullLiteral.cs
@@ -14,7 +14,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class PreferNullLiteral : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.PreferNullLiteralRuleId,
             CreateLocalizableResourceString(nameof(PreferNullLiteralTitle)),
             CreateLocalizableResourceString(nameof(PreferNullLiteralMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Diagnostics.Analyzers
     {
         private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(DoNotCopyValueTitle));
 
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueMessage)),
@@ -34,7 +34,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor UnsupportedUseRule = new(
+        internal static readonly DiagnosticDescriptor UnsupportedUseRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueUnsupportedUseMessage)),
@@ -45,7 +45,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor AvoidNullableWrapperRule = new(
+        internal static readonly DiagnosticDescriptor AvoidNullableWrapperRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueAvoidNullableWrapperMessage)),
@@ -56,7 +56,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoAssignValueFromReferenceRule = new(
+        internal static readonly DiagnosticDescriptor NoAssignValueFromReferenceRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoAssignValueFromReferenceMessage)),
@@ -67,7 +67,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoReturnValueFromReferenceRule = new(
+        internal static readonly DiagnosticDescriptor NoReturnValueFromReferenceRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoReturnValueFromReferenceMessage)),
@@ -78,7 +78,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoBoxingRule = new(
+        internal static readonly DiagnosticDescriptor NoBoxingRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoBoxingMessage)),
@@ -89,7 +89,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoUnboxingRule = new(
+        internal static readonly DiagnosticDescriptor NoUnboxingRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoUnboxingMessage)),
@@ -100,7 +100,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoFieldOfCopyableTypeRule = new(
+        internal static readonly DiagnosticDescriptor NoFieldOfCopyableTypeRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoFieldOfCopyableTypeMessage)),
@@ -111,7 +111,7 @@ namespace Roslyn.Diagnostics.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        internal static DiagnosticDescriptor NoAutoPropertyRule = new(
+        internal static readonly DiagnosticDescriptor NoAutoPropertyRule = new(
             RoslynDiagnosticIds.DoNotCopyValueRuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(DoNotCopyValueNoAutoPropertyMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DefaultableTypeShouldHaveDefaultableFieldsAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DefaultableTypeShouldHaveDefaultableFieldsAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Roslyn.Diagnostics.Analyzers
 #pragma warning restore RS1004 // Recommend adding language support to diagnostic analyzer
     public class DefaultableTypeShouldHaveDefaultableFieldsAnalyzer : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.DefaultableTypeShouldHaveDefaultableFieldsRuleId,
             CreateLocalizableResourceString(nameof(DefaultableTypeShouldHaveDefaultableFieldsTitle)),
             CreateLocalizableResourceString(nameof(DefaultableTypeShouldHaveDefaultableFieldsMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/DoNotMixAttributesFromDifferentVersionsOfMEF.cs
@@ -21,7 +21,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class DoNotMixAttributesFromDifferentVersionsOfMEFAnalyzer : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.MixedVersionsOfMefAttributesRuleId,
             CreateLocalizableResourceString(nameof(DoNotMixAttributesFromDifferentVersionsOfMEFTitle)),
             CreateLocalizableResourceString(nameof(DoNotMixAttributesFromDifferentVersionsOfMEFMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class ExportedPartsShouldHaveImportingConstructor : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.ExportedPartsShouldHaveImportingConstructorRuleId,
             CreateLocalizableResourceString(nameof(ExportedPartsShouldHaveImportingConstructorTitle)),
             CreateLocalizableResourceString(nameof(ExportedPartsShouldHaveImportingConstructorMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -24,7 +24,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class ImportingConstructorShouldBeObsolete : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.ImportingConstructorShouldBeObsoleteRuleId,
             CreateLocalizableResourceString(nameof(ImportingConstructorShouldBeObsoleteTitle)),
             CreateLocalizableResourceString(nameof(ImportingConstructorShouldBeObsoleteMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/PartsExportedWithMEFv2MustBeMarkedAsShared.cs
@@ -19,7 +19,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class PartsExportedWithMEFv2MustBeMarkedAsSharedAnalyzer : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.MissingSharedAttributeRuleId,
             CreateLocalizableResourceString(nameof(PartsExportedWithMEFv2MustBeMarkedAsSharedTitle)),
             CreateLocalizableResourceString(nameof(PartsExportedWithMEFv2MustBeMarkedAsSharedMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/TemporaryArrayAsRefAnalyzer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/TemporaryArrayAsRefAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public class TemporaryArrayAsRefAnalyzer : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.TemporaryArrayAsRefRuleId,
             CreateLocalizableResourceString(nameof(TemporaryArrayAsRefTitle)),
             CreateLocalizableResourceString(nameof(TemporaryArrayAsRefMessage)),

--- a/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/TestExportsShouldNotBeDiscoverable.cs
@@ -23,7 +23,7 @@ namespace Roslyn.Diagnostics.Analyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class TestExportsShouldNotBeDiscoverable : DiagnosticAnalyzer
     {
-        internal static DiagnosticDescriptor Rule = new(
+        internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.TestExportsShouldNotBeDiscoverableRuleId,
             CreateLocalizableResourceString(nameof(TestExportsShouldNotBeDiscoverableTitle)),
             CreateLocalizableResourceString(nameof(TestExportsShouldNotBeDiscoverableMessage)),

--- a/src/Text.Analyzers/Core/EnumsShouldHavePluralNames.cs
+++ b/src/Text.Analyzers/Core/EnumsShouldHavePluralNames.cs
@@ -24,7 +24,7 @@ namespace Text.Analyzers
     {
         internal const string RuleId_Plural = "CA1714";
 
-        internal static DiagnosticDescriptor Rule_CA1714 =
+        internal static readonly DiagnosticDescriptor Rule_CA1714 =
             DiagnosticDescriptorHelper.Create(
                 RuleId_Plural,
                 CreateLocalizableResourceString(nameof(FlagsEnumsShouldHavePluralNamesTitle)),
@@ -37,7 +37,7 @@ namespace Text.Analyzers
 
         internal const string RuleId_NoPlural = "CA1717";
 
-        internal static DiagnosticDescriptor Rule_CA1717 =
+        internal static readonly DiagnosticDescriptor Rule_CA1717 =
             DiagnosticDescriptorHelper.Create(
                 RuleId_NoPlural,
                 CreateLocalizableResourceString(nameof(OnlyFlagsEnumsShouldHavePluralNamesTitle)),

--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -30,7 +30,7 @@ namespace Text.Analyzers
         private static readonly SourceTextValueProvider<CodeAnalysisDictionary> s_dicDictionaryProvider = new(ParseDicDictionary);
         private static readonly CodeAnalysisDictionary s_mainDictionary = GetMainDictionary();
 
-        internal static DiagnosticDescriptor FileParseRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor FileParseRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyFileParse)),
@@ -40,7 +40,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor AssemblyRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor AssemblyRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageAssembly)),
@@ -50,7 +50,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor NamespaceRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor NamespaceRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageNamespace)),
@@ -60,7 +60,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor TypeRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor TypeRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageType)),
@@ -70,7 +70,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor VariableRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor VariableRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageVariable)),
@@ -80,7 +80,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MemberRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MemberRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMember)),
@@ -90,7 +90,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MemberParameterRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MemberParameterRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMemberParameter)),
@@ -100,7 +100,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor DelegateParameterRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor DelegateParameterRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageDelegateParameter)),
@@ -110,7 +110,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor TypeTypeParameterRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor TypeTypeParameterRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageTypeTypeParameter)),
@@ -120,7 +120,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MethodTypeParameterRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MethodTypeParameterRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMethodTypeParameter)),
@@ -130,7 +130,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor AssemblyMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor AssemblyMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageAssemblyMoreMeaningfulName)),
@@ -140,7 +140,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor NamespaceMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor NamespaceMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageNamespaceMoreMeaningfulName)),
@@ -150,7 +150,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor TypeMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor TypeMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageTypeMoreMeaningfulName)),
@@ -160,7 +160,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MemberMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MemberMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMemberMoreMeaningfulName)),
@@ -170,7 +170,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MemberParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MemberParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMemberParameterMoreMeaningfulName)),
@@ -180,7 +180,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor DelegateParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor DelegateParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageDelegateParameterMoreMeaningfulName)),
@@ -190,7 +190,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor TypeTypeParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor TypeTypeParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageTypeTypeParameterMoreMeaningfulName)),
@@ -200,7 +200,7 @@ namespace Text.Analyzers
             isPortedFxCopRule: true,
             isDataflowRule: false);
 
-        internal static DiagnosticDescriptor MethodTypeParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
+        internal static readonly DiagnosticDescriptor MethodTypeParameterMoreMeaningfulNameRule = DiagnosticDescriptorHelper.Create(
             RuleId,
             s_localizableTitle,
             CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyMessageMethodTypeParameterMoreMeaningfulName)),


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5169