### PR TITLE
CA2252 Add VB override for GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes method

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -94,7 +94,7 @@ Imports System
 Imports System.Runtime.Versioning
 Imports System.Collections.Generic
 Module Preview_Feature_Scratch
-    Public Class {|#2:AFoo|}(Of T As Foo)
+    Public Class AFoo(Of T As {|#2:Foo|})
         <RequiresPreviewFeatures>
         Private _value As Foo
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
@@ -176,6 +176,46 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         End Function
 
         Protected Overrides Function GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(typeOrMethodSymbol As ISymbol, previewInterfaceConstraintSymbol As ISymbol) As SyntaxNode
+            Dim typeSymbolDeclaringReferences = typeOrMethodSymbol.DeclaringSyntaxReferences
+
+            For Each syntaxReference In typeSymbolDeclaringReferences
+                Dim classStatement = TryCast(syntaxReference.GetSyntax(), ClassStatementSyntax)
+                If classStatement IsNot Nothing AndAlso classStatement.TypeParameterList IsNot Nothing Then
+                    Return GetSyntaxNodeFromTypeConstraints(classStatement.TypeParameterList, previewInterfaceConstraintSymbol)
+                End If
+
+                Dim methodDeclaration = TryCast(syntaxReference.GetSyntax(), MethodStatementSyntax)
+                If methodDeclaration IsNot Nothing AndAlso methodDeclaration.TypeParameterList IsNot Nothing Then
+                    Return GetSyntaxNodeFromTypeConstraints(methodDeclaration.TypeParameterList, previewInterfaceConstraintSymbol)
+                End If
+            Next
+            Return Nothing
+        End Function
+
+        Private Function GetSyntaxNodeFromTypeConstraints(typeParameters As TypeParameterListSyntax, previewSymbol As ISymbol) As SyntaxNode
+            For Each typeParameter In typeParameters.Parameters
+                Dim singleConstraint = TryCast(typeParameter.TypeParameterConstraintClause, TypeParameterSingleConstraintClauseSyntax)
+                If singleConstraint IsNot Nothing Then
+                    Return GetTypeConstraints(singleConstraint.Constraint, previewSymbol)
+                End If
+
+                Dim multipleConstraint = TryCast(typeParameter.TypeParameterConstraintClause, TypeParameterMultipleConstraintClauseSyntax)
+                If multipleConstraint IsNot Nothing Then
+                    For Each constriant In multipleConstraint.Constraints
+                        Return GetTypeConstraints(constriant, previewSymbol)
+                    Next
+                End If
+            Next
+
+            Return Nothing
+        End Function
+
+        Private Function GetTypeConstraints(constraint As ConstraintSyntax, previewSymbol As ISymbol) As SyntaxNode
+            Dim typeConstraint = TryCast(constraint, TypeConstraintSyntax)
+            If typeConstraint IsNot Nothing AndAlso IsIdentifierNameSyntax(typeConstraint.Type, previewSymbol) Then
+                Return typeConstraint.Type
+            End If
+
             Return Nothing
         End Function
 
@@ -199,6 +239,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
 
             Return Nothing
         End Function
+
         Protected Overrides Function GetPreviewReturnTypeSyntaxNodeForMethodOrProperty(methodOrPropertySymbol As ISymbol, previewReturnTypeSymbol As ISymbol) As SyntaxNode
             Dim methodOrPropertySymbolDeclaringReferences = methodOrPropertySymbol.DeclaringSyntaxReferences
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5646

Add VB implementation for `GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes` abstract method of `PreviewFeature` analyzer. Updated/added a test accordingly
