### PR TITLE
Support all Debug.Assert(...) overloads in flow analysis

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3523,6 +3523,55 @@ End Class";
         }
 
         [Fact]
+        public async Task GuardedWith_DebugAssertWithMessage()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Runtime.InteropServices;
+
+class Test
+{
+    void M1()
+    {
+        Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), ""{0} is only supported on windows"", nameof(M3));
+        M3();
+        [|M2()|];
+
+        Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2), ""Only supported on windows"");
+        M2();
+        M3();
+    }
+
+    [SupportedOSPlatform(""Windows10.1.2.3"")]
+    void M2() { }
+
+    [SupportedOSPlatform(""Windows"")]
+    void M3() { }
+}";
+            await VerifyAnalyzerCSAsync(source);
+
+            var vbSource = @"
+Imports System.Diagnostics
+Imports System.Runtime.Versioning
+Imports System
+
+Class Test
+    Private Sub M1()
+        [|M2()|]
+        Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2), ""Only supported on windows"")
+        M2()
+    End Sub
+
+    <SupportedOSPlatform(""Windows10.1.2.3"")>
+    Private Sub M2()
+    End Sub
+End Class";
+            await VerifyAnalyzerVBAsync(vbSource);
+        }
+
+        [Fact]
         public async Task GuardedWith_ResultSavedInLocalAsync()
         {
             var source = @"

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -3535,13 +3535,17 @@ class Test
 {
     void M1()
     {
-        Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), ""{0} is only supported on windows"", nameof(M3));
+        Debug.Assert(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), ""Only supported on windows"", ""Detailed message"");
         M3();
         [|M2()|];
+        [|M4()|];
 
         Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2), ""Only supported on windows"");
         M2();
         M3();
+
+        Debug.Assert(OperatingSystem.IsLinux(), ""{0}  is only supported on windows"", ""Detailed message"", nameof(M4));
+        M4();
     }
 
     [SupportedOSPlatform(""Windows10.1.2.3"")]
@@ -3549,23 +3553,40 @@ class Test
 
     [SupportedOSPlatform(""Windows"")]
     void M3() { }
+
+    [SupportedOSPlatform(""linux"")]
+    void M4() { }
 }";
             await VerifyAnalyzerCSAsync(source);
 
             var vbSource = @"
+Imports System
 Imports System.Diagnostics
 Imports System.Runtime.Versioning
-Imports System
 
 Class Test
     Private Sub M1()
+        Debug.Assert(OperatingSystem.IsWindows(), ""Only supported on windows"", ""Detailed message"")
+        M3()
         [|M2()|]
+        [|M4()|]
+
         Debug.Assert(OperatingSystem.IsOSPlatformVersionAtLeast(""Windows"", 10, 2), ""Only supported on windows"")
         M2()
+        M3()
+
+        Debug.Assert(OperatingSystem.IsLinux(), ""{0}  is only supported on windows"", ""Detailed message"", nameof(M4))
+        M4()
     End Sub
 
     <SupportedOSPlatform(""Windows10.1.2.3"")>
     Private Sub M2()
+    End Sub
+    <SupportedOSPlatform(""Windows"")>
+    Private Sub M3()
+    End Sub
+    <SupportedOSPlatform(""Linux"")>
+    Private Sub M4()
     End Sub
 End Class";
             await VerifyAnalyzerVBAsync(vbSource);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -990,8 +990,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return false;
         }
 
-        private bool IsDebugAssertMethod(IMethodSymbol method)
-            => Equals(method, DebugAssertMethod);
+        private bool IsDebugAssertMethod(IMethodSymbol method) =>
+            DebugAssertMethod != null &&
+            method.ContainingSymbol.Equals(DebugAssertMethod.ContainingSymbol, SymbolEqualityComparer.Default) &&
+            method.Name == DebugAssertMethod.Name &&
+            method.ReturnType == DebugAssertMethod.ReturnType;
 
         protected bool IsAnyAssertMethod(IMethodSymbol method)
             => IsDebugAssertMethod(method) || IsContractCheckMethod(method);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -967,7 +967,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private bool IsContractCheckArgument(IArgumentOperation operation)
             => operation.Parent is IInvocationOperation invocation &&
                invocation.Arguments[0] == operation &&
-               (IsDebugAssertMethod(invocation.TargetMethod) || IsContractCheckMethod(invocation.TargetMethod));
+               (IsAnyDebugAssertMethod(invocation.TargetMethod) || IsContractCheckMethod(invocation.TargetMethod));
 
         private bool IsContractCheckMethod(IMethodSymbol method)
         {
@@ -990,14 +990,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             return false;
         }
 
-        private bool IsDebugAssertMethod(IMethodSymbol method) =>
+        /// <summary>
+        /// Checks if the method is an overload of the <see cref="Debug.Assert(bool)"/> method.
+        /// </summary>
+        /// <param name="method">The IMethodSymbol to test.</param>
+        /// <returns>True if the method is an overlaod of the <see cref="Debug.Assert(bool)"/> method.</returns>
+        private bool IsAnyDebugAssertMethod(IMethodSymbol method) =>
             DebugAssertMethod != null &&
             method.ContainingSymbol.Equals(DebugAssertMethod.ContainingSymbol, SymbolEqualityComparer.Default) &&
             method.Name == DebugAssertMethod.Name &&
             method.ReturnType == DebugAssertMethod.ReturnType;
 
         protected bool IsAnyAssertMethod(IMethodSymbol method)
-            => IsDebugAssertMethod(method) || IsContractCheckMethod(method);
+            => IsAnyDebugAssertMethod(method) || IsContractCheckMethod(method);
 
         #region Helper methods to get or cache analysis data for visited operations.
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5403

Flow analysis doesn't support `Debug.Assert(bool, string? message)` or any other overload except `Debug.Assert(bool)`:
```cs
void M1()
{
    Debug.Assert(OperatingSystem.IsWindows(), "Only supported on windows");
    WindowsOnly(); // warns even not supposed to

    Debug.Assert(OperatingSystem.IsWindows());
    WindowsOnly(); // not warn
}

[SupportedOSPlatform("windows")]
void WindwosOnly () { }
```
I believe all overloads of Debug.Assert(...) should be supported cc @mavasani 