### PR TITLE
Don't throw exception: "Passing '.editorconfig' files as additional files is no longer needed."

### DIFF
--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -578,11 +578,6 @@ namespace Analyzer.Utilities
         private static ICategorizedAnalyzerConfigOptions GetOrComputeCategorizedAnalyzerConfigOptions(
             this AnalyzerOptions options, Compilation compilation)
         {
-            if (options.AdditionalFiles.Any(f => PathHelper.GetFileName(f.Path).Equals(".editorconfig".AsSpan(), StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new InvalidOperationException("Passing '.editorconfig' files as additional files is no longer needed. It will be implicitly discovered (if the file is in the project's directory or any ancestor directory), or it should be converted into a 'globalconfig'. See 'https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files'.");
-            }
-
             // TryGetValue upfront to avoid allocating createValueCallback if the entry already exists.
             if (s_cachedOptions.TryGetValue(options, out var categorizedAnalyzerConfigOptions))
             {


### PR DESCRIPTION
Closes #5725
Closes #5748

@sharwell @mavasani Do you think this is a good fix?

<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild /t:Pack /v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
