### PR TITLE
Fix 'Compare symbols correctly' false positive with custom comparers

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/CompareSymbolsCorrectlyAnalyzer.cs
@@ -87,7 +87,6 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
                     context => HandleInvocationOperation(in context, symbolType, symbolEqualityComparerType, equalityComparerMethods, systemHashCode, iEqualityComparer),
                     OperationKind.Invocation);
 
-
                 if (symbolEqualityComparerType is not null && iEqualityComparer is not null)
                 {
                     var collectionTypesBuilder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -1249,7 +1249,7 @@ public class C
         }
 
         [Fact]
-        public async Task RS1024_CustomComparer()
+        public async Task RS1024_CustomComparer_Instance_Is_Interface()
         {
             var code = @"
 using System.Collections.Generic;
@@ -1285,7 +1285,7 @@ internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
         }
 
         [Fact]
-        public async Task RS1024_CustomComparer2()
+        public async Task RS1024_CustomComparer_Instance_Is_Type()
         {
             var code = @"
 using System.Collections.Generic;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -1320,6 +1320,81 @@ internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task RS1024_CustomComparer_ToDictionary()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+public class C
+{
+    public void M(IEnumerable<ITypeSymbol> symbols)
+    {
+        _ = symbols.ToDictionary(s => s, s => s.ToDisplayString(), SymbolNameComparer.Instance);
+        _ = symbols.ToDictionary(s => s, s => s.ToDisplayString(), SymbolEqualityComparer.Default);
+    }
+}
+
+internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
+{
+    private SymbolNameComparer() { }
+
+    internal static IEqualityComparer<ISymbol> Instance { get; } = new SymbolNameComparer();
+
+    public override bool Equals(ISymbol x, ISymbol y) => true;
+
+    public override int GetHashCode(ISymbol obj) => 0;
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = code,
+                ReferenceAssemblies = CreateNetCoreReferenceAssemblies(),
+
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task RS1024_CustomComparer_ToDictionary2()
+        {
+            var code = @"
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+public class C
+{
+    public void M(IEnumerable<ITypeSymbol> symbols)
+    {
+        _ = symbols.ToDictionary(s => s, s => s.ToDisplayString(), SymbolNameComparer.Instance);
+    }
+}
+
+internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
+{
+    private SymbolNameComparer() { }
+
+    internal static SymbolNameComparer Instance { get; } = new SymbolNameComparer();
+
+    public override bool Equals(ISymbol x, ISymbol y) => true;
+
+    public override int GetHashCode(ISymbol obj) => 0;
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = code,
+                ReferenceAssemblies = CreateNetCoreReferenceAssemblies(),
+
+            }.RunAsync();
+        }
+
         private static ReferenceAssemblies CreateNetCoreReferenceAssemblies()
             => ReferenceAssemblies.NetCore.NetCoreApp31.AddPackages(ImmutableArray.Create(
                 new PackageIdentity("Microsoft.CodeAnalysis", "4.0.1"),

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/CompareSymbolsCorrectlyTests.cs
@@ -1248,9 +1248,81 @@ public class C
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task RS1024_CustomComparer()
+        {
+            var code = @"
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+public class C
+{
+    public void M()
+    {
+        _ = new HashSet<ISymbol>(SymbolNameComparer.Instance);
+    }
+}
+
+internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
+{
+    private SymbolNameComparer() { }
+
+    internal static IEqualityComparer<ISymbol> Instance { get; } = new SymbolNameComparer();
+
+    public override bool Equals(ISymbol x, ISymbol y) => true;
+
+    public override int GetHashCode(ISymbol obj) => 0;
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = code,
+                ReferenceAssemblies = CreateNetCoreReferenceAssemblies(),
+
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task RS1024_CustomComparer2()
+        {
+            var code = @"
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+public class C
+{
+    public void M()
+    {
+        _ = new HashSet<ISymbol>(SymbolNameComparer.Instance);
+    }
+}
+
+internal sealed class SymbolNameComparer : EqualityComparer<ISymbol>
+{
+    private SymbolNameComparer() { }
+
+    internal static SymbolNameComparer Instance { get; } = new SymbolNameComparer();
+
+    public override bool Equals(ISymbol x, ISymbol y) => true;
+
+    public override int GetHashCode(ISymbol obj) => 0;
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                FixedCode = code,
+                ReferenceAssemblies = CreateNetCoreReferenceAssemblies(),
+
+            }.RunAsync();
+        }
+
         private static ReferenceAssemblies CreateNetCoreReferenceAssemblies()
             => ReferenceAssemblies.NetCore.NetCoreApp31.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Microsoft.CodeAnalysis", "3.0.0"),
+                new PackageIdentity("Microsoft.CodeAnalysis", "4.0.1"),
                 new PackageIdentity("System.Runtime.Serialization.Formatters", "4.3.0"),
                 new PackageIdentity("System.Configuration.ConfigurationManager", "4.7.0"),
                 new PackageIdentity("System.Security.Cryptography.Cng", "4.7.0"),


### PR DESCRIPTION
Fixes #5715
