### PR TITLE
Simplify detect preview feature and fix NRE

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Fields.cs
@@ -167,15 +167,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 
             }
 
-            public class AGenericClass<T>
-                where T : {|#3:PreviewType|}
+            public class AGenericClass<{|#3:T|}>
+                where T : PreviewType
             {
 
             }
 
 #nullable enable
-            public class AGenericClassWithNullable<T>
-                where T : {|#6:PreviewType?|}
+            public class AGenericClassWithNullable<{|#6:T|}>
+                where T : PreviewType?
             {
                 private {|#7:PreviewType|}? _fieldNullable;
                 private {|#8:PreviewType|}[]? _fieldArrayNullable;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Generics.cs
@@ -54,8 +54,8 @@ namespace Preview_Feature_Scratch
 
     class Program
     {
-        public bool GenericMethod<T>()
-            where T : {|#0:Foo|}
+        public bool GenericMethod<{|#0:T|}>()
+            where T : Foo
         {
             return true;
         }
@@ -88,8 +88,8 @@ namespace Preview_Feature_Scratch
     class Program
     {
 #nullable enable
-        public bool GenericMethod<T>()
-            where T : {|#0:Foo?|}
+        public bool GenericMethod<{|#0:T|}>()
+            where T : Foo?
         {
             return true;
         }
@@ -121,8 +121,8 @@ namespace Preview_Feature_Scratch
 {
 
 #nullable enable
-    class Program<T>
-        where T : {|#0:Foo?|}
+    class Program<{|#0:T|}>
+        where T : Foo?
     {
         static void Main(string[] args)
         {
@@ -267,7 +267,7 @@ namespace Preview_Feature_Scratch
         }
     }
 
-class A<T> where T : {|#1:IFoo|}, new()
+class A<{|#1:T|}> where T : IFoo, new()
 {
     public A()
     {
@@ -312,7 +312,7 @@ namespace Preview_Feature_Scratch
         }
     }
 
-class A<T> where T : {|#1:IFoo|}, new()
+class A<{|#1:T|}> where T : IFoo, new()
 {
     public A()
     {
@@ -412,7 +412,7 @@ namespace Preview_Feature_Scratch
             A<Foo> aFooInstance = new A<Foo>();
         }
     }
-class A<T> where T : {|#1:IFoo|}, new()
+class A<{|#1:T|}> where T : IFoo, new()
 {
     public A()
     {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureTests.Properties.cs
@@ -45,7 +45,7 @@ using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
 
-    class AFoo<T> where T : {|#2:Foo|}, new()
+    class AFoo<{|#2:T|}> where T : Foo, new()
     {
         [RequiresPreviewFeatures]
         private Foo _value;
@@ -94,7 +94,7 @@ Imports System
 Imports System.Runtime.Versioning
 Imports System.Collections.Generic
 Module Preview_Feature_Scratch
-    Public Class {|#2:AFoo|}(Of T As Foo)
+    Public Class AFoo(Of {|#2:T As Foo|})
         <RequiresPreviewFeatures>
         Private _value As Foo
 
@@ -133,7 +133,7 @@ using System.Collections.Generic;
 namespace Preview_Feature_Scratch
 {
 
-    class AFoo<T> where T : {|#2:Foo|}, new()
+    class AFoo<{|#2:T|}> where T : Foo, new()
     {
         private List<{|#3:Foo|}> _value;
 
@@ -318,7 +318,7 @@ using System.Runtime.Versioning; using System;
 namespace Preview_Feature_Scratch
 {
 
-    class AFoo<T> where T : {|#0:Foo|}, new()
+    class AFoo<{|#0:T|}> where T : Foo, new()
     {
         private {|#1:Foo|} _value;
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
@@ -700,7 +700,7 @@ namespace Preview_Feature_Scratch
 {" +
     @"
 
-    class AFoo<T> where T : {|#2:Foo|}, new()
+    class AFoo<{|#2:T|}> where T : Foo, new()
     {
         public {|#1:Foo|}[] _fooArray;
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicDetectPreviewFeatureAnalyzer.vb
@@ -175,10 +175,6 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             Return Nothing
         End Function
 
-        Protected Overrides Function GetConstraintSyntaxNodeForTypeConstrainedByPreviewTypes(typeOrMethodSymbol As ISymbol, previewInterfaceConstraintSymbol As ISymbol) As SyntaxNode
-            Return Nothing
-        End Function
-
         Private Function TryGetNodeFromAsClauseForMethodOrProperty(asClause As AsClauseSyntax, previewReturnTypeSymbol As ISymbol) As SyntaxNode
             Dim simpleAsClause = TryCast(asClause, SimpleAsClauseSyntax)
             If simpleAsClause IsNot Nothing Then


### PR DESCRIPTION
Fixes #5802

@jeffhandley @buyaa-n The bit of refactoring I made have caused some changes in diagnostic locations.

The new code is more reliable as it compares actual symbols instead of dealing with syntax nodes which can give inaccurate results.