### PR TITLE
Remove Debugger.Break in production code

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.Fixer.cs
@@ -25,7 +25,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            System.Diagnostics.Debugger.Break();
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
I accidentally left this in when I created the DynamicInterfaceCastableImplementation analyzer and just found it. We should remove this from production code.