### PR TITLE
Add an option to control the default behavior of IEnumerable Analyzer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerations.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerations.cs
@@ -178,15 +178,22 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
             }
 
             var syntaxTree = operationBlocks[0].Syntax.SyntaxTree;
-            var customizedEnumerationMethods = operationBlockStartAnalysisContext.Options.GetEnumerationMethodsOption(
+            var options = operationBlockStartAnalysisContext.Options;
+            var customizedEnumerationMethods = options.GetEnumerationMethodsOption(
                     MultipleEnumerableDescriptor,
                     syntaxTree,
-                    operationBlockStartAnalysisContext.Compilation);
+                    compilation);
 
-            var customizedLinqChainMethods = operationBlockStartAnalysisContext.Options.GetLinqChainMethodsOption(
+            var customizedLinqChainMethods = options.GetLinqChainMethodsOption(
                     MultipleEnumerableDescriptor,
                     syntaxTree,
-                    operationBlockStartAnalysisContext.Compilation);
+                    compilation);
+
+            var assumeMethodEnumeratesArguments = options.GetAssumeMethodEnumeratesArgumentsOption(
+                MultipleEnumerableDescriptor,
+                syntaxTree,
+                compilation,
+                defaultValue: false);
 
             // In CFG blocks there is no foreach loop related Operation, so use the
             // the GetEnumerator method to find the foreach loop
@@ -199,7 +206,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
                 additionalDeferTypes,
                 getEnumeratorSymbols,
                 customizedEnumerationMethods,
-                customizedLinqChainMethods);
+                customizedLinqChainMethods,
+                assumeMethodEnumeratesArguments);
 
             var potentialDiagnosticOperationsBuilder = PooledHashSet<IOperation>.GetInstance();
             operationBlockStartAnalysisContext.RegisterOperationAction(

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerations.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerations.cs
@@ -189,7 +189,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
                     syntaxTree,
                     compilation);
 
-            var assumeMethodEnumeratesArguments = options.GetAssumeMethodEnumeratesArgumentsOption(
+
+            var assumeMethodEnumeratesArguments = options.GetBoolOptionValue(
+                EditorConfigOptionNames.AssumeMethodEnumeratesArguments,
                 MultipleEnumerableDescriptor,
                 syntaxTree,
                 compilation,

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerationsHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/AvoidMultipleEnumerationsHelpers.cs
@@ -249,7 +249,14 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
             }
 
             // Enumeration methods specified in editorConfig
-            return wellKnownSymbolsInfo.IsCustomizedEnumerationMethods(originalMethod);
+            if (wellKnownSymbolsInfo.IsCustomizedEnumerationMethods(originalMethod))
+            {
+                return true;
+            }
+
+            // Analyzer is in aggressive mode, assuming all methods enumerated the argument if we know the type of mapping parameter is IEnumerable type.
+            return wellKnownSymbolsInfo.AssumeMethodEnumeratesArguments
+                && IsDeferredType(argumentMappingParameter.Type?.OriginalDefinition, wellKnownSymbolsInfo.AdditionalDeferredTypes);
         }
 
         /// <summary>

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/WellKnownSymbolsInfo.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/WellKnownSymbolsInfo.cs
@@ -57,6 +57,11 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
         /// </summary>
         public SymbolNamesWithValueOption<Unit> CustomizedLinqChainMethods { get; }
 
+        /// <summary>
+        /// User specified value that should assume method enumerates take IEnumerable type arguments or not.
+        /// </summary>
+        public bool AssumeMethodEnumeratesArguments { get; }
+
         public WellKnownSymbolsInfo(
             ImmutableArray<IMethodSymbol> linqChainMethods,
             ImmutableArray<IMethodSymbol> noEnumerationMethods,
@@ -64,8 +69,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
             ImmutableArray<IMethodSymbol> noEffectLinqChainMethods,
             ImmutableArray<ITypeSymbol> additionalDeferredTypes,
             ImmutableArray<IMethodSymbol> getEnumeratorMethods,
-            SymbolNamesWithValueOption<Unit> customizedEnumerationMethods,
-            SymbolNamesWithValueOption<Unit> customizedLinqChainMethods)
+            SymbolNamesWithValueOption<Unit> customizedEumerationMethods,
+            SymbolNamesWithValueOption<Unit> customizedLinqChainMethods,
+            bool assumeMethodEnumeratesArguments)
         {
             LinqChainMethods = linqChainMethods;
             NoEnumerationMethods = noEnumerationMethods;
@@ -73,8 +79,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
             NoEffectLinqChainMethods = noEffectLinqChainMethods;
             AdditionalDeferredTypes = additionalDeferredTypes;
             GetEnumeratorMethods = getEnumeratorMethods;
-            CustomizedEumerationMethods = customizedEnumerationMethods;
+            CustomizedEumerationMethods = customizedEumerationMethods;
             CustomizedLinqChainMethods = customizedLinqChainMethods;
+            AssumeMethodEnumeratesArguments = assumeMethodEnumeratesArguments;
         }
 
         public bool IsCustomizedEnumerationMethods(IMethodSymbol methodSymbol)

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -435,6 +435,14 @@ namespace Analyzer.Utilities
             Compilation compilation)
             => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.LinqChainMethods, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), namePrefix: "M:");
 
+        public static bool GetAssumeMethodEnumeratesArgumentsOption(
+            this AnalyzerOptions options,
+            DiagnosticDescriptor rule,
+            SyntaxTree tree,
+            Compilation compilation,
+            bool defaultValue)
+            => options.GetBoolOptionValue(EditorConfigOptionNames.AssumeMethodEnumeratesArguments, rule, tree, compilation, defaultValue);
+
         private static SymbolNamesWithValueOption<TValue> GetSymbolNamesWithValueOption<TValue>(
             this AnalyzerOptions options,
             string optionName,

--- a/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
+++ b/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs
@@ -435,14 +435,6 @@ namespace Analyzer.Utilities
             Compilation compilation)
             => options.GetSymbolNamesWithValueOption<Unit>(EditorConfigOptionNames.LinqChainMethods, rule, tree, compilation, static name => new SymbolNamesWithValueOption<Unit>.NameParts(name, Unit.Default), namePrefix: "M:");
 
-        public static bool GetAssumeMethodEnumeratesArgumentsOption(
-            this AnalyzerOptions options,
-            DiagnosticDescriptor rule,
-            SyntaxTree tree,
-            Compilation compilation,
-            bool defaultValue)
-            => options.GetBoolOptionValue(EditorConfigOptionNames.AssumeMethodEnumeratesArguments, rule, tree, compilation, defaultValue);
-
         private static SymbolNamesWithValueOption<TValue> GetSymbolNamesWithValueOption<TValue>(
             this AnalyzerOptions options,
             string optionName,

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -208,17 +208,20 @@ namespace Analyzer.Utilities
         /// <summary>
         /// String option to configure names of method symbols (separated by '|') that marks all of the parameters with IEnumerable type
         /// would be enumerated.
+        /// Configurable rule: CA1851 (https://docs.microsoft.com/visualstudio/code-quality/ca1851).
         /// </summary>
         public const string EnumerationMethods = "enumeration_methods";
 
         /// <summary>
         /// String option to configure names of method symbols (separated by '|') that accepting parameter with IEnumerable type and return a new IEnumerable type, like 'Select' and 'Where'.
+        /// Configurable rule: CA1851 (https://docs.microsoft.com/visualstudio/code-quality/ca1851).
         /// </summary>
         public const string LinqChainMethods = "linq_chain_methods";
 
         /// <summary>
         /// Boolean option to configure the assumption that IEnumerable type arguments would be enumerated by method invocation or not.
         /// It does not affect linq_chain_methods.
+        /// Configurable rule: CA1851 (https://docs.microsoft.com/visualstudio/code-quality/ca1851).
         /// </summary>
         public const string AssumeMethodEnumeratesArguments = "assume_method_enumerates_arguments";
 

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -217,6 +217,12 @@ namespace Analyzer.Utilities
         public const string LinqChainMethods = "linq_chain_methods";
 
         /// <summary>
+        /// Boolean option to configure the assumption that IEnumerable type arguments would be enumerated by method invocation or not.
+        /// It does not affect linq_chain_methods.
+        /// </summary>
+        public const string AssumeMethodEnumeratesArguments = "assume_method_enumerates_arguments";
+
+        /// <summary>
         /// String option to configure names of additional "None" enum case (separated by '|') for CA1008.
         /// </summary>
         public const string AdditionalEnumNoneNames = "additional_enum_none_names";


### PR DESCRIPTION
A small PR addresses this comment
https://github.com/dotnet/roslyn-analyzers/pull/5882#discussion_r817505300