### PR TITLE
Update Run Iterations refactoring to work with attribute lists

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/RunIterationsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/RunIterationsTests.cs
@@ -116,6 +116,102 @@ Class CustomTheoryAttribute : Inherits TheoryAttribute : End Class
         }
 
         [Theory]
+        [InlineData("Fact")]
+        [InlineData("FactAttribute")]
+        [InlineData("CustomFact")]
+        [InlineData("CustomFactAttribute")]
+        public async Task RunIterationsOfFactWithTrait_CSharp(string attributeName)
+        {
+            var updatedName = attributeName switch
+            {
+                "Fact" => "Theory",
+                "FactAttribute" => "TheoryAttribute",
+                "CustomFact" => "CustomTheory",
+                "CustomFactAttribute" => "CustomTheoryAttribute",
+                _ => throw new ArgumentException(),
+            };
+
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = xunitWithCombinatorial,
+                TestCode = $@"using Xunit;
+
+class TestClass
+{{
+    [{attributeName}, Trait(""Key"", ""Value"")]
+    public void $$Method()
+    {{
+    }}
+}}
+
+class CustomFactAttribute : FactAttribute {{ }}
+class CustomTheoryAttribute : TheoryAttribute {{ }}
+",
+                FixedCode = $@"using Xunit;
+
+class TestClass
+{{
+    [{updatedName}, Trait(""Key"", ""Value"")]
+    [CombinatorialData]
+    public void $$Method([CombinatorialRange(0, 10)] int iteration)
+    {{
+        _ = iteration;
+    }}
+}}
+
+class CustomFactAttribute : FactAttribute {{ }}
+class CustomTheoryAttribute : TheoryAttribute {{ }}
+",
+            }.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("Fact")]
+        [InlineData("FactAttribute")]
+        [InlineData("CustomFact")]
+        [InlineData("CustomFactAttribute")]
+        public async Task RunIterationsOfFactWithTrait_VisualBasic(string attributeName)
+        {
+            // Visual Basic syntax generator, formatter, and/or simplifier drops the Attribute suffix automatically
+            var updatedName = attributeName switch
+            {
+                "Fact" => "Theory",
+                "FactAttribute" => "Theory",
+                "CustomFact" => "CustomTheory",
+                "CustomFactAttribute" => "CustomTheory",
+                _ => throw new ArgumentException(),
+            };
+
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = xunitWithCombinatorial,
+                TestCode = $@"Imports Xunit
+
+Class TestClass
+    <{attributeName}, Trait(""Key"", ""Value"")>
+    Public Sub $$Method()
+    End Sub
+End Class
+
+Class CustomFactAttribute : Inherits FactAttribute : End Class
+Class CustomTheoryAttribute : Inherits TheoryAttribute : End Class
+",
+                FixedCode = $@"Imports Xunit
+
+Class TestClass
+    <{updatedName}, Trait(""Key"", ""Value"")>
+    <CombinatorialData>
+    Public Sub $$Method(<CombinatorialRange(0, 10)> iteration As Integer)
+    End Sub
+End Class
+
+Class CustomFactAttribute : Inherits FactAttribute : End Class
+Class CustomTheoryAttribute : Inherits TheoryAttribute : End Class
+",
+            }.RunAsync();
+        }
+
+        [Theory]
         [InlineData("Theory")]
         [InlineData("TheoryAttribute")]
         [InlineData("CustomTheory")]


### PR DESCRIPTION
`SyntaxGenerator.WithName` converts `Fact` to `[Theory]` (wrapping `AttributeSyntax` in an `AttributeListSyntax`), which makes it incompatible for direct replacement. This change unwraps the `AttributeSyntax` before replacing the original node in the tree.