### PR TITLE
Fix handling of recursive types in DisableRuntimeMarshalling analyzer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshalling.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshalling.cs
@@ -337,47 +337,63 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             private bool TypeIsAutoLayoutOrContainsAutoLayout(ITypeSymbol type)
             {
-                Debug.Assert(type.IsValueType);
-
-                if (_isAutoLayoutOrContainsAutoLayoutCache.TryGetValue(type, out bool isAutoLayoutOrContainsAutoLayout))
+                return TypeIsAutoLayoutOrContainsAutoLayout(type, ImmutableHashSet<ITypeSymbol>.Empty.WithComparer(SymbolEqualityComparer.Default));
+                bool TypeIsAutoLayoutOrContainsAutoLayout(ITypeSymbol type, ImmutableHashSet<ITypeSymbol> seenTypes)
                 {
-                    return isAutoLayoutOrContainsAutoLayout;
-                }
+                    Debug.Assert(type.IsValueType);
 
-                if (_structLayoutAttribute is not null)
-                {
-                    foreach (var attr in type.GetAttributes(_structLayoutAttribute))
+                    if (_isAutoLayoutOrContainsAutoLayoutCache.TryGetValue(type, out bool isAutoLayoutOrContainsAutoLayout))
                     {
-                        if (attr.ConstructorArguments.Length > 0
-                            && attr.ConstructorArguments[0] is TypedConstant argument
-                            && argument.Type is not null)
-                        {
-                            SpecialType specialType = argument.Type.TypeKind == TypeKind.Enum ?
-                                ((INamedTypeSymbol)argument.Type).EnumUnderlyingType.SpecialType :
-                                argument.Type.SpecialType;
+                        return isAutoLayoutOrContainsAutoLayout;
+                    }
 
-                            if (DiagnosticHelpers.TryConvertToUInt64(argument.Value, specialType, out ulong convertedLayoutKindValue) &&
-                                convertedLayoutKindValue == (ulong)LayoutKind.Auto)
+                    if (seenTypes.Contains(type.OriginalDefinition))
+                    {
+                        // If we have a recursive type, we are in one of two scenarios.
+                        // 1. We're analyzing CoreLib and see the struct definition of a primitive type.
+                        // In all of these cases, the type does not have auto layout.
+                        // 2. We found a recursive type definition.
+                        // Recursive type definitions are invalid and Roslyn will emit another error diagnostic anyway,
+                        // so we don't care here.
+                        _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, false);
+                        return false;
+                    }
+
+                    if (_structLayoutAttribute is not null)
+                    {
+                        foreach (var attr in type.GetAttributes(_structLayoutAttribute))
+                        {
+                            if (attr.ConstructorArguments.Length > 0
+                                && attr.ConstructorArguments[0] is TypedConstant argument
+                                && argument.Type is not null)
                             {
-                                _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, true);
-                                return true;
+                                SpecialType specialType = argument.Type.TypeKind == TypeKind.Enum ?
+                                    ((INamedTypeSymbol)argument.Type).EnumUnderlyingType.SpecialType :
+                                    argument.Type.SpecialType;
+
+                                if (DiagnosticHelpers.TryConvertToUInt64(argument.Value, specialType, out ulong convertedLayoutKindValue) &&
+                                    convertedLayoutKindValue == (ulong)LayoutKind.Auto)
+                                {
+                                    _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, true);
+                                    return true;
+                                }
                             }
                         }
                     }
-                }
 
-                foreach (var member in type.GetMembers())
-                {
-                    if (member is IFieldSymbol { IsStatic: false, Type.IsValueType: true } valueTypeField
-                        && TypeIsAutoLayoutOrContainsAutoLayout(valueTypeField.Type))
+                    foreach (var member in type.GetMembers())
                     {
-                        _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, true);
-                        return true;
+                        if (member is IFieldSymbol { IsStatic: false, Type.IsValueType: true } valueTypeField
+                            && TypeIsAutoLayoutOrContainsAutoLayout(valueTypeField.Type, seenTypes.Add(type.OriginalDefinition)))
+                        {
+                            _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, true);
+                            return true;
+                        }
                     }
-                }
 
-                _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, false);
-                return false;
+                    _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, false);
+                    return false;
+                }
             }
         }
     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshalling.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshalling.cs
@@ -381,10 +381,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         }
                     }
 
+                    var seenTypesWithCurrentType = seenTypes.Add(type.OriginalDefinition);
+
                     foreach (var member in type.GetMembers())
                     {
                         if (member is IFieldSymbol { IsStatic: false, Type.IsValueType: true } valueTypeField
-                            && TypeIsAutoLayoutOrContainsAutoLayout(valueTypeField.Type, seenTypes.Add(type.OriginalDefinition)))
+                            && TypeIsAutoLayoutOrContainsAutoLayout(valueTypeField.Type, seenTypesWithCurrentType))
                         {
                             _isAutoLayoutOrContainsAutoLayoutCache.TryAdd(type, true);
                             return true;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshallingTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/DisableRuntimeMarshallingTests.cs
@@ -254,6 +254,56 @@ struct ValueType
         }
 
         [Fact]
+        public async Task CS_PInvokeWithRecursiveManagedValueTypeReturnValue_DoesNotEmitDiagnostic()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+[assembly:DisableRuntimeMarshalling]
+
+class C
+{
+    [DllImport(""NativeLibrary"")]
+    public static extern ValueType Method();
+}
+
+struct ValueType
+{
+    ValueType {|CS0523:v|};
+}
+";
+            await VerifyCSAnalyzerAsync(source);
+        }
+
+        [Fact]
+        public async Task CS_PInvokeWithMutuallyRecursiveManagedValueTypeReturnValue_DoesNotEmitDiagnostic()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+[assembly:DisableRuntimeMarshalling]
+
+class C
+{
+    [DllImport(""NativeLibrary"")]
+    public static extern ValueType Method();
+}
+
+struct ValueType
+{
+    ValueType2 {|CS0523:v|};
+}
+struct ValueType2
+{
+    ValueType {|CS0523:v|};
+}
+";
+            await VerifyCSAnalyzerAsync(source);
+        }
+
+        [Fact]
         public async Task VB_PInvokeWithManagedValueTypeReturnValue_Emits_Diagnostic()
         {
             string source = @"


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

This fixes a bug in the DisableRuntimeMarshallingAnalyzer that causes it to stack-overflow on recursive types. Generally these types are invalid in C#, but some special cases (the definitions of primitive types) exist. This bug is blocking dotnet/runtime from intaking new copies of dotnet/roslyn-analyzers

cc: @dotnet/roslyn-analysis @dotnet/runtime-infrastructure 
