### PR TITLE
Fix CA1416 failure with NullReferenceExcpetion

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -2074,6 +2074,37 @@ class Some
         }
 
         [Fact]
+        public async Task MergePlatformAttributesCrushTest()
+        {
+            var source = @"
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform(""ios10.0"")]
+static class Program
+{
+    public static void Main()
+    {
+        [|Some.Api1()|]; // This call site is reachable on all platforms. 'Some.Api1()' is only supported on: 'ios' 14.0 and later, 'maccatalyst' 14.0 and later
+    }
+}
+
+[SupportedOSPlatform(""ios10.0"")]
+[SupportedOSPlatform(""tvos10.0"")]
+[SupportedOSPlatform(""macos10.14"")]
+[SupportedOSPlatform(""maccatalyst13.1"")]
+[UnsupportedOSPlatform(""watchos"")]
+class Some
+{
+    [UnsupportedOSPlatform(""watchos"")]
+    [UnsupportedOSPlatform(""tvos"")]
+    [UnsupportedOSPlatform(""macos"")]
+    [SupportedOSPlatform(""ios14.0"")]
+    public static void Api1() {}
+}";
+            await VerifyAnalyzerCSAsync(source);
+        }
+
+        [Fact]
         public async Task PlatformOverridesAsync()
         {
             var source = @"

--- a/src/Utilities/Compiler/SmallDictionary.cs
+++ b/src/Utilities/Compiler/SmallDictionary.cs
@@ -137,13 +137,13 @@ namespace Analyzer.Utilities
 
             if (balance == -2)
             {
-                rotated = currentNode.Right!.Balance < 0 ?
+                rotated = currentNode.Right!.Balance <= 0 ?
                     LeftSimple(currentNode) :
                     LeftComplex(currentNode);
             }
             else if (balance == 2)
             {
-                rotated = currentNode.Left!.Balance > 0 ?
+                rotated = currentNode.Left!.Balance >= 0 ?
                     RightSimple(currentNode) :
                     RightComplex(currentNode);
             }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn-analyzers/issues/5936

Platform compatibility analyzer crushes for some platform attributes combinations while removing Unsupported  platforms from Supported platforms list
