### PR TITLE
Fix a typo in IEnumerable Analyzer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/MicrosoftCodeQualityAnalyzersResources.resx
@@ -1312,7 +1312,7 @@
     <value>Add operator overload named alternate</value>
   </data>
   <data name="AvoidMultipleEnumerationsMessage" xml:space="preserve">
-    <value>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</value>
+    <value>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</value>
     <comment>{Locked="IEnumerable"}</comment>
   </data>
   <data name="AvoidMultipleEnumerationsTitle" xml:space="preserve">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.cs.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Je možných více výčtů kolekce IEnumerable. Zvažte použití implementace, která zabraňuje více výčtům.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Je možných více výčtů kolekce IEnumerable. Zvažte použití implementace, která zabraňuje více výčtům.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.de.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Mögliche mehrere Enumerationen der „IEnumerable“-Auflistung. Erwägen Sie die Verwendung einer Implementierung, die mehrere Enumerationen vermeidet.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Mögliche mehrere Enumerationen der „IEnumerable“-Auflistung. Erwägen Sie die Verwendung einer Implementierung, die mehrere Enumerationen vermeidet.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.es.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Posibles enumeraciones múltiples de la colección 'IEnumerable'. Considere la posibilidad de usar una implementación que evite múltiples enumeraciones.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Posibles enumeraciones múltiples de la colección 'IEnumerable'. Considere la posibilidad de usar una implementación que evite múltiples enumeraciones.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.fr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Possibilité d'énumérations multiples de la collection 'IEnumerable'. Envisagez d'utiliser une mise en œuvre qui évite les énumérations multiples.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Possibilité d'énumérations multiples de la collection 'IEnumerable'. Envisagez d'utiliser une mise en œuvre qui évite les énumérations multiples.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.it.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Possibili enumerazioni multiple della raccolta 'IEnumerable'. Considerare l'utilizzo di un'implementazione che eviti enumerazioni multiple.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Possibili enumerazioni multiple della raccolta 'IEnumerable'. Considerare l'utilizzo di un'implementazione che eviti enumerazioni multiple.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ja.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">'IEnumerable' コレクションを複数列挙している可能性があります。複数列挙を回避する実装を検討してください。</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">'IEnumerable' コレクションを複数列挙している可能性があります。複数列挙を回避する実装を検討してください。</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ko.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">'IEnumerable' 컬렉션에 대해 여러 개의 열거형이 가능합니다. 여러 열거형을 방지하는 구현을 사용하는 것이 좋습니다.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">'IEnumerable' 컬렉션에 대해 여러 개의 열거형이 가능합니다. 여러 열거형을 방지하는 구현을 사용하는 것이 좋습니다.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pl.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Możliwe wielokrotne wyliczenia kolekcji „IEnumerable“. Rozważ użycie implementacji, która pozwala uniknąć wielu wyliczeń.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Możliwe wielokrotne wyliczenia kolekcji „IEnumerable“. Rozważ użycie implementacji, która pozwala uniknąć wielu wyliczeń.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.pt-BR.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Possíveis várias enumerações da coleção 'IEnumerable'. Considere usar uma implementação que evite várias enumerações.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Possíveis várias enumerações da coleção 'IEnumerable'. Considere usar uma implementação que evite várias enumerações.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.ru.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">Возможно несколько перечислений коллекции IEnumerable. Рассмотрите возможность использования реализации без нескольких перечислений.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">Возможно несколько перечислений коллекции IEnumerable. Рассмотрите возможность использования реализации без нескольких перечислений.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.tr.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">'IEnumerable' koleksiyonunun birden çok numaralandırması olabilir. Birden çok numaralandırmayı önleyen bir uygulama kullanmayı düşünün.</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">'IEnumerable' koleksiyonunun birden çok numaralandırması olabilir. Birden çok numaralandırmayı önleyen bir uygulama kullanmayı düşünün.</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hans.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">“IEnumerable”集合可能的多个枚举。请考虑使用避免多个枚举的实现。</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">“IEnumerable”集合可能的多个枚举。请考虑使用避免多个枚举的实现。</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/xlf/MicrosoftCodeQualityAnalyzersResources.zh-Hant.xlf
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsMessage">
-        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.</source>
-        <target state="translated">'IEnumerable' 集合可能有多個列舉。請考慮使用避免多個列舉的實作。</target>
+        <source>Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.</source>
+        <target state="needs-review-translation">'IEnumerable' 集合可能有多個列舉。請考慮使用避免多個列舉的實作。</target>
         <note>{Locked="IEnumerable"}</note>
       </trans-unit>
       <trans-unit id="AvoidMultipleEnumerationsTitle">

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1502,7 +1502,7 @@ It is more efficient to use the static 'HashData' method over creating and manag
 
 ## [CA1851](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851): Possible multiple enumerations of 'IEnumerable' collection
 
-Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.
+Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.
 
 |Item|Value|
 |-|-|

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -249,7 +249,7 @@
         "CA1851": {
           "id": "CA1851",
           "shortDescription": "Possible multiple enumerations of 'IEnumerable' collection",
-          "fullDescription": "Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.",
+          "fullDescription": "Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.",
           "defaultLevel": "warning",
           "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851",
           "properties": {
@@ -5903,7 +5903,7 @@
         "CA1851": {
           "id": "CA1851",
           "shortDescription": "Possible multiple enumerations of 'IEnumerable' collection",
-          "fullDescription": "Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoid multiple enumerations.",
+          "fullDescription": "Possible multiple enumerations of 'IEnumerable' collection. Consider using an implementation that avoids multiple enumerations.",
           "defaultLevel": "warning",
           "helpUri": "https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1851",
           "properties": {


### PR DESCRIPTION
In this comment https://github.com/dotnet/docs/pull/28732#discussion_r831458450
@gewarren mentioned it should be 'avoids' instead of 'avoid'
Bring this change to the analyzer resources