### PR TITLE
Reset the value when CreationOperation is visited again for IEnumerable

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/FlowAnalysis/GlobalFlowStateDictionaryAnalysisValue.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/FlowAnalysis/GlobalFlowStateDictionaryAnalysisValue.cs
@@ -116,6 +116,18 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
             return new GlobalFlowStateDictionaryAnalysisValue(builder.ToImmutable(), GlobalFlowStateDictionaryAnalysisValueKind.Known);
         }
 
+        public GlobalFlowStateDictionaryAnalysisValue RemoveTrackedDeferredTypeEntity(IDeferredTypeEntity entity)
+        {
+            if (this.TrackedEntities.ContainsKey(entity))
+            {
+                return this.TrackedEntities.Count == 1
+                    ? Empty
+                    : new GlobalFlowStateDictionaryAnalysisValue(TrackedEntities.Remove(entity), GlobalFlowStateDictionaryAnalysisValueKind.Known);
+            }
+
+            return this;
+        }
+
         protected override bool ComputeEqualsByHashCodeParts(CacheBasedEquatable<GlobalFlowStateDictionaryAnalysisValue> obj)
         {
             var other = (GlobalFlowStateDictionaryAnalysisValue)obj;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/FlowAnalysis/GlobalFlowStateDictionaryFlowOperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerations/FlowAnalysis/GlobalFlowStateDictionaryFlowOperationVisitor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines.AvoidMultipleEnumera
 
         protected sealed override void SetAbstractValue(GlobalFlowStateDictionaryAnalysisData analysisData, AnalysisEntity analysisEntity, GlobalFlowStateDictionaryAnalysisValue value)
         {
-            if (value.Kind == GlobalFlowStateDictionaryAnalysisValueKind.Known)
+            if (value.Kind is GlobalFlowStateDictionaryAnalysisValueKind.Known or GlobalFlowStateDictionaryAnalysisValueKind.Empty)
             {
                 analysisData[analysisEntity] = value;
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
@@ -4105,5 +4105,141 @@ End Namespace
 ";
             await VerifyVB.VerifyAnalyzerAsync(vbCode);
         }
+
+        [Fact]
+        public async Task TestValueReset1()
+        {
+            var csharpCode = @"
+using System.Collections.Generic;
+using System.Linq;
+
+public class Bar
+{
+    public void Sub()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            var x = Create();
+            var d = x.ElementAt(10);
+        }
+    }
+
+    private IEnumerable<int> Create() => Enumerable.Range(1, 10);
+}";
+            await VerifyCS.VerifyAnalyzerAsync(csharpCode);
+
+            var vbCode = @"
+Imports System.Collections.Generic
+Imports System.Linq
+
+Namespace Ns
+    Public Class Hoo
+        Public Sub Goo()
+            For i As Integer = 1 To 100
+                Dim x = Create()
+                Dim d = x.ElementAt(10)
+            Next
+        End Sub
+
+        Private Function Create() As IEnumerable(Of Integer)
+            Return Enumerable.Range(1, 10)
+        End Function
+    End Class
+End Namespace
+";
+            await VerifyVB.VerifyAnalyzerAsync(vbCode);
+        }
+
+        [Fact]
+        public async Task TestValueReset2()
+        {
+            var csharpCode = @"
+using System.Collections.Generic;
+using System.Linq;
+
+public class Bar
+{
+    public void Sub()
+    {
+        var x = Create();
+        for (int i = 0; i < 100; i++)
+        {
+            var a = Create();
+            var y = x;
+            var d = [|y|].ElementAt(10);
+        }
+    }
+
+    private IEnumerable<int> Create() => Enumerable.Range(1, 10);
+}";
+            await VerifyCS.VerifyAnalyzerAsync(csharpCode);
+
+            var vbCode = @"
+Imports System.Collections.Generic
+Imports System.Linq
+
+Namespace Ns
+    Public Class Hoo
+        Public Sub Goo()
+            Dim x = Create()
+            For i As Integer = 1 To 100
+                Dim a = Create()
+                Dim y = x
+                Dim d = [|y|].ElementAt(10)
+            Next
+        End Sub
+
+        Private Function Create() As IEnumerable(Of Integer)
+            Return Enumerable.Range(1, 10)
+        End Function
+    End Class
+End Namespace
+";
+            await VerifyVB.VerifyAnalyzerAsync(vbCode);
+        }
+
+        [Fact]
+        public async Task TestValueReset3()
+        {
+            var csharpCode = @"
+using System.Collections.Generic;
+using System.Linq;
+
+public class Bar
+{
+    public void Sub(IEnumerable<int> n)
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            var x = Create().Concat([|n|]);
+            var d = x.ElementAt(10);
+        }
+    }
+
+    private IEnumerable<int> Create() => Enumerable.Range(1, 10);
+}";
+            await VerifyCS.VerifyAnalyzerAsync(csharpCode);
+
+            var vbCode = @"
+Imports System.Collections.Generic
+Imports System.Linq
+
+Namespace Ns
+    Public Class Hoo
+        Public Sub Goo(n As IEnumerable(Of Integer))
+            For i As Integer = 1 To 100
+                Dim x = Create().Concat([|n|])
+                Dim d = x.ElementAt(10)
+            Next
+        End Sub
+
+        Private Function Create() As IEnumerable(Of Integer)
+            Return Enumerable.Range(1, 10)
+        End Function
+    End Class
+End Namespace
+";
+            await VerifyVB.VerifyAnalyzerAsync(vbCode);
+        }
     }
 }


### PR DESCRIPTION
Found this problem during my daily use of the analyzer.
Currently, there is a false positive this sample
```
foreach (var l in collection)
{
     var x = Create();
     var d = [|x|].ElementAt(100);
}
```
It is because the analyzer is tracking a dictionary like
'Create()' operation -> 'x.ElementAt(10)' in the after the first iteration of the loop.

Then in the second iteration,
'Create()' operation is visited again, but since it is the same creation operation, it is consider 'x.ElementAt()' enumerate 'Create()' operation twice.

This PR adds a reset logic in the OperationVisitor, when an assignment operation is visited, and the assigned operation has been tracked, reset it. So the example above would become:
After the first iteration, the tracked entity is like:
'Create()' operation -> 'x.ElementAt(10)'

The second iteration:
after 'var x = Create()' is visited. The dictionary is empty.
And then when 'x.ElementAt(10)' is visited, it would still think 'Create()' operation is enumerated once