### PR TITLE
Make CA1852 aware of InternalsVisibleTo

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypes.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypes.cs
@@ -36,6 +36,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static void OnCompilationStart(CompilationStartAnalysisContext context)
         {
+            // To avoid false positives, as with CA1812 (avoid uninstantiated internal classes), skip any assemblies with InternalsVisibleTo.
+            var internalsVisibleToAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesInternalsVisibleToAttribute);
+            if (context.Compilation.Assembly.HasAttribute(internalsVisibleToAttributeSymbol))
+            {
+                return;
+            }
+
             INamedTypeSymbol? comImportAttributeType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeInteropServicesComImportAttribute);
 
             var candidateTypes = PooledConcurrentSet<INamedTypeSymbol>.GetInstance(SymbolEqualityComparer.Default);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
@@ -219,6 +219,15 @@ End Class";
         }
 
         [Fact]
+        public Task InternalsVisibleTo_NoDiagnostic()
+        {
+            string source = @"[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""TestProject"")]
+                              internal class C { }";
+
+            return VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
         public Task ComImportAttributedType_NoDiagnostic_CS()
         {
             string source = $"[System.Runtime.InteropServices.ComImport] [System.Runtime.InteropServices.Guid(\"E8D59775-E821-4D6C-B63D-BB0D969361DA\")] internal class C {{ }}";


### PR DESCRIPTION
Without this there are too many false positives in libraries that use InternalsVisibleTo, in particular to tests.

cc: @GrabYourPitchforks, @mavasani 