### PR TITLE
Suppress CA1305 for `Guid.Parse`

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -147,7 +147,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 targetMethod.ContainingType.IsErrorType() ||
                 (activatorType != null && activatorType.Equals(targetMethod.ContainingType)) ||
                 (resourceManagerType != null && resourceManagerType.Equals(targetMethod.ContainingType)) ||
-                IsValidToStringCall(invocationExpression, invariantToStringTypes, dateTimeType, dateTimeOffsetType, timeSpanType))
+                IsValidToStringCall(invocationExpression, invariantToStringTypes, dateTimeType, dateTimeOffsetType, timeSpanType) ||
+                IsValidParseCall(invocationExpression, guidType))
                 {
                     return;
                 }
@@ -308,6 +309,23 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return nullableTypeArgument;
                 return typeSymbol;
             }
+        }
+
+        private static bool IsValidParseCall(IInvocationOperation invocationOperation, INamedTypeSymbol? guidType)
+        {
+            var targetMethod = invocationOperation.TargetMethod;
+
+            if (targetMethod.Name != "Parse")
+            {
+                return false;
+            }
+
+            if (guidType != null && targetMethod.ContainingType.Equals(guidType))
+            {
+                return false;
+            }
+
+            return false;
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -322,7 +322,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             if (guidType != null && targetMethod.ContainingType.Equals(guidType))
             {
-                return false;
+                return true;
             }
 
             return false;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -320,7 +320,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 return false;
             }
 
-            if (guidType != null && targetMethod.ContainingType.Equals(guidType))
+            if (targetMethod.ContainingType.Equals(guidType))
             {
                 return true;
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
@@ -946,6 +946,45 @@ End Class
         }
 
         [Fact]
+        [WorkItem(5999, "https://github.com/dotnet/roslyn-analyzers/issues/5999")]
+        public async Task CA1305_GuidParse_NoDiagnosticsAsync()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = new ReferenceAssemblies(""), // workaround for lack of .NET 7 Preview 4 reference assemblies
+                TestCode = @"
+namespace System
+{
+    public class Object { }
+    public abstract class ValueType { }
+    public struct Void { }
+    public class String { }
+    public interface IFormatProvider { }
+    public struct Guid
+    {
+        public static Guid Parse(string s) => default;
+        public static Guid Parse(string s, IFormatProvider provider) => default;
+    }
+}
+namespace System.Globalization
+{
+    public class CultureInfo : IFormatProvider { }
+}
+namespace Test
+{
+    using System;
+    public class SomeClass
+    {
+        public Guid SomeMethod(string s)
+        {
+            return Guid.Parse(s);
+        }
+    }
+}",
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task CA1305_NullableInvariantTypes_NoDiagnosticAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
Fixes #5999.

Provides an extensible method to add other types later if some of the other new `Parse` methods in .NET 7 also end up triggering this warning. For now, it seems that since `char` etc. implement `IParseable<T>.Parse(string, IFormatProvider)` explicitly, a call to `char.Parse(string)` doesn't trigger CA1305 (which is good), so this PR only implements an opt-out for `Guid`.