### PR TITLE
CA1311 various fixes

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -1877,7 +1877,7 @@
     <value>Specify current culture</value>
   </data>
   <data name="UseInvariantVersion" xml:space="preserve">
-    <value>User an invariant version</value>
+    <value>Use an invariant version</value>
   </data>
   <data name="FeatureUnsupportedWhenRuntimeMarshallingDisabledDescription" xml:space="preserve">
     <value>Using features that require runtime marshalling when runtime marshalling is disabled will result in runtime exceptions.</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Uživatel s neutrální verzí</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Uživatel s neutrální verzí</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Verwenden Sie eine unveränderliche Version</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Verwenden Sie eine unveränderliche Version</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Usuario de una versión invariable</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Usuario de una versión invariable</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Utilisateur avec une version invariante</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Utilisateur avec une version invariante</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Utente di una versione invariante</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Utente di una versione invariante</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">インバリアント バージョンを使用する</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">インバリアント バージョンを使用する</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">사용자 불변 버전</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">사용자 불변 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Użyj niezmiennej wersji</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Użyj niezmiennej wersji</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Usar uma versão invariável</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Usar uma versão invariável</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Использование инвариантной версии</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Использование инвариантной версии</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">Sabit bir sürüm kullanın</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">Sabit bir sürüm kullanın</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">用户固定版本</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">用户固定版本</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2753,8 +2753,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UseInvariantVersion">
-        <source>User an invariant version</source>
-        <target state="translated">使用者固定版本</target>
+        <source>Use an invariant version</source>
+        <target state="needs-review-translation">使用者固定版本</target>
         <note />
       </trans-unit>
       <trans-unit id="UseManagedEquivalentsOfWin32ApiDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureForToLowerAndToUpperTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyCultureForToLowerAndToUpperTests.Fixer.cs
@@ -124,6 +124,42 @@ End Class
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task CA1311_FixToLowerBasicAsync_SpecifyCurrentCulture_MemberAccessSyntax()
+        {
+            var source = @"
+Imports System.Globalization
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.[|ToLower|]
+        a?.[|ToLower|]
+        Dim b = a.[|ToLower|]
+        Dim c = a?.[|ToLower|]
+    End Sub
+End Class
+";
+
+            var fixedSource = @"
+Imports System.Globalization
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.ToLower(CultureInfo.CurrentCulture)
+        a?.ToLower(CultureInfo.CurrentCulture)
+        Dim b = a.ToLower(CultureInfo.CurrentCulture)
+        Dim c = a?.ToLower(CultureInfo.CurrentCulture)
+    End Sub
+End Class
+";
+            await new VerifyVB.Test
+            {
+                TestState = { Sources = { source } },
+                FixedState = { Sources = { fixedSource } },
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = nameof(MicrosoftNetCoreAnalyzersResources.SpecifyCurrentCulture),
+            }.RunAsync();
+        }
 
         [Fact]
         public async Task CA1311_FixToLowerBasicAsync_UseInvariantVersion()
@@ -144,6 +180,42 @@ Class C
         Dim a = ""test""
         a.ToLowerInvariant()
         a?.ToLowerInvariant()
+    End Sub
+End Class
+";
+
+            await new VerifyVB.Test
+            {
+                TestState = { Sources = { source } },
+                FixedState = { Sources = { fixedSource } },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(MicrosoftNetCoreAnalyzersResources.UseInvariantVersion),
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CA1311_FixToLowerBasicAsync_UseInvariantVersion_MemberAccessSyntax()
+        {
+            const string source = @"
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.[|ToLower|]
+        a?.[|ToLower|]
+        Dim b = a.[|ToLower|]
+        Dim c = a?.[|ToLower|]
+    End Sub
+End Class
+";
+
+            const string fixedSource = @"
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.ToLowerInvariant
+        a?.ToLowerInvariant
+        Dim b = a.ToLowerInvariant
+        Dim c = a?.ToLowerInvariant
     End Sub
 End Class
 ";
@@ -268,6 +340,42 @@ End Class
             }.RunAsync();
         }
 
+        [Fact]
+        public async Task CA1311_FixToUpperBasicAsync_SpecifyCurrentCulture_MemberAccessSyntax()
+        {
+            var source = @"
+Imports System.Globalization
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.[|ToUpper|]
+        a?.[|ToUpper|]
+        Dim b = a.[|ToUpper|]
+        Dim c = a?.[|ToUpper|]
+    End Sub
+End Class
+";
+
+            var fixedSource = @"
+Imports System.Globalization
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.ToUpper(CultureInfo.CurrentCulture)
+        a?.ToUpper(CultureInfo.CurrentCulture)
+        Dim b = a.ToUpper(CultureInfo.CurrentCulture)
+        Dim c = a?.ToUpper(CultureInfo.CurrentCulture)
+    End Sub
+End Class
+";
+            await new VerifyVB.Test
+            {
+                TestState = { Sources = { source } },
+                FixedState = { Sources = { fixedSource } },
+                CodeActionIndex = 0,
+                CodeActionEquivalenceKey = nameof(MicrosoftNetCoreAnalyzersResources.SpecifyCurrentCulture),
+            }.RunAsync();
+        }
 
         [Fact]
         public async Task CA1311_FixToUpperBasicAsync_UseInvariantVersion()
@@ -288,6 +396,42 @@ Class C
         Dim a = ""test""
         a.ToUpperInvariant()
         a?.ToUpperInvariant()
+    End Sub
+End Class
+";
+
+            await new VerifyVB.Test
+            {
+                TestState = { Sources = { source } },
+                FixedState = { Sources = { fixedSource } },
+                CodeActionIndex = 1,
+                CodeActionEquivalenceKey = nameof(MicrosoftNetCoreAnalyzersResources.UseInvariantVersion),
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CA1311_FixToUpperBasicAsync_UseInvariantVersion_MemberAccessSyntax()
+        {
+            const string source = @"
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.[|ToUpper|]
+        a?.[|ToUpper|]
+        Dim b = a.[|ToUpper|]
+        Dim c = a?.[|ToUpper|]
+    End Sub
+End Class
+";
+
+            const string fixedSource = @"
+Class C
+    Sub M()
+        Dim a = ""test""
+        a.ToUpperInvariant
+        a?.ToUpperInvariant
+        Dim b = a.ToUpperInvariant
+        Dim c = a?.ToUpperInvariant
     End Sub
 End Class
 ";

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
         Inherits SpecifyCultureForToLowerAndToUpperAnalyzer
 
         Protected Overrides Function GetMethodNameLocation(node As SyntaxNode) As Location
-            Debug.Assert(node.IsKind(SyntaxKind.InvocationExpression) Or node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
+            Debug.Assert(node.IsKind(SyntaxKind.InvocationExpression) OrElse node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
 
             If node.IsKind(SyntaxKind.InvocationExpression) Then
                 Dim invocation = DirectCast(node, InvocationExpressionSyntax)

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.vb
@@ -11,15 +11,21 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     Public Class BasicSpecifyCultureForToLowerAndToUpperAnalyzer
         Inherits SpecifyCultureForToLowerAndToUpperAnalyzer
 
-        Protected Overrides Function GetMethodNameLocation(invocationNode As SyntaxNode) As Location
-            Debug.Assert(invocationNode.IsKind(SyntaxKind.InvocationExpression))
+        Protected Overrides Function GetMethodNameLocation(node As SyntaxNode) As Location
+            Debug.Assert(node.IsKind(SyntaxKind.InvocationExpression) Or node.IsKind(SyntaxKind.SimpleMemberAccessExpression))
 
-            Dim invocation = CType(invocationNode, InvocationExpressionSyntax)
-            If invocation.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
-                Return DirectCast(invocation.Expression, MemberAccessExpressionSyntax).Name.GetLocation()
+            If node.IsKind(SyntaxKind.InvocationExpression) Then
+                Dim invocation = DirectCast(node, InvocationExpressionSyntax)
+                If invocation.Expression.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
+                    Return DirectCast(invocation.Expression, MemberAccessExpressionSyntax).Name.GetLocation()
+                End If
             End If
 
-            Return invocation.GetLocation()
+            If node.IsKind(SyntaxKind.SimpleMemberAccessExpression) Then
+                Return DirectCast(node, MemberAccessExpressionSyntax).Name.GetLocation()
+            End If
+
+            Return node.GetLocation()
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
This PR is a follow-up of these two - https://github.com/dotnet/roslyn-analyzers/pull/5970/ https://github.com/dotnet/roslyn-analyzers/pull/2186

@buyaa-n @Youssef1313 Here's the new PR addressing the issues left over from the previous ones.
I've updated the fixer to address the VB edge case and I've also fixed the typo in the resource files.
I haven't however moved unit tests into a single file. Is that a must? I see that many analyzers/fixers in the codebase have separate files for unit tests.