### PR TITLE
CA1311 VB - short-circuiting or

### DIFF
--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.Fixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Runtime/BasicSpecifyCultureForToLowerAndToUpper.Fixer.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
             If ShouldFix(node) Then
                 Dim memberAccess = DirectCast(node.Parent, MemberAccessExpressionSyntax)
 
-                If memberAccess.Parent Is Nothing Or Not memberAccess.Parent.IsKind(SyntaxKind.InvocationExpression) Then
+                If memberAccess.Parent Is Nothing OrElse Not memberAccess.Parent.IsKind(SyntaxKind.InvocationExpression) Then
                     Return Await SpecifyCurrentCultureWhenTheresNoArgumentListAsync(document, generator, root, memberAccess, memberAccess, cancellationToken)
                 End If
 


### PR DESCRIPTION
Even though the `IsKind` extension method is implemented in a null-tolerant way, it is still better to not check the right hand side of the or expression when it's not necessary, hence this PR.

@buyaa-n this is a follow-up of this - https://github.com/dotnet/roslyn-analyzers/pull/6010