### PR TITLE
Fix the incorrect merge logic for back edges for GlobalFlowStateAnalysis

### DIFF
--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -7,6 +7,5 @@ CA1420 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-r
 CA1421 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421> | This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied |
 CA1852 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852> | Seal internal types |
 CA1853 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853> | Unnecessary call to 'Dictionary.ContainsKey(key)' |
-CA1854 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1854> | Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method |
 CA2019 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2019> | Improper 'ThreadStatic' field initialization |
 CA2259 | <https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2259> | 'ThreadStatic' only affects static fields |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3840,6 +3840,38 @@ class TestType
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [Fact, WorkItem(6015, "https://github.com/dotnet/roslyn-analyzers/issues/6015")]
+        public async Task TestGuardedCheckInsideLoopWithIfAsync()
+        {
+            var source = @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+class C
+{
+    void M(IEnumerable<D> list)
+    {
+        foreach (var d in list)
+        {
+            if ([|d.Flag|]) // This call site is reachable on all platforms. 'C.D.Flag' is only supported on: 'Windows'.
+            {
+                if (OperatingSystem.IsWindows() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763, 0))
+                {
+                }
+            }
+        }
+    }
+
+    [SupportedOSPlatform(""Windows"")]
+    private class D
+    {
+        public bool Flag { get; }
+    }
+}";
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
 #if DEBUG
         [Fact]
         public async Task IosSupportedOnMacCatalystAsync()

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -68,13 +68,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 {
                     return GlobalFlowStateAnalysisValueSet.Unknown;
                 }
-                else if (value1.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
+                else if (value1.Kind == GlobalFlowStateAnalysisValueSetKind.Empty || value2.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
                 {
-                    return value2;
-                }
-                else if (value2.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
-                {
-                    return value1;
+                    return GlobalFlowStateAnalysisValueSet.Empty;
                 }
 
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateValueSetFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateValueSetFlowOperationVisitor.cs
@@ -82,6 +82,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
             GlobalFlowStateAnalysisDomainInstance.Intersect(value1, value2, GlobalFlowStateAnalysisValueSetDomain.Intersect) :
             GlobalFlowStateAnalysisDomainInstance.Merge(value1, value2);
 
+        protected sealed override GlobalFlowStateAnalysisData MergeAnalysisDataForBackEdge(GlobalFlowStateAnalysisData value1, GlobalFlowStateAnalysisData value2, BasicBlock forBlock)
+        {
+            // If we are merging analysis data for back edge, we have done at least one analysis pass for the block
+            // and should replace 'Unset' value with 'Empty' value for the next pass.
+            if (value1.TryGetValue(GlobalEntity, out var value) && value == GlobalFlowStateAnalysisValueSet.Unset)
+                value1[GlobalEntity] = GlobalFlowStateAnalysisValueSet.Empty;
+
+            if (value2.TryGetValue(GlobalEntity, out value) && value == GlobalFlowStateAnalysisValueSet.Unset)
+                value2[GlobalEntity] = GlobalFlowStateAnalysisValueSet.Empty;
+
+            return base.MergeAnalysisDataForBackEdge(value1, value2, forBlock);
+        }
+
         protected sealed override GlobalFlowStateAnalysisData GetExitBlockOutputData(GlobalFlowStateAnalysisResult analysisResult)
             => new(analysisResult.ExitBlockOutput.Data);
 


### PR DESCRIPTION
Fixes #6015

`GlobalFlowStateAnalysisValueSet.Unset` is used to represent unanalyzed flow state, `GlobalFlowStateAnalysisValueSet.Empty` is used to represent analyzed flow state with no analysis values. We initialize the flow states for the entry basic block of the CFG with `Unset` value, but never replace the `Unset` with `Empty` for subsequent passes. This in turn leads to incorrect merge when a `Known` value flows from the back edge to the loop start and ends up overriding the `Unset` value instead of being overridden by the `Empty` value. Now we correctly perform this merge logic.

I verified that prior to this fix, the added unit test hang due to this issue. I also verified that building the github repo cited in the feedback ticket with platform compat analyzer also leads to a hang before this fix. Both these repros are fixed after this PR.

<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
