### PR TITLE
Remove duplicate `PackageReference`

### DIFF
--- a/PostReleaseActivities.md
+++ b/PostReleaseActivities.md
@@ -25,7 +25,7 @@ Please follow the below steps after publishing analyzer NuGet packages from this
 1. Checkout the sources for the release branch locally. This would normally be the main branch.
 2. Build.
 3. Ensure that nuget.exe is on path.
-4. Generate notes: Switch to the output directory, say `artifacts\bin\ReleaseNotesUtil\Debug\netcoreapp3.1` and execute `GenDiffNotes.cmd` to generate release notes.  Example command line for v2.9.4 to v2.9.5: `GenDiffNotes.cmd C:\scratch nuget.org 2.9.4 2.9.5`.
+4. Generate notes: Switch to the output directory, say `artifacts\bin\ReleaseNotesUtil\Debug\net6.0` and execute `GenDiffNotes.cmd` to generate release notes.  Example command line for v2.9.4 to v2.9.5: `GenDiffNotes.cmd C:\scratch nuget.org 2.9.4 2.9.5`.
 
 ## Followup items
 

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.csproj
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.csproj
@@ -11,10 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.VisualBasic" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests" />

--- a/src/Tools/ReleaseNotesUtil/Program.cs
+++ b/src/Tools/ReleaseNotesUtil/Program.cs
@@ -114,7 +114,7 @@ namespace ReleaseNotesUtil
         {
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(RuleFileContent));
             using FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return (RuleFileContent)serializer.ReadObject(fs);
+            return (RuleFileContent)serializer.ReadObject(fs)!;
         }
 
         private static void GenerateAddRemovedRulesDiffMarkdown(StringBuilder sb, string heading, IEnumerable<RuleInfo> rules)

--- a/src/Tools/ReleaseNotesUtil/ReleaseNotesUtil.csproj
+++ b/src/Tools/ReleaseNotesUtil/ReleaseNotesUtil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NonShipping>true</NonShipping>
   </PropertyGroup>  
   <ItemGroup>


### PR DESCRIPTION
The other reference comes from

https://github.com/dotnet/roslyn-analyzers/blob/0e7f40d1709f0d7ffd316d89e452151a7365354b/src/Utilities/Compiler/Analyzer.Utilities.projitems#L145-L147