### PR TITLE
[Port] Fix the incorrect merge logic for back edges for GlobalFlowStateAnalysis

### DIFF
--- a/PostReleaseActivities.md
+++ b/PostReleaseActivities.md
@@ -25,4 +25,4 @@ Please follow the below steps after publishing analyzer NuGet packages from this
 1. Checkout the sources for the release branch locally. This would normally be the main branch.
 2. Build.
 3. Ensure that nuget.exe is on path.
-4. Generate notes: Switch to the output directory, say `artifacts\bin\ReleaseNotesUtil\Debug\netcoreapp3.1` and execute `GenDiffNotes.cmd` to generate release notes.  Example command line for v2.9.4 to v2.9.5: `GenDiffNotes.cmd C:\scratch nuget.org 2.9.4 2.9.5`.
+4. Generate notes: Switch to the output directory, say `artifacts\bin\ReleaseNotesUtil\Debug\net6.0` and execute `GenDiffNotes.cmd` to generate release notes.  Example command line for v2.9.4 to v2.9.5: `GenDiffNotes.cmd C:\scratch nuget.org 2.9.4 2.9.5`.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21430.12",
+    "dotnet": "6.0.106",
     "runtimes": {
       "dotnet": [
         "3.1.7"
@@ -12,7 +12,7 @@
     "xcopy-msbuild": "16.10.0-preview2"
   },
   "sdk": {
-    "version": "6.0.100-rc.1.21430.12",
+    "version": "6.0.106",
     "allowPrerelease": true,
     "rollForward": "patch"
   },

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.csproj
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.csproj
@@ -11,10 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.VisualBasic" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests" />

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3791,6 +3791,38 @@ class TestType
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [Fact, WorkItem(6015, "https://github.com/dotnet/roslyn-analyzers/issues/6015")]
+        public async Task TestGuardedCheckInsideLoopWithIfAsync()
+        {
+            var source = @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+class C
+{
+    void M(IEnumerable<D> list)
+    {
+        foreach (var d in list)
+        {
+            if ([|d.Flag|]) // This call site is reachable on all platforms. 'C.D.Flag' is only supported on: 'Windows'.
+            {
+                if (OperatingSystem.IsWindows() && OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17763, 0))
+                {
+                }
+            }
+        }
+    }
+
+    [SupportedOSPlatform(""Windows"")]
+    private class D
+    {
+        public bool Flag { get; }
+    }
+}";
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
 #if DEBUG
         [Fact]
         public async Task IosSupportedOnMacCatalystAsync()

--- a/src/Tools/ReleaseNotesUtil/Program.cs
+++ b/src/Tools/ReleaseNotesUtil/Program.cs
@@ -114,7 +114,7 @@ namespace ReleaseNotesUtil
         {
             DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(RuleFileContent));
             using FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return (RuleFileContent)serializer.ReadObject(fs);
+            return (RuleFileContent)serializer.ReadObject(fs)!;
         }
 
         private static void GenerateAddRemovedRulesDiffMarkdown(StringBuilder sb, string heading, IEnumerable<RuleInfo> rules)

--- a/src/Tools/ReleaseNotesUtil/ReleaseNotesUtil.csproj
+++ b/src/Tools/ReleaseNotesUtil/ReleaseNotesUtil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NonShipping>true</NonShipping>
   </PropertyGroup>  
   <ItemGroup>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateAnalysis.GlobalFlowStateAnalysisValueSetDomain.cs
@@ -68,13 +68,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
                 {
                     return GlobalFlowStateAnalysisValueSet.Unknown;
                 }
-                else if (value1.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
+                else if (value1.Kind == GlobalFlowStateAnalysisValueSetKind.Empty || value2.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
                 {
-                    return value2;
-                }
-                else if (value2.Kind == GlobalFlowStateAnalysisValueSetKind.Empty)
-                {
-                    return value1;
+                    return GlobalFlowStateAnalysisValueSet.Empty;
                 }
 
                 Debug.Assert(value1.Kind == GlobalFlowStateAnalysisValueSetKind.Known);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/GlobalFlowStateAnalysis/GlobalFlowStateDataFlowOperationVisitor.cs
@@ -166,6 +166,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.GlobalFlowStateAnalysis
             => _hasPredicatedGlobalState && forBlock.DominatesPredecessors(DataFlowAnalysisContext.ControlFlowGraph) ?
             GlobalFlowStateAnalysisDomainInstance.Intersect(value1, value2, GlobalFlowStateAnalysisValueSetDomain.Intersect) :
             GlobalFlowStateAnalysisDomainInstance.Merge(value1, value2);
+
+        protected sealed override GlobalFlowStateAnalysisData MergeAnalysisDataForBackEdge(GlobalFlowStateAnalysisData value1, GlobalFlowStateAnalysisData value2, BasicBlock forBlock)
+        {
+            // If we are merging analysis data for back edge, we have done at least one analysis pass for the block
+            // and should replace 'Unset' value with 'Empty' value for the next pass.
+            if (value1.TryGetValue(_globalEntity, out var value) && value == GlobalFlowStateAnalysisValueSet.Unset)
+                value1[_globalEntity] = GlobalFlowStateAnalysisValueSet.Empty;
+
+            if (value2.TryGetValue(_globalEntity, out value) && value == GlobalFlowStateAnalysisValueSet.Unset)
+                value2[_globalEntity] = GlobalFlowStateAnalysisValueSet.Empty;
+
+            return base.MergeAnalysisDataForBackEdge(value1, value2, forBlock);
+        }
+
         protected sealed override void UpdateValuesForAnalysisData(GlobalFlowStateAnalysisData targetAnalysisData)
             => UpdateValuesForAnalysisData(targetAnalysisData, CurrentAnalysisData);
         protected sealed override GlobalFlowStateAnalysisData GetClonedAnalysisData(GlobalFlowStateAnalysisData analysisData)


### PR DESCRIPTION
Ports https://github.com/dotnet/roslyn-analyzers/pull/6029 to .NET6 release branch.

## Customer Impact

A customer reported the issue in VS feedbacks which transferred to github: https://github.com/dotnet/roslyn-analyzers/issues/6015 and it is reproduceable with the [linked project](https://github.com/Slazanger/SMT/tree/dotnet6_upgrade). 

When builds the project with CA1416 Platform Compatibility Analyzer enabled then the build never ends and memory grows continually, even stopping the build and closed the VS the `VBCSCompiler` process stays alive and memory keep growing, only option is kill the process

CA1416 is included in SDK and enabled by default, therefore it could happen for any customer's project that happens to have a code section that reproes the issue.

## Testing

- **Unit tested** verified that prior to this fix, the added unit test hang due to this issue. 
- **Manually tested** with the repro: verified that building the github repo cited in the feedback ticket with platform compat analyzer also leads to a hang before this fix. Both these repros are fixed after this PR.

## Risk
**Very low** - `GlobalFlowStateAnalysisValueSet.Unset` is used to represent unanalyzed flow state, `GlobalFlowStateAnalysisValueSet.Empty` is used to represent analyzed flow state with no analysis values. We initialize the flow states for the entry basic block of the CFG with `Unset` value, but never replace the `Unset` with `Empty` for subsequent passes. This in turn leads to incorrect merge when a `Known` value flows from the back edge to the loop start and ends up overriding the `Unset` value instead of being overridden by the `Empty` value. Now we correctly perform this merge logic.
