### PR TITLE
Clean up mock API that not needed anymore

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -164,12 +164,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         m.Parameters[0].Type.Equals(osPlatformType));
 
                 var guardMethods = GetOperatingSystemGuardMethods(runtimeIsOSPlatformMethod, operatingSystemType, out var relatedPlatforms);
-#if DEBUG
-                if (context.Compilation.TryGetOrCreateTypeByMetadataName("System.MockOperatingSystem", out var mockOSType))
-                {
-                    guardMethods.AddRange(FilterPlatformCheckMethods(mockOSType, relatedPlatforms));
-                }
-#endif
                 var platformSpecificMembers = new ConcurrentDictionary<ISymbol, PlatformAttributes>();
                 var osPlatformCreateMethod = osPlatformType?.GetMembers("Create").OfType<IMethodSymbol>().FirstOrDefault(m =>
                     m.IsStatic &&

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4581,7 +4581,6 @@ class WindowsOnlyType
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
-#if DEBUG
         [Fact]
         public async Task IosGuardsMacCatalystAsync()
         {
@@ -4614,7 +4613,7 @@ class Test
 
     void M1()
     {
-        if (MockOperatingSystem.IsIOS())
+        if (OperatingSystem.IsIOS())
         {
             SupportedOnIOSLinuxMacCatalyst();
             [|SupportsMacCatalyst()|]; // This call site is reachable on: 'IOS'. 'Test.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.
@@ -4624,7 +4623,7 @@ class Test
             [|UnsupportsMacCatalyst()|];     // This call site is reachable on: 'maccatalyst'. 'Test.UnsupportsMacCatalyst()' is unsupported on: 'maccatalyst'.
         }
 
-        if (MockOperatingSystem.IsMacCatalyst())
+        if (OperatingSystem.IsMacCatalyst())
         {          
             SupportedOnIOSLinuxMacCatalyst();
             SupportsMacCatalyst();
@@ -4634,7 +4633,7 @@ class Test
             [|UnsupportsMacCatalyst()|];     // This call site is reachable on: 'MacCatalyst'. 'Test.UnsupportsMacCatalyst()' is unsupported on: 'maccatalyst'.
         }
 
-        if (MockOperatingSystem.IsIOS() && !MockOperatingSystem.IsMacCatalyst())
+        if (OperatingSystem.IsIOS() && !OperatingSystem.IsMacCatalyst())
         {            
             SupportedOnIOSLinuxMacCatalyst();              
             [|SupportsMacCatalyst()|];       // This call site is reachable on: 'IOS'. 'Test.SupportsMacCatalyst()' is only supported on: 'maccatalyst'.     
@@ -4644,7 +4643,7 @@ class Test
             UnsupportsMacCatalyst();      
         }
     }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
@@ -4735,7 +4734,7 @@ class Test
             UnsupportsMacCatalyst(); 
         }
     }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
@@ -4811,7 +4810,7 @@ class Test
             UnsupportsMacCatalyst();     // This call site is reachable on: 'MacCatalyst'. 'Test.UnsupportsMacCatalyst()' is unsupported on: 'maccatalyst'.
         }
     }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
@@ -4854,7 +4853,7 @@ class MyUsage
 [SupportedOSPlatform(""windows10.0.10240"")]
 [UnsupportedOSPlatform(""MacCatalyst13.0"")]
 class MyType { }
-" + MockApisCsSource;
+";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
@@ -4976,26 +4975,10 @@ class MyUsage
 [UnsupportedOSPlatform(""windows8.1"")]
 [SupportedOSPlatform(""MacCatalyst13.0"")]
 class MyType { }
-" + MockApisCsSource;
+";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
-
-        private readonly string MockApisCsSource = @"
-namespace System
-{
-    public class MockOperatingSystem
-    {
-        [SupportedOSPlatformGuard(""maccatalyst"")]
-        public static bool IsIOS() => true;
-        [SupportedOSPlatformGuard(""maccatalyst"")]
-        public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
-        public static bool IsMacCatalyst() => false;
-        public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0) => true;
-    }
-}
-";
-#endif
 
         private readonly string TargetTypesForTest = @"
 namespace PlatformCompatDemo.SupportedUnupported

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -3872,7 +3872,6 @@ class C
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
-#if DEBUG
         [Fact]
         public async Task IosSupportedOnMacCatalystAsync()
         {
@@ -3938,7 +3937,7 @@ class TestType
         [|UnsupportsIos()|];            // This call site is reachable on: 'ios'. 'TestType.UnsupportsIos()' is unsupported on: 'ios'.
         UnsupportsMacCatalyst();    
     }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source);
         }
@@ -4016,7 +4015,7 @@ class AllPlatforms
         [|SupportsIos.SupportsIOSNotMacCatalyst()|]; // This call site is unreachable on: 'ios'. 'SupportsIos.SupportsIOSNotMacCatalyst()' is only supported on: 'ios'.
         [|SupportsIos.WorksOnMacCatalystNotIOS()|];  // This call site is reachable on all platforms. 'SupportsIos.WorksOnMacCatalystNotIOS()' is supported on: 'maccatalyst'.  
     }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source);
         }
@@ -4056,7 +4055,7 @@ class TestType
 
     [SupportedOSPlatform(""ios12.0"")]
     static void SupportsIOS() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source);
         }
@@ -4095,7 +4094,7 @@ class TestType
     
     [UnsupportedOSPlatform(""iOS"")]
     static void UnsupportsIos() { }
-}" + MockApisCsSource;
+}";
 
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
@@ -4135,10 +4134,9 @@ class TestType
 
     [UnsupportedOSPlatform(""iOS12.0"")]
     static void UnsupportsIos() { }
-}" + MockApisCsSource;
+}";
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
-#endif
 
         private string GetFormattedString(string resource, params string[] args) =>
             string.Format(CultureInfo.InvariantCulture, resource, args);


### PR DESCRIPTION
### Just a simple clean up of mock APIs that not needed anymore
The `MockOperatingSystem` type was used for testing the iOS is MacCatalyst scenario before the updates of real `OperatingSystem` type updates became available in the repo.

It was mockink the `OperatingSystem.IsIOS()`, `OperatingSystem.IsIOSVersionAtLeast(...)` APIs  as applied the `[SupportedOSPlatformGuard(""maccatalyst"")]` attribute and also newly added APIs like `OperatingSystem.IsMacCatalyst()`, `OperatingSystem.IsMacCatalystVersionAtLeast(...)` 
```cs
public class MockOperatingSystem
{
    [SupportedOSPlatformGuard("maccatalyst")]
    public static bool IsIOS() => true;
    [SupportedOSPlatformGuard("maccatalyst")]
    public static bool IsIOSVersionAtLeast(int major, int minor = 0, int build = 0) => false;
    public static bool IsMacCatalyst() => false;
    public static bool IsMacCatalystVersionAtLeast(int major, int minor = 0, int build = 0) => true;
}
```