### PR TITLE
track disposable calls through explicit interface implementations

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants),NET_ANALYZERS_TEST</DefineConstants>
     <ServerGarbageCollection>true</ServerGarbageCollection>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="$(RepoRoot)\NuGet.config" CopyToOutputDirectory="PreserveNewest" />

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposableFieldsShouldBeDisposedTests.cs
@@ -652,7 +652,7 @@ End Class",
         }
 
         [Fact, WorkItem(6075, "https://github.com/dotnet/roslyn-analyzers/issues/6075")]
-        public async Task AsyncDisposableDisposedInAsyncDisposable_Disposed_NoDiagnosticAsync()
+        public async Task AsyncDisposableDisposedInExplicitAsyncDisposable_Disposed_NoDiagnosticAsync()
         {
             await new VerifyCS.Test
             {
@@ -682,6 +682,38 @@ public sealed class Test : IAsyncDisposable, IDisposable
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
         await stream.DisposeAsync();
+    }
+}
+"
+            }.RunAsync();
+        }
+        [Fact, WorkItem(6075, "https://github.com/dotnet/roslyn-analyzers/issues/6075")]
+        public async Task DisposableDisposedInExplicitDisposable_Disposed_NoDiagnosticAsync()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                TestCode = @"
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public sealed class Test : IDisposable
+{
+    private readonly HttpClient client;
+    private readonly FileStream stream;
+
+    public Test()
+    {
+        client = new HttpClient();
+        stream = new FileStream(""C://some-path"", FileMode.CreateNew);
+    }
+
+    void IDisposable.Dispose()
+    {
+        client.Dispose();
+        stream.Dispose();
     }
 }
 "

--- a/src/TestReferenceAssembly/TestReferenceAssembly.csproj
+++ b/src/TestReferenceAssembly/TestReferenceAssembly.csproj
@@ -6,4 +6,9 @@
     <NonShipping>true</NonShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <EmbeddedResource Remove="obj\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

Fixes https://github.com/dotnet/roslyn-analyzers/issues/6075