### PR TITLE
Update public pool names

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -15,7 +15,7 @@ stages:
         jobs:
         - job: Debug_Build
           pool:
-            name: NetCore1ESPool-Svc-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
           variables:
             - name: _BuildConfig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
         _configuration: Release
         _codeCoverage: False
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
   timeoutInMinutes: 40
 
@@ -60,7 +60,7 @@ jobs:
   strategy:
     maxParallel: 4
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Windows.Amd64.VS2019.Pre.ES.Open
   timeoutInMinutes: 40
 
@@ -98,7 +98,7 @@ jobs:
       Release:
         _configuration: Release
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore-Svc-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.amd64.Open
   timeoutInMinutes: 40
   steps:


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.