### PR TITLE
CA1041: Add test where argument order doesn't match parameter order

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
@@ -160,6 +160,8 @@ class A
     int Property { get; set; }
     [Obsolete(""valid"", false)]
     void Method() {}
+    [Obsolete(error: false, message: ""valid"")]
+    void Method2() {}
 }
 ");
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ProvideObsoleteAttributeMessageTests.cs
@@ -39,6 +39,8 @@ public class A
 public interface I {}
 [Obsolete]
 public delegate void del(int x);
+[Obsolete(error: false, message: """")]
+public delegate void del2(int x);
 ",
             GetCSharpResultAt(4, 2, "A"),
             GetCSharpResultAt(7, 6, ".ctor"),
@@ -47,7 +49,8 @@ public delegate void del(int x);
             GetCSharpResultAt(13, 6, "Method"),
             GetCSharpResultAt(15, 6, "event1"),
             GetCSharpResultAt(18, 2, "I"),
-            GetCSharpResultAt(20, 2, "del"));
+            GetCSharpResultAt(20, 2, "del"),
+            GetCSharpResultAt(22, 2, "del2"));
         }
 
         [Fact]


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
