### PR TITLE
`IsDisposable` now also allows value types to be considered disposable

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposableTests.cs
@@ -1168,5 +1168,48 @@ Public Class NoDisposeMethod
 End Class
 ");
         }
+
+        [Fact]
+        [WorkItem(6151, "https://github.com/dotnet/roslyn-analyzers/issues/6151")]
+        public async Task CA1001CSharpDisposedCalledInStructAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.IO;
+
+internal struct Invalid : IDisposable
+{
+    private readonly Stream stream;
+
+    public Invalid(int length) => this.stream = new MemoryStream(length);
+
+    public void Dispose() => this.stream.Dispose();
+}
+");
+        }
+
+        [Fact]
+        [WorkItem(6151, "https://github.com/dotnet/roslyn-analyzers/issues/6151")]
+        public async Task CA1001BasicDisposedCalledInStructAsync()
+        {
+            await VerifyVB.VerifyAnalyzerAsync(@"
+Imports System
+Imports System.IO
+
+Friend Structure Invalid
+    Implements IDisposable
+
+    Dim stream as Stream
+
+    Public Sub New(length As Integer)
+        stream = New MemoryStream(length)
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        stream.Dispose()
+    End Sub
+End Structure
+");
+        }
     }
 }

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -142,10 +142,11 @@ namespace Analyzer.Utilities.Extensions
             INamedTypeSymbol? iDisposable,
             INamedTypeSymbol? iAsyncDisposable)
         {
-            if (type.IsReferenceType)
+            // structs can be Disposable as well
+            if (type.IsReferenceType || type.IsValueType)
             {
-                return IsInterfaceOrImplementsInterface(type, iDisposable)
-                    || IsInterfaceOrImplementsInterface(type, iAsyncDisposable);
+                if (IsInterfaceOrImplementsInterface(type, iDisposable) || IsInterfaceOrImplementsInterface(type, iAsyncDisposable))
+                    return true;
             }
 
 #if CODEANALYSIS_V3_OR_BETTER


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

Closes #6151 