### PR TITLE
Run CI using the new VM images

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -41,7 +41,7 @@ stages:
       - job: Signed_Build
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
+          demands: ImageOverride -equals windows.vs2022preview.amd64
         variables:
           - group: DotNet-Blob-Feed
           - group: Publish-Build-Assets

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -16,7 +16,7 @@ stages:
         - job: Debug_Build
           pool:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
           variables:
             - name: _BuildConfig
               value: Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         _codeCoverage: False
   pool:
     name: NetCore-Public
-    demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+    demands: ImageOverride -equals windows.vs2022preview.amd64.open
   timeoutInMinutes: 120
 
   steps:


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
