### PR TITLE
Fix CA2101 triggering when BestFitMapping=false

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzer.cs
@@ -121,7 +121,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 }
 
                 // CA2101 - Specify marshalling for PInvoke string arguments
-                if (dllImportData.BestFitMapping != false ||
+                if (dllImportData.BestFitMapping != false &&
                     context.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.InvariantGlobalization, context.Compilation) is not "true")
                 {
                     bool appliedCA2101ToMethod = false;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PInvokeDiagnosticAnalyzerTests.cs
@@ -640,6 +640,43 @@ End Class
                 BasicResult2101(22, 30));
         }
 
+        [Fact]
+        public async Task CA2101WithoutBestFitMappingCSharpTestAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Runtime.InteropServices;
+using System.Text;
+
+class C
+{
+
+    [DllImport(""user32.dll"", BestFitMapping = false)]
+    private static extern void Method1(string s);
+
+    [DllImport(""user32.dll"", CharSet = CharSet.Ansi, BestFitMapping = false)]
+    private static extern void Method2(string s);
+
+    [DllImport(""user32.dll"", BestFitMapping = false)]
+    private static extern void Method3(StringBuilder s);
+
+    [DllImport(""user32.dll"", CharSet = CharSet.Ansi, BestFitMapping = false)]
+    private static extern void Method4(StringBuilder s);
+
+    [DllImport(""user32.dll"", BestFitMapping = false)]
+    private static extern string Method5();
+
+    [DllImport(""user32.dll"", BestFitMapping = false)]
+    private static extern StringBuilder Method6();
+
+    [DllImport(""user32.dll"", CharSet = CharSet.Ansi, BestFitMapping = false)]
+    private static extern string Method7();
+
+    [DllImport(""user32.dll"", CharSet = CharSet.Ansi, BestFitMapping = false)]
+    private static extern StringBuilder Method8();
+}
+");
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
The documentation for CA2101 clearly indicates that the problem is not the use of single-byte character marshalling itself, but that when doing so .NET will by default try and substitute characters that cannot be directly marshalled, which could cause globalization or even security problems in the code being analyzed.

Unfortunately, when a developer actually tries to use BestFitMapping=false, such as when using ANSI-only APIs (which are particularly common on non-Windows operating systems), CA2101 triggers anyway and the developer has no choice but to suppress the Diagnostic or disable the rule, adding noise to their code and reducing trust in the analyzer.

CA2101 appears to work correctly in Microsoft.CodeAnalysis.FxCopAnalyzers and in Microsoft.CodeAnalysis.NetAnalyzers through version 5.0.3. BestFitMapping=false only started causing problems in version 6.0.0.

This appears to me to be due to a small mistake when refactoring to take the new `InvariantGlobalization` setting into account, in #4807 / ce3463e4e5d2a26a790370a37b8f95f666c5d5c1.

This PR adds some basic tests for BestFitMapping (which for some reason was completely untested previously) and fixes the refactoring error.

This should fix:

- #2886
- #5009
- #5479
