### PR TITLE
Update markdown-lint CI to ubuntu 22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
 
 - job: Markdownlint
   pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-22.04
   steps:
     - script: sudo npm install -g markdownlint-cli@0.31.1
       displayName: Install markdownlint-cli


### PR DESCRIPTION
Ubuntu 18.04 is obsolete and needs to be updated to either 20.04 or 22.04.

