### PR TITLE
Update SupportedOSPlatformGuard/UnsupportedOSPlatformGuard logic to support dynamic versions

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -33,12 +33,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             /// <summary>
-            /// If the <paramref name="symbol"/> provided annotated with any guard attributes updates the <paramref name="value"/> accordingly.
+            /// If the <paramref name="symbol"/> provided annotated with any guard attribute update the <paramref name="value"/> accordingly.
             /// </summary>
-            /// <param name="symbol">Symbol which attributes will be examined.</param>
+            /// <param name="symbol">Symbol for which the attributes will be examined.</param>
             /// <param name="value">Resulting flow analysis value.</param>
-            /// <param name="visitedArguments">Arguments passed to this method symbol.</param>
-            /// <returns>True if any guard attribute found and <paramref name="value"/> changed, false otherwise</returns>
+            /// <param name="visitedArguments">Arguments passed to the method symbol.</param>
+            /// <returns>True if any guard attribute found and <paramref name="value"/> changed accordingly, false otherwise</returns>
             internal bool TryParseGuardAttributes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value, ImmutableArray<IArgumentOperation> visitedArguments)
             {
                 var attributes = symbol.GetAttributes();
@@ -67,7 +67,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             /// <summary>
-            /// Checks if there is any guard attribute within <paramref name="attributes"/>, parse found attributes into to platform to version map <paramref name="mappedAttributes"/>
+            /// Checks if there is any guard attribute within <paramref name="attributes"/>, parse found attributes into platform to version map <paramref name="mappedAttributes"/>
             /// </summary>
             /// <param name="attributes">Attributes to check</param>
             /// <param name="methodArguments">If the symbol is method symbol provide its arguments</param>
@@ -114,11 +114,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             }
 
             /// <summary>
-            /// Convert each platform and versions pair from <paramref name="mappedAttributes"/> into <see cref="PlatformMethodValue"/>s and adds into <paramref name="infosBuilder"/> array
+            /// Convert each platform and versions pair from <paramref name="mappedAttributes"/> map into <see cref="PlatformMethodValue"/>s and add into <paramref name="infosBuilder"/> array
             /// </summary>
-            /// <param name="mappedAttributes">Map of platforms into versions populated from guard attributes</param>
-            /// <param name="infosBuilder">Converted array of <see cref="PlatformMethodValue"/></param>
-            /// <returns></returns>
+            /// <param name="mappedAttributes">Map of platforms to versions populated from guard attributes</param>
+            /// <param name="infosBuilder">Converted array of <see cref="PlatformMethodValue"/>s</param>
+            /// <returns>True if any <see cref="PlatformMethodValue"/> added into the <paramref name="infosBuilder"/>, false otherwise</returns>
             public bool TryDecodeGuardAttributes(SmallDictionary<string, Versions> mappedAttributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
             {
                 foreach (var (name, versions) in mappedAttributes)
@@ -208,7 +208,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         return value;
                     }
                 }
-                else // Not a known guard method, check annotated with guard attributes
+                else // Not a known guard method, check if annotated with guard attributes
                 {
                     TryParseGuardAttributes(method, ref value, visitedArguments);
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.OperationVisitor.cs
@@ -32,12 +32,19 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 _relatedPlatforms = relatedPlatforms;
             }
 
-            internal bool TryParseGuardAttributes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value)
+            /// <summary>
+            /// If the <paramref name="symbol"/> provided annotated with any guard attributes updates the <paramref name="value"/> accordingly.
+            /// </summary>
+            /// <param name="symbol">Symbol which attributes will be examined.</param>
+            /// <param name="value">Resulting flow analysis value.</param>
+            /// <param name="visitedArguments">Arguments passed to this method symbol.</param>
+            /// <returns>True if any guard attribute found and <paramref name="value"/> changed, false otherwise</returns>
+            internal bool TryParseGuardAttributes(ISymbol symbol, ref GlobalFlowStateAnalysisValueSet value, ImmutableArray<IArgumentOperation> visitedArguments)
             {
                 var attributes = symbol.GetAttributes();
 
                 if (symbol.GetMemberType()!.SpecialType != SpecialType.System_Boolean ||
-                    !HasAnyGuardAttribute(attributes, out var guardAttributes))
+                    !HasAnyGuardAttribute(attributes, visitedArguments, out var guardAttributes))
                 {
                     return false;
                 }
@@ -56,12 +63,17 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     return true;
                 }
 
-                value = GlobalFlowStateAnalysisValueSet.Unknown;
-
                 return false;
             }
 
-            private static bool HasAnyGuardAttribute(ImmutableArray<AttributeData> attributes, [NotNullWhen(true)] out SmallDictionary<string, Versions>? mappedAttributes)
+            /// <summary>
+            /// Checks if there is any guard attribute within <paramref name="attributes"/>, parse found attributes into to platform to version map <paramref name="mappedAttributes"/>
+            /// </summary>
+            /// <param name="attributes">Attributes to check</param>
+            /// <param name="methodArguments">If the symbol is method symbol provide its arguments</param>
+            /// <param name="mappedAttributes">Guard attributes parsed into platform to version map</param>
+            /// <returns>True if there were any guard attributes found and parsed successfully, false otherwise</returns>
+            private static bool HasAnyGuardAttribute(ImmutableArray<AttributeData> attributes, ImmutableArray<IArgumentOperation> methodArguments, [NotNullWhen(true)] out SmallDictionary<string, Versions>? mappedAttributes)
             {
                 mappedAttributes = null;
 
@@ -70,6 +82,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     if (attribute.AttributeClass.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute &&
                         TryParsePlatformNameAndVersion(attribute, out var platformName, out var version))
                     {
+                        if (version == EmptyVersion && !methodArguments.IsEmpty &&
+                            TryDecodeOSVersion(methodArguments, null, out var apiVersion))
+                        {
+                            version = apiVersion;
+                        }
+
                         mappedAttributes ??= new(StringComparer.OrdinalIgnoreCase);
                         if (!mappedAttributes.TryGetValue(platformName, out var versions))
                         {
@@ -95,6 +113,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return mappedAttributes != null;
             }
 
+            /// <summary>
+            /// Convert each platform and versions pair from <paramref name="mappedAttributes"/> into <see cref="PlatformMethodValue"/>s and adds into <paramref name="infosBuilder"/> array
+            /// </summary>
+            /// <param name="mappedAttributes">Map of platforms into versions populated from guard attributes</param>
+            /// <param name="infosBuilder">Converted array of <see cref="PlatformMethodValue"/></param>
+            /// <returns></returns>
             public bool TryDecodeGuardAttributes(SmallDictionary<string, Versions> mappedAttributes, ArrayBuilder<PlatformMethodValue> infosBuilder)
             {
                 foreach (var (name, versions) in mappedAttributes)
@@ -183,12 +207,10 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
                         return value;
                     }
-
-                    return GlobalFlowStateAnalysisValueSet.Unknown;
                 }
-                else if (TryParseGuardAttributes(method, ref value))
+                else // Not a known guard method, check annotated with guard attributes
                 {
-                    return value;
+                    TryParseGuardAttributes(method, ref value, visitedArguments);
                 }
 
                 return value;
@@ -232,7 +254,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 var value = base.VisitFieldReference(operation, argument);
 
-                if (TryParseGuardAttributes(operation.Field, ref value))
+                if (TryParseGuardAttributes(operation.Field, ref value, ImmutableArray<IArgumentOperation>.Empty))
                 {
                     return value;
                 }
@@ -244,7 +266,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             {
                 var value = base.VisitPropertyReference(operation, argument);
 
-                if (TryParseGuardAttributes(operation.Property, ref value))
+                if (TryParseGuardAttributes(operation.Property, ref value, ImmutableArray<IArgumentOperation>.Empty))
                 {
                     return value;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -235,20 +235,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return false;
             }
 
-            static Version CreateVersion(ArrayBuilder<int> versionBuilder)
+            static Version CreateVersion(ArrayBuilder<int> versionBuilder) => versionBuilder switch
             {
-                if (versionBuilder[3] == 0)
-                {
-                    if (versionBuilder[2] == 0)
-                    {
-                        return new Version(versionBuilder[0], versionBuilder[1]);
-                    }
-
-                    return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2]);
-                }
-
-                return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2], versionBuilder[3]);
-            }
+                [int major, int minor, 0, 0] => new Version(major, minor),
+                [int major, int minor, int build, 0] => new Version(major, minor, build),
+                [int major, int minor, int build, int revision] => new Version(major, minor, build, revision),
+                _ => EmptyVersion
+            };
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.Value.cs
@@ -145,71 +145,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return false;
             }
 
-            private static bool TryDecodeOSVersion(
-                ImmutableArray<IArgumentOperation> arguments,
-                ValueContentAnalysisResult? valueContentAnalysisResult,
-                [NotNullWhen(returnValue: true)] out Version? osVersion,
-                int skip = 0)
-            {
-
-                using var versionBuilder = ArrayBuilder<int>.GetInstance(4, fillWithValue: 0);
-                var index = 0;
-
-                foreach (var argument in arguments.GetArgumentsInParameterOrder().Skip(skip))
-                {
-                    if (!TryDecodeOSVersionPart(argument, valueContentAnalysisResult, out var osVersionPart))
-                    {
-                        osVersion = null;
-                        return false;
-                    }
-
-                    versionBuilder[index++] = osVersionPart;
-                }
-
-                osVersion = CreateVersion(versionBuilder);
-                return true;
-
-                static bool TryDecodeOSVersionPart(IArgumentOperation argument, ValueContentAnalysisResult? valueContentAnalysisResult, out int osVersionPart)
-                {
-                    if (argument.Value.ConstantValue.HasValue &&
-                        argument.Value.ConstantValue.Value is int versionPart)
-                    {
-                        osVersionPart = versionPart;
-                        return true;
-                    }
-
-                    if (valueContentAnalysisResult != null)
-                    {
-                        var valueContentValue = valueContentAnalysisResult[argument.Value];
-                        if (valueContentValue.IsLiteralState &&
-                            valueContentValue.LiteralValues.Count == 1 &&
-                            valueContentValue.LiteralValues.Single() is int part)
-                        {
-                            osVersionPart = part;
-                            return true;
-                        }
-                    }
-
-                    osVersionPart = default;
-                    return false;
-                }
-
-                static Version CreateVersion(ArrayBuilder<int> versionBuilder)
-                {
-                    if (versionBuilder[3] == 0)
-                    {
-                        if (versionBuilder[2] == 0)
-                        {
-                            return new Version(versionBuilder[0], versionBuilder[1]);
-                        }
-
-                        return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2]);
-                    }
-
-                    return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2], versionBuilder[3]);
-                }
-            }
-
             public override string ToString()
             {
                 var result = $"{PlatformName};{Version}";
@@ -248,6 +183,71 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             public static bool operator !=(PlatformMethodValue left, PlatformMethodValue right)
             {
                 return !(left == right);
+            }
+        }
+
+        private static bool TryDecodeOSVersion(
+                ImmutableArray<IArgumentOperation> arguments,
+                ValueContentAnalysisResult? valueContentAnalysisResult,
+                [NotNullWhen(returnValue: true)] out Version? osVersion,
+                int skip = 0)
+        {
+
+            using var versionBuilder = ArrayBuilder<int>.GetInstance(4, fillWithValue: 0);
+            var index = 0;
+
+            foreach (var argument in arguments.GetArgumentsInParameterOrder().Skip(skip))
+            {
+                if (!TryDecodeOSVersionPart(argument, valueContentAnalysisResult, out var osVersionPart))
+                {
+                    osVersion = null;
+                    return false;
+                }
+
+                versionBuilder[index++] = osVersionPart;
+            }
+
+            osVersion = CreateVersion(versionBuilder);
+            return true;
+
+            static bool TryDecodeOSVersionPart(IArgumentOperation argument, ValueContentAnalysisResult? valueContentAnalysisResult, out int osVersionPart)
+            {
+                if (argument.Value.ConstantValue.HasValue &&
+                    argument.Value.ConstantValue.Value is int versionPart)
+                {
+                    osVersionPart = versionPart;
+                    return true;
+                }
+
+                if (valueContentAnalysisResult != null)
+                {
+                    var valueContentValue = valueContentAnalysisResult[argument.Value];
+                    if (valueContentValue.IsLiteralState &&
+                        valueContentValue.LiteralValues.Count == 1 &&
+                        valueContentValue.LiteralValues.Single() is int part)
+                    {
+                        osVersionPart = part;
+                        return true;
+                    }
+                }
+
+                osVersionPart = default;
+                return false;
+            }
+
+            static Version CreateVersion(ArrayBuilder<int> versionBuilder)
+            {
+                if (versionBuilder[3] == 0)
+                {
+                    if (versionBuilder[2] == 0)
+                    {
+                        return new Version(versionBuilder[0], versionBuilder[1]);
+                    }
+
+                    return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2]);
+                }
+
+                return new Version(versionBuilder[0], versionBuilder[1], versionBuilder[2], versionBuilder[3]);
             }
         }
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4816,7 +4816,7 @@ class Test
         }
 
         [Fact]
-        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments()
+        public async Task DynamicallyLoadGuardingVersionFromCallingApiArguments()
         {
             var source = @"
 using System;
@@ -4870,7 +4870,7 @@ class Test
         }
 
         [Fact]
-        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments_Multiple()
+        public async Task DynamicallyLoadGuardingVersionFromCallingApiArguments_MultipleAttriubtesApplied()
         {
             var source = @"
 using System;
@@ -4925,7 +4925,7 @@ class Test
         }
 
         [Fact]
-        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments_NotWarningCases()
+        public async Task DynamicallyLoadGuardingVersionFromCallingApiArguments_NotWarningCases()
         {
             var source = @"
 using System;
@@ -4969,7 +4969,7 @@ class Test
         }
 
         [Fact]
-        public async Task ApiAndGuardAttributeBothHasVersion_AttributeVersionWins()
+        public async Task ApiAndGuardAttributeBothHasVersions_AttributeVersionWins()
         {
             var source = @"
 using System;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4816,6 +4816,195 @@ class Test
         }
 
         [Fact]
+        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""ios"")]
+    private bool IsIosSupported(int major, int minor) => true;
+
+    [UnsupportedOSPlatformGuard(""ios"")]
+    private bool IosNotSupportedFrom(int major) => true;
+
+    void M1()
+    {
+        [|SupportedOniOS11()|]; 
+        [|UnsupportedOniOS11()|];
+
+        if (IsIosSupported(11, 0))
+        {
+            SupportedOniOS11();    
+            [|UnsupportedOniOS11()|];
+        }
+        else
+        {
+            [|SupportedOniOS11()|];    
+            UnsupportedOniOS11();
+        }
+
+        if (IosNotSupportedFrom(11))
+        {
+            [|SupportedOniOS11()|];    
+            UnsupportedOniOS11();
+        }
+        else
+        {
+            SupportedOniOS11();    
+            [|UnsupportedOniOS11()|];
+        }
+    }
+
+    [SupportedOSPlatform(""ios11.0"")]
+    void SupportedOniOS11() { }
+
+    [UnsupportedOSPlatform(""ios11.0"")]
+    void UnsupportedOniOS11() { }
+}";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
+        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments_Multiple()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""ios"")]
+    [SupportedOSPlatformGuard(""watchos"")]
+    private bool IsIosWatchOsSupported(int major, int minor, int build = 0) => true;
+
+    [SupportedOSPlatformGuard(""ios"")]
+    private bool IsIosSupported(int major, int minor, int build = 0) => true;
+
+    [SupportedOSPlatform(""ios13.0.2"")]
+    [SupportedOSPlatform(""watchos13.0"")]
+    void SupportedOnIosAndWatchOs13() { }
+
+    [SupportedOSPlatform(""ios13.0.2"")]
+    void SupportedOnIos13() { }
+
+    [SupportedOSPlatform(""watchos10.0"")]
+    void SupportedOnWatchOs10() { }
+
+    void M1()
+    {
+        if (IsIosWatchOsSupported(13, 0, 2))
+        {
+            [|SupportedOnIos13()|];    
+            [|SupportedOnWatchOs10()|];
+            SupportedOnIosAndWatchOs13();
+        }
+
+        if (OperatingSystem.IsIOSVersionAtLeast(13, 0, 2) || OperatingSystem.IsWatchOSVersionAtLeast(13))
+        {
+            [|SupportedOnIos13()|];    
+            [|SupportedOnWatchOs10()|];
+            SupportedOnIosAndWatchOs13();
+        }
+
+        if (IsIosSupported(13, 0, 2))
+        {
+            SupportedOnIos13();    
+            [|SupportedOnWatchOs10()|];
+            SupportedOnIosAndWatchOs13();
+        }
+    }
+}";
+
+            await VerifyAnalyzerCSAsync(source);
+        }
+
+        [Fact]
+        public async Task DynamicallyLoadGuardingVersionFromAPIsArguments_NotWarningCases()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""ios"")]
+    private bool IsIosSupported(int major, string minor, int build = 0) => true; // string parameter not accepted
+
+    [SupportedOSPlatformGuard(""ios"")]
+    private bool IsIosSupported(int major, long minor, int build = 0) => true; // long parameter not accepted
+
+    [SupportedOSPlatformGuard(""ios"")]
+    private string IsIosSupported(int major, int minor, int build = 0) => ""true""; // not return boolean
+
+    [SupportedOSPlatform(""ios13.0.2"")]
+    void SupportedOnIos13() { }
+
+    void M1()
+    {
+        if (IsIosSupported(13, ""0"", 2))
+        {
+            [|SupportedOnIos13()|];    
+        }
+
+        if (IsIosSupported(13, 0l, 2))
+        {
+            [|SupportedOnIos13()|];    
+        }
+
+        if (IsIosSupported(13, 0, 2) == ""true"")
+        {
+            [|SupportedOnIos13()|];
+        }
+    }
+}";
+
+            await VerifyAnalyzerCSAsync(source);
+        }
+
+        [Fact]
+        public async Task ApiAndGuardAttributeBothHasVersion_AttributeVersionWins()
+        {
+            var source = @"
+using System;
+using System.Diagnostics;
+using System.Runtime.Versioning;
+
+class Test
+{
+    [SupportedOSPlatformGuard(""ios10.0"")]
+    private bool IsIos10Supported(int major, int minor) => true;
+
+    [SupportedOSPlatformGuard(""ios11.0"")]
+    private bool IsIos11Supported(int major, int minor) => true;
+
+    [SupportedOSPlatform(""ios11.0"")]
+    void SupportedOnIos11() { }
+
+    void M1()
+    {
+        if (IsIos10Supported(11, 0))
+        {
+            [|SupportedOnIos11()|];  // Warns because API version 11.0+ is ignored and attribute version ios 10.0+ accounted 
+        }
+
+        if (IsIos11Supported(10, 0))
+        {
+            SupportedOnIos11();  // Not warn because API version 10.0+ is ignored and attribute version ios 11.0+ accounted 
+        }
+    }
+}";
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [Fact]
         public async Task OneOfSupportsNeedsGuard_AllOtherSuppressedByCallsite()
         {
             var source = @"


### PR DESCRIPTION
### Update SupportedOSPlatformGuard/UnsupportedOSPlatformGuard logic to support dynamic versions

CA1416 by default recognizes platform version check APIs provided by .Net libraries, in addition to that a user API can be annotated with SupportedOSPlatformGuard/UnsupportedOSPlatformGuard attribute in order to recognized by the analyzer during platform/version check. 

The platform name and version must be passed with the attribute constructor argument. As mentioned in https://github.com/dotnet/roslyn-analyzers/issues/6204 we need to update that logic to support dynamic versions that provided by the called API, example:

```cs
public class UIDevice
{
    [SupportedOSPlatformGuard("ios")]
    public bool CheckSystemVersion(int major, int minor);
}

public class Test
{
    [SupportedOSPlatform("ios13.0")]
    void SupportedOnIos13() { }
        
    void M1()
    {
         [|SupportedOnIos13()|];  // warns
        if (UIDevice.CheckSystemVersion(13, 0)) // guards iOS 13.0+
        {
            SupportedOnIos13();    // not warn
        }
    }
}
```

Fixes https://github.com/dotnet/roslyn-analyzers/issues/6204+