### PR TITLE
Update `NumberCommentsRefactoring` to support raw string literals

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentsRefactoring.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentsRefactoring.cs
@@ -24,8 +24,8 @@ namespace Roslyn.Diagnostics.Analyzers
     /// This pattern is commonly used by compiler tests.
     /// Comments that don't look like numbered comments are left alone. For instance, any comment that contains alpha characters.
     /// </summary>
-    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(NumberCommentslRefactoring)), Shared]
-    internal sealed class NumberCommentslRefactoring : CodeRefactoringProvider
+    [ExportCodeRefactoringProvider(LanguageNames.CSharp, Name = nameof(NumberCommentsRefactoring)), Shared]
+    internal sealed class NumberCommentsRefactoring : CodeRefactoringProvider
     {
         public override async Task ComputeRefactoringsAsync(CodeRefactoringContext context)
         {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentsRefactoring.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/NumberCommentsRefactoring.cs
@@ -48,7 +48,10 @@ namespace Roslyn.Diagnostics.Analyzers
             var newValueText = FixComments(stringLiteral.Token.ValueText, prefix: null);
             var oldText = stringLiteral.Token.Text;
             var newText = FixComments(oldText, getPrefix(oldText));
-            var newStringLiteral = stringLiteral.Update(SyntaxFactory.Literal(text: newText, value: newValueText)).WithTriviaFrom(stringLiteral);
+
+            var oldToken = stringLiteral.Token;
+            var newToken = SyntaxFactory.Token(oldToken.LeadingTrivia, kind: oldToken.Kind(), text: newText, valueText: newValueText, oldToken.TrailingTrivia);
+            var newStringLiteral = stringLiteral.Update(newToken);
 
             var editor = await DocumentEditor.CreateAsync(document, c).ConfigureAwait(false);
             editor.ReplaceNode(stringLiteral, newStringLiteral);

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/NumberCommentsRefactoringTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/NumberCommentsRefactoringTests.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpCodeRefactoringVerifier<Roslyn.Diagnostics.Analyzers.NumberCommentslRefactoring>;
+using VerifyCS = Test.Utilities.CSharpCodeRefactoringVerifier<Roslyn.Diagnostics.Analyzers.NumberCommentsRefactoring>;
 
 namespace Roslyn.Diagnostics.Analyzers.UnitTests
 {
@@ -26,6 +27,74 @@ class D { } // 1
 "";
 }";
             await VerifyCS.VerifyRefactoringAsync(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task TestAsync_RawStringLiteral()
+        {
+            const string source = """"
+public class C
+{
+    string s = """
+[||]class D { } //
+""";
+}
+"""";
+            const string fixedSource = """"
+public class C
+{
+    string s = """
+class D { } // 1
+""";
+}
+"""";
+            await VerifyCSharp11Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task TestAsync_RawStringLiteral_Indented()
+        {
+            const string source = """"
+public class C
+{
+    string s = """
+        [||]class D { } //
+        """;
+}
+"""";
+            const string fixedSource = """"
+public class C
+{
+    string s = """
+        class D { } // 1
+        """;
+}
+"""";
+            await VerifyCSharp11Async(source, fixedSource);
+        }
+
+        [Fact]
+        public async Task TestAsync_RawStringLiteral_Indented_Multiple()
+        {
+            const string source = """"
+public class C
+{
+    string s = """
+        [||]class D { } //
+        class E { } //,
+        """;
+}
+"""";
+            const string fixedSource = """"
+public class C
+{
+    string s = """
+        class D { } // 1
+        class E { } // 2, 3
+        """;
+}
+"""";
+            await VerifyCSharp11Async(source, fixedSource);
         }
 
         [Fact]
@@ -219,5 +288,20 @@ class C // 1
 
             await VerifyCS.VerifyRefactoringAsync(source, fixedSource);
         }
+
+        #region Utilities
+        private async Task VerifyCSharp11Async(string source, string fixedSource)
+        {
+            var test = new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp11,
+            };
+
+            test.ExpectedDiagnostics.AddRange(DiagnosticResult.EmptyDiagnosticResults);
+            await test.RunAsync();
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
For context, this refactoring helps fix number comments in roslyn tests. See a pictured example below.
The problem is that it didn't work with the newly added raw strings literals. This PR fixes that.

![image](https://user-images.githubusercontent.com/12466233/198524624-932c8ca6-cdf7-45fb-bb6a-80fbf753d2b1.png)
