### PR TITLE
Added support for StringSyntaxAttribute.CompositeFormat in CA2241 (#6…

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -452,15 +452,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 for (var i = 0; i < parameters.Length; i++)
                 {
-                    ImmutableArray<AttributeData> attributes = parameters[i].GetAttributes();
-                    for (int j = 0; j < attributes.Length; j++)
+                    if (String.Equals(parameters[i].Type, SymbolEqualityComparer.Default))
                     {
-                        if (StringSyntaxAttribute!.Equals(attributes[j].AttributeClass))
+                        foreach (AttributeData attribute in parameters[i].GetAttributes())
                         {
-                            ImmutableArray<TypedConstant> arguments = attributes[j].ConstructorArguments;
-                            if (arguments.Length == 1 && CompositeFormat.Equals(arguments[0].Value))
+                            if (StringSyntaxAttribute!.Equals(attribute.AttributeClass, SymbolEqualityComparer.Default))
                             {
-                                return i;
+                                ImmutableArray<TypedConstant> arguments = attribute.ConstructorArguments;
+                                if (arguments.Length == 1 && CompositeFormat.Equals(arguments[0].Value))
+                                {
+                                    return i;
+                                }
                             }
                         }
                     }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -346,7 +346,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return info;
                 }
 
-                if (TryGetFormatInfoByCompositeFormatStringSyntaxAttribute(method, out info))
+                if (StringSyntaxAttribute is not null &&
+                    TryGetFormatInfoByCompositeFormatStringSyntaxAttribute(method, out info))
                 {
                     return info;
                 }
@@ -408,6 +409,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     // no valid format string
                     return false;
                 }
+
                 if (method.Parameters[formatIndex].Type.SpecialType != SpecialType.System_String)
                 {
                     // no valid format string
@@ -448,20 +450,15 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             private int FindParameterIndexOfCompositeFormatStringSyntaxAttribute(ImmutableArray<IParameterSymbol> parameters)
             {
-                if (StringSyntaxAttribute is null)
-                {
-                    return -1;
-                }
-
                 for (var i = 0; i < parameters.Length; i++)
                 {
                     ImmutableArray<AttributeData> attributes = parameters[i].GetAttributes();
                     for (int j = 0; j < attributes.Length; j++)
                     {
-                        if (Equals(attributes[j].AttributeClass, StringSyntaxAttribute))
+                        if (StringSyntaxAttribute!.Equals(attributes[j].AttributeClass))
                         {
                             ImmutableArray<TypedConstant> arguments = attributes[j].ConstructorArguments;
-                            if (arguments.Length == 1 && Equals(arguments[0].Value, CompositeFormat))
+                            if (arguments.Length == 1 && CompositeFormat.Equals(arguments[0].Value))
                             {
                                 return i;
                             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
@@ -531,28 +531,9 @@ class Test
     {
         var a = MyFormat("""", 1);
     }
-}",
-                        @"
-namespace System.Diagnostics.CodeAnalysis
-{
-    /// <summary>Specifies the syntax used in a string.</summary>
-    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    public sealed class StringSyntaxAttribute : Attribute
-    {
-        /// <summary>The syntax identifier for strings containing composite formats for string formatting.</summary>
-        public const string CompositeFormat = nameof(CompositeFormat);
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref=""StringSyntaxAttribute""/> class with the identifier of the syntax used.
-        /// </summary>
-        /// <param name=""syntax"">The syntax identifier.</param>
-        public StringSyntaxAttribute(string syntax)
-        {
-        }
-    }
-}
-"
-                    }
+}"
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
                 }
             };
 
@@ -579,22 +560,9 @@ Class Test
     Private Sub M1(ByVal param As String)
         Dim a = MyFormat("""", 1)
     End Sub
-End Class",
-                                                @"
-Namespace System.Diagnostics.CodeAnalysis
-    <AttributeUsage(AttributeTargets.Parameter Or AttributeTargets.Field Or AttributeTargets.Property, AllowMultiple := False, Inherited := False)>
-    Public Class StringSyntaxAttribute
-        Inherits Attribute
-
-        Public Const CompositeFormat As String = ""CompositeFormat""
-
-        Sub  New(ByVal syntax As String)
-        End Sub
-    End Class
-End Namespace
-"
-
-                    }
+End Class"
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
                 }
             };
 

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -202,6 +202,7 @@ namespace Analyzer.Utilities
         public const string SystemDiagnosticsCodeAnalysisConstantExpectedAttribute = "System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute";
         public const string SystemDiagnosticsCodeAnalysisNotNullAttribute = "System.Diagnostics.CodeAnalysis.NotNullAttribute";
         public const string SystemDiagnosticsCodeAnalysisNotNullIfNotNullAttribute = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
+        public const string SystemDiagnosticsCodeAnalysisStringSyntaxAttributeName = "System.Diagnostics.CodeAnalysis.StringSyntaxAttribute";
         public const string SystemDiagnosticsConditionalAttribute = "System.Diagnostics.ConditionalAttribute";
         public const string SystemDiagnosticsContractsPureAttribute = "System.Diagnostics.Contracts.PureAttribute";
         public const string SystemDiagnosticsDebug = "System.Diagnostics.Debug";


### PR DESCRIPTION
Fixes #6012 

@stephentoub The existing implementation uses an ImmutableDictionary for the pre-defined methods. 

This means that for all other methods, if called multiple times, the check if the methods is a format method is re-done every invocation.

I added one extra commit to use a ConcurrentDictionary instead which is updated when a method is discovered so the next time this method is called it is found immediately.

I don't know if this is safe.  The class is created as part of a `RegisterCompilationStartAction` so isolated per compilation.

One other optimization is to also add methods to the dictionary that have been checked, but not found to be format methods. 
This way we only need to check every method definition once.
