### PR TITLE
Fix PublicAPI enablement checks

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -118,7 +118,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                             context.ReportDiagnostic(cur);
                         }
                     });
+
+                    return;
                 }
+
+                Debug.Assert(errors.Count == 0);
 
                 RegisterImplActions(compilationContext, new Impl(compilationContext.Compilation, shippedData, unshippedData, isPublic, compilationContext.Options));
 

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -102,47 +102,45 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
-            var errors = new List<Diagnostic>();
-            // Switch to "RegisterAdditionalFileAction" available in Microsoft.CodeAnalysis "3.8.x" to report additional file diagnostics: https://github.com/dotnet/roslyn-analyzers/issues/3918
-            if (!TryGetAndValidateApiFiles(compilationContext.Options, compilationContext.Compilation, isPublic: true, compilationContext.CancellationToken, errors, out ApiData publicShippedData, out ApiData publicUnshippedData)
-                || !TryGetAndValidateApiFiles(compilationContext.Options, compilationContext.Compilation, isPublic: false, compilationContext.CancellationToken, errors, out ApiData internalShippedData, out ApiData internalUnshippedData))
+            CheckAndRegisterImplementation(isPublic: true);
+            CheckAndRegisterImplementation(isPublic: false);
+
+            void CheckAndRegisterImplementation(bool isPublic)
             {
-                compilationContext.RegisterCompilationEndAction(context =>
+                var errors = new List<Diagnostic>();
+                // Switch to "RegisterAdditionalFileAction" available in Microsoft.CodeAnalysis "3.8.x" to report additional file diagnostics: https://github.com/dotnet/roslyn-analyzers/issues/3918
+                if (!TryGetAndValidateApiFiles(compilationContext.Options, compilationContext.Compilation, isPublic, compilationContext.CancellationToken, errors, out ApiData shippedData, out ApiData unshippedData))
                 {
-                    foreach (Diagnostic cur in errors)
+                    compilationContext.RegisterCompilationEndAction(context =>
                     {
-                        context.ReportDiagnostic(cur);
-                    }
-                });
+                        foreach (Diagnostic cur in errors)
+                        {
+                            context.ReportDiagnostic(cur);
+                        }
+                    });
+                }
 
-                return;
-            }
+                RegisterImplActions(compilationContext, new Impl(compilationContext.Compilation, shippedData, unshippedData, isPublic, compilationContext.Options));
 
-            Debug.Assert(errors.Count == 0);
+                static bool TryGetAndValidateApiFiles(AnalyzerOptions options, Compilation compilation, bool isPublic, CancellationToken cancellationToken, List<Diagnostic> errors, out ApiData shippedData, out ApiData unshippedData)
+                {
+                    return TryGetApiData(options, compilation, isPublic, errors, cancellationToken, out shippedData, out unshippedData)
+                           && ValidateApiFiles(shippedData, unshippedData, isPublic, errors);
+                }
 
-            var publicImpl = new Impl(compilationContext.Compilation, publicShippedData, publicUnshippedData, isPublic: true, compilationContext.Options);
-            var internalImpl = new Impl(compilationContext.Compilation, internalShippedData, internalUnshippedData, isPublic: false, compilationContext.Options);
-            RegisterImplActions(compilationContext, publicImpl);
-            RegisterImplActions(compilationContext, internalImpl);
-
-            static bool TryGetAndValidateApiFiles(AnalyzerOptions options, Compilation compilation, bool isPublic, CancellationToken cancellationToken, List<Diagnostic> errors, out ApiData shippedData, out ApiData unshippedData)
-            {
-                return TryGetApiData(options, compilation, isPublic, errors, cancellationToken, out shippedData, out unshippedData)
-                       && ValidateApiFiles(shippedData, unshippedData, isPublic, errors);
-            }
-
-            static void RegisterImplActions(CompilationStartAnalysisContext compilationContext, Impl impl)
-            {
-                compilationContext.RegisterSymbolAction(
-                    impl.OnSymbolAction,
-                    SymbolKind.NamedType,
-                    SymbolKind.Event,
-                    SymbolKind.Field,
-                    SymbolKind.Method);
-                compilationContext.RegisterSymbolAction(
-                    impl.OnPropertyAction,
-                    SymbolKind.Property);
-                compilationContext.RegisterCompilationEndAction(impl.OnCompilationEnd);
+                static void RegisterImplActions(CompilationStartAnalysisContext compilationContext, Impl impl)
+                {
+                    compilationContext.RegisterSymbolAction(
+                        impl.OnSymbolAction,
+                        SymbolKind.NamedType,
+                        SymbolKind.Event,
+                        SymbolKind.Field,
+                        SymbolKind.Method);
+                    compilationContext.RegisterSymbolAction(
+                        impl.OnPropertyAction,
+                        SymbolKind.Property);
+                    compilationContext.RegisterCompilationEndAction(impl.OnCompilationEnd);
+                }
             }
         }
 

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -311,6 +311,25 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
         }
 
         [Fact]
+        public async Task AnalyzerFilePresent_MissingNonEnabledText()
+        {
+            var source = $$"""
+
+                {{EnabledModifierCSharp}} class C
+                {
+                    private C() { }
+                }
+                """;
+
+            string? shippedText = "";
+            string? unshippedText = "";
+
+            var expectedDiagnostics = new[] { GetCSharpResultAt(2, 8 + EnabledModifierCSharp.Length, DeclareNewApiRule, "C") };
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText, $"[*]\r\ndotnet_public_api_analyzer.require_api_files = true", expectedDiagnostics);
+        }
+
+        [Fact]
         public async Task EmptyPublicAPIFilesAsync()
         {
             var source = @"";


### PR DESCRIPTION
The current logic was broken for projects that only have public or only have internal APIs. I refactored the registration logic to run completely separately for both public and internal to fix this.
