### PR TITLE
Handle conversion operation as operands of IThrowOperation

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetails.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetails.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             {
                 var throwOperation = (IThrowOperation)context.Operation;
 
-                if (throwOperation.Exception is not ILocalReferenceOperation localReference)
+                if (throwOperation.GetThrownException() is not ILocalReferenceOperation localReference)
                 {
                     return;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.cs
@@ -139,7 +139,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 if (conditional.Condition is IPropertyReferenceOperation propertyReference &&
                     SymbolEqualityComparer.Default.Equals(propertyReference.Property, IsCancellationRequestedProperty) &&
                     whenTrueUnwrapped is IThrowOperation @throw &&
-                    @throw.Exception is IObjectCreationOperation objectCreation &&
+                    @throw.GetThrownException() is IObjectCreationOperation objectCreation &&
                     IsDefaultOrTokenOperationCanceledExceptionCtor(objectCreation.Constructor))
                 {
                     isCancellationRequestedPropertyReference = propertyReference;
@@ -171,7 +171,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     unary.Operand is IPropertyReferenceOperation propertyReference &&
                     SymbolEqualityComparer.Default.Equals(propertyReference.Property, IsCancellationRequestedProperty) &&
                     whenFalseUnwrapped is IThrowOperation @throw &&
-                    @throw.Exception is IObjectCreationOperation objectCreation &&
+                    @throw.GetThrownException() is IObjectCreationOperation objectCreation &&
                     IsDefaultOrTokenOperationCanceledExceptionCtor(objectCreation.Constructor))
                 {
                     isCancellationRequestedPropertyReference = propertyReference;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
@@ -146,7 +146,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     // any exceptions where a meaningful message may have been provided.  This is an attempt to reduce
                     // false positives, at the expense of potentially more false negatives in cases where a non-valuable
                     // error message was used.
-                    if (throwOperation.Exception.WalkDownConversion() is not IObjectCreationOperation objectCreationOperation ||
+                    if (throwOperation.GetThrownException() is not IObjectCreationOperation objectCreationOperation ||
                         HasPossiblyMeaningfulAdditionalArguments(objectCreationOperation))
                     {
                         return;

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RethrowToPreserveStackDetailsTests.cs
@@ -138,10 +138,14 @@ public abstract class C
 ");
         }
 
-        [Fact]
-        public async Task CA2200_DiagnosticForThrowCaughtExceptionAsync()
+        [Theory]
+        [InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp7)]
+        [InlineData(CodeAnalysis.CSharp.LanguageVersion.CSharp10)]
+        public async Task CA2200_DiagnosticForThrowCaughtExceptionAsync(Microsoft.CodeAnalysis.CSharp.LanguageVersion languageVersion)
         {
-            await VerifyCS.VerifyAnalyzerAsync(@"
+            await new VerifyCS.Test
+            {
+                TestCode = @"
 using System;
 
 class Program
@@ -162,8 +166,9 @@ class Program
     {
         throw new ArithmeticException();
     }
-}
-");
+}",
+                LanguageVersion = languageVersion,
+            }.RunAsync();
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -741,7 +741,7 @@ namespace Analyzer.Utilities.Extensions
             return operation;
         }
 
-        public static ITypeSymbol? GetThrownExceptionType(this IThrowOperation operation)
+        public static IOperation? GetThrownException(this IThrowOperation operation)
         {
             var thrownObject = operation.Exception;
 
@@ -752,8 +752,11 @@ namespace Analyzer.Utilities.Extensions
                 thrownObject = conversion.Operand;
             }
 
-            return thrownObject?.Type;
+            return thrownObject;
         }
+
+        public static ITypeSymbol? GetThrownExceptionType(this IThrowOperation operation)
+            => operation.GetThrownException()?.Type;
 
         /// <summary>
         /// Determines if the one of the invocation's arguments' values is an argument of the specified type, and if so, find

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -746,8 +746,9 @@ namespace Analyzer.Utilities.Extensions
             var thrownObject = operation.Exception;
 
             // Starting C# 8.0, C# compiler wraps the thrown operation within an implicit conversion to System.Exception type.
+            // We also want to walk down explicit conversions such as "throw (Exception)new ArgumentNullException())".
             if (thrownObject is IConversionOperation conversion &&
-                conversion.IsImplicit)
+                conversion.Conversion.Exists)
             {
                 thrownObject = conversion.Operand;
             }


### PR DESCRIPTION
Fixes #6284

Starting C# 8.0, C# compiler wraps the thrown operation within an implicit conversion to `System.Exception` type.
