### PR TITLE
Let community-pr workflow has all permissions for `pull_request_target`

### DIFF
--- a/.github/workflows/community-pr.yml
+++ b/.github/workflows/community-pr.yml
@@ -2,9 +2,7 @@ name: Label community PRs
 on:
   pull_request_target:
     types: [opened]
-permissions:
-  issues: write
-  pull-requests: write
+
 jobs:
   add_community_label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hopefully, this should let the Action determine whether someone belongs to the dotnet organization correctly even if the member visibility is private.