### PR TITLE
Simplify AvoidUninstantiatedInternalClasses

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -48,6 +48,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 var internalTypes = new ConcurrentDictionary<INamedTypeSymbol, object?>();
 
                 var compilation = startContext.Compilation;
+                var entryPointContainingType = compilation.GetEntryPoint(startContext.CancellationToken)?.ContainingType;
                 var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(compilation);
 
                 // If the assembly being built by this compilation exposes its internals to
@@ -99,6 +100,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                     var type = (INamedTypeSymbol)context.Symbol;
                     if (!type.IsExternallyVisible() &&
                         !IsOkToBeUninstantiated(type, compilation,
+                            entryPointContainingType,
                             systemAttributeSymbol,
                             iConfigurationSectionHandlerSymbol,
                             configurationSectionSymbol,
@@ -283,6 +285,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private static bool IsOkToBeUninstantiated(
             INamedTypeSymbol type,
             Compilation compilation,
+            INamedTypeSymbol? entryPointContainingType,
             INamedTypeSymbol? systemAttributeSymbol,
             INamedTypeSymbol? iConfigurationSectionHandlerSymbol,
             INamedTypeSymbol? configurationSectionSymbol,
@@ -303,7 +306,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
             }
 
             // The type containing the assembly's entry point is OK.
-            if (SymbolEqualityComparer.Default.Equals(compilation.GetEntryPoint().ContainingType, type))
+            if (SymbolEqualityComparer.Default.Equals(entryPointContainingType, type))
             {
                 return true;
             }
@@ -345,6 +348,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
             return false;
         }
+
         public static bool IsMefExported(
             INamedTypeSymbol type,
             INamedTypeSymbol? mef1ExportAttributeSymbol,

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 {
                     var type = (INamedTypeSymbol)context.Symbol;
                     if (!type.IsExternallyVisible() &&
-                        !IsOkToBeUninstantiated(type, compilation,
+                        !IsOkToBeUninstantiated(type,
                             entryPointContainingType,
                             systemAttributeSymbol,
                             iConfigurationSectionHandlerSymbol,
@@ -284,7 +284,6 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
         private static bool IsOkToBeUninstantiated(
             INamedTypeSymbol type,
-            Compilation compilation,
             INamedTypeSymbol? entryPointContainingType,
             INamedTypeSymbol? systemAttributeSymbol,
             INamedTypeSymbol? iConfigurationSectionHandlerSymbol,

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -302,14 +302,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 return true;
             }
 
-            // Ignore type generated for holding top level statements
-            if (type.IsTopLevelStatementsEntryPointType())
-            {
-                return true;
-            }
-
             // The type containing the assembly's entry point is OK.
-            if (ContainsEntryPoint(type, compilation))
+            if (SymbolEqualityComparer.Default.Equals(compilation.GetEntryPoint().ContainingType, type))
             {
                 return true;
             }
@@ -358,81 +352,6 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         {
             return (mef1ExportAttributeSymbol != null && type.HasAttribute(mef1ExportAttributeSymbol))
                 || (mef2ExportAttributeSymbol != null && type.HasAttribute(mef2ExportAttributeSymbol));
-        }
-
-        private static bool ContainsEntryPoint(INamedTypeSymbol type, Compilation compilation)
-        {
-            // If this type doesn't live in an application assembly (.exe), it can't contain
-            // the entry point.
-            if (compilation.Options.OutputKind is not OutputKind.ConsoleApplication and
-                not OutputKind.WindowsApplication and
-                not OutputKind.WindowsRuntimeApplication)
-            {
-                return false;
-            }
-
-            var wellKnowTypeProvider = WellKnownTypeProvider.GetOrCreate(compilation);
-            var taskSymbol = wellKnowTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
-            var genericTaskSymbol = wellKnowTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1);
-
-            // TODO: Handle the case where Compilation.Options.MainTypeName matches this type.
-            // TODO: Test: can't have type parameters.
-            // TODO: Main in nested class? If allowed, what name does it have?
-            // TODO: Test that parameter is array of int.
-            return type.GetMembers("Main")
-                .Where(m => m is IMethodSymbol)
-                .Cast<IMethodSymbol>()
-                .Any(m => IsEntryPoint(m, taskSymbol, genericTaskSymbol));
-        }
-
-        private static bool IsEntryPoint(IMethodSymbol method, ITypeSymbol? taskSymbol, ITypeSymbol? genericTaskSymbol)
-        {
-            if (!method.IsStatic)
-            {
-                return false;
-            }
-
-            if (!IsSupportedReturnType(method, taskSymbol, genericTaskSymbol))
-            {
-                return false;
-            }
-
-            if (!method.Parameters.Any())
-            {
-                return true;
-            }
-
-            if (method.Parameters.HasMoreThan(1))
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        private static bool IsSupportedReturnType(IMethodSymbol method, ITypeSymbol? taskSymbol, ITypeSymbol? genericTaskSymbol)
-        {
-            if (method.ReturnType.SpecialType == SpecialType.System_Int32)
-            {
-                return true;
-            }
-
-            if (method.ReturnsVoid)
-            {
-                return true;
-            }
-
-            if (taskSymbol != null && Equals(method.ReturnType, taskSymbol))
-            {
-                return true;
-            }
-
-            if (genericTaskSymbol != null && Equals(method.ReturnType.OriginalDefinition, genericTaskSymbol) && ((INamedTypeSymbol)method.ReturnType).TypeArguments.Single().SpecialType == SpecialType.System_Int32)
-            {
-                return true;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -366,7 +366,7 @@ End Class",
         }
 
         [Fact]
-        public async Task CA1812_Basic_NoDiagnostic_MainMethodIsDifferentlyCasedAsync()
+        public async Task CA1812_Basic_Diagnostic_MainMethodIsDifferentlyCasedAsync()
         {
             await new VerifyVB.Test
             {
@@ -375,7 +375,7 @@ End Class",
                     OutputKind = OutputKind.ConsoleApplication,
                     Sources =
                     {
-@"Friend Class C
+@"Friend Class [|C|]
     Private Shared Sub mAiN()
     End Sub
 End Class",


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
