### PR TITLE
Update UseExceptionThrowHelpers to only recommend ANE for classes

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
@@ -180,7 +180,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     if (SymbolEqualityComparer.Default.Equals(objectCreationOperation.Type, ane))
                     {
                         if (aneThrowIfNull is not null &&
-                            IsParameterNullCheck(condition.Condition, out IParameterReferenceOperation? nullCheckParameter))
+                            IsParameterNullCheck(condition.Condition, out IParameterReferenceOperation? nullCheckParameter) &&
+                            nullCheckParameter.Type.TypeKind == TypeKind.Class)
                         {
                             context.ReportDiagnostic(condition.CreateDiagnostic(
                                 UseArgumentNullExceptionThrowIfNullRule,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
@@ -181,7 +181,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     {
                         if (aneThrowIfNull is not null &&
                             IsParameterNullCheck(condition.Condition, out IParameterReferenceOperation? nullCheckParameter) &&
-                            nullCheckParameter.Type.TypeKind == TypeKind.Class)
+                            nullCheckParameter.Type.IsReferenceType)
                         {
                             context.ReportDiagnostic(condition.CreateDiagnostic(
                                 UseArgumentNullExceptionThrowIfNullRule,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
@@ -187,6 +187,21 @@ class C
     {
         if (arg is null) throw new ArgumentNullException(nameof(arg));
     }
+
+    void GenericMethodWithClassConstraint<T>(T arg) where T : class
+    {
+        {|CA1510:if (arg is null) throw new ArgumentNullException(nameof(arg));|}
+    }
+
+    void GenericMethodWithTypeConstraint<T>(T arg) where T : C
+    {
+        {|CA1510:if (arg is null) throw new ArgumentNullException(nameof(arg));|}
+    }
+
+    void GenericMethodWithInterfaceConstraint<T>(T arg) where T : IDisposable
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
 }
 
 class GenericType<T>
@@ -285,6 +300,21 @@ class C
     }
 
     void GenericMethod<T>(T arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
+
+    void GenericMethodWithClassConstraint<T>(T arg) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(arg);
+    }
+
+    void GenericMethodWithTypeConstraint<T>(T arg) where T : C
+    {
+        ArgumentNullException.ThrowIfNull(arg);
+    }
+
+    void GenericMethodWithInterfaceConstraint<T>(T arg) where T : IDisposable
     {
         if (arg is null) throw new ArgumentNullException(nameof(arg));
     }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
@@ -177,6 +177,24 @@ class C
             return name;
         }
     }
+
+    void NullableArg(int? arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
+
+    void GenericMethod<T>(T arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
+}
+
+class GenericType<T>
+{
+    void M(T arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
 }
 ",
                 FixedCode =
@@ -259,6 +277,24 @@ class C
             ArgumentNullException.ThrowIfNull(name);
             return name;
         }
+    }
+
+    void NullableArg(int? arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
+
+    void GenericMethod<T>(T arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
+    }
+}
+
+class GenericType<T>
+{
+    void M(T arg)
+    {
+        if (arg is null) throw new ArgumentNullException(nameof(arg));
     }
 }
 "


### PR DESCRIPTION
I went back and forth on this initially, but decided it makes more sense to be conservative here and only recommend using ArgumentNullException.ThrowIfNull if the type of the parameter is known to be a class.  While it could be used for nullable value types or unconstrained generics, both result in boxing that we then rely on the JIT to eliminate.