### PR TITLE
Don't run CI for doc changes

### DIFF
--- a/azure-pipelines-perf.yml
+++ b/azure-pipelines-perf.yml
@@ -7,11 +7,19 @@ trigger:
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:
-- main
-- release/*
-- features/*
-- 2.9.x
-
+  branches:
+    include:
+    - main
+    - release/*
+    - features/*
+    - 2.9.x
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
+      - .devcontainer/*
+      - CODE-OF-CONDUCT.md
+      - README.md
 jobs:
 - job: Performance
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,21 @@ trigger:
 
 # Branch(es) that trigger(s) build(s) on PR
 pr:
-- main
-- release/*
-- features/*
-- 2.9.x
+  branches:
+    include:
+    - main
+    - release/*
+    - features/*
+    - 2.9.x
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
+      - .devcontainer/*
+      - .vsconfig
+      - CODE-OF-CONDUCT.md
+      - CONTRIBUTING.md
+      - README.md
 
 jobs:
 - job: Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,7 @@ pr:
       - docs/*
       - .github/*
       - .devcontainer/*
-      - .vsconfig
       - CODE-OF-CONDUCT.md
-      - CONTRIBUTING.md
       - README.md
 
 jobs:


### PR DESCRIPTION
This is a change similar to https://github.com/dotnet/roslyn/pull/58723 to avoid running PR unnecessarily when modifying specific files.