### PR TITLE
Move `GetOrCreateTypeByMetadataName` to compilation start

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -50,21 +50,22 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             // When compilation begins, check whether Array.Empty<T> is available.
             // Only if it is, register the syntax node action provided by the derived implementations.
-            context.RegisterCompilationStartAction(ctx =>
+            context.RegisterCompilationStartAction(context =>
             {
-                INamedTypeSymbol typeSymbol = ctx.Compilation.GetSpecialType(SpecialType.System_Array);
+                INamedTypeSymbol typeSymbol = context.Compilation.GetSpecialType(SpecialType.System_Array);
                 if (typeSymbol.DeclaredAccessibility == Accessibility.Public)
                 {
                     if (typeSymbol.GetMembers(ArrayEmptyMethodName).FirstOrDefault() is IMethodSymbol methodSymbol && methodSymbol.DeclaredAccessibility == Accessibility.Public &&
                         methodSymbol.IsStatic && methodSymbol.Arity == 1 && methodSymbol.Parameters.IsEmpty)
                     {
-                        ctx.RegisterOperationAction(c => AnalyzeOperation(c, methodSymbol), OperationKind.ArrayCreation);
+                        var linqExpressionType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
+                        context.RegisterOperationAction(c => AnalyzeOperation(c, methodSymbol, linqExpressionType), OperationKind.ArrayCreation);
                     }
                 }
             });
         }
 
-        private void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol)
+        private void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol linqExpressionType)
         {
             AnalyzeOperation(context, arrayEmptyMethodSymbol, IsAttributeSyntax);
         }
@@ -79,8 +80,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 return;
             }
-
-            var linqExpressionType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqExpressionsExpression1);
+            
             if (arrayCreationExpression.IsWithinExpressionTree(linqExpressionType))
             {
                 return;


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://docs.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
