### PR TITLE
Avoid name collision of analyzer class names and title resources

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPath.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPath.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class DoNotAddArchiveItemPathToTheTargetFileSystemPath : SourceTriggeredTaintedDataAnalyzerBase
+    public class DoNotAddArchiveItemPathToTheTargetFileSystemPathAnalyzer : SourceTriggeredTaintedDataAnalyzerBase
     {
         internal const string RuleId = "CA5389";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAddSchemaByURL.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAddSchemaByURL.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA3061: <inheritdoc cref="DoNotAddSchemaByURL"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotAddSchemaByURL : DiagnosticAnalyzer
+    public sealed class DoNotAddSchemaByURLAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA3061";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -21,7 +21,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5360: <inheritdoc cref="DoNotCallDangerousMethodsInDeserialization"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotCallDangerousMethodsInDeserialization : DiagnosticAnalyzer
+    public sealed class DoNotCallDangerousMethodsInDeserializationAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5360";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidation.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidation.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5359: <inheritdoc cref="DoNotDisableCertificateValidation"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotDisableCertificateValidation : DiagnosticAnalyzer
+    public sealed class DoNotDisableCertificateValidationAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5359";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpHeaderChecking.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableHttpHeaderChecking.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5365: <inheritdoc cref="DoNotDisableHTTPHeaderChecking"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotDisableHTTPHeaderChecking : DiagnosticAnalyzer
+    public sealed class DoNotDisableHTTPHeaderCheckingAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5365";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableRequestValidation.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableRequestValidation.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5363: <inheritdoc cref="DoNotDisableRequestValidation"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotDisableRequestValidation : DiagnosticAnalyzer
+    public sealed class DoNotDisableRequestValidationAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5363";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeCertificate.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeCertificate.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class DoNotHardCodeCertificate : SourceTriggeredTaintedDataAnalyzerBase
+    public class DoNotHardCodeCertificateAnalyzer : SourceTriggeredTaintedDataAnalyzerBase
     {
         internal static readonly DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5403",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeEncryptionKey.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeEncryptionKey.cs
@@ -10,7 +10,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class DoNotHardCodeEncryptionKey : SourceTriggeredTaintedDataAnalyzerBase
+    public class DoNotHardCodeEncryptionKeyAnalyzer : SourceTriggeredTaintedDataAnalyzerBase
     {
         internal static readonly DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5390",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseAccountSAS.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseAccountSAS.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5375: <inheritdoc cref="DoNotUseAccountSAS"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseAccountSAS : DiagnosticAnalyzer
+    public sealed class DoNotUseAccountSASAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5375";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseDSA.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseDSA.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5384: <inheritdoc cref="DoNotUseDSA"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseDSA : DiagnosticAnalyzer
+    public sealed class DoNotUseDSAAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5384";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseDeprecatedSecurityProtocols.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseDeprecatedSecurityProtocols.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5386: <inheritdoc cref="HardCodedSecurityProtocolTitle"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseDeprecatedSecurityProtocols : DiagnosticAnalyzer
+    public sealed class DoNotUseDeprecatedSecurityProtocolsAnalyzer : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor DeprecatedRule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5364",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureRandomness.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureRandomness.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5394: <inheritdoc cref="DoNotUseInsecureRandomness"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseInsecureRandomness : DiagnosticAnalyzer
+    public sealed class DoNotUseInsecureRandomnessAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5394";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseObsoleteKDFAlgorithm.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseObsoleteKDFAlgorithm.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5373: <inheritdoc cref="DoNotUseObsoleteKDFAlgorithm"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseObsoleteKDFAlgorithm : DiagnosticAnalyzer
+    public sealed class DoNotUseObsoleteKDFAlgorithmAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5373";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFAlgorithm.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFAlgorithm.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5379: <inheritdoc cref="DoNotUseWeakKDFAlgorithm"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseWeakKDFAlgorithm : DiagnosticAnalyzer
+    public sealed class DoNotUseWeakKDFAlgorithmAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5379";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseXslTransform.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotUseXslTransform.cs
@@ -15,7 +15,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5374: <inheritdoc cref="DoNotUseXslTransform"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class DoNotUseXslTransform : DiagnosticAnalyzer
+    public sealed class DoNotUseXslTransformAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5374";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookie.cs
@@ -22,7 +22,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5396: <inheritdoc cref="SetHttpOnlyForHttpCookie"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    internal class SetHttpOnlyForHttpCookie : DiagnosticAnalyzer
+    internal class SetHttpOnlyForHttpCookieAnalyzer : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor Rule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5396",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKey.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKey.cs
@@ -16,7 +16,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5368: <inheritdoc cref="SetViewStateUserKey"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class SetViewStateUserKey : DiagnosticAnalyzer
+    public sealed class SetViewStateUserKeyAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5368";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryToken.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryToken.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5395: <inheritdoc cref="MissHttpVerbAttribute"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseAutoValidateAntiforgeryToken : DiagnosticAnalyzer
+    public sealed class UseAutoValidateAntiforgeryTokenAnalyzer : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor UseAutoValidateAntiforgeryTokenRule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5391",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicy.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicy.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5377: <inheritdoc cref="UseContainerLevelAccessPolicy"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseContainerLevelAccessPolicy : DiagnosticAnalyzer
+    public sealed class UseContainerLevelAccessPolicyAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5377";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseDefaultDllImportSearchPathsAttribute.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseDefaultDllImportSearchPathsAttribute.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5393: <inheritdoc cref="DoNotUseUnsafeDllImportSearchPath"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseDefaultDllImportSearchPathsAttribute : DiagnosticAnalyzer
+    public sealed class UseDefaultDllImportSearchPathsAttributeAnalyzer : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor UseDefaultDllImportSearchPathsAttributeRule = SecurityHelpers.CreateDiagnosticDescriptor(
             "CA5392",

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseRSAWithSufficientKeySize.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseRSAWithSufficientKeySize.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5385: <inheritdoc cref="UseRSAWithSufficientKeySize"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseRSAWithSufficientKeySize : DiagnosticAnalyzer
+    public sealed class UseRSAWithSufficientKeySizeAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5385";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnly.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     /// CA5376: <inheritdoc cref="UseSharedAccessProtocolHttpsOnly"/>
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseSharedAccessProtocolHttpsOnly : DiagnosticAnalyzer
+    public sealed class UseSharedAccessProtocolHttpsOnlyAnalyzer : DiagnosticAnalyzer
     {
         internal const string DiagnosticId = "CA5376";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDataSetReadXml.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDataSetReadXml.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseXmlReaderForDataSetReadXml : UseXmlReaderBase
+    public sealed class UseXmlReaderForDataSetReadXmlAnalyzer : UseXmlReaderBase
     {
         internal const string DiagnosticId = "CA5366";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDeserialize.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDeserialize.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseXmlReaderForDeserialize : UseXmlReaderBase
+    public sealed class UseXmlReaderForDeserializeAnalyzer : UseXmlReaderBase
     {
         internal const string DiagnosticId = "CA5369";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForSchemaRead.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForSchemaRead.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseXmlReaderForSchemaRead : UseXmlReaderBase
+    public sealed class UseXmlReaderForSchemaReadAnalyzer : UseXmlReaderBase
     {
         internal const string DiagnosticId = "CA5371";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForValidatingReader.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForValidatingReader.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseXmlReaderForValidatingReader : UseXmlReaderBase
+    public sealed class UseXmlReaderForValidatingReaderAnalyzer : UseXmlReaderBase
     {
         internal const string DiagnosticId = "CA5370";
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForXPathDocument.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForXPathDocument.cs
@@ -9,7 +9,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     using static MicrosoftNetCoreAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public sealed class UseXmlReaderForXPathDocument : UseXmlReaderBase
+    public sealed class UseXmlReaderForXPathDocumentAnalyzer : UseXmlReaderBase
     {
         internal const string DiagnosticId = "CA5372";
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -4803,7 +4803,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotAddSchemaByURL",
+            "typeName": "DoNotAddSchemaByURLAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -4963,7 +4963,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotDisableCertificateValidation",
+            "typeName": "DoNotDisableCertificateValidationAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -4983,7 +4983,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotCallDangerousMethodsInDeserialization",
+            "typeName": "DoNotCallDangerousMethodsInDeserializationAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5046,7 +5046,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotDisableRequestValidation",
+            "typeName": "DoNotDisableRequestValidationAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5066,7 +5066,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotUseDeprecatedSecurityProtocols",
+            "typeName": "DoNotUseDeprecatedSecurityProtocolsAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5086,7 +5086,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotDisableHTTPHeaderChecking",
+            "typeName": "DoNotDisableHTTPHeaderCheckingAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5106,7 +5106,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseXmlReaderForDataSetReadXml",
+            "typeName": "UseXmlReaderForDataSetReadXmlAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5147,7 +5147,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "SetViewStateUserKey",
+            "typeName": "SetViewStateUserKeyAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5167,7 +5167,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseXmlReaderForDeserialize",
+            "typeName": "UseXmlReaderForDeserializeAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5187,7 +5187,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseXmlReaderForValidatingReader",
+            "typeName": "UseXmlReaderForValidatingReaderAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5207,7 +5207,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseXmlReaderForSchemaRead",
+            "typeName": "UseXmlReaderForSchemaReadAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5227,7 +5227,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseXmlReaderForXPathDocument",
+            "typeName": "UseXmlReaderForXPathDocumentAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5247,7 +5247,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotUseObsoleteKDFAlgorithm",
+            "typeName": "DoNotUseObsoleteKDFAlgorithmAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5267,7 +5267,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotUseXslTransform",
+            "typeName": "DoNotUseXslTransformAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5287,7 +5287,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotUseAccountSAS",
+            "typeName": "DoNotUseAccountSASAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5307,7 +5307,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseSharedAccessProtocolHttpsOnly",
+            "typeName": "UseSharedAccessProtocolHttpsOnlyAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5328,7 +5328,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseContainerLevelAccessPolicy",
+            "typeName": "UseContainerLevelAccessPolicyAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5370,7 +5370,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotUseWeakKDFAlgorithm",
+            "typeName": "DoNotUseWeakKDFAlgorithmAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5478,7 +5478,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "DoNotUseDSA",
+            "typeName": "DoNotUseDSAAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5498,7 +5498,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": true,
-            "typeName": "UseRSAWithSufficientKeySize",
+            "typeName": "UseRSAWithSufficientKeySizeAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5518,7 +5518,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotUseDeprecatedSecurityProtocols",
+            "typeName": "DoNotUseDeprecatedSecurityProtocolsAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5582,7 +5582,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotAddArchiveItemPathToTheTargetFileSystemPath",
+            "typeName": "DoNotAddArchiveItemPathToTheTargetFileSystemPathAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5603,7 +5603,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotHardCodeEncryptionKey",
+            "typeName": "DoNotHardCodeEncryptionKeyAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5624,7 +5624,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseAutoValidateAntiforgeryToken",
+            "typeName": "UseAutoValidateAntiforgeryTokenAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5645,7 +5645,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseDefaultDllImportSearchPathsAttribute",
+            "typeName": "UseDefaultDllImportSearchPathsAttributeAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5665,7 +5665,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseDefaultDllImportSearchPathsAttribute",
+            "typeName": "UseDefaultDllImportSearchPathsAttributeAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5685,7 +5685,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotUseInsecureRandomness",
+            "typeName": "DoNotUseInsecureRandomnessAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5705,7 +5705,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "UseAutoValidateAntiforgeryToken",
+            "typeName": "UseAutoValidateAntiforgeryTokenAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5726,7 +5726,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "SetHttpOnlyForHttpCookie",
+            "typeName": "SetHttpOnlyForHttpCookieAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"
@@ -5876,7 +5876,7 @@
           "properties": {
             "category": "Security",
             "isEnabledByDefault": false,
-            "typeName": "DoNotHardCodeCertificate",
+            "typeName": "DoNotHardCodeCertificateAnalyzer",
             "languages": [
               "C#",
               "Visual Basic"

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -8,8 +8,5 @@ CA1510 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1511 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511> | Use ArgumentException throw helper |
 CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512> | Use ArgumentOutOfRangeException throw helper |
 CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513> | Use ObjectDisposedException throw helper |
-CA1852 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852> | Seal internal types |
-CA1853 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853> | Unnecessary call to 'Dictionary.ContainsKey(key)' |
-CA1855 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855> | Prefer 'Clear' over 'Fill' |
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPathTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPathTests.cs
@@ -9,9 +9,9 @@ using Xunit;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotAddArchiveItemPathToTheTargetFileSystemPathTests : TaintedDataAnalyzerTestBase<DoNotAddArchiveItemPathToTheTargetFileSystemPath, DoNotAddArchiveItemPathToTheTargetFileSystemPath>
+    public class DoNotAddArchiveItemPathToTheTargetFileSystemPathTests : TaintedDataAnalyzerTestBase<DoNotAddArchiveItemPathToTheTargetFileSystemPathAnalyzer, DoNotAddArchiveItemPathToTheTargetFileSystemPathAnalyzer>
     {
-        protected override DiagnosticDescriptor Rule => DoNotAddArchiveItemPathToTheTargetFileSystemPath.Rule;
+        protected override DiagnosticDescriptor Rule => DoNotAddArchiveItemPathToTheTargetFileSystemPathAnalyzer.Rule;
 
         protected override IEnumerable<string> AdditionalCSharpSources => new string[] { zipArchiveEntryAndZipFileExtensionsCSharpSourceCode };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotAddSchemaByURLTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotAddSchemaByURLTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURL,
+    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURLAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURL,
+    Microsoft.NetCore.Analyzers.Security.DoNotAddSchemaByURLAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserialization,
+    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserializationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserialization,
+    Microsoft.NetCore.Analyzers.Security.DoNotCallDangerousMethodsInDeserializationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableCertificateValidationTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidation,
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidation,
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableCertificateValidationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableHTTPHeaderCheckingTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableHTTPHeaderCheckingTests.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotDisableHTTPHeaderChecking,
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableHTTPHeaderCheckingAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableRequestValidationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotDisableRequestValidationTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotDisableRequestValidation,
+    Microsoft.NetCore.Analyzers.Security.DoNotDisableRequestValidationAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeCertificateTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeCertificateTests.cs
@@ -4,13 +4,13 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<Microsoft.NetCore.Analyzers.Security.DoNotHardCodeCertificate, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<Microsoft.NetCore.Analyzers.Security.DoNotHardCodeCertificateAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotHardCodeCertificateTests : TaintedDataAnalyzerTestBase<DoNotHardCodeCertificate, DoNotHardCodeCertificate>
+    public class DoNotHardCodeCertificateTests : TaintedDataAnalyzerTestBase<DoNotHardCodeCertificateAnalyzer, DoNotHardCodeCertificateAnalyzer>
     {
-        protected override DiagnosticDescriptor Rule => DoNotHardCodeCertificate.Rule;
+        protected override DiagnosticDescriptor Rule => DoNotHardCodeCertificateAnalyzer.Rule;
 
         [Fact]
         public async Task Test_Source_ContantByteArray_DiagnosticAsync()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeEncryptionKeyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotHardCodeEncryptionKeyTests.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Test.Utilities;
 using Xunit;
-using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<Microsoft.NetCore.Analyzers.Security.DoNotHardCodeEncryptionKey, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<Microsoft.NetCore.Analyzers.Security.DoNotHardCodeEncryptionKeyAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
 {
-    public class DoNotHardCodeEncryptionKeyTests : TaintedDataAnalyzerTestBase<DoNotHardCodeEncryptionKey, DoNotHardCodeEncryptionKey>
+    public class DoNotHardCodeEncryptionKeyTests : TaintedDataAnalyzerTestBase<DoNotHardCodeEncryptionKeyAnalyzer, DoNotHardCodeEncryptionKeyAnalyzer>
     {
-        protected override DiagnosticDescriptor Rule => DoNotHardCodeEncryptionKey.Rule;
+        protected override DiagnosticDescriptor Rule => DoNotHardCodeEncryptionKeyAnalyzer.Rule;
 
         protected override IEnumerable<string> AdditionalCSharpSources => new string[] { readOnlySpanAndAesGcmAndAesCcmCSharpSourceCode };
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseAccountSASTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseAccountSASTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseAccountSAS,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseAccountSASAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseDSATests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseDSATests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseDSA,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDSAAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseDeprecatedSecurityProtocolsTests.cs
@@ -5,10 +5,10 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocols,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocolsAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocols,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseDeprecatedSecurityProtocolsAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
@@ -30,8 +30,8 @@ public class ExampleClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
     }
 }",
-            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"),
-            GetCSharpResultAt(10, 77, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"));
+            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"),
+            GetCSharpResultAt(10, 77, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"));
         }
 
         [Fact]
@@ -48,8 +48,8 @@ Public Class TestClass
     End Sub
 End Class
 ",
-            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"),
-            GetBasicResultAt(8, 78, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"));
+            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"),
+            GetBasicResultAt(8, 78, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ public class ExampleClass
         ServicePointManager.SecurityProtocol = (SecurityProtocolType) 768;    // TLS 1.1
     }
 }",
-            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "768"));
+            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "768"));
         }
 
         [Fact]
@@ -84,7 +84,7 @@ Public Class TestClass
     End Sub
 End Class
 ",
-            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "768"));
+            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "768"));
         }
 
         [Fact]
@@ -135,7 +135,7 @@ public class ExampleClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
     }
 }",
-            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"));
+            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"));
         }
 
         [Fact]
@@ -152,7 +152,7 @@ Public Class TestClass
     End Sub
 End Class
 ",
-            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"));
+            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"));
         }
 
         [Fact]
@@ -170,7 +170,7 @@ public class ExampleClass
         ServicePointManager.SecurityProtocol = (SecurityProtocolType) 3072;    // TLS 1.2
     }
 }",
-            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "3072"));
+            GetCSharpResultAt(10, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "3072"));
         }
 
         [Fact]
@@ -187,7 +187,7 @@ Public Class TestClass
     End Sub
 End Class
 ",
-            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "3072"));
+            GetBasicResultAt(8, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "3072"));
         }
 
         [Fact]
@@ -204,7 +204,7 @@ class TestClass
         var a = SecurityProtocolType.Ssl3;
     }
 }",
-            GetCSharpResultAt(9, 17, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Ssl3"));
+            GetCSharpResultAt(9, 17, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Ssl3"));
         }
 
         [Fact]
@@ -221,7 +221,7 @@ class TestClass
         var a = SecurityProtocolType.Tls;
     }
 }",
-            GetCSharpResultAt(9, 17, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls"));
+            GetCSharpResultAt(9, 17, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls"));
         }
 
         [Fact]
@@ -238,7 +238,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls11;
     }
 }",
-            GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
+            GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"));
         }
 
         [Fact]
@@ -281,7 +281,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
     }
 }",
-                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"));
+                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"));
         }
 
         [Fact]
@@ -308,7 +308,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls13"),
+                        GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls13"),
                     },
                 }
             }.RunAsync();
@@ -328,8 +328,8 @@ class TestClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
     }
 }",
-                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"),
-                GetCSharpResultAt(9, 77, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
+                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"),
+                GetCSharpResultAt(9, 77, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"));
         }
 
         [Fact]
@@ -346,7 +346,7 @@ class TestClass
         ServicePointManager.SecurityProtocol |= (SecurityProtocolType)192;
     }
 }",
-                GetCSharpResultAt(9, 49, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "192"));
+                GetCSharpResultAt(9, 49, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "192"));
         }
 
         [Fact]
@@ -364,7 +364,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = (SecurityProtocolType)384;
     }
 }",
-                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "384"));
+                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "384"));
         }
 
         [Fact]
@@ -381,7 +381,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | (SecurityProtocolType)768;
     }
 }",
-                GetCSharpResultAt(9, 87, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "768"));
+                GetCSharpResultAt(9, 87, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "768"));
         }
 
         [Fact]
@@ -398,7 +398,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = ServicePointManager.SecurityProtocol | (SecurityProtocolType)12288;
     }
 }",
-                GetCSharpResultAt(9, 87, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "12288"));
+                GetCSharpResultAt(9, 87, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "12288"));
         }
 
         [Fact]
@@ -415,8 +415,8 @@ class TestClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | (SecurityProtocolType)192;
     }
 }",
-                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "Tls12"),
-                GetCSharpResultAt(9, 77, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
+                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "Tls12"),
+                GetCSharpResultAt(9, 77, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"));
         }
 
         [Fact]
@@ -433,8 +433,8 @@ class TestClass
         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | (SecurityProtocolType)192;
     }
 }",
-                VerifyCS.Diagnostic(DoNotUseDeprecatedSecurityProtocols.DeprecatedRule).WithSpan(9, 48, 9, 102).WithArguments("3264"),
-                VerifyCS.Diagnostic(DoNotUseDeprecatedSecurityProtocols.HardCodedRule).WithSpan(9, 48, 9, 74).WithArguments("Tls12"));
+                VerifyCS.Diagnostic(DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule).WithSpan(9, 48, 9, 102).WithArguments("3264"),
+                VerifyCS.Diagnostic(DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule).WithSpan(9, 48, 9, 74).WithArguments("Tls12"));
         }
 
         [Fact]
@@ -469,7 +469,7 @@ class TestClass
         ServicePointManager.SecurityProtocol = (SecurityProtocolType)(24 + 24);
     }
 }",
-                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "48"));
+                GetCSharpResultAt(9, 48, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "48"));
         }
 
         [Fact]
@@ -519,10 +519,10 @@ class TestClass
         t &= ~(SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls | SecurityProtocolType.Tls11);
     }
 }",
-                GetCSharpResultAt(10, 14, DoNotUseDeprecatedSecurityProtocols.HardCodedRule, "-1009"),
-                GetCSharpResultAt(10, 16, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Ssl3"),
-                GetCSharpResultAt(10, 44, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls"),
-                GetCSharpResultAt(10, 71, DoNotUseDeprecatedSecurityProtocols.DeprecatedRule, "Tls11"));
+                GetCSharpResultAt(10, 14, DoNotUseDeprecatedSecurityProtocolsAnalyzer.HardCodedRule, "-1009"),
+                GetCSharpResultAt(10, 16, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Ssl3"),
+                GetCSharpResultAt(10, 44, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls"),
+                GetCSharpResultAt(10, 71, DoNotUseDeprecatedSecurityProtocolsAnalyzer.DeprecatedRule, "Tls11"));
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, DiagnosticDescriptor rule, params string[] arguments)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureRandomnessTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseInsecureRandomnessTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureRandomness,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureRandomnessAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureRandomness,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseInsecureRandomnessAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseObsoleteKDFAlgorithmTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseObsoleteKDFAlgorithm,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseObsoleteKDFAlgorithmAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFAlgorithmTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseWeakKDFAlgorithmTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseWeakKDFAlgorithm,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseWeakKDFAlgorithmAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseXslTransformTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotUseXslTransformTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.DoNotUseXslTransform,
+    Microsoft.NetCore.Analyzers.Security.DoNotUseXslTransformAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookieTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetHttpOnlyForHttpCookieTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.SetHttpOnlyForHttpCookie,
+    Microsoft.NetCore.Analyzers.Security.SetHttpOnlyForHttpCookieAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKeyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/SetViewStateUserKeyTests.cs
@@ -5,10 +5,10 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKey,
+    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKeyAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKey,
+    Microsoft.NetCore.Analyzers.Security.SetViewStateUserKeyAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryTokenTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseAutoValidateAntiforgeryTokenTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseAutoValidateAntiforgeryToken,
+    Microsoft.NetCore.Analyzers.Security.UseAutoValidateAntiforgeryTokenAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
@@ -78,7 +78,7 @@ class BlahClass
         filterCollection.Add(typeof(FilterClass));
     }
 }",
-            GetCSharpResultAt(26, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
+            GetCSharpResultAt(26, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
         }
 
         [Fact]
@@ -122,7 +122,7 @@ class BlahClass
         filterCollection.Add(typeof(FilterClass));
     }
 }",
-            GetCSharpResultAt(25, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
+            GetCSharpResultAt(25, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
         }
 
         [Fact]
@@ -174,7 +174,7 @@ class BlahClass
         filterCollection.Add(typeof(FilterClass));
     }
 }",
-            GetCSharpResultAt(33, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
+            GetCSharpResultAt(33, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
         }
 
         [Fact]
@@ -197,7 +197,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(13, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
+            GetCSharpResultAt(13, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
         }
 
         [Fact]
@@ -220,7 +220,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(13, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPatch"));
+            GetCSharpResultAt(13, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPatch"));
         }
 
         [Fact]
@@ -242,7 +242,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
+            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
         }
 
         [Fact]
@@ -264,7 +264,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPut"));
+            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPut"));
         }
 
         [Fact]
@@ -286,7 +286,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
+            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
         }
 
         [Fact]
@@ -313,7 +313,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(17, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
+            GetCSharpResultAt(17, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete"));
         }
 
         [Fact]
@@ -338,7 +338,7 @@ class TestClass : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(15, 35, UseAutoValidateAntiforgeryToken.MissHttpVerbAttributeRule, "CustomizedActionMethod"));
+            GetCSharpResultAt(15, 35, UseAutoValidateAntiforgeryTokenAnalyzer.MissHttpVerbAttributeRule, "CustomizedActionMethod"));
         }
 
         [Fact, WorkItem(2844, "https://github.com/dotnet/roslyn-analyzers/issues/2844")]
@@ -396,11 +396,11 @@ class TestClass5 : Controller
         return null;
     }
 }",
-            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPut"),
-            GetCSharpResultAt(21, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod2", "HttpPut"),
-            GetCSharpResultAt(30, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod3", "HttpPut"),
-            GetCSharpResultAt(39, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod4", "HttpPut"),
-            GetCSharpResultAt(48, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod5", "HttpPut"));
+            GetCSharpResultAt(12, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPut"),
+            GetCSharpResultAt(21, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod2", "HttpPut"),
+            GetCSharpResultAt(30, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod3", "HttpPut"),
+            GetCSharpResultAt(39, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod4", "HttpPut"),
+            GetCSharpResultAt(48, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod5", "HttpPut"));
         }
 
         [Fact]
@@ -441,7 +441,7 @@ dotnet_code_quality.CA5391.exclude_aspnet_core_mvc_controllerbase = false") }
             };
 
             csharpTest.ExpectedDiagnostics.Add(
-                GetCSharpResultAt(15, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete")
+                GetCSharpResultAt(15, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpDelete")
             );
 
             await csharpTest.RunAsync();
@@ -595,7 +595,7 @@ class BlahClass
         filterCollection.Add(typeof(FilterClass));
     }
 }",
-                GetCSharpResultAt(36, 35, UseAutoValidateAntiforgeryToken.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
+                GetCSharpResultAt(36, 35, UseAutoValidateAntiforgeryTokenAnalyzer.UseAutoValidateAntiforgeryTokenRule, "CustomizedActionMethod", "HttpPost"));
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseContainerLevelAccessPolicyTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseContainerLevelAccessPolicy,
+    Microsoft.NetCore.Analyzers.Security.UseContainerLevelAccessPolicyAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseDefaultDllImportSearchPathsAttributeTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseDefaultDllImportSearchPathsAttribute,
+    Microsoft.NetCore.Analyzers.Security.UseDefaultDllImportSearchPathsAttributeAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests
@@ -36,7 +36,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttribute.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
+            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
         }
 
         [Fact]
@@ -56,7 +56,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttribute.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
+            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttribute.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
+            GetCSharpResultAt(8, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.UseDefaultDllImportSearchPathsAttributeRule, "MessageBox"));
         }
 
         [Fact]
@@ -97,7 +97,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
+            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
         }
 
         [Fact]
@@ -118,7 +118,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
+            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
         }
 
         [Fact]
@@ -139,7 +139,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"));
+            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"));
         }
 
         [Fact]
@@ -160,7 +160,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "LegacyBehavior"));
+            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "LegacyBehavior"));
         }
 
         [Fact]
@@ -181,7 +181,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UseDllDirectoryForDependencies"));
+            GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "UseDllDirectoryForDependencies"));
         }
 
         [Fact]
@@ -203,7 +203,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(10, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
+            GetCSharpResultAt(10, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
         }
 
         [Fact]
@@ -226,7 +226,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(11, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "ApplicationDirectory"));
+            GetCSharpResultAt(11, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "ApplicationDirectory"));
         }
 
         [Fact]
@@ -249,7 +249,7 @@ class TestClass
         MessageBox(new IntPtr(0), ""Hello World!"", ""Hello Dialog"", 0);
     }
 }",
-            GetCSharpResultAt(11, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
+            GetCSharpResultAt(11, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory"));
         }
 
         [Theory]
@@ -282,7 +282,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"),
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "AssemblyDirectory, ApplicationDirectory"),
                     },
                     AnalyzerConfigFiles = { ("/.editorconfig", $@"root = true
 
@@ -321,7 +321,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "System32"),
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "System32"),
                     },
                     AnalyzerConfigFiles = { ("/.editorconfig", $@"root = true
 
@@ -360,7 +360,7 @@ class TestClass
                     },
                     ExpectedDiagnostics =
                     {
-                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttribute.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories"),
+                        GetCSharpResultAt(9, 30, UseDefaultDllImportSearchPathsAttributeAnalyzer.DoNotUseUnsafeDllImportSearchPathRule, "UserDirectories"),
                     },
                     AnalyzerConfigFiles = { ("/.editorconfig", $@"root = true
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseRSAWithSufficientKeySizeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseRSAWithSufficientKeySizeTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseRSAWithSufficientKeySize,
+    Microsoft.NetCore.Analyzers.Security.UseRSAWithSufficientKeySizeAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseSharedAccessProtocolHttpsOnlyTests.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseSharedAccessProtocolHttpsOnly,
+    Microsoft.NetCore.Analyzers.Security.UseSharedAccessProtocolHttpsOnlyAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDataSetReadXmlTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDataSetReadXmlTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXml,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXmlAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXml,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDataSetReadXmlAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDeserializeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForDeserializeTests.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserialize,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserializeAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 using VerifyVB = Test.Utilities.VisualBasicSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserialize,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForDeserializeAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForSchemaReadTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForSchemaReadTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForSchemaRead,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForSchemaReadAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForValidatingReaderTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForValidatingReaderTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForValidatingReader,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForValidatingReaderAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForXPathDocumentTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/UseXmlReaderForXPathDocumentTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpSecurityCodeFixVerifier<
-    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForXPathDocument,
+    Microsoft.NetCore.Analyzers.Security.UseXmlReaderForXPathDocumentAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Security.UnitTests


### PR DESCRIPTION
Found during the work for unused resources analyzer.

The following line (as an example):

https://github.com/dotnet/roslyn-analyzers/blob/ed54cef1ea015f7aa013aad4a82b6dd549b48af8/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotAddArchiveItemPathToTheTargetFileSystemPath.cs#L19

binds to the class, instead of binding to the resource:

https://github.com/dotnet/roslyn-analyzers/blob/ed54cef1ea015f7aa013aad4a82b6dd549b48af8/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx#L1083-L1085

Causing an incorrect "unused resource" warning.

Having different names will avoid this warning and will let `nameof(...)` bind properly to the resource.