### PR TITLE
Fix bugs found in MAUI repo

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -563,10 +563,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     }
                                 }
 
-                                if (attribute.SupportedFirst != null &&
-                                    info.Version.IsGreaterThanOrEqualTo(attribute.SupportedFirst))
+                                var checkVersion = attribute.SupportedSecond ?? attribute.SupportedFirst;
+
+                                if (checkVersion != null &&
+                                    info.Version.IsGreaterThanOrEqualTo(checkVersion))
                                 {
                                     attribute.SupportedFirst = null;
+                                    attribute.SupportedSecond = null;
                                     RemoveUnsupportedWithLessVersion(info.Version, attribute);
                                     RemoveOtherSupportsOnDifferentPlatforms(attributes, info.PlatformName);
                                 }
@@ -816,8 +819,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     csPlatformNames = string.Join(CommaSeparator, csPlatformNames, PlatformCompatibilityAllPlatforms);
                 }
 
-                var rule = supportedRule ? SwitchSupportedRule(callsite) : SwitchRule(callsite, true);
-                context.ReportDiagnostic(operation.CreateDiagnostic(rule, operationName, JoinNames(platformNames), csPlatformNames));
+                if (!platformNames.IsEmpty)
+                {
+                    var rule = supportedRule ? SwitchSupportedRule(callsite) : SwitchRule(callsite, true);
+                    context.ReportDiagnostic(operation.CreateDiagnostic(rule, operationName, JoinNames(platformNames), csPlatformNames));
+                }
 
                 if (!obsoletedPlatforms.IsEmpty)
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
@@ -454,6 +454,37 @@ public class Test
             await VerifyAnalyzerCSAsync(csSource, s_msBuildPlatforms);
         }
 
+        [Fact]
+        public async Task CalledApiHasSupportedAndObsoletedAttributes_CallsiteSupressesSupportedAttributeWarnsForObsoletedOnly()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+class Program
+{
+    [Mock.ObsoletedOSPlatform(""ios7.0"", ""Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead."")]
+    [Mock.ObsoletedOSPlatform(""maccatalyst7.0"", ""Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead."")]
+    [SupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""maccatalyst"")]
+    public static void M3() { }
+    
+    [SupportedOSPlatform(""ios"")]
+    public static void M1()
+    {
+         {|CA1422:M3()|}; // This call site is reachable on: 'ios', 'maccatalyst'. 'Program.M3()' is obsoleted on: 'ios' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.), 'maccatalyst' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.).
+    }
+
+    [SupportedOSPlatform(""ios10.0"")]
+    public static void M2()
+    {
+         {|CA1422:M3()|}; // This call site is reachable on: 'ios' 10.0 and later, 'maccatalyst' 10.0 and later. 'Program.M3()' is obsoleted on: 'ios' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.), 'maccatalyst' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.).
+    }
+}" + MockObsoletedAttributeCS;
+
+            await VerifyAnalyzerCSAsync(source);
+        }
+
         private readonly string MockObsoletedAttributeCS = @"
 namespace Mock
 {


### PR DESCRIPTION
Two bugs found while investigating #6158 that fixed with this PR
1. When a child API narrows down parent support version the guarding version was compared with parent version only when it should be compared with child version

```cs
[SupportedOSPlatform("ios")]
[SupportedOSPlatform("tvos")]
[SupportedOSPlatform("maccatalyst")]
class Program
{
    [SupportedOSPlatform("tvos10.2")]
    [SupportedOSPlatform("ios10.3")]
    [SupportedOSPlatform("maccatalyst10.3")]
    public static int P1 => 1;
}

class Test
{
    [SupportedOSPlatform("ios10.0")]
    public void M1()
    {
        var rate = (OperatingSystem.IsIOSVersionAtLeast(10, 3) || OperatingSystem.IsMacCatalystVersionAtLeast(10, 3) || OperatingSystem.IsTvOSVersionAtLeast(10, 3))
		    ? Program.P1 // was warning here even if it was guarded
                    : 0; 
    }
}
```
2. When a called API has `SupportedOSPlatform` and `ObsoletedOSPlatform` attributes both and if the callsite attribute suppresses the Supported version the analyzer should warn only for the Obsoleted version. It was still warning for the Supported attribute even if it was empty / suppressed.

```cs
class Program
{
    [ObsoletedOSPlatform("ios7.0", "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")]
    [ObsoletedOSPlatform("maccatalyst7.0", "Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.")] // maccatalyst covered by ios, this attribute redundant
    [SupportedOSPlatform("ios")]
    [SupportedOSPlatform("maccatalyst")] // maccatalyst covered by ios, this attribute redundant
    public static void M3() { }
    
    [SupportedOSPlatform("ios")]
    public static void M1()
    {
         M3(); // it was reporting 2 diagnostics here, CA1416 and CA1422 when only CA1422 was expected
    }
}
 ```
Fixes https://github.com/dotnet/roslyn-analyzers/issues/6158
