### PR TITLE
[release/7.0] Fix bugs found in MAUI repo

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -563,10 +563,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                     }
                                 }
 
-                                if (attribute.SupportedFirst != null &&
-                                    info.Version.IsGreaterThanOrEqualTo(attribute.SupportedFirst))
+                                var checkVersion = attribute.SupportedSecond ?? attribute.SupportedFirst;
+
+                                if (checkVersion != null &&
+                                    info.Version.IsGreaterThanOrEqualTo(checkVersion))
                                 {
                                     attribute.SupportedFirst = null;
+                                    attribute.SupportedSecond = null;
                                     RemoveUnsupportedWithLessVersion(info.Version, attribute);
                                     RemoveOtherSupportsOnDifferentPlatforms(attributes, info.PlatformName);
                                 }
@@ -816,8 +819,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                     csPlatformNames = string.Join(CommaSeparator, csPlatformNames, PlatformCompatibilityAllPlatforms);
                 }
 
-                var rule = supportedRule ? SwitchSupportedRule(callsite) : SwitchRule(callsite, true);
-                context.ReportDiagnostic(operation.CreateDiagnostic(rule, operationName, JoinNames(platformNames), csPlatformNames));
+                if (!platformNames.IsEmpty)
+                {
+                    var rule = supportedRule ? SwitchSupportedRule(callsite) : SwitchRule(callsite, true);
+                    context.ReportDiagnostic(operation.CreateDiagnostic(rule, operationName, JoinNames(platformNames), csPlatformNames));
+                }
 
                 if (!obsoletedPlatforms.IsEmpty)
                 {

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
-        "version": "7.0.0",
+        "version": "7.0.1",
         "language": "en-US"
       },
       "rules": {
@@ -538,7 +538,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.NetAnalyzers",
-        "version": "7.0.0",
+        "version": "7.0.1",
         "language": "en-US"
       },
       "rules": {
@@ -5815,7 +5815,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers",
-        "version": "7.0.0",
+        "version": "7.0.1",
         "language": "en-US"
       },
       "rules": {

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -2,5 +2,3 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-CA1311 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311> | Specify a culture or use an invariant version |
-CA1421 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421> | This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -4,6 +4,3 @@ Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA1311 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311> | Specify a culture or use an invariant version |
 CA1421 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421> | This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied |
-CA1852 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1852> | Seal internal types |
-CA1853 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1853> | Unnecessary call to 'Dictionary.ContainsKey(key)' |
-CA1855 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1855> | Prefer 'Clear' over 'Fill' |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
@@ -454,6 +454,37 @@ public class Test
             await VerifyAnalyzerCSAsync(csSource, s_msBuildPlatforms);
         }
 
+        [Fact]
+        public async Task CalledApiHasSupportedAndObsoletedAttributes_CallsiteSupressesSupportedAttributeWarnsForObsoletedOnly()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+class Program
+{
+    [Mock.ObsoletedOSPlatform(""ios7.0"", ""Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead."")]
+    [Mock.ObsoletedOSPlatform(""maccatalyst7.0"", ""Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead."")]
+    [SupportedOSPlatform(""ios"")]
+    [SupportedOSPlatform(""maccatalyst"")]
+    public static void M3() { }
+    
+    [SupportedOSPlatform(""ios"")]
+    public static void M1()
+    {
+         {|CA1422:M3()|}; // This call site is reachable on: 'ios', 'maccatalyst'. 'Program.M3()' is obsoleted on: 'ios' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.), 'maccatalyst' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.).
+    }
+
+    [SupportedOSPlatform(""ios10.0"")]
+    public static void M2()
+    {
+         {|CA1422:M3()|}; // This call site is reachable on: 'ios' 10.0 and later, 'maccatalyst' 10.0 and later. 'Program.M3()' is obsoleted on: 'ios' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.), 'maccatalyst' 7.0 and later (Use 'NSString.GetBoundingRect (CGSize, NSStringDrawingOptions, UIStringAttributes, NSStringDrawingContext)' instead.).
+    }
+}" + MockObsoletedAttributeCS;
+
+            await VerifyAnalyzerCSAsync(source);
+        }
+
         private readonly string MockObsoletedAttributeCS = @"
 namespace Mock
 {


### PR DESCRIPTION
Backport https://github.com/dotnet/roslyn-analyzers/pull/6361 into .NET 7 release branch.
Issue: [.NET MAUI seeing lots of new CA1416 warnings](https://github.com/dotnet/roslyn-analyzers/issues/6158)

## Description 

With https://github.com/dotnet/runtime/issues/68557 we added `ObsoletedOSPlatformAttribute` for annotating APIs that is Obsoleted but still works with a custom message for suggested alternative, then [added support for reporting new diagnostic with custom message in PCA](https://github.com/dotnet/roslyn-analyzers/pull/6082) which introduced one of the 2 bugs that fixed. The other bug was not known edge case scenario happening when a complex guard is used for calling an API that has annotations in the parent and the child API. 

## Customer Impact

The CA1416 Platform compatibility analyzer is included in SDK and warns by default.

The `ObsoletedOSPlatform` attribute [support in Platform Compatibility Analyzer](https://github.com/dotnet/roslyn-analyzers/pull/6082) introduced the regression in .Net 7 which was not caught until xamarin team started using the `ObsoletedOSPlatformAttribute` in their APIs. When those bits flowed through and consumed by MAUI repo it introduces [new warnings](https://github.com/dotnet/roslyn-analyzers/issues/6158) in their repo. As it was regression introduced in .NET 7 the fix better to be ported into . NET  7. The MAUI team wants the fix ported to .NET 7.0

The other bug causes false positive warning when the API call was properly guarded which could happen for any customer that has a code section that reproes it.

## Regression?

One of the 2 bugs that fixed is regression from .NET 6.0. 

## Testing

Added unit tests that reproduces the false positive warnings and manually tested the fix with MAUI repo build.

## Risk

Very low. This fix will not introduce additional warning, instead it fixes/ suppresses false positive warnings