### PR TITLE
BannedApiAnalyzer - allow comments in banned symbols file

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -24,7 +24,7 @@ To add a symbol to the banned list, just add an entry in the format below to one
 
 Lines beginning with a `#` character will be treated as comment lines and ignored.
 
-For details on ID string format, please refer to ["Documentation comments"](https://github.com/dotnet/csharplang/blob/main/spec/documentation-comments.md#id-string-format).
+For details on ID string format, please refer to ["ID string format"](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/documentation-comments.md#d42-id-string-format).
 
 Examples of BannedSymbols.txt entries for symbols declared in the source below:
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -22,6 +22,8 @@ To add a symbol to the banned list, just add an entry in the format below to one
 {Documentation Comment ID string for the symbol}[;Description Text]
 ```
 
+Lines beginning with a `#` character will be treated as comment lines and ignored.
+
 For details on ID string format, please refer to ["Documentation comments"](https://github.com/dotnet/csharplang/blob/main/spec/documentation-comments.md#id-string-format).
 
 Examples of BannedSymbols.txt entries for symbols declared in the source below:

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -22,7 +22,7 @@ To add a symbol to the banned list, just add an entry in the format below to one
 {Documentation Comment ID string for the symbol}[;Description Text]
 ```
 
-Lines beginning with a `#` character will be treated as comment lines and ignored.
+Comments can be indicated with `//`, in the same way that they work in C#.
 
 For details on ID string format, please refer to ["ID string format"](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/documentation-comments.md#d42-id-string-format).
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 where sourceText != null
                 from line in sourceText.Lines
                 let text = line.ToString()
-                where !string.IsNullOrWhiteSpace(text)
+                where !string.IsNullOrWhiteSpace(text) && text[0] != '#'
                 select new BanFileEntry(text, line.Span, sourceText, additionalFile.Path);
 
             var entries = query.ToList();

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -59,7 +59,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 where sourceText != null
                 from line in sourceText.Lines
                 let text = line.ToString()
-                where !string.IsNullOrWhiteSpace(text)
                 let commentIndex = text.IndexOf("//", StringComparison.Ordinal)
                 let textWithoutComment = commentIndex == -1 ? text : text[..commentIndex]
                 where !string.IsNullOrWhiteSpace(textWithoutComment)

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -59,8 +59,13 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 where sourceText != null
                 from line in sourceText.Lines
                 let text = line.ToString()
-                where !string.IsNullOrWhiteSpace(text) && text[0] != '#'
-                select new BanFileEntry(text, line.Span, sourceText, additionalFile.Path);
+                where !string.IsNullOrWhiteSpace(text)
+                let commentIndex = text.IndexOf("//", StringComparison.Ordinal)
+                let textWithoutComment = commentIndex == -1 ? text : text[..commentIndex]
+                where !string.IsNullOrWhiteSpace(textWithoutComment)
+                let trimmedTextWithoutComment = textWithoutComment.TrimEnd()
+                let span = commentIndex == -1 ? line.Span : new Text.TextSpan(line.Span.Start, trimmedTextWithoutComment.Length)
+                select new BanFileEntry(trimmedTextWithoutComment, span, sourceText, additionalFile.Path);
 
             var entries = query.ToList();
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -140,6 +140,65 @@ End Class");
             await test.RunAsync();
         }
 
+        #region Comments in BannedSymbols.txt tests
+
+        [Fact]
+        public async Task NoDiagnosticReportedForCommentLine()
+        {
+            var source = @"";
+            var bannedText = @"# this comment line will be ignored";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText);
+            await VerifyBasicAnalyzerAsync(source, bannedText);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticReportedForCommentedOutBannedApiLineAsync()
+        {
+            var bannedText = @"#T:N.Banned";
+
+            var csharpSource = @"
+namespace N
+{
+    class Banned { }
+    class C
+    {
+        void M()
+        {
+            var c = {|#0:new Banned()|};
+        }
+    }
+}";
+
+            await VerifyCSharpAnalyzerAsync(csharpSource, bannedText);
+
+            var visualBasicSource = @"
+Namespace N
+    Class Banned : End Class
+    Class C
+        Sub M()
+            Dim c As New Banned()
+        End Sub
+    End Class
+End Namespace";
+
+            await VerifyBasicAnalyzerAsync(visualBasicSource, bannedText);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticReportedForCommentedOutDuplicateBannedApiLinesAsync()
+        {
+            var source = @"";
+            var bannedText = @"
+#T:System.Console
+#T:System.Console";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText);
+            await VerifyBasicAnalyzerAsync(source, bannedText);
+        }
+
+        #endregion Comments in BannedSymbols.txt tests
+
         [Fact]
         public async Task CSharp_BannedApiFile_MessageIncludedInDiagnosticAsync()
         {

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -82,6 +82,19 @@ End Class");
         }
 
         [Fact]
+        public async Task NoDiagnosticReportedForMultilineBlankBannedTextAsync()
+        {
+            var source = @"
+
+
+";
+
+            var bannedText = @"";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText);
+        }
+
+        [Fact]
         public async Task DiagnosticReportedForDuplicateBannedApiLinesAsync()
         {
             var source = @"";


### PR DESCRIPTION
Hi, this is a PR to allow comment lines in the BannedApiAnalyzer's BannedSymbols.txt file.

Proposed format is:
```
# this is a comment line
T:MyNamespace.BannedClass
```

Internally at WiseTech Global, we use this to add comments to our banned symbols, giving some background information about why the particular symbol is banned and where to go for further information.

This is my first PR to this repo, so feedback is welcome.

Regards,
Mark