### PR TITLE
More work on CA1859

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -104,6 +104,7 @@ Configurable Rules:
 [CA1815](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1815),
 [CA1819](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1819),
 [CA1822](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1822),
+[CA1859](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859),
 [CA2208](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208),
 [CA2217](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2217),
 [CA2225](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2225),
@@ -120,7 +121,9 @@ Option Values:
 | `private` | Analyzes private APIs that are only visible within the containing type. |
 | `all` | Analyzes all APIs, regardless of the symbol visibility. |
 
-Default Value: `public`
+Default Value: `public`, except as listed below
+
+  1. CA1859: default value is `private`.
 
 Example: `dotnet_code_quality.api_surface = all`
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -2010,6 +2010,9 @@ Widening and user defined conversions are not supported with generic types.</val
   <data name="UseConcreteTypeForMethodReturnMessage" xml:space="preserve">
     <value>Change return type of method '{0}' from '{1}' to '{2}' for improved performance</value>
   </data>
+  <data name="UseConcreteTypeForPropertyMessage" xml:space="preserve">
+    <value>Change type of property '{0}' from '{1}' to '{2}' for improved performance</value>
+  </data>
   <data name="UseConcreteTypeForParameterMessage" xml:space="preserve">
     <value>Change type of parameter '{0}' from '{1}' to '{2}' for improved performance</value>
   </data>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Pokud chcete zlepšit výkon, změňte typ parametru {0} z {1} na {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Pokud je to možné, používejte konkrétní typy pro zvýšení výkonu.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Ändern Sie den Typ des Parameters "{0}" von "{1}" in "{2}", um die Leistung zu verbessern.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Verwenden Sie nach Möglichkeit konkrete Typen, um die Leistung zu verbessern.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Cambiar el tipo de parámetro '{0}' de '{1}' a '{2}' para mejorar el rendimiento</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Usar tipos concretos cuando sea posible para mejorar el rendimiento</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Modifier le type de paramètre « {0} » de « {1} » en « {2} » pour améliorer les performances</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Utiliser des types concrets si possible pour améliorer les performances</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Modificare il tipo di parametro '{0}' da '{1}' a '{2}' per migliorare le prestazioni</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Usare tipi concreti quando possibile per migliorare le prestazioni</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">パフォーマンスを向上させるために、パラメーター '{0}' の型を '{1}' から '{2}' に変更します</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">可能な場合は具象型を使用してパフォーマンスを向上させる</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">성능 향상을 위해 '{0}' 매개 변수 형식을 '{1}'에서 '{2}'(으)로 변경하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">성능 향상을 위해 가능한 경우 구체적인 형식 사용하세요.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Zmień typ parametru „{0}” z „{1}” na „{2}”, aby zwiększyć wydajność</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Używaj konkretnych typów, aby zwiększyć wydajność – gdy jest to możliwe</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Altere o tipo de parâmetro '{0}' de '{1}' para '{2}' para melhorar o desempenho</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Usar tipos concretos quando possível para melhorar o desempenho</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Измените тип параметра "{0}" с "{1}" на "{2}" для повышения производительности</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Используйте конкретные типы, когда это возможно, для повышения производительности</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">Daha iyi performans için '{1}' olan '{0}' parametre türünü '{2}' olarak değiştirin</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">Daha iyi performans için mümkün olduğunda somut türler kullanın</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">将参数“{0}”的类型从“{1}”更改为“{2}”以提高性能</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">尽可能使用具体类型以提高性能</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2753,6 +2753,11 @@ Widening and user defined conversions are not supported with generic types.</tar
         <target state="translated">將參數 '{0}' 的類型從 '{1}' 變更為 '{2}' 以提高效能</target>
         <note />
       </trans-unit>
+      <trans-unit id="UseConcreteTypeForPropertyMessage">
+        <source>Change type of property '{0}' from '{1}' to '{2}' for improved performance</source>
+        <target state="new">Change type of property '{0}' from '{1}' to '{2}' for improved performance</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UseConcreteTypeTitle">
         <source>Use concrete types when possible for improved performance</source>
         <target state="translated">盡可能使用具象類型以提高效能</target>


### PR DESCRIPTION
- Add support to control the API surface the rule reports on using the normal api_surface annotation in .editorconfig. The rule defaults to 'private' only behavior.

- Add support to analyze properties.

- Skip analyzing interface types since that ends up being completely useless as there's nothing to recommend. So this saves some cycles.

- Reject analyzing partial method implementations earlier to save some
cycles.

- Fixes https://github.com/dotnet/roslyn-analyzers/issues/6452

- Fixes https://github.com/dotnet/roslyn-analyzers/issues/6440

- Fixes https://github.com/dotnet/roslyn-analyzers/issues/6451

- No longer recommends changing the method signature (either return
types or parameter types) for virtual and override methods.

- Now properly recognizes interpolated string expressions,
nameof and sizeof, which all improve analysis accuracy.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
