### PR TITLE
Fix buildtransitive vs buildTransitive difference

### DIFF
--- a/src/Tools/GenerateAnalyzerNuspec/Program.cs
+++ b/src/Tools/GenerateAnalyzerNuspec/Program.cs
@@ -239,7 +239,7 @@ if (globalAnalyzerConfigsDir.Length > 0 && Directory.Exists(globalAnalyzerConfig
     {
         if (Path.GetExtension(globalconfig) == ".globalconfig")
         {
-            result.AppendLine(FileElement(Path.Combine(globalAnalyzerConfigsDir, globalconfig), $"buildtransitive\\config"));
+            result.AppendLine(FileElement(Path.Combine(globalAnalyzerConfigsDir, globalconfig), $"buildTransitive\\config"));
         }
         else
         {


### PR DESCRIPTION
NuGet expects build files that should be transitively applied to a consuming project to be in a folder called "buildTransitive". https://github.com/dotnet/roslyn-analyzers/commit/afee469c0c862c6af3670d30a4b4e5ff6f8fe45c moved config files into that folder but the change had a typo as it specified "buildtransitive" instead of "buildTransitive". That resulted in a mismatch during pack time.

Fixes dependency update in https://github.com/dotnet/sdk/pull/29911