### PR TITLE
Fix RS1014 false positive discovered in roslyn

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/ImmutableObjectMethodAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/ImmutableObjectMethodAnalyzer.cs
@@ -76,7 +76,8 @@ namespace Microsoft.CodeAnalysis.Analyzers
         public static void AnalyzeInvocationForIgnoredReturnValue(OperationAnalysisContext context, ImmutableArray<INamedTypeSymbol> immutableTypeSymbols)
         {
             var invocation = (IInvocationOperation)context.Operation;
-            if (invocation.Parent is not IExpressionStatementOperation)
+            // Returns void happens for the internal AddDebugSourceDocumentsForChecksumDirectives in the compiler itself.
+            if (invocation.Parent is not IExpressionStatementOperation || invocation.TargetMethod.ReturnsVoid)
             {
                 return;
             }

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UseReturnValueFromImmutableObjectMethodTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/UseReturnValueFromImmutableObjectMethodTests.cs
@@ -169,6 +169,41 @@ End Namespace";
             await VerifyVB.VerifyAnalyzerAsync(source);
         }
 
+        [Fact]
+        public async Task CSharp_ReturnsVoid()
+        {
+            var source = @"
+namespace Microsoft.CodeAnalysis
+{
+    public class Compilation
+    {
+        internal void AddSomething()
+        {
+        }
+
+        internal void M() => AddSomething();
+    }
+}";
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
+        public async Task VisualBasic_ReturnsVoid()
+        {
+            var source = @"
+Namespace Microsoft.CodeAnalysis
+    Public Class Compilation
+        Friend Sub AddSomething()
+        End Sub
+
+        Friend Sub M()
+            AddSomething()
+        End Sub
+    End Class
+End Namespace";
+            await VerifyVB.VerifyCodeFixAsync(source, source);
+        }
+
         private static DiagnosticResult GetCSharpExpectedDiagnostic(int markupKey, string objectName, string methodName) =>
             VerifyCS.Diagnostic().WithLocation(markupKey).WithArguments(objectName, methodName);
 


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
