### PR TITLE
Fix regression in CodeAnalysisTreatWarningsAsErrors when set to false

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/README.md
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/README.md
@@ -22,4 +22,5 @@ Following are the precedence rules as per the values of these properties:
 2. For CAxxxx rules:
 
    1. If `CodeAnalysisTreatWarningsAsErrors` is set to true, enabled CA warnings are bulk escalated to errors by choosing the appropriate globalconfig file with the error severity settings.
-   2. Otherwise, if `TreatWarningsAsErrors` is set to true, this property translates to `/warnaserror` command line switch and the compiler bumps all warnings, including enabled CA warnings, to errors.
+   2. If `CodeAnalysisTreatWarningsAsErrors` is set to false and `TreatWarningsAsErrors` is set to true, we append all CA rule IDs to `WarningsNotAsErrors` to ensure they are not escalated to errors. Users can still bump individual rule IDs to errors by editorconfig/ruleset entry, etc.
+   3. Otherwise, if `TreatWarningsAsErrors` is set to true, this property translates to `/warnaserror` command line switch and the compiler bumps all warnings, including enabled CA warnings, to errors.


### PR DESCRIPTION
Fixes [AB#1726853](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1726853)

https://github.com/dotnet/roslyn-analyzers/pull/6427 re-implemented CodeAnalysisTreatWarningsAsErrors support using global config files instead of appending CA rule IDs to WarningsAsErrors and WarningsNotAsErrors properties. However, this new implementation only works as expected for `CodeAnalysisTreatWarningsAsErrors = true` case, but doesn't prevent escalating CA warnings to errors for `CodeAnalysisTreatWarningsAsErrors = false` and `TreatWarningsAsErrors = true` case. I am restoring the WarningsNotAsErrors logic deleted from https://github.com/dotnet/roslyn-analyzers/pull/6427 to fix this case.

I am also planning to file a separate tracking issue in Roslyn to see if we can implement this whole CodeAnalysisTreatWarningsAsErrors functionality in the compiler layer itself, instead of the current hybrid implementations in this repo, which seems to be quite a bit fragile.
