### PR TITLE
Changes to support 'PVP flow' in source-build

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,12 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.CodeAnalysis" Version="3.3.1">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>66a912c9463eebe832cf742d2fe8bb2e1a4600ec</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23066.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e52b885a6ec2fc87c9e94b80d9ff7a862786390b</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.4.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>1ce8866c9de4c2d67351ef6863699dee03b0804a</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.4.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>1ce8866c9de4c2d67351ef6863699dee03b0804a</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="4.4.0">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>1ce8866c9de4c2d67351ef6863699dee03b0804a</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -39,9 +39,9 @@
     <!-- Use the correct compiler version -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNETCoreCompilersPackageVersion>4.4.0</MicrosoftNETCoreCompilersPackageVersion>
-    <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftNetCompilersToolsetVersion>
-    <CodeStyleAnalyersVersion>$(MicrosoftNETCoreCompilersPackageVersion)</CodeStyleAnalyersVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.4.0</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.4.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+    <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>4.4.0</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>
     <!-- Roslyn -->
     <MicrosoftCodeAnalysisVersion>3.3.1</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.7.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -46,10 +46,10 @@
 
       <!-- Code Style analyzers -->
       <ItemGroup Condition="'$(Language)' == 'C#'">
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
       </ItemGroup>
       <ItemGroup Condition="'$(Language)' == 'VB'">
-        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(CodeStyleAnalyersVersion)" />
+        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle" Version="$(MicrosoftCodeAnalysisVisualBasicCodeStyleVersion)" />
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
PVP flow is a method of flowing dependencies in source build that only overrides versions of packages that the repo has a declared dependency on in Version.Details.xml. This means that the package flow is closer to the Microsoft's way of building .NET.

To enable this for roslyn-analyzers, we just need to add dependencis on the packages that should be overridden in source build. In this case, it's the compiler toolset package, and the Microsoft.CodeAnalysis package. I also cleaned up the CodeAnalysisVersion property to match the package name, however, I generally avoided adding dependencies that do not participate in source build. For example, System.CommandLine is used only in tooling that is not included in SB. It may be worth adding these dependencies to make it easier to track and update dependencies.

To fully enable PVP flow, the repo project in the VMR will needto set `<PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>` once these changes flow in.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
