### PR TITLE
Lower the severity until bugs fixed

### DIFF
--- a/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
+++ b/src/NetAnalyzers/Core/AnalyzerReleases.Unshipped.md
@@ -12,7 +12,7 @@ CA1856 | Performance | Error | ConstantExpectedAnalyzer, [Documentation](https:/
 CA1857 | Performance | Warning | ConstantExpectedAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857)
 CA1858 | Performance | Info | UseStartsWithInsteadOfIndexOfComparisonWithZero, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1858)
 CA1859 | Performance | Info | UseConcreteTypeAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859)
-CA2021 | Reliability | Warning | DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer, [Documentation](https://docs.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021)
+CA2021 | Reliability | Info | DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021)
 
 ### Removed Rules
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableTitle,
                                                                              s_localizableCastMessage,
                                                                              DiagnosticCategory.Reliability,
-                                                                             RuleLevel.BuildWarning,
+                                                                             RuleLevel.IdeSuggestion,
                                                                              s_localizableDescription,
                                                                              isPortedFxCopRule: false,
                                                                              isDataflowRule: false);
@@ -39,7 +39,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                                                              s_localizableTitle,
                                                                              s_localizableOfTypeMessage,
                                                                              DiagnosticCategory.Reliability,
-                                                                             RuleLevel.BuildWarning,
+                                                                             RuleLevel.IdeSuggestion,
                                                                              s_localizableDescription,
                                                                              isPortedFxCopRule: false,
                                                                              isDataflowRule: false);

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1874,7 +1874,7 @@ Widening and user defined conversions are not supported with generic types.
 |-|-|
 |Category|Reliability|
 |Enabled|True|
-|Severity|Warning|
+|Severity|Info|
 |CodeFix|False|
 ---
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3362,7 +3362,7 @@
           "id": "CA2021",
           "shortDescription": "Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types",
           "fullDescription": "Enumerable.Cast<T> and Enumerable.OfType<T> require compatible types to function expectedly.  \u000aThe generic cast (IL 'unbox.any') used by the sequence returned by Enumerable.Cast<T> will throw InvalidCastException at runtime on elements of the types specified.  \u000aThe generic type check (C# 'is' operator/IL 'isinst') used by Enumerable.OfType<T> will never succeed with elements of types specified, resulting in an empty sequence.  \u000aWidening and user defined conversions are not supported with generic types.",
-          "defaultLevel": "warning",
+          "defaultLevel": "note",
           "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021",
           "properties": {
             "category": "Reliability",

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -2,8 +2,6 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-CA1311 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1311> | Specify a culture or use an invariant version |
-CA1421 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1421> | This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied |
 CA1510 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510> | Use ArgumentNullException throw helper |
 CA1511 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1511> | Use ArgumentException throw helper |
 CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1512> | Use ArgumentOutOfRangeException throw helper |


### PR DESCRIPTION
CA2021 is failing the CI build of the [PR that updating dependencies in runtime](https://github.com/dotnet/runtime/pull/80916), mostly on test projects. From failures we see several bugs that needs to fixed. As the analyzer is at warning level it could fail other repos too, so lowering the severity until the bugs are fixed CC @fowl2.

I will create an issue for the bugs shortly
