### PR TITLE
Add missing binding redirects for Newtonsoft.Json

### DIFF
--- a/src/Common/Test/App.config
+++ b/src/Common/Test/App.config
@@ -3,4 +3,12 @@
   <appSettings>
     <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/Text.Analyzers/UnitTests/app.config
+++ b/src/Text.Analyzers/UnitTests/app.config
@@ -3,4 +3,12 @@
   <appSettings>
     <add key="xunit.shadowCopy" value="false"/>
   </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
Fixes failure to run net472 tests in the IDE.