### PR TITLE
Don't emit CA1704 for interface implementations

### DIFF
--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -240,6 +240,7 @@ namespace Text.Analyzers
 
         private static void OnCompilationStart(CompilationStartAnalysisContext compilationStartContext)
         {
+
             var dictionaries = ReadDictionaries();
             var projectDictionary = CodeAnalysisDictionary.CreateFromDictionaries(dictionaries.Concat(s_mainDictionary));
 
@@ -357,6 +358,14 @@ namespace Text.Analyzers
                         foreach (var typeParameter in type.TypeParameters)
                         {
                             ReportDiagnosticsForSymbol(typeParameter, RemovePrefixIfPresent('T', typeParameter.Name), symbolContext.ReportDiagnostic);
+                        }
+
+                        break;
+                    case IParameterSymbol parameter:
+                        //check if the member this parameter is part of is an override/interface implementation
+                        if (parameter.ContainingSymbol.IsImplementationOfAnyImplicitInterfaceMember() || parameter.ContainingSymbol.IsImplementationOfAnyExplicitInterfaceMember())
+                        {
+                            return;
                         }
 
                         break;

--- a/src/Text.Analyzers/UnitTests/IdentifiersShouldBeSpelledCorrectlyTests.cs
+++ b/src/Text.Analyzers/UnitTests/IdentifiersShouldBeSpelledCorrectlyTests.cs
@@ -370,6 +370,82 @@ namespace Text.Analyzers.UnitTests
         }
 
         [Fact]
+        public async Task MemberParameterMisspelledInterfaceImplementation_Verify_EmitsDiagnosticOnlyAtDefinitionAsync()
+        {
+            var source = @"
+        interface IProgram
+        {
+            void Method(string {|#0:explaintain|});
+            
+            string this[int {|#1:indxe|}] { get; }
+        }
+
+        class Program : IProgram
+        {
+            public void Method(string explaintain)
+            {
+            }
+
+            public string this[int indxe] => null;
+
+            public void Method2(long {|#2:enviromentId|})
+            {
+            }
+
+        }";
+
+            await VerifyCSharpAsync(
+                source,
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterRule)
+                    .WithLocation(0)
+                    .WithArguments("IProgram.Method(string)", "explaintain", "explaintain"),
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterRule)
+                    .WithLocation(1)
+                    .WithArguments("IProgram.this[int]", "indxe", "indxe"),
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterRule)
+                    .WithLocation(2)
+                    .WithArguments("Program.Method2(long)", "enviroment", "enviromentId"));
+        }
+
+        [Fact]
+        public async Task MemberParameterUnmeaningfulInterfaceImplementation_Verify_EmitsDiagnosticOnlyAtDefinitionAsync()
+        {
+            var source = @"
+        interface IProgram
+        {
+            void Method(string {|#0:a|});
+            
+            string this[int {|#1:i|}] { get; }
+        }
+
+        class Program : IProgram
+        {
+            public void Method(string a)
+            {
+            }
+
+            public string this[int i] => null;
+
+            public void Method2(long {|#2:x|})
+            {
+            }
+
+        }";
+
+            await VerifyCSharpAsync(
+                source,
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterMoreMeaningfulNameRule)
+                    .WithLocation(0)
+                    .WithArguments("IProgram.Method(string)", "a"),
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterMoreMeaningfulNameRule)
+                    .WithLocation(1)
+                    .WithArguments("IProgram.this[int]", "i"),
+                VerifyCS.Diagnostic(IdentifiersShouldBeSpelledCorrectlyAnalyzer.MemberParameterMoreMeaningfulNameRule)
+                    .WithLocation(2)
+                    .WithArguments("Program.Method2(long)", "x"));
+        }
+
+        [Fact]
         public async Task DelegateParameterMisspelled_Verify_EmitsDiagnosticAsync()
         {
             var source = "delegate void MyDelegate(string {|#0:firstNaem|});";


### PR DESCRIPTION
updates CA1704 as described in #6472.
if the method a parameter is part of is an interface implementation or an override, CA1704 is not emitted. This prevents warnings/errors that cannot be fixed if CA1725 is also active.