### PR TITLE
AD0001 for CA2009 - System.InvalidCastException

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -91,9 +91,8 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                         return;
                     }
 
-                    var receiverType = (INamedTypeSymbol?)invocation.GetReceiverType(operationContext.Compilation, beforeConversion: true, cancellationToken: operationContext.CancellationToken);
-                    if (receiverType != null &&
-                        receiverType.DerivesFromOrImplementsAnyConstructionOf(immutableCollectionType))
+                    if (invocation.GetReceiverType(operationContext.Compilation, beforeConversion: true, cancellationToken: operationContext.CancellationToken) is INamedTypeSymbol receiverType
+                        && receiverType.DerivesFromOrImplementsAnyConstructionOf(immutableCollectionType))
                     {
                         operationContext.ReportDiagnostic(
                             invocation.CreateDiagnostic(

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
@@ -194,6 +194,21 @@ End Class
 ");
         }
 
+        [Fact]
+        public async Task NoDiagnosticCases_ArrayToImmutableArray()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+public class C
+{
+    public ImmutableArray<Type> Types = new[] { typeof(int) }.ToImmutableArray();
+}
+");
+        }
+
         #endregion
 
         #region Diagnostic Tests


### PR DESCRIPTION
Fixes the following AD0001

```
Analyzer 'Microsoft.NetCore.Analyzers.ImmutableCollections.DoNotCallToImmutableCollectionOnAnImmutableCollectionValueAnalyzer' threw an exception of type 'System.InvalidCastException' with message 'Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.ArrayTypeSymbol' to type 'Microsoft.CodeAnalysis.INamedTypeSymbol'.'.
Exception occurred with following context:
Compilation: <redacted>
IOperation: Invocation
SyntaxTree: <redacted>
SyntaxNode: new[] { typeof(<redacted>... [InvocationExpressionSyntax]@[1339..1403) (33,10)-(33,74)

System.InvalidCastException: Unable to cast object of type 'Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel.ArrayTypeSymbol' to type 'Microsoft.CodeAnalysis.INamedTypeSymbol'.
   at Microsoft.NetCore.Analyzers.ImmutableCollections.DoNotCallToImmutableCollectionOnAnImmutableCollectionValueAnalyzer.<>c__DisplayClass10_0.<Initialize>b__1(OperationAnalysisContext operationContext)
   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.<>c.<ExecuteOperationAction>b__63_0(ValueTuple`2 data)
   at Microsoft.CodeAnalysis.Diagnostics.AnalyzerExecutor.ExecuteAndCatchIfThrows_NoLock[TArg](DiagnosticAnalyzer analyzer, Action`1 analyze, TArg argument, Nullable`1 info)
```

