### PR TITLE
Fix https://github.com/dotnet/roslyn-analyzers/issues/6479

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
@@ -12,6 +12,31 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
     public static partial class UseConcreteTypeTests
     {
         [Fact]
+        public static async Task ShouldNotTrigger_Visibility()
+        {
+            await TestCSAsync(@"
+                internal class C
+                {
+                    internal object Obj = new Nested();
+                    internal object GetObj() => new Nested();
+
+                    private sealed class Nested { }
+
+                    public void Test(object o)
+                    {
+                        o.ToString();
+                    }
+
+                    public void Foo()
+                    {
+                        Obj.ToString();
+                        Test(new Nested());
+                    }
+                }
+            ", $"dotnet_code_quality.CA1859.api_surface = private,internal");
+        }
+
+        [Fact]
         public static async Task ShouldNotTrigger_VirtualOverrides()
         {
             const string Source = @"


### PR DESCRIPTION
CA1859 was recommending upgrading types to types that are less visible than the affected symbol, which would lead to broken code. These cases are now explicitly disallowed.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
