### PR TITLE
[release/7.0.1xx] SealInternalTypes (CA1852): Don't warn for top-level type (#6278)

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypes.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypes.cs
@@ -60,7 +60,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     !type.IsStatic &&
                     !type.IsSealed &&
                     !type.IsExternallyVisible() &&
-                    !type.HasAttribute(comImportAttributeType))
+                    !type.HasAttribute(comImportAttributeType) &&
+                    !type.IsTopLevelStatementsEntryPointType())
                 {
                     candidateTypes.Add(type);
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Test.Utilities;
 using Xunit;
 
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
@@ -202,6 +203,20 @@ End Class";
         #endregion
 
         #region No Diagnostic
+        [Fact, WorkItem(6141, "https://github.com/dotnet/roslyn-analyzers/issues/6141")]
+        public Task TopLevelStatementsProgram()
+        {
+            return new VerifyCS.Test()
+            {
+                TestState =
+                {
+                    Sources = { "System.Console.WriteLine();" },
+                    OutputKind = OutputKind.ConsoleApplication,
+                },
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+            }.RunAsync();
+        }
+
         [Fact]
         public Task PublicClassType_NoDiagnostic_CS()
         {


### PR DESCRIPTION
Backport #6278 into the .NET7 release branch
Issue: #6141 - CA1852 warns on generated Program for top-level statements

## Customer Impact 
The CA1852 analyzer is hidden by default, but it is bulk configurable. Which means it is will be on if user choose to warn on all analyzers or on `Performance` category analyzers. Several customers asked about the porting in the issue #6141. For the customer who opened this PR they have all analyzers enabled with `TreatWarningsAsErrors` set to true in their project. So, they explicitly have to suppress this analyzer in order to compile. There is no workaround except suppressing the warning or upgrading to .NET 8 previews which is not desirable.  Accounting that top level statements are getting more and more popular the fix better to be serviced in 7.0.

## Regression 
No, but if we account that the analyzer newly added in 7.0 with the bug it could cause an unexpected warning when the analyzers bulk configured to `Warn`

## Testing
- Unit test added with the fix
- Manual testing done with the repro

## Risk
Very low, the fix is quite simple and self-descriptive. It would not introduce a new warning nor would affect any other code/analyzer.

CC @jeffhandley @stephentoub 