### PR TITLE
Fix CA1853 firing when another dictionary used for ContainsKey

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKey.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKey.cs
@@ -83,8 +83,9 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     switch (conditionalOperation.WhenTrue.Children.First())
                     {
                         case IInvocationOperation childInvocationOperation:
-                            if (childInvocationOperation.TargetMethod.OriginalDefinition.Equals(remove1Param, SymbolEqualityComparer.Default) ||
-                                childInvocationOperation.TargetMethod.OriginalDefinition.Equals(remove2Param, SymbolEqualityComparer.Default))
+                            if ((childInvocationOperation.TargetMethod.OriginalDefinition.Equals(remove1Param, SymbolEqualityComparer.Default) ||
+                                 childInvocationOperation.TargetMethod.OriginalDefinition.Equals(remove2Param, SymbolEqualityComparer.Default)) &&
+                                AreInvocationsOnSameInstance(childInvocationOperation, invocationOperation))
                             {
                                 additionalLocation.Add(childInvocationOperation.Syntax.Parent.GetLocation());
                                 context.ReportDiagnostic(invocationOperation.CreateDiagnostic(Rule, additionalLocations: additionalLocation.ToImmutable(), null));
@@ -101,7 +102,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                                                             .FirstOrDefault(op => op.TargetMethod.OriginalDefinition.Equals(remove1Param, SymbolEqualityComparer.Default) ||
                                                                                   op.TargetMethod.OriginalDefinition.Equals(remove2Param, SymbolEqualityComparer.Default));
 
-                            if (nestedInvocationOperation != null)
+                            if (nestedInvocationOperation != null && AreInvocationsOnSameInstance(nestedInvocationOperation, invocationOperation))
                             {
                                 additionalLocation.Add(nestedInvocationOperation.Syntax.Parent.GetLocation());
                                 context.ReportDiagnostic(invocationOperation.CreateDiagnostic(Rule, additionalLocations: additionalLocation.ToImmutable(), null));
@@ -112,6 +113,18 @@ namespace Microsoft.NetCore.Analyzers.Performance
                             break;
                     }
                 }
+            }
+
+            static bool AreInvocationsOnSameInstance(IInvocationOperation invocationOp1, IInvocationOperation invocationOp2)
+            {
+                return (invocationOp1.Instance, invocationOp2.Instance) switch
+                {
+                    (IFieldReferenceOperation fieldRefOp1, IFieldReferenceOperation fieldRefOp2) => fieldRefOp1.Member == fieldRefOp2.Member,
+                    (IPropertyReferenceOperation propRefOp1, IPropertyReferenceOperation propRefOp2) => propRefOp1.Member == propRefOp2.Member,
+                    (IParameterReferenceOperation paramRefOp1, IParameterReferenceOperation paramRefOp2) => paramRefOp1.Parameter == paramRefOp2.Parameter,
+                    (ILocalReferenceOperation localRefOp1, ILocalReferenceOperation localRefOp2) => localRefOp1.Local == localRefOp2.Local,
+                    _ => false,
+                };
             }
 
             static bool TryGetDictionaryTypeAndMethods(Compilation compilation, [NotNullWhen(true)] out IMethodSymbol? containsKey,


### PR DESCRIPTION
Only if `ContainsKey()` & `Remove()` are invoked on the **exact same field, property, parameter or local variable** will the CA1853 rule now kick in.

_Note that, as a result, if the methods are called using syntactically different but semantically equal references (e.g. 2 variables that have reference equality), the rule will not trigger._

Fixes #6377