### PR TITLE
Support banning namespaces

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/BannedApiAnalyzers.Help.md
@@ -68,3 +68,4 @@ namespace N
 | `string BannedField`                  | `F:N.BannedType.BannedField`
 | `string BannedProperty { get; }`      | `P:N.BannedType.BannedProperty`
 | `event EventHandler BannedEvent;`     | `E:N.BannedType.BannedEvent`
+| `namespace N`                         | `N:N`

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -33,11 +33,10 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 case 'M': // Methods
                 case 'P': // Properties
                 case 'T': // Types
-                    break;
                 case 'N': // Namespaces
+                    break;
                 default:
-                    // Documentation comment id must start with E, F, M, N, P or T. Note: we don't support banning full
-                    // namespaces, so we bail in that case as well.
+                    // Documentation comment id must start with E, F, M, N, P or T.
                     return null;
             }
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -535,6 +535,159 @@ T:N.Banned";
         }
 
         [Fact]
+        public async Task CSharp_BannedNamespace_ConstructorAsync()
+        {
+            var source = @"
+namespace N
+{
+    class C
+    {
+        void M()
+        {
+            var c = {|#0:new N.C()|};
+        }
+    }
+}
+";
+
+            var bannedText = @"
+N:N";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_Parent_ConstructorAsync()
+        {
+            var source = @"
+namespace N.NN
+{
+    class C
+    {
+        void M()
+        {
+            var a = {|#0:new N.NN.C()|};
+        }
+    }
+}
+";
+
+            var bannedText = @"
+N:N";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_MethodGroupAsync()
+        {
+            var source = @"
+namespace N
+{
+    delegate void D();
+    class C
+    {
+        void M()
+        {
+            D d = {|#0:M|};
+        }
+    }
+}
+";
+
+            var bannedText = @"
+N:N";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_PropertyAsync()
+        {
+            var source = @"
+namespace N
+{
+    class C
+    {
+        public int P { get; set; }
+        void M()
+        {
+            {|#0:P|} = {|#1:P|};
+        }
+    }
+}
+";
+
+            var bannedText = @"
+N:N";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText,
+                GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""),
+                GetCSharpResultAt(1, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_MethodAsync()
+        {
+            var source = @"
+namespace N
+{
+    interface I
+    {
+        void M();
+    }
+}
+
+class C
+{
+    void M()
+    {
+        N.I i = null;
+        {|#0:i.M()|};
+    }
+}";
+            var bannedText = @"N:N";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_TypeOfArgument()
+        {
+            var source = @"
+namespace N
+{
+    class Banned {  }
+}
+class C
+{
+    void M()
+    {
+        var type = {|#0:typeof(N.Banned)|};
+    }
+}
+";
+            var bannedText = @"N:N";
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "N", ""));
+        }
+
+        [Fact]
+        public async Task CSharp_BannedNamespace_Constituent()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        var thread = {|#0:new System.Threading.Thread((System.Threading.ThreadStart)null)|};
+    }
+}
+";
+            var bannedText = @"N:System.Threading";
+            await VerifyCSharpAnalyzerAsync(source, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "System.Threading", ""));
+        }
+
+        [Fact]
         public async Task CSharp_BannedGenericType_ConstructorAsync()
         {
             var source = @"


### PR DESCRIPTION
The BannedApiAnalyzer refers to ["ID string format"](https://github.com/dotnet/csharpstandard/blob/standard-v6/standard/documentation-comments.md#d42-id-string-format) for reference on what symbols to ban. One of those symbols is Namespaces, but this is not supported. As this has been [requested before](https://github.com/dotnet/roslyn-analyzers/issues/2748) and is also something I ran into earlier today, it seems like a good fit to add to the project.

This will ban everything under namespace `A`, including child namespaces like `A.B` and `A.B.C`. Having an invocation like `new A.B.C.D()` will yield the error "The symbol 'A' is banned in this project":
```
N:A
```

I've chosen to report on the namespace of the symbol instead of the symbol itself for clarity. Reporting the symbol would yield the message "The symbol 'D' is banned in this project" which might be confusing as it is actually any parent namespace that is banned.

This PR should be further tested other than the provided unit tests. <s>I've tried banning `System.Threading` in the tests, but that didn't work. Could it be that the `INamespaceSymbol` implements equality other than just a name comparison?</s> Update: this also works now, thanks to @mavasani.