### PR TITLE
Enhance the text for NetAnalyzers upgrade warning

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1667,7 +1667,7 @@ $@"<Project>{GetCommonContents(packageName, categories)}{GetPackageSpecificConte
                     NetAnalyzersPackageName => $@"
   <!-- Target to report a warning when SDK NetAnalyzers version is higher than the referenced NuGet NetAnalyzers version -->
   <Target Name=""_ReportUpgradeNetAnalyzersNuGetWarning"" BeforeTargets=""CoreCompile"" Condition=""'$(_SkipUpgradeNetAnalyzersNuGetWarning)' != 'true' "">
-    <Warning Text =""The .NET SDK has newer analyzers with version '$({NetAnalyzersSDKAssemblyVersionPropertyName})' than what version '$({NetAnalyzersNugetAssemblyVersionPropertyName})' of '{NetAnalyzersPackageName}' package provides. Update or remove this package reference.""
+    <Warning Text =""The .NET SDK has newer analyzers with version '$({NetAnalyzersSDKAssemblyVersionPropertyName})' than what version '$({NetAnalyzersNugetAssemblyVersionPropertyName})' of '{NetAnalyzersPackageName}' package provides. Update or remove this package reference. You can suppress this warning by setting the MSBuild property '_SkipUpgradeNetAnalyzersNuGetWarning' to 'true'.""
              Condition=""'$({NetAnalyzersNugetAssemblyVersionPropertyName})' != '' AND
                          '$({NetAnalyzersSDKAssemblyVersionPropertyName})' != '' AND
                           $({NetAnalyzersNugetAssemblyVersionPropertyName}) &lt; $({NetAnalyzersSDKAssemblyVersionPropertyName})""/>


### PR DESCRIPTION
Currently, we report an MSBuild warning when SDK NetAnalyzers version is higher than the referenced NuGet NetAnalyzers version. However, this seems to cause lot of annoyance if we haven't released the newer NuGet at the time newer SDK is released. This PR enhances this text by stating that this warning can be temporarily suppressed by setting '_SkipUpgradeNetAnalyzersNuGetWarning' property to 'true'.
