### PR TITLE
Fix CA2021 for casting interfaces from/to structs

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
@@ -272,6 +272,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     case (TypeKind.Class, TypeKind.Interface):
                         return castFrom.IsSealed && !castFrom.AllInterfaces.Contains(castTo);
 
+                    case (TypeKind.Interface, TypeKind.Struct):
+                        return !castTo.AllInterfaces.Contains(castFrom);
+                    case (TypeKind.Struct, TypeKind.Interface):
+                        return !castFrom.AllInterfaces.Contains(castTo);
+
                     case (TypeKind.Class, TypeKind.Enum):
                         return castFrom.OriginalDefinition.SpecialType is not SpecialType.System_Enum
                                                                       and not SpecialType.System_ValueType;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -23,6 +23,30 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         private readonly DiagnosticDescriptor ofTypeRule = DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.OfTypeRule;
 
         [Fact]
+        public async Task CanCastRoundtripStructToInterface()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+interface IInterface {}
+
+readonly struct Implementation : IInterface {}
+
+class C
+{
+    void M()
+    {
+        IEnumerable<Implementation> e = default;
+        var to = e.Cast<IInterface>();
+        _ = to.Cast<Implementation>();
+    }
+}
+");
+        }
+
+        [Fact]
         public async Task OnlyWellKnownIEnumerable()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
Fix another case of #6457 where casting struct <-> interface would always flag.