### PR TITLE
Support for target-typed new in Insecure XSLT script processing (CA3076)

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureXSLTScriptExecution.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/DoNotUseInsecureXSLTScriptExecution.cs
@@ -195,6 +195,12 @@ namespace Microsoft.NetFramework.Analyzers
                     return;
                 }
 
+                // handle target-typed new
+                if (rhs is IConversionOperation { IsImplicit: true })
+                {
+                    rhs = rhs.WalkDownConversion();
+                }
+
                 IMethodSymbol? rhsMethodSymbol = rhs.Kind switch
                 {
                     OperationKind.Invocation => ((IInvocationOperation)rhs).TargetMethod,

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -9,4 +9,5 @@ CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
 CA1859 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859> | Use concrete types when possible for improved performance |
+CA1860 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860> | Avoid using 'Enumerable.Any()' extension method |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -9,5 +9,4 @@ CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
 CA1859 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859> | Use concrete types when possible for improved performance |
-CA1860 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1860> | Avoid using 'Enumerable.Any()' extension method |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureXSLTScriptExecutionXslCompiledTransformLoadInsecureConstructedSettingsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetFramework.Analyzers/DoNotUseInsecureXSLTScriptExecutionXslCompiledTransformLoadInsecureConstructedSettingsTests.cs
@@ -731,6 +731,34 @@ End Namespace");
         }
 
         [Fact]
+        public async Task UseXslCompiledTransformLoadDefaultTargetTypedNewAndNonSecureResolverShouldNotGenerateDiagnosticAsync()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new();
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}"
+                }
+            );
+        }
+
+        [Fact]
         public async Task UseXslCompiledTransformLoadDefaultAndSecureResolverShouldNotGenerateDiagnosticAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
@@ -848,6 +876,35 @@ End Namespace",
         }
 
         [Fact]
+        public async Task UseXslCompiledTransformLoadEnableScriptTargetTypedNewAndNonSecureResolverShouldGenerateDiagnosticAsync()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new() { EnableScript = true };
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}",
+                },
+                GetCA3076LoadCSharpResultAt(14, 13, "TestMethod")
+            );
+        }
+
+        [Fact]
         public async Task UseXslCompiledTransformLoadSetEnableScriptToTrueAndNonSecureResolverShouldGenerateDiagnosticAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
@@ -930,6 +987,35 @@ Namespace TestNamespace
     End Class
 End Namespace",
                 GetCA3076LoadBasicResultAt(13, 13, "TestMethod")
+            );
+        }
+
+        [Fact]
+        public async Task UseXslCompiledTransformLoadEnableDocumentFunctionTargetTypedNewAndNonSecureResolverShouldGenerateDiagnosticAsync()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new() { EnableDocumentFunction = true };
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}",
+                },
+                GetCA3076LoadCSharpResultAt(14, 13, "TestMethod")
             );
         }
 
@@ -1096,6 +1182,35 @@ End Namespace",
         }
 
         [Fact]
+        public async Task UseXslCompiledTransformLoadConstructSettingsWithTrueParamTargetTypedNewAndNonSecureResolverShouldGenerateDiagnostic1Async()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new(true, false);
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}",
+                },
+                GetCA3076LoadCSharpResultAt(14, 13, "TestMethod")
+            );
+        }
+
+        [Fact]
         public async Task UseXslCompiledTransformLoadConstructSettingsWithTrueParamAndNonSecureResolverShouldGenerateDiagnostic2Async()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
@@ -1137,6 +1252,35 @@ End Namespace",
         }
 
         [Fact]
+        public async Task UseXslCompiledTransformLoadConstructSettingsWithTrueParamTargetTypedNewAndNonSecureResolverShouldGenerateDiagnostic2Async()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new(false, true);
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}",
+                },
+                GetCA3076LoadCSharpResultAt(14, 13, "TestMethod")
+            );
+        }
+
+        [Fact]
         public async Task UseXslCompiledTransformLoadConstructSettingsWithFalseParamsAndNonSecureResolverShouldNotGenerateDiagnosticAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"
@@ -1172,6 +1316,34 @@ Namespace TestNamespace
         End Sub
     End Class
 End Namespace");
+        }
+
+        [Fact]
+        public async Task UseXslCompiledTransformLoadConstructSettingsWithFalseParamsTargetTypedNewAndNonSecureResolverShouldNotGenerateDiagnosticAsync()
+        {
+            await VerifyCS.RunTestAsync(
+                new VerifyCS.Test
+                {
+                    LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                    TestCode = @"
+using System.Xml;
+using System.Xml.Xsl;
+
+namespace TestNamespace
+{
+    class TestClass
+    {
+        private static void TestMethod()
+        {
+            XslCompiledTransform xslCompiledTransform = new XslCompiledTransform();
+            XsltSettings settings = new(false, false);
+            var resolver = new XmlUrlResolver();
+            xslCompiledTransform.Load(""testStylesheet"", settings, resolver);
+        }
+    }
+}"
+                }
+            );
         }
 
         [Fact]

--- a/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2.cs
@@ -30,8 +30,7 @@ namespace Test.Utilities
                 TestCode = source,
             };
 
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync();
+            await RunTestAsync(test, expected);
         }
 
         public static Task VerifyCodeFixAsync(string source, string fixedSource)
@@ -48,6 +47,11 @@ namespace Test.Utilities
                 FixedCode = fixedSource,
             };
 
+            await RunTestAsync(test, expected);
+        }
+
+        public static async Task RunTestAsync(Test test, params DiagnosticResult[] expected)
+        {
             test.ExpectedDiagnostics.AddRange(expected);
             await test.RunAsync();
         }


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

Fixes #6394.