### PR TITLE
Convert FixerWithFixAllAnalyzer to a symbol start/stop analyzer

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -92,7 +92,6 @@
               "Visual Basic"
             ],
             "tags": [
-              "CompilationEnd",
               "Telemetry"
             ]
           }
@@ -111,7 +110,6 @@
               "Visual Basic"
             ],
             "tags": [
-              "CompilationEnd",
               "Telemetry"
             ]
           }
@@ -166,7 +164,6 @@
               "Visual Basic"
             ],
             "tags": [
-              "CompilationEnd",
               "Telemetry"
             ]
           }


### PR DESCRIPTION
Removes the Full Solution Analysis requirement from the following diagnostics:

* RS1010: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
* RS1011: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
* RS1016: Code fix providers should provide FixAll support
