### PR TITLE
Don't warn CA2227 about members implementing interfaces

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnly.cs
@@ -131,6 +131,11 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
+            if (property.IsImplementationOfAnyInterfaceMember())
+            {
+                return;
+            }
+
             context.ReportDiagnostic(property.CreateDiagnostic(Rule, property.Name));
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/CollectionPropertiesShouldBeReadOnlyTests.cs
@@ -471,5 +471,22 @@ struct S
 }",
             }.RunAsync();
         }
+
+        [Fact]
+        public Task CA2227_CSharp_InheritedPropertyAsync()
+        {
+            return VerifyCS.VerifyAnalyzerAsync(@"
+using System.Collections.Generic;
+
+public class Test : ITest
+{
+	public ICollection<int> Collection { get; set; }
+}
+
+public interface ITest
+{
+	ICollection<int> {|#0:Collection|} { get; set; }
+}", DiagnosticResult.CompilerWarning(CollectionPropertiesShouldBeReadOnlyAnalyzer.RuleId).WithLocation(0));
+        }
     }
 }


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

When implementing a property from an interface which defines a setter, the CA2227 warning is emitted. However it may not be possible to change the interface (due to it originating from external code or other reasons), so in these cases CA2227 should not be emitted. 