### PR TITLE
Fix detection of single arguments for CA2017

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/LoggerMessageDefineAnalyzer.cs
@@ -159,16 +159,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                 return;
                             }
 
-                            //Detect if current argument can be passed directly to args
-                            argsIsArray = argument.ArgumentKind == ArgumentKind.ParamArray && parameterType.TypeKind == TypeKind.Array && ((IArrayTypeSymbol)parameterType).ElementType.SpecialType == SpecialType.System_Object;
-
-                            if (argument.ArgumentKind == ArgumentKind.ParamArray
-                                && argument.Value is IArrayCreationOperation arrayCreation)
+                            if (argument.Value is IArrayCreationOperation arrayCreation)
                             {
                                 paramsCount += arrayCreation.Initializer.ElementValues.Length;
                             }
                             else
                             {
+                                argsIsArray = true;
                                 paramsCount++;
                             }
                         }


### PR DESCRIPTION
fixes #5738

`AnalyzeInvocation` incorrectly set `argsIsArray = true` for every value of `paramsArgument`, so the analyzer did not work when a single argument was passed. We can accurately count the number of arguments whenever the value of `paramsArgument` is an array creation expression, implicit or otherwise.

Please let me know if I went overboard on the tests!