### PR TITLE
Performance fix for CA5360 (Do not call dangerous methods in deserialization)

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -735,14 +735,14 @@
   <data name="DoNotAddSchemaByURLMessage" xml:space="preserve">
     <value>This overload of the Add method is potentially unsafe because it may resolve dangerous external references</value>
   </data>
-  <data name="DoNotCallDangerousMethodsInDeserialization" xml:space="preserve">
+  <data name="DoNotCallDangerousMethodsInDeserializationTitle" xml:space="preserve">
     <value>Do Not Call Dangerous Methods In Deserialization</value>
   </data>
   <data name="DoNotCallDangerousMethodsInDeserializationDescription" xml:space="preserve">
     <value>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</value>
   </data>
   <data name="DoNotCallDangerousMethodsInDeserializationMessage" xml:space="preserve">
-    <value>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</value>
+    <value>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</value>
   </data>
   <data name="DoNotDisableCertificateValidation" xml:space="preserve">
     <value>Do Not Disable Certificate Validation</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -193,67 +193,49 @@ namespace Microsoft.NetCore.Analyzers.Security
                         (CompilationAnalysisContext compilationAnalysisContext) =>
                         {
                             var visited = new HashSet<ISymbol>();
-                            var results = new Dictionary<ISymbol, HashSet<(ISymbol DangerousMethod, ArrayBuilder<ISymbol> IntermediateMethods)>>();
+                            var results = new Dictionary<ISymbol, HashSet<ISymbol>>();
                             var symbolDisplayStringCache = SymbolDisplayStringCache.GetOrCreate(
                                 compilation,
                                 SymbolDisplayFormat.MinimallyQualifiedFormat);
                             var methodSymbolArray = new ISymbol[1];    // So we can call .Concat() without allocating new arrays.
 
-                            try
+                            foreach (var methodSymbol in callGraph.Keys.OfType<IMethodSymbol>())
                             {
-                                foreach (var methodSymbol in callGraph.Keys.OfType<IMethodSymbol>())
+                                // Determine if the method is called automatically when an object is deserialized.
+                                // This includes methods with OnDeserializing attribute, method with OnDeserialized attribute, deserialization callbacks as well as cleanup/dispose calls.
+                                var flagSerializable = methodSymbol.ContainingType.HasAttribute(serializableAttributeTypeSymbol);
+                                var parameters = methodSymbol.GetParameters();
+                                var flagHasDeserializeAttributes = !attributeTypeSymbols.IsEmpty
+                                    && attributeTypeSymbols.Any(s => methodSymbol.HasAttribute(s))
+                                    && parameters.Length == 1
+                                    && parameters[0].Type.Equals(streamingContextTypeSymbol);
+                                var flagImplementOnDeserializationMethod = methodSymbol.IsOnDeserializationImplementation(IDeserializationCallbackTypeSymbol);
+                                var flagImplementDisposeMethod = methodSymbol.IsDisposeImplementation(compilation);
+                                var flagIsFinalizer = methodSymbol.IsFinalizer();
+
+                                if (!flagSerializable || !flagHasDeserializeAttributes && !flagImplementOnDeserializationMethod && !flagImplementDisposeMethod && !flagIsFinalizer)
                                 {
-                                    // Determine if the method is called automatically when an object is deserialized.
-                                    // This includes methods with OnDeserializing attribute, method with OnDeserialized attribute, deserialization callbacks as well as cleanup/dispose calls.
-                                    var flagSerializable = methodSymbol.ContainingType.HasAttribute(serializableAttributeTypeSymbol);
-                                    var parameters = methodSymbol.GetParameters();
-                                    var flagHasDeserializeAttributes = !attributeTypeSymbols.IsEmpty
-                                        && attributeTypeSymbols.Any(s => methodSymbol.HasAttribute(s))
-                                        && parameters.Length == 1
-                                        && parameters[0].Type.Equals(streamingContextTypeSymbol);
-                                    var flagImplementOnDeserializationMethod = methodSymbol.IsOnDeserializationImplementation(IDeserializationCallbackTypeSymbol);
-                                    var flagImplementDisposeMethod = methodSymbol.IsDisposeImplementation(compilation);
-                                    var flagIsFinalizer = methodSymbol.IsFinalizer();
-
-                                    if (!flagSerializable || !flagHasDeserializeAttributes && !flagImplementOnDeserializationMethod && !flagImplementDisposeMethod && !flagIsFinalizer)
-                                    {
-                                        continue;
-                                    }
-
-                                    FindCalledDangerousMethod(methodSymbol, visited, results);
-
-                                    foreach (var (DangerousMethod, IntermediateMethods) in results[methodSymbol])
-                                    {
-                                        methodSymbolArray[0] = methodSymbol;
-                                        compilationAnalysisContext.ReportDiagnostic(
-                                            methodSymbol.CreateDiagnostic(
-                                                Rule,
-                                                methodSymbol.ContainingType.Name,
-                                                methodSymbol.MetadataName,
-                                                DangerousMethod.MetadataName,
-                                                string.Join(
-                                                    " -> ",
-                                                    methodSymbolArray
-                                                        .Concat(IntermediateMethods)
-                                                        .Concat(DangerousMethod)
-                                                        .Select(
-                                                            s => symbolDisplayStringCache.GetDisplayString(s)))));
-                                    }
+                                    continue;
                                 }
-                            }
-                            finally
-                            {
-                                foreach (var entry in results)
-                                {
-                                    if (entry.Value == null)
-                                    {
-                                        continue;
-                                    }
 
-                                    foreach (var (DangerousMethod, IntermediateMethods) in entry.Value)
-                                    {
-                                        IntermediateMethods?.Dispose();
-                                    }
+                                FindCalledDangerousMethod(methodSymbol, visited, results);
+
+                                if (!results.TryGetValue(methodSymbol, out var dangerousMethods))
+                                    continue;
+
+                                foreach (var dangerousMethod in dangerousMethods)
+                                {
+                                    methodSymbolArray[0] = methodSymbol;
+                                    var methodSymbols = methodSymbolArray.Concat(dangerousMethod);
+                                    compilationAnalysisContext.ReportDiagnostic(
+                                        methodSymbol.CreateDiagnostic(
+                                            Rule,
+                                            methodSymbol.ContainingType.Name,
+                                            methodSymbol.MetadataName,
+                                            dangerousMethod.MetadataName,
+                                            string.Join(
+                                                " -> ",
+                                                methodSymbols.Select(s => symbolDisplayStringCache.GetDisplayString(s)))));
                                 }
                             }
                         });
@@ -268,12 +250,10 @@ namespace Microsoft.NetCore.Analyzers.Security
                     void FindCalledDangerousMethod(
                         ISymbol methodSymbol,
                         HashSet<ISymbol> visited,
-                        Dictionary<ISymbol, HashSet<(ISymbol, ArrayBuilder<ISymbol>)>> results)
+                        Dictionary<ISymbol, HashSet<ISymbol>> results)
                     {
                         if (visited.Add(methodSymbol))
                         {
-                            results.Add(methodSymbol, new HashSet<(ISymbol, ArrayBuilder<ISymbol>)>());
-
                             if (!callGraph.TryGetValue(methodSymbol, out var calledMethods))
                             {
                                 Debug.Fail(methodSymbol.Name + " was not found in callGraph");
@@ -281,11 +261,18 @@ namespace Microsoft.NetCore.Analyzers.Security
                                 return;
                             }
 
+                            HashSet<ISymbol>? methodSymbolSet = null;
                             foreach (var child in calledMethods.Keys)
                             {
                                 if (dangerousMethodSymbols.Contains(child))
                                 {
-                                    results[methodSymbol].Add((child, ArrayBuilder<ISymbol>.GetInstance()));
+                                    if (methodSymbolSet == null)
+                                    {
+                                        methodSymbolSet = new();
+                                        results[methodSymbol] = methodSymbolSet;
+                                    }
+
+                                    methodSymbolSet.Add(child);
                                 }
 
                                 if (Equals(child, methodSymbol))
@@ -295,20 +282,17 @@ namespace Microsoft.NetCore.Analyzers.Security
 
                                 FindCalledDangerousMethod(child, visited, results);
 
-                                if (results.TryGetValue(child, out var result))
+                                if (results.TryGetValue(child, out var dangerousMethods))
                                 {
-                                    // If we find results in the calling method
-                                    foreach ((ISymbol dangerousMethod, ArrayBuilder<ISymbol> intermediateCalls) in result)
+                                    Debug.Assert(dangerousMethods.Count > 0);
+
+                                    if (methodSymbolSet == null)
                                     {
-                                        var newIntermediateCalls = ArrayBuilder<ISymbol>.GetInstance();
-                                        newIntermediateCalls.Add(child);
-                                        newIntermediateCalls.AddRange(intermediateCalls);
-                                        results[methodSymbol].Add((dangerousMethod, newIntermediateCalls));
+                                        methodSymbolSet = new();
+                                        results[methodSymbol] = methodSymbolSet;
                                     }
-                                }
-                                else
-                                {
-                                    Debug.Fail(child.Name + " was not found in results");
+
+                                    methodSymbolSet.AddRange(dangerousMethods);
                                 }
                             }
                         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
-using Analyzer.Utilities.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -37,7 +36,7 @@ namespace Microsoft.NetCore.Analyzers.Security
 
         internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
             DiagnosticId,
-            CreateLocalizableResourceString(nameof(DoNotCallDangerousMethodsInDeserialization)),
+            CreateLocalizableResourceString(nameof(DoNotCallDangerousMethodsInDeserializationTitle)),
             CreateLocalizableResourceString(nameof(DoNotCallDangerousMethodsInDeserializationMessage)),
             DiagnosticCategory.Security,
             RuleLevel.IdeHidden_BulkConfigurable,
@@ -197,7 +196,6 @@ namespace Microsoft.NetCore.Analyzers.Security
                             var symbolDisplayStringCache = SymbolDisplayStringCache.GetOrCreate(
                                 compilation,
                                 SymbolDisplayFormat.MinimallyQualifiedFormat);
-                            var methodSymbolArray = new ISymbol[1];    // So we can call .Concat() without allocating new arrays.
 
                             foreach (var methodSymbol in callGraph.Keys.OfType<IMethodSymbol>())
                             {
@@ -225,17 +223,12 @@ namespace Microsoft.NetCore.Analyzers.Security
 
                                 foreach (var dangerousMethod in dangerousMethods)
                                 {
-                                    methodSymbolArray[0] = methodSymbol;
-                                    var methodSymbols = methodSymbolArray.Concat(dangerousMethod);
                                     compilationAnalysisContext.ReportDiagnostic(
                                         methodSymbol.CreateDiagnostic(
                                             Rule,
                                             methodSymbol.ContainingType.Name,
                                             methodSymbol.MetadataName,
-                                            dangerousMethod.MetadataName,
-                                            string.Join(
-                                                " -> ",
-                                                methodSymbols.Select(s => symbolDisplayStringCache.GetDisplayString(s)))));
+                                            symbolDisplayStringCache.GetDisplayString(dangerousMethod)));
                                 }
                             }
                         });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Vždy nepřeskakovat ověření tokenu v delegátech</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Nevolejte nebezpečné metody při deserializaci</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">Nezabezpečená deserializace je ohrožení zabezpečení, které nastane, když se nedůvěryhodná data použijí ke zneužití logiky aplikace, vyvolání útoku na dostupnost služby (DoS), nebo dokonce spuštění libovolného kódu při deserializaci. Možnost zneužití funkcí deserializace se pro kyberzločince často vyskytne, když aplikace deserializuje nedůvěryhodná data, která jsou pod jejich kontrolou. Konkrétně se stane to, že při deserializaci vyvoláte nebezpečné metody. Úspěšné útoky na nezabezpečenou deserializaci by mohly útočníkovi umožnit provedení útoků, jako jsou útoky DoS, obcházení ověřování a vzdálené spuštění kódu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Při deserializaci instance třídy {0} může metoda {1} volat nebezpečnou metodu {2}. Možná volání metod: {3}</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Tokenvalidierung in Delegaten nicht immer überspringen</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Keine gefährlichen Methoden bei der Deserialisierung aufrufen</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">Bei der unsicheren Deserialisierung handelt es sich um ein Sicherheitsrisiko, das auftreten kann, wenn nicht vertrauenswürdige Daten verwendet werden, um die Logik einer Anwendung auf nicht beabsichtigte Weise zu verwenden, einen Denial-of-Service-Angriff (DoS) durchzuführen oder beliebigen Code auszuführen, um diese zu deserialisieren. Angreifer nutzen diese Deserialisierungsfeatures häufig aus, indem sie ihre nicht vertrauenswürdigen Daten von der Anwendung deserialisieren lassen. Während der Deserialisierung werden so insbesondere gefährliche Methoden aufgerufen. Eine erfolgreich durchgeführte unsichere Deserialisierung kann dazu führen, dass der Angreifer DoS-Angriffe durchführen, die Authentifizierung umgehen oder Code remote ausführen kann.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Wenn eine Instanz der Klasse "{0}" deserialisiert wird, kann die Methode "{1}" die gefährliche Methode "{2}" aufrufen. Mögliche Methodenaufrufe: {3}</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -537,19 +537,19 @@
         <target state="translated">No omitir siempre la validación de tokens en delegados</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">No llame a métodos peligrosos durante la deserialización</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">La Deserialización insegura es un problema de vulnerabilidad que se produce cuando se utilizan datos no fiables para abusar de la lógica de una aplicación, inflige un ataque de Denegacíón de servicio (DoS) o incluso ejecuta código arbitrario sobre la propia deserialización. A menudo, los usuarios malintencionados pueden abusar de estas funciones de deserialización cuando la aplicación deserializa datos no fiables que están bajo su control. Específicamente, pueden invocar métodos peligrosos para el proceso de deserialización. Los ataques de deserialización insegura que logran su cometido pueden permitir al atacante llevar a cabo ataques DoS, omisiones del método de autenticación y la ejecución remota de código.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Al deserializar una instancia de la clase {0}, el método {1} puede llamar al método peligroso {2}. Invocaciones de métodos posibles: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Ne pas toujours ignorer la validation des jetons dans les délégués</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Ne pas appeler de méthodes dangereuses dans la désérialisation</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">La désérialisation non sécurisée et une vulnérabilité qui se produit quand des données non approuvées sont utilisées pour exploiter la logique d'une application, infliger une attaque par déni de service (DoS) ou même exécuter du code arbitraire pendant leur désérialisation. Les utilisateurs malveillants peuvent souvent exploiter les fonctionnalités de ces désérialisations quand l'application désérialise des données non approuvées qui sont sous leur contrôle. Plus précisément, ils appellent des méthodes dangereuses dans le processus de désérialisation. Les attaques pendant une désérialisation non sécurisée peuvent permettre à un utilisateur malveillant d'effectuer des attaques de type attaques DoS, contournements d'authentification et exécution du code à distance.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Quand vous désérialisez une instance de la classe {0}, la méthode {1} peut appeler une méthode dangereuse {2}. Les appels de méthode potentiels sont : {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Non ignorare sempre la convalida dei token nei delegati</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Non chiamare metodi pericolosi durante la deserializzazione</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">La deserializzazione non sicura è una vulnerabilità che si riscontra quando vengono usati dati non attendibili per violare la logica di un'applicazione, causare un attacco Denial of Service (DoS) o persino eseguire codice arbitrario durante la deserializzazione. Gli utenti malintenzionati sfruttano spesso queste funzionalità di deserializzazione quando l'applicazione deserializza dati non attendibili controllati da loro, in particolare richiamando metodi pericolosi nel processo di deserializzazione. Attacchi riusciti di deserializzazione non sicura possono consentire a un utente malintenzionato di portare a termine attacchi di tipo DoS, bypass di autenticazione ed esecuzione di codice da remoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Durante la deserializzazione di un'istanza della classe {0} il metodo {1} può chiamare il metodo pericoloso {2}. Le potenziali chiamate al metodo sono: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -537,19 +537,19 @@
         <target state="translated">委任のトークンの検証を常にスキップしない</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">逆シリアル化で危険なメソッドを呼び出さないでください</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">安全でない逆シリアル化は、アプリケーションのロジックを悪用したり、サービス拒否 (DoS) 攻撃を仕掛けたり、逆シリアル化されたときに任意のコードを実行したりすることさえあるために、信頼できないデータが使用される場合に発生する脆弱性です。 悪意のあるユーザーが、自分の管理下にある信頼できないデータをアプリケーションで逆シリアル化しているときに、これらの逆シリアル化機能を悪用することがよくあります。 具体的には、逆シリアル化の過程で危険なメソッドを呼び出します。 安全でない逆シリアル化攻撃が成功すると、攻撃者は DoS 攻撃、認証回避、リモートでのコード実行などの攻撃を仕掛ける可能性があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">クラス {0} のインスタンスを逆シリアル化すると、メソッド {1} によって危険なメソッド {2} を呼び出されるおそれがあります。考えられるメソッド呼び出し: {3}。</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -537,19 +537,19 @@
         <target state="translated">대리자에서 토큰 유효성 검사를 항상 건너뛰지 마세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">역직렬화에서 위험한 메서드를 호출하면 안 됨</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">안전하지 않은 deserialization은 트러스트되지 않은 데이터를 사용하여 애플리케이션 논리를 남용할 때 발생하는 취약성이고, DoS(서비스 거부) 공격을 가하거나 deserialize될 때 임의의 코드를 실행하기도 합니다. 종종 악의적인 사용자가 제어하는 트리스트되지 않은 데이터를 애플리케이션에서 deserialize할 때 이러한 deserialization 기능을 사용할 수 있습니다. 특히 deserialization 과정에 위험한 메서드를 호출합니다. 안전하지 않은 deserialization 공격이 성공하면 공격자가 DoS 공격, 인증 건너뜀 및 원격 코드 실행과 같은 공격을 수행할 수 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">{0} 클래스의 인스턴스를 역직렬화할 때 {1} 메서드가 위험한 메서드 {2}을(를) 호출할 수 있습니다. 잠재적인 메서드 호출은 {3}입니다.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Nigdy nie pomijaj walidacji tokenów w delegacjach</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Nie wywołuj niebezpiecznych metod w deserializacji</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">Niezabezpieczona deserializacja to luka w zabezpieczeniach, która występuje, gdy niezaufane dane są używane w przypadku nadużywania logiki aplikacji, przeprowadzania ataku typu „odmowa usługi” (DoS), a nawet wykonywania kodu umownego w trakcie deserializacji. Złośliwi użytkownicy często mogą nadużywać tych funkcji deserializacji, gdy aplikacja deserializuje niezaufane dane, które są kontrolowane przez te funkcje. W szczególności może ona wywoływać niebezpieczne metody w procesie deserializacji. Skuteczne ataki typu „niezabezpieczona deserializacja” mogą pozwolić osobie atakującej na przeprowadzanie ataków, takich jak ataki DoS, pomijanie uwierzytelniania i zdalne wykonywanie kodu.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Podczas deserializacji wystąpienia klasy {0} metoda {1} może wywołać niebezpieczną metodę {2}. Potencjalne wywołania metod to: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Nem sempre a validação no token de omissão em representantes</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Não Chame Métodos Perigosos Durante a Desserialização</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">A Desserialização Não Segura é uma vulnerabilidade que ocorre quando dados não confiáveis são usados para explorar a lógica de um aplicativo, causar um ataque de negação de serviço (DoS) ou até mesmo executar código arbitrário durante a desserialização. É frequentemente possível que usuários mal-intencionados explorem essas funcionalidades da desserialização quando o aplicativo desserializa dados não confiáveis sob seu controle. Especificamente, eles invocam métodos perigosos no processo de desserialização. Ataques de desserialização não segura bem sucedidos podem permitir que um invasor realize ataques como ataques de Negação de Serviço, bypass de autenticação e execução remota de código.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">Ao desserializar uma instância da classe {0}, o método {1} pode chamar o método perigoso {2}. As possíveis invocações de método são: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Не пропускать всегда проверку токенов в делегатах</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Не вызывать опасные методы десериализации</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">Небезопасная десериализация — это уязвимость, которая возникает, когда недоверенные данные используются для нарушения логики работы приложения, проведения атак типа "отказ в обслуживании" или даже для выполнения произвольного кода при его десериализации. Злоумышленники часто используют эти возможности десериализации, контролируя недоверенные данные, которые десериализуются приложением, в частности, путем вызова опасных методов в ходе десериализации. При успешном проведении атак с небезопасной десериализацией злоумышленник может провести атаки типа "отказ в обслуживании", обойти проверку подлинности и выполнить код удаленно.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">При десериализации экземпляра класса {0} метод {1} может вызывать опасный метод {2}. Потенциальные вызовы методов: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -537,19 +537,19 @@
         <target state="translated">Temsilcilerde belirteç doğrulamasını her zaman atlamayın</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">Seri Durumdan Çıkarırken Tehlikeli Metotlar Çağırma</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">Güvenli Olmayan Seri Durumdan Çıkarma, güvenilmeyen verilerin bir uygulamanın mantığını kötüye kullanmak, bir Hizmet Reddi (DoS) saldırısı gerçekleştirmek veya seri durumdan çıkarıldığında rastgele kod yürütmek için kullanılması durumunda oluşan bir güvenlik açığıdır. Kötü amaçlı kullanıcıların uygulama kendi denetimlerindeki güvenilmeyen verileri seri durumdan çıkarırken bu seri durumdan çıkarma özelliklerini kötüye kullanması mümkündür. Özellikle, seri durumdan çıkarma işleminde tehlikeli yöntemler çağrılabilir. Başarılı güvenli olmayan seri durumdan çıkarma salgırıları, saldırganların DoS saldırıları gerçekleştirmesine, kimlik doğrulamasını atlamasına ve uzaktan kod yürütmesine olanak sağlar.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">{0} sınıfının bir örneği seri durumdan çıkarılırken, {1} metodu tehlikeli {2} metodunu çağırabilir. Olası metot çağırmaları: {3}.</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -537,19 +537,19 @@
         <target state="translated">不要总是跳过委托中的令牌验证</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">在反序列化中不要调用危险方法</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">不安全反序列化是一种漏洞，当不受信任的数据被用来滥用应用程序的逻辑、实施拒绝服务(dos)攻击，甚至在反序列化时执行任意代码时发生。当应用程序反序列化由其控制的不受信任的数据时，恶意用户通常可能会滥用这些反序列化功能。具体来说，在反序列化过程中调用危险方法。成功的不安全反序列化攻击可能允许攻击者执行攻击，例如 dos 攻击、身份验证绕过和远程代码执行。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">反序列化类 {0} 的实例时，方法 {1} 可调用危险方法 {2}。潜在的方法调用为: {3}。</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -537,19 +537,19 @@
         <target state="translated">永遠不要在委派中略過權杖驗證</target>
         <note />
       </trans-unit>
-      <trans-unit id="DoNotCallDangerousMethodsInDeserialization">
-        <source>Do Not Call Dangerous Methods In Deserialization</source>
-        <target state="translated">不要在還原序列化期間呼叫危險的方法</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationDescription">
         <source>Insecure Deserialization is a vulnerability which occurs when untrusted data is used to abuse the logic of an application, inflict a Denial-of-Service (DoS) attack, or even execute arbitrary code upon it being deserialized. It’s frequently possible for malicious users to abuse these deserialization features when the application is deserializing untrusted data which is under their control. Specifically, invoke dangerous methods in the process of deserialization. Successful insecure deserialization attacks could allow an attacker to carry out attacks such as DoS attacks, authentication bypasses, and remote code execution.</source>
         <target state="translated">不安全的還原序列化是一種弱點，會在有人使用未受信任的資料來不當使用應用程式的邏輯、發動拒絕服務的攻擊 (DoS)，甚至是在任何程式碼的還原序列化期間執行該程式碼時出現。惡意使用者經常會在應用程式將他們控制的未受信任資料還原序列化時，濫用這些還原序列化功能 (基本上就是在還原序列化期間叫用危險的方法)。不安全的還原序列化攻擊一旦成功，攻擊者就有機會發動後續攻擊，例如 DoS 攻擊、驗證略過和遠端程式碼執行。</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallDangerousMethodsInDeserializationMessage">
-        <source>When deserializing an instance of class {0}, method {1} can call dangerous method {2}. The potential method invocations are: {3}.</source>
-        <target state="translated">將類別 {0} 的執行個體還原序列化時，方法 {1} 可以呼叫危險的方法 {2}。潛在的方法引動過程為: {3}。</target>
+        <source>When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</source>
+        <target state="new">When deserializing an instance of class '{0}', method '{1}' can directly or indirectly call dangerous method '{2}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotCallDangerousMethodsInDeserializationTitle">
+        <source>Do Not Call Dangerous Methods In Deserialization</source>
+        <target state="new">Do Not Call Dangerous Methods In Deserialization</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesDescription">

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserializationTests.cs
@@ -45,8 +45,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializingMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializingMethod(StreamingContext context) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -70,8 +69,7 @@ End Namespace",
                 13,
                 "TestClass",
                 "OnDeserializingMethod",
-                "WriteAllBytes",
-                "Sub TestClass.OnDeserializingMethod(context As StreamingContext) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -99,8 +97,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializedMethod(StreamingContext context) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -124,8 +121,7 @@ End Namespace",
                 13,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "Sub TestClass.OnDeserializedMethod(context As StreamingContext) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -154,8 +150,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializedMethod(StreamingContext context) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -180,8 +175,7 @@ End Namespace",
                 13,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "Sub TestClass.OnDeserializedMethod(context As StreamingContext) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -217,15 +211,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializedMethod(StreamingContext context) -> void File.WriteAllBytes(string path, byte[] bytes)"),
-            GetCSharpResultAt(
-                12,
-                19,
-                "TestClass",
-                "OnDeserializedMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializedMethod(StreamingContext context) -> void TestClass.TestMethod() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -256,15 +242,7 @@ End Namespace",
                 13,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                 "Sub TestClass.OnDeserializedMethod(context As StreamingContext) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"),
-            GetBasicResultAt(
-                12,
-                13,
-                "TestClass",
-                "OnDeserializedMethod",
-                "WriteAllBytes",
-                 "Sub TestClass.OnDeserializedMethod(context As StreamingContext) -> Sub TestClass.TestMethod() -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -305,8 +283,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializedMethod(StreamingContext context) -> void TestClass.TestMethod(int count) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -341,8 +318,7 @@ End Namespace",
                 13,
                 "TestClass",
                 "OnDeserializedMethod",
-                "WriteAllBytes",
-                "Sub TestClass.OnDeserializedMethod(context As StreamingContext) -> Sub TestClass.TestMethod(count As Integer) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -372,8 +348,7 @@ public class TestClass : IDeserializationCallback
                 17,
                 "TestClass",
                 "OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -403,8 +378,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -428,8 +402,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserializationExplictlyImplemented",
-                "WriteAllBytes",
-                "Sub TestClass.OnDeserializationExplictlyImplemented(sender As Object) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -459,8 +432,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllLines",
-                "void TestClass.OnDeserialization(object sender) -> void File.WriteAllLines(string path, string[] contents, Encoding encoding)"));
+                "void File.WriteAllLines(string path, string[] contents, Encoding encoding)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -487,8 +459,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "WriteAllLines",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.WriteAllLines(path As String, contents As String(), encoding As Encoding)"));
+                "Sub File.WriteAllLines(path As String, contents As String(), encoding As Encoding)"));
         }
 
         [Fact]
@@ -518,8 +489,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllText",
-                "void TestClass.OnDeserialization(object sender) -> void File.WriteAllText(string path, string contents)"));
+                "void File.WriteAllText(string path, string contents)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -546,8 +516,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "WriteAllText",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.WriteAllText(path As String, contents As String)"));
+                "Sub File.WriteAllText(path As String, contents As String)"));
         }
 
         [Fact]
@@ -577,8 +546,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Copy",
-                "void TestClass.OnDeserialization(object sender) -> void File.Copy(string sourceFileName, string destFileName)"));
+                "void File.Copy(string sourceFileName, string destFileName)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -605,8 +573,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Copy",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.Copy(sourceFileName As String, destFileName As String)"));
+                "Sub File.Copy(sourceFileName As String, destFileName As String)"));
         }
 
         [Fact]
@@ -636,8 +603,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Move",
-                "void TestClass.OnDeserialization(object sender) -> void File.Move(string sourceFileName, string destFileName)"));
+                "void File.Move(string sourceFileName, string destFileName)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -665,8 +631,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Move",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.Move(sourceFileName As String, destFileName As String)"));
+                "Sub File.Move(sourceFileName As String, destFileName As String)"));
         }
 
         [Fact]
@@ -696,8 +661,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "AppendAllLines",
-                "void TestClass.OnDeserialization(object sender) -> void File.AppendAllLines(string path, IEnumerable<string> contents)"));
+                "void File.AppendAllLines(string path, IEnumerable<string> contents)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -723,8 +687,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "AppendAllLines",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.AppendAllLines(path As String, contents As IEnumerable(Of String))"));
+                "Sub File.AppendAllLines(path As String, contents As IEnumerable(Of String))"));
         }
 
         [Fact]
@@ -754,8 +717,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "AppendAllText",
-                "void TestClass.OnDeserialization(object sender) -> void File.AppendAllText(string path, string contents)"));
+                "void File.AppendAllText(string path, string contents)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -781,8 +743,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "AppendAllText",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.AppendAllText(path As String, contents As String)"));
+                "Sub File.AppendAllText(path As String, contents As String)"));
         }
 
         [Fact]
@@ -811,8 +772,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "AppendText",
-                "void TestClass.OnDeserialization(object sender) -> StreamWriter File.AppendText(string path)"));
+                "StreamWriter File.AppendText(string path)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -837,8 +797,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "AppendText",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function File.AppendText(path As String) As StreamWriter"));
+                "Function File.AppendText(path As String) As StreamWriter"));
         }
 
         [Fact]
@@ -867,8 +826,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Delete",
-                "void TestClass.OnDeserialization(object sender) -> void File.Delete(string path)"));
+                "void File.Delete(string path)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -893,8 +851,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Delete",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub File.Delete(path As String)"));
+                "Sub File.Delete(path As String)"));
         }
 
         [Fact]
@@ -923,8 +880,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Delete",
-                "void TestClass.OnDeserialization(object sender) -> void Directory.Delete(string path)"));
+                "void Directory.Delete(string path)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -949,8 +905,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Delete",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub Directory.Delete(path As String)"));
+                "Sub Directory.Delete(path As String)"));
         }
 
         [Fact]
@@ -978,8 +933,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Delete",
-                "void TestClass.OnDeserialization(object sender) -> void FileInfo.Delete()"));
+                "void FileInfo.Delete()"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1003,8 +957,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Delete",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub FileInfo.Delete()"));
+                "Sub FileInfo.Delete()"));
         }
 
         [Fact]
@@ -1032,8 +985,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Delete",
-                "void TestClass.OnDeserialization(object sender) -> void DirectoryInfo.Delete()"));
+                "void DirectoryInfo.Delete()"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1057,8 +1009,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Delete",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub DirectoryInfo.Delete()"));
+                "Sub DirectoryInfo.Delete()"));
         }
 
         [Fact]
@@ -1102,8 +1053,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Delete",
-                "void TestClass.OnDeserialization(object sender) -> void LogStore.Delete(string path)"));
+                "void LogStore.Delete(string path)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1140,8 +1090,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Delete",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Sub LogStore.Delete(path As String)"));
+                "Sub LogStore.Delete(path As String)"));
         }
 
         [Fact]
@@ -1170,8 +1119,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "GetLoadedModules",
-                "void TestClass.OnDeserialization(object sender) -> Module[] Assembly.GetLoadedModules()"));
+                "Module[] Assembly.GetLoadedModules()"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1196,8 +1144,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "GetLoadedModules",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.GetLoadedModules() As [Module]()"));
+                "Function Assembly.GetLoadedModules() As [Module]()"));
         }
 
         [Fact]
@@ -1228,8 +1175,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "Load",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.Load(AssemblyName assemblyRef)"));
+                "Assembly Assembly.Load(AssemblyName assemblyRef)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1257,8 +1203,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "Load",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.Load(assemblyRef As AssemblyName) As Assembly"));
+                "Function Assembly.Load(assemblyRef As AssemblyName) As Assembly"));
         }
 
         [Fact]
@@ -1287,8 +1232,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "LoadFile",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.LoadFile(string path)"));
+                "Assembly Assembly.LoadFile(string path)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1314,8 +1258,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "LoadFile",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.LoadFile(path As String) As Assembly"));
+                "Function Assembly.LoadFile(path As String) As Assembly"));
         }
 
         [Fact]
@@ -1344,8 +1287,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "LoadFrom",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.LoadFrom(string assemblyFile)"));
+                "Assembly Assembly.LoadFrom(string assemblyFile)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1371,8 +1313,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "LoadFrom",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.LoadFrom(assemblyFile As String) As Assembly"));
+                "Function Assembly.LoadFrom(assemblyFile As String) As Assembly"));
         }
 
         [Fact]
@@ -1403,8 +1344,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "LoadModule",
-                $"void TestClass.OnDeserialization(object sender) -> Module Assembly.LoadModule(string moduleName, byte[]{NullableSuffixOnNetCoreApp} rawModule)"));
+                $"Module Assembly.LoadModule(string moduleName, byte[]{NullableSuffixOnNetCoreApp} rawModule)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1432,8 +1372,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "LoadModule",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.LoadModule(moduleName As String, rawModule As Byte()) As [Module]"));
+                "Function Assembly.LoadModule(moduleName As String, rawModule As Byte()) As [Module]"));
         }
 
         [Fact]
@@ -1461,8 +1400,7 @@ public class TestClass : IDeserializationCallback
                 13,
                 35,
                 "TestClass", "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "LoadWithPartialName",
-                $"void TestClass.OnDeserialization(object sender) -> Assembly{NullableSuffixOnNetCoreApp} Assembly.LoadWithPartialName(string partialName)"));
+                $"Assembly{NullableSuffixOnNetCoreApp} Assembly.LoadWithPartialName(string partialName)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1488,8 +1426,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "LoadWithPartialName",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.LoadWithPartialName(partialName As String) As Assembly"));
+                "Function Assembly.LoadWithPartialName(partialName As String) As Assembly"));
         }
 
         [Fact]
@@ -1518,8 +1455,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "ReflectionOnlyLoad",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.ReflectionOnlyLoad(byte[] rawAssembly)"));
+                "Assembly Assembly.ReflectionOnlyLoad(byte[] rawAssembly)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1544,8 +1480,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "ReflectionOnlyLoad",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.ReflectionOnlyLoad(rawAssembly As Byte()) As Assembly"));
+                "Function Assembly.ReflectionOnlyLoad(rawAssembly As Byte()) As Assembly"));
         }
 
         [Fact]
@@ -1574,8 +1509,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "ReflectionOnlyLoadFrom",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.ReflectionOnlyLoadFrom(string assemblyFile)"));
+                "Assembly Assembly.ReflectionOnlyLoadFrom(string assemblyFile)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1601,8 +1535,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "ReflectionOnlyLoadFrom",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.ReflectionOnlyLoadFrom(assemblyFile As String) As Assembly"));
+                "Function Assembly.ReflectionOnlyLoadFrom(assemblyFile As String) As Assembly"));
         }
 
         [Fact]
@@ -1631,8 +1564,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "UnsafeLoadFrom",
-                "void TestClass.OnDeserialization(object sender) -> Assembly Assembly.UnsafeLoadFrom(string assemblyFile)"));
+                "Assembly Assembly.UnsafeLoadFrom(string assemblyFile)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1658,8 +1590,7 @@ End Namespace",
                 20,
                 "TestClass",
                 "OnDeserialization",
-                "UnsafeLoadFrom",
-                "Sub TestClass.OnDeserialization(sender As Object) -> Function Assembly.UnsafeLoadFrom(assemblyFile As String) As Assembly"));
+                "Function Assembly.UnsafeLoadFrom(assemblyFile As String) As Assembly"));
         }
 
         [Fact]
@@ -1700,8 +1631,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void TestGenericClass<T>.TestGenericMethod() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -1745,8 +1675,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void TestInterfaceImplement.TestInterfaceMethod() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -1785,8 +1714,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> TestDelegate TestAnotherClass.staticDelegateField -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -1827,8 +1755,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -1872,8 +1799,7 @@ public class TestClass : IDeserializationCallback
                 35,
                 "TestClass",
                 "System.Runtime.Serialization.IDeserializationCallback.OnDeserialization",
-                "WriteAllBytes",
-                "void TestClass.OnDeserialization(object sender) -> void TestDerivedClass.TestAbstractMethod() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]
@@ -1900,8 +1826,7 @@ public class TestClass
                 6,
                 "TestClass",
                 "Finalize",
-                "WriteAllBytes",
-                "TestClass.~TestClass() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -1924,8 +1849,7 @@ End Namespace",
                 33,
                 "TestClass",
                 "Finalize",
-                "WriteAllBytes",
-                "Sub TestClass.Finalize() -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -1975,15 +1899,13 @@ public class TestClass : IDisposable
                 17,
                 "TestClass",
                 "Dispose",
-                "WriteAllBytes",
-                "void TestClass.Dispose() -> void TestClass.Dispose(bool disposing) -> void File.WriteAllBytes(string path, byte[] bytes)"),
+                "void File.WriteAllBytes(string path, byte[] bytes)"),
             GetCSharpResultAt(
                 35,
                 6,
                 "TestClass",
                 "Finalize",
-                "WriteAllBytes",
-                "TestClass.~TestClass() -> void TestClass.Dispose(bool disposing) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -2022,14 +1944,12 @@ End Namespace",
                 20,
                 "TestClass",
                 "Dispose",
-                "WriteAllBytes",
-                "Sub TestClass.Dispose() -> Sub TestClass.Dispose(disposing As Boolean) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"),
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"),
             GetBasicResultAt(28,
                 33,
                 "TestClass",
                 "Finalize",
-                "WriteAllBytes",
-                    "Sub TestClass.Finalize() -> Sub TestClass.Dispose(disposing As Boolean) -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -2066,8 +1986,7 @@ public class SubTestClass : TestClass
                 6,
                 "SubTestClass",
                 "Finalize",
-                "WriteAllBytes",
-                "SubTestClass.~SubTestClass() -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
 
             await VerifyVB.VerifyAnalyzerAsync(@"
 Imports System
@@ -2099,8 +2018,7 @@ End Namespace",
                 33,
                 "SubTestClass",
                 "Finalize",
-                "WriteAllBytes",
-                "Sub SubTestClass.Finalize() -> Sub File.WriteAllBytes(path As String, bytes As Byte())"));
+                "Sub File.WriteAllBytes(path As String, bytes As Byte())"));
         }
 
         [Fact]
@@ -2956,8 +2874,7 @@ public class TestClass
                 19,
                 "TestClass",
                 "OnDeserializingMethod",
-                "WriteAllBytes",
-                "void TestClass.OnDeserializingMethod(StreamingContext context) -> void File.WriteAllBytes(string path, byte[] bytes)"));
+                "void File.WriteAllBytes(string path, byte[] bytes)"));
         }
 
         [Fact]


### PR DESCRIPTION
Performance fix for [CA5360](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5360): Stop tracking intermediate methods in CA5360 analysis. This seems to cause exponential increase in allocations and memory usage during analysis.