### PR TITLE
Only report CA1512 if the specific helper required exists

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
@@ -122,7 +122,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 ISymbol? aooreThrowIfNegative = aoore.GetMembers("ThrowIfNegative").FirstOrDefault();
                 ISymbol? aooreThrowIfNegativeOrZero = aoore.GetMembers("ThrowIfNegativeOrZero").FirstOrDefault();
                 ISymbol? aooreThrowIfGreaterThan = aoore.GetMembers("ThrowIfGreaterThan").FirstOrDefault();
-                ISymbol? aooreThrowIfGreaterThanOrEqual = aoore.GetMembers("aooreThrowIfGreaterThanOrEqual").FirstOrDefault();
+                ISymbol? aooreThrowIfGreaterThanOrEqual = aoore.GetMembers("ThrowIfGreaterThanOrEqual").FirstOrDefault();
                 ISymbol? aooreThrowIfLessThan = aoore.GetMembers("ThrowIfLessThan").FirstOrDefault();
                 ISymbol? aooreThrowIfLessThanOrEqual = aoore.GetMembers("ThrowIfLessThanOrEqual").FirstOrDefault();
                 ISymbol? aooreThrowIfEqual = aoore.GetMembers("ThrowIfEqual").FirstOrDefault();
@@ -244,11 +244,24 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                             if (additionalLocations.Length != 0 && !AvoidComparing(aooreParameter!))
                             {
-                                context.ReportDiagnostic(condition.CreateDiagnostic(
-                                    UseArgumentOutOfRangeExceptionThrowIfRule,
-                                    additionalLocations,
-                                    properties: ImmutableDictionary<string, string?>.Empty.Add(MethodNamePropertyKey, methodName),
-                                    args: new object[] { nameof(ArgumentOutOfRangeException), methodName! }));
+                                switch (methodName)
+                                {
+                                    case "ThrowIfZero" when aooreThrowIfZero is not null:
+                                    case "ThrowIfNegative" when aooreThrowIfNegative is not null:
+                                    case "ThrowIfNegativeOrZero" when aooreThrowIfNegativeOrZero is not null:
+                                    case "ThrowIfGreaterThan" when aooreThrowIfGreaterThan is not null:
+                                    case "ThrowIfGreaterThanOrEqual" when aooreThrowIfGreaterThanOrEqual is not null:
+                                    case "ThrowIfLessThan" when aooreThrowIfLessThan is not null:
+                                    case "ThrowIfLessThanOrEqual" when aooreThrowIfLessThanOrEqual is not null:
+                                    case "ThrowIfEqual" when aooreThrowIfEqual is not null:
+                                    case "ThrowIfNotEqual" when aooreThrowIfNotEqual is not null:
+                                        context.ReportDiagnostic(condition.CreateDiagnostic(
+                                            UseArgumentOutOfRangeExceptionThrowIfRule,
+                                            additionalLocations,
+                                            properties: ImmutableDictionary<string, string?>.Empty.Add(MethodNamePropertyKey, methodName),
+                                            args: new object[] { nameof(ArgumentOutOfRangeException), methodName! }));
+                                        break;
+                                }
                             }
 
                             static bool AvoidComparing(IParameterReferenceOperation p) =>

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpersTests.cs
@@ -913,6 +913,50 @@ class C
         }
 
         [Fact]
+        public async Task ArgumentOutOfRangeExceptionThrowIf_NoDiagnosticForMissingHelper()
+        {
+            await new VerifyCS.Test()
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9,
+                TestCode =
+@"
+using System;
+
+namespace System
+{
+    public class ArgumentOutOfRangeException : Exception
+    {
+        public ArgumentOutOfRangeException(string paramName) { }
+        public ArgumentOutOfRangeException(string paramName, string message) { }
+        public static void ThrowIfZero<T>(T arg) { }
+        public static void ThrowIfNegative<T>(T arg) { }
+        public static void ThrowIfNegativeOrZero<T>(T arg) { }
+        public static void ThrowIfGreaterThan<T>(T arg, T other) { }
+        public static void ThrowIfGreaterThanOrEqual<T>(T arg, T other) { }
+        public static void ThrowIfLessThan<T>(T arg, T other) { }
+        public static void ThrowIfLessThanOrEqual<T>(T arg, T other) { }
+    }
+}
+
+class C
+{
+    void M(int arg)
+    {
+        if (arg != 42)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arg));
+        }
+        if (42 != arg)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arg));
+        }
+    }
+}
+"
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task ObjectDisposedExceptionThrowIf_DoesntExist_NoDiagnostics()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
We were raising the diagnostic if any of the helpers on the type existed even if the specific one required didn't.