### PR TITLE
Relax name validation in CA2208

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Globalization;
 using Analyzer.Utilities;
@@ -234,7 +235,17 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             foreach (IParameterSymbol parameter in symbol.GetParameters())
             {
+                // If the parameter name matches exactly, it's a match.
                 if (parameter.Name == stringArgumentValue)
+                {
+                    return true;
+                }
+
+                // If the string argument begins with the parameter name followed by punctuation, it's also considered a match.
+                // e.g. "arg.Length", "arg[0]", etc.
+                if (stringArgumentValue.Length > parameter.Name.Length &&
+                    stringArgumentValue.StartsWith(parameter.Name, StringComparison.Ordinal) &&
+                    char.IsPunctuation(stringArgumentValue, parameter.Name.Length))
                 {
                     return true;
                 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -792,6 +792,57 @@ dotnet_code_quality.CA2208.api_surface = public") }
         }
 
         [Fact]
+        public async Task ArgumentNullException_ParameterNameFollowedByPunctuation_DoesNotWarnAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test1(string first)
+                    {
+                        throw new System.ArgumentNullException(""first.Length"");
+                    }
+
+                    public void Test2(string first)
+                    {
+                        throw new System.ArgumentNullException(""first[0]"");
+                    }
+                }");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+               Public Class [MyClass]
+                   Public Sub Test1(first As String)
+                       Throw New System.ArgumentNullException(""first.Length"")
+                   End Sub
+
+                   Public Sub Test2(first As String)
+                       Throw New System.ArgumentNullException(""first(0)"")
+                   End Sub
+               End Class");
+        }
+
+        [Fact]
+        public async Task ArgumentNullException_ParameterNameFollowedByNonPunctuation_WarnsAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test(string first)
+                    {
+                        throw new System.ArgumentNullException(""first123"");
+                    }
+                }",
+                GetCSharpIncorrectParameterNameExpectedResult(6, 31, "Test", "first123", "paramName", "ArgumentNullException"));
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+                Public Class [MyClass]
+                    Public Sub Test(first As String)
+                        Throw New System.ArgumentNullException(""first123"")
+                    End Sub
+                End Class",
+                GetBasicIncorrectParameterNameExpectedResult(4, 31, "Test", "first123", "paramName", "ArgumentNullException"));
+        }
+
+        [Fact]
         public async Task ArgumentNullException_VariableUsed_DoesNotWarnAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
InstantiateArgumentExceptionsCorrectlyAnalyzer is checking whether a parameter name exactly matches.  We recently decided our guidance is too strict here, and that it's reasonable for an ArgumentException ParameterName to be not just a parameter name but also inclusive of member access, e.g. "arg.Length", "arg[i]", etc.  This adds such a check to the analyzer to suppress diagnostics in such cases.

@terrajobst, @bartonjs, @tannergooding, @buyaa-n, this is what we talked about a few API reviews ago.