### PR TITLE
Cache the ApiData values we produce for an AdditionalText file.

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -66,23 +66,13 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             }
         }
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-        private readonly struct ApiData
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public static readonly ApiData Empty = new(ImmutableArray<ApiLine>.Empty, ImmutableArray<RemovedApiLine>.Empty, nullableRank: -1);
-
-            public ImmutableArray<ApiLine> ApiList { get; }
-            public ImmutableArray<RemovedApiLine> RemovedApiList { get; }
+        private sealed record ApiData(
+            ImmutableArray<ApiLine> ApiList,
+            ImmutableArray<RemovedApiLine> RemovedApiList,
             // Number for the max line where #nullable enable was found (-1 otherwise)
-            public int NullableRank { get; }
-
-            internal ApiData(ImmutableArray<ApiLine> apiList, ImmutableArray<RemovedApiLine> removedApiList, int nullableRank)
-            {
-                ApiList = apiList;
-                RemovedApiList = removedApiList;
-                NullableRank = nullableRank;
-            }
+            int NullableRank)
+        {
+            public static readonly ApiData Empty = new(ImmutableArray<ApiLine>.Empty, ImmutableArray<RemovedApiLine>.Empty, NullableRank: -1);
         }
 
         private sealed class Impl

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -24,9 +24,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private readonly record struct ApiLine(string Text, TextSpan Span, AdditionalFileInfo FileInfo)
         {
+            public bool IsDefault => FileInfo == null;
+
             public SourceText SourceText => FileInfo.SourceText;
             public string Path => FileInfo.Path;
-            public bool IsShippedApi => FileInfo?.IsShippedApi is true;
+            public bool IsShippedApi => FileInfo.IsShippedApi;
         }
 
         private readonly record struct RemovedApiLine(string Text, ApiLine ApiLine);
@@ -247,7 +249,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 if (symbol.Kind == SymbolKind.Method)
                 {
                     var method = (IMethodSymbol)symbol;
-                    var isMethodShippedApi = foundApiLine.IsShippedApi;
+                    var isMethodShippedApi = !foundApiLine.IsDefault && foundApiLine.IsShippedApi;
 
                     // Check if a public API is a constructor that makes this class instantiable, even though the base class
                     // is not instantiable. That API pattern is not allowed, because it causes protected members of

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -22,52 +22,16 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
     {
         private sealed record AdditionalFileInfo(string Path, SourceText SourceText, bool IsShippedApi);
 
-        private readonly record struct ApiLine
+        private readonly record struct ApiLine(string Text, TextSpan Span, AdditionalFileInfo FileInfo)
         {
-            public string Text { get; }
-            public TextSpan Span { get; }
-
-            private readonly AdditionalFileInfo _fileInfo;
-
-            public SourceText SourceText => _fileInfo.SourceText;
-            public string Path => _fileInfo.Path;
-            public bool IsShippedApi => _fileInfo != null && _fileInfo.IsShippedApi;
-
-            public ApiLine(string text, TextSpan span, AdditionalFileInfo fileInfo)
-            {
-                Text = text;
-                Span = span;
-                _fileInfo = fileInfo;
-            }
+            public SourceText SourceText => FileInfo.SourceText;
+            public string Path => FileInfo.Path;
+            public bool IsShippedApi => FileInfo?.IsShippedApi is true;
         }
 
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-        private readonly struct RemovedApiLine
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public string Text { get; }
-            public ApiLine ApiLine { get; }
+        private readonly record struct RemovedApiLine(string Text, ApiLine ApiLine);
 
-            internal RemovedApiLine(string text, ApiLine apiLine)
-            {
-                Text = text;
-                ApiLine = apiLine;
-            }
-        }
-
-#pragma warning disable CA1815 // Override equals and operator equals on value types
-        private readonly struct ApiName
-#pragma warning restore CA1815 // Override equals and operator equals on value types
-        {
-            public string Name { get; }
-            public string NameWithNullability { get; }
-
-            public ApiName(string name, string nameWithNullability)
-            {
-                Name = name;
-                NameWithNullability = nameWithNullability;
-            }
-        }
+        private readonly record struct ApiName(string Name, string NameWithNullability);
 
         private sealed record ApiData(
             ImmutableArray<ApiLine> ApiList,

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -33,11 +33,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private readonly record struct ApiName(string Name, string NameWithNullability);
 
-        private sealed record ApiData(
-            ImmutableArray<ApiLine> ApiList,
-            ImmutableArray<RemovedApiLine> RemovedApiList,
-            // Number for the max line where #nullable enable was found (-1 otherwise)
-            int NullableRank)
+        /// <param name="NullableRank">Number for the max line where #nullable enable was found (-1 otherwise)</param>
+        private sealed record ApiData(ImmutableArray<ApiLine> ApiList, ImmutableArray<RemovedApiLine> RemovedApiList, int NullableRank)
         {
             public static readonly ApiData Empty = new(ImmutableArray<ApiLine>.Empty, ImmutableArray<RemovedApiLine>.Empty, NullableRank: -1);
         }

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -33,10 +33,10 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
         private readonly record struct ApiName(string Name, string NameWithNullability);
 
-        /// <param name="NullableRank">Number for the max line where #nullable enable was found (-1 otherwise)</param>
-        private sealed record ApiData(ImmutableArray<ApiLine> ApiList, ImmutableArray<RemovedApiLine> RemovedApiList, int NullableRank)
+        /// <param name="NullableLineNumber">Number for the max line where #nullable enable was found (-1 otherwise)</param>
+        private sealed record ApiData(ImmutableArray<ApiLine> ApiList, ImmutableArray<RemovedApiLine> RemovedApiList, int NullableLineNumber)
         {
-            public static readonly ApiData Empty = new(ImmutableArray<ApiLine>.Empty, ImmutableArray<RemovedApiLine>.Empty, NullableRank: -1);
+            public static readonly ApiData Empty = new(ImmutableArray<ApiLine>.Empty, ImmutableArray<RemovedApiLine>.Empty, NullableLineNumber: -1);
         }
 
         private sealed class Impl
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             internal Impl(Compilation compilation, ApiData shippedData, ApiData unshippedData, bool isPublic, AnalyzerOptions analyzerOptions)
             {
                 _compilation = compilation;
-                _useNullability = shippedData.NullableRank >= 0 || unshippedData.NullableRank >= 0;
+                _useNullability = shippedData.NullableLineNumber >= 0 || unshippedData.NullableLineNumber >= 0;
                 _unshippedData = unshippedData;
 
                 var publicApiMap = new Dictionary<string, ApiLine>(StringComparer.Ordinal);

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -20,21 +20,24 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 {
     public partial class DeclarePublicApiAnalyzer : DiagnosticAnalyzer
     {
+        private sealed record AdditionalFileInfo(string Path, SourceText SourceText, bool IsShippedApi);
+
         private sealed class ApiLine
         {
             public string Text { get; }
             public TextSpan Span { get; }
-            public SourceText SourceText { get; }
-            public string Path { get; }
-            public bool IsShippedApi { get; }
 
-            internal ApiLine(string text, TextSpan span, SourceText sourceText, string path, bool isShippedApi)
+            private readonly AdditionalFileInfo _fileInfo;
+
+            public SourceText SourceText => _fileInfo.SourceText;
+            public string Path => _fileInfo.Path;
+            public bool IsShippedApi => _fileInfo.IsShippedApi;
+
+            public ApiLine(string text, TextSpan span, AdditionalFileInfo fileInfo)
             {
                 Text = text;
                 Span = span;
-                SourceText = sourceText;
-                Path = path;
-                IsShippedApi = isShippedApi;
+                _fileInfo = fileInfo;
             }
         }
 

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
     {
         private sealed record AdditionalFileInfo(string Path, SourceText SourceText, bool IsShippedApi);
 
-        private sealed class ApiLine
+        private readonly record struct ApiLine
         {
             public string Text { get; }
             public TextSpan Span { get; }
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             public SourceText SourceText => _fileInfo.SourceText;
             public string Path => _fileInfo.Path;
-            public bool IsShippedApi => _fileInfo.IsShippedApi;
+            public bool IsShippedApi => _fileInfo != null && _fileInfo.IsShippedApi;
 
             public ApiLine(string text, TextSpan span, AdditionalFileInfo fileInfo)
             {
@@ -286,7 +286,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 if (symbol.Kind == SymbolKind.Method)
                 {
                     var method = (IMethodSymbol)symbol;
-                    var isMethodShippedApi = foundApiLine?.IsShippedApi == true;
+                    var isMethodShippedApi = foundApiLine.IsShippedApi;
 
                     // Check if a public API is a constructor that makes this class instantiable, even though the base class
                     // is not instantiable. That API pattern is not allowed, because it causes protected members of

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -177,6 +177,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             var maxNullableRank = -1;
             var rank = -1;
 
+            var additionalFileInfo = new AdditionalFileInfo(path, sourceText, isShippedApi);
+
             foreach (var line in sourceText.Lines)
             {
                 string text = line.ToString();
@@ -191,7 +193,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                     continue;
                 }
 
-                var apiLine = new ApiLine(text, line.Span, sourceText, path, isShippedApi);
+                var apiLine = new ApiLine(text, line.Span, additionalFileInfo);
                 if (text.StartsWith(RemovedApiPrefix, StringComparison.Ordinal))
                 {
                     string removedText = text[RemovedApiPrefix.Length..];

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -210,7 +210,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         /// Takes potentially multiple <see cref="ApiData"/> instances, corresponding to different additional text
         /// files, and flattens them into the final instance we will use when analyzing the compilation.
         /// </summary>
-        private static ApiData Flatten(List<ApiData> allData)
+        private static ApiData Flatten(ArrayBuilder<ApiData> allData)
         {
             Debug.Assert(allData.Count > 0);
 
@@ -223,8 +223,9 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             var removedBuilder = ArrayBuilder<RemovedApiLine>.GetInstance();
             var maxNullableRank = -1;
 
-            foreach (var data in allData)
+            for (int i = 0, n = allData.Count; i < n; i++)
             {
+                var data = allData[i];
                 apiBuilder.AddRange(data.ApiList);
                 removedBuilder.AddRange(data.RemovedApiList);
                 maxNullableRank = Math.Max(maxNullableRank, data.NullableRank);
@@ -242,8 +243,9 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             [NotNullWhen(true)] out ApiData? shippedData,
             [NotNullWhen(true)] out ApiData? unshippedData)
         {
-            var allShippedData = new List<ApiData>();
-            var allUnshippedData = new List<ApiData>();
+            using var allShippedData = ArrayBuilder<ApiData>.GetInstance();
+            using var allUnshippedData = ArrayBuilder<ApiData>.GetInstance();
+
             AddApiTexts(
                 analyzerOptions.AdditionalFiles, isPublic, allShippedData, allUnshippedData, cancellationToken);
 
@@ -362,8 +364,8 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         private static void AddApiTexts(
             ImmutableArray<AdditionalText> additionalTexts,
             bool isPublic,
-            List<ApiData> allShippedData,
-            List<ApiData> allUnshippedData,
+            ArrayBuilder<ApiData> allShippedData,
+            ArrayBuilder<ApiData> allUnshippedData,
             CancellationToken cancellationToken)
         {
             foreach (var additionalText in additionalTexts)

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -194,14 +194,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             return new ApiData(apiBuilder.ToImmutableAndFree(), removedBuilder.ToImmutableAndFree(), maxNullableRank);
         }
 
-        private static bool TryGetApiData(
-            AnalyzerOptions analyzerOptions,
-            Compilation compilation,
-            bool isPublic,
-            List<Diagnostic> errors,
-            CancellationToken cancellationToken,
-            [NotNullWhen(true)] out ApiData? shippedData,
-            [NotNullWhen(true)] out ApiData? unshippedData)
+        private static bool TryGetApiData(AnalyzerOptions analyzerOptions, Compilation compilation, bool isPublic, List<Diagnostic> errors, CancellationToken cancellationToken, [NotNullWhen(true)] out ApiData? shippedData, [NotNullWhen(true)] out ApiData? unshippedData)
         {
             using var allShippedData = ArrayBuilder<ApiData>.GetInstance();
             using var allUnshippedData = ArrayBuilder<ApiData>.GetInstance();

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -116,14 +116,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             {
                 var errors = new List<Diagnostic>();
                 // Switch to "RegisterAdditionalFileAction" available in Microsoft.CodeAnalysis "3.8.x" to report additional file diagnostics: https://github.com/dotnet/roslyn-analyzers/issues/3918
-                if (!TryGetAndValidateApiFiles(
-                        compilationContext.Options,
-                        compilationContext.Compilation,
-                        isPublic,
-                        compilationContext.CancellationToken,
-                        errors,
-                        out var shippedData,
-                        out var unshippedData))
+                if (!TryGetAndValidateApiFiles(compilationContext.Options, compilationContext.Compilation, isPublic, compilationContext.CancellationToken, errors, out var shippedData, out var unshippedData))
                 {
                     compilationContext.RegisterCompilationEndAction(context =>
                     {

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -165,7 +165,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             var removedBuilder = ArrayBuilder<RemovedApiLine>.GetInstance();
             var lastNullableLineNumber = -1;
 
-            // current line we're on.  Note: we ignore whitespace lines when computin gthis.
+            // current line we're on.  Note: we ignore whitespace lines when computing this.
             var lineNumber = -1;
 
             var additionalFileInfo = new AdditionalFileInfo(path, sourceText, isShippedApi);

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -167,7 +167,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             foreach (var line in sourceText.Lines)
             {
-                string text = line.ToString();
+                var text = line.ToString();
                 if (string.IsNullOrWhiteSpace(text))
                     continue;
 
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 var apiLine = new ApiLine(text, line.Span, additionalFileInfo);
                 if (text.StartsWith(RemovedApiPrefix, StringComparison.Ordinal))
                 {
-                    string removedText = text[RemovedApiPrefix.Length..];
+                    var removedText = text[RemovedApiPrefix.Length..];
                     removedBuilder.Add(new RemovedApiLine(removedText, apiLine));
                 }
                 else

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -199,8 +199,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
             using var allShippedData = ArrayBuilder<ApiData>.GetInstance();
             using var allUnshippedData = ArrayBuilder<ApiData>.GetInstance();
 
-            AddApiTexts(
-                analyzerOptions.AdditionalFiles, isPublic, allShippedData, allUnshippedData, cancellationToken);
+            AddApiTexts(analyzerOptions.AdditionalFiles, isPublic, allShippedData, allUnshippedData, cancellationToken);
 
             if (allShippedData.Count == 0 && allUnshippedData.Count == 0)
             {

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -134,14 +134,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 RegisterImplActions(compilationContext, new Impl(compilationContext.Compilation, shippedData, unshippedData, isPublic, compilationContext.Options));
                 return;
 
-                static bool TryGetAndValidateApiFiles(
-                    AnalyzerOptions options,
-                    Compilation compilation,
-                    bool isPublic,
-                    CancellationToken cancellationToken,
-                    List<Diagnostic> errors,
-                    [NotNullWhen(true)] out ApiData? shippedData,
-                    [NotNullWhen(true)] out ApiData? unshippedData)
+                static bool TryGetAndValidateApiFiles(AnalyzerOptions options, Compilation compilation, bool isPublic, CancellationToken cancellationToken, List<Diagnostic> errors, [NotNullWhen(true)] out ApiData? shippedData, [NotNullWhen(true)] out ApiData? unshippedData)
                 {
                     return TryGetApiData(options, compilation, isPublic, errors, cancellationToken, out shippedData, out unshippedData)
                            && ValidateApiFiles(shippedData, unshippedData, isPublic, errors);


### PR DESCRIPTION
Typing in roslyn shows this to be the highest allocation hitter.  This is because diagnostics will end up calling into this analyzer, which then rereads teh SourceText for these additional files, over and over again.

For example, this was typing just for just a few seconds:

![image](https://user-images.githubusercontent.com/4564579/228689977-2e29963c-04dd-4d6e-827b-2798d498333a.png)
