### PR TITLE
Fix the addition of resx files

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1629,10 +1629,10 @@ $@"<Project>{GetCommonContents(packageName, categories)}{GetPackageSpecificConte
                 {
                     CodeAnalysisAnalyzersPackageName => @"
   <!-- Target to add all 'EmbeddedResource' files with '.resx' extension as analyzer additional files -->
-  <Target Name=""AddAllResxFilesAsAdditionalFiles"" BeforeTargets=""CoreCompile"" Condition=""'@(EmbeddedResource)' != '' AND '$(SkipAddAllResxFilesAsAdditionalFiles)' != 'true'"">
+  <Target Name=""AddAllResxFilesAsAdditionalFiles"" BeforeTargets=""GenerateMSBuildEditorConfigFileCore;CoreCompile"" Condition=""'@(EmbeddedResource)' != '' AND '$(SkipAddAllResxFilesAsAdditionalFiles)' != 'true'"">
     <ItemGroup>
       <EmbeddedResourceWithResxExtension Include=""@(EmbeddedResource)"" Condition=""'%(Extension)' == '.resx'"" />
-      <AdditionalFiles Include=""%(EmbeddedResourceWithResxExtension.Identity)"" />
+      <AdditionalFiles Include=""@(EmbeddedResourceWithResxExtension)"" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
* Add resx files to AdditionalFiles before generating global configuration files
* Preserve item metadata when adding resx files to AdditionalFiles
