### PR TITLE
Reduce allocations more in public api analyzer

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -586,7 +586,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
             private static bool ContainsPublicApiName(string apiLineText, string publicApiNameToSearch)
             {
-                apiLineText = apiLineText.Trim(ObliviousMarker);
+                apiLineText = apiLineText.TrimStart(ObliviousMarkerArray);
 
                 // Ensure we don't search in parameter list/return type.
                 var indexOfParamsList = apiLineText.IndexOf('(');

--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         internal const string FileName = "FileName";
 
         private const char ObliviousMarker = '~';
+        private static readonly char[] ObliviousMarkerArray = { ObliviousMarker };
 
         /// <summary>
         /// Boolean option to configure if public API analyzer should bail out silently if public API files are missing.
@@ -397,7 +398,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 errors.Add(Diagnostic.Create(descriptor, Location.None, InvalidReasonMisplacedNullableEnable));
             }
 
-            var publicApiMap = new Dictionary<string, ApiLine>(StringComparer.Ordinal);
+            using var publicApiMap = PooledDictionary<string, ApiLine>.GetInstance(StringComparer.Ordinal);
             ValidateApiList(publicApiMap, shippedData.ApiList, isPublic, errors);
             ValidateApiList(publicApiMap, unshippedData.ApiList, isPublic, errors);
 
@@ -408,7 +409,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
         {
             foreach (ApiLine cur in apiList)
             {
-                string textWithoutOblivious = cur.Text.TrimStart(ObliviousMarker);
+                string textWithoutOblivious = cur.Text.TrimStart(ObliviousMarkerArray);
                 if (publicApiMap.TryGetValue(textWithoutOblivious, out ApiLine existingLine))
                 {
                     LinePositionSpan existingLinePositionSpan = existingLine.SourceText.Lines.GetLinePositionSpan(existingLine.Span);


### PR DESCRIPTION
About .6% when typing in roslyn.   Half is the arrays allocated for each line for .TrimStart, the other half are all the dictionary entries created over and over again as we merge apidata files.