### PR TITLE
Reduce excessive allocations in BannedSymbols analyzer.

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/SymbolIsBannedInAnalyzersAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/SymbolIsBannedInAnalyzersAnalyzer.cs
@@ -86,38 +86,39 @@ namespace Microsoft.CodeAnalysis.Analyzers
         }
 
 #pragma warning disable RS1012 // 'compilationContext' does not register any analyzer actions. Consider moving actions registered in 'Initialize' that depend on this start action to 'compilationContext'.
-        protected sealed override Dictionary<ISymbol, BanFileEntry>? ReadBannedApis(CompilationStartAnalysisContext compilationContext)
+        protected sealed override Dictionary<(string ContainerName, string SymbolName), ImmutableArray<BanFileEntry>>? ReadBannedApis(CompilationStartAnalysisContext compilationContext)
         {
-            var propertyValue = compilationContext.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.EnforceExtendedAnalyzerRules, compilationContext.Compilation);
+            var compilation = compilationContext.Compilation;
+            var propertyValue = compilationContext.Options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.EnforceExtendedAnalyzerRules, compilation);
             if (propertyValue != "true")
-            {
                 return null;
-            }
 
             const string fileName = "Microsoft.CodeAnalysis.Analyzers.AnalyzerBannedSymbols.txt";
             using var stream = typeof(SymbolIsBannedInAnalyzersAnalyzer<>).Assembly.GetManifestResourceStream(fileName);
             var source = SourceText.From(stream);
-            var result = new Dictionary<ISymbol, BanFileEntry>(SymbolEqualityComparer.Default);
+
+            var result = new Dictionary<(string ContainerName, string SymbolName), List<BanFileEntry>>();
             foreach (var line in source.Lines)
             {
                 var text = line.ToString();
                 if (string.IsNullOrWhiteSpace(text))
-                {
                     continue;
-                }
 
-                var entry = new BanFileEntry(text, line.Span, source, fileName);
-                var symbols = DocumentationCommentId.GetSymbolsForDeclarationId(entry.DeclarationId, compilationContext.Compilation);
-                if (!symbols.IsDefaultOrEmpty)
+                var entry = new BanFileEntry(compilation, text, line.Span, source, fileName);
+                var parsed = DocumentationCommentIdParser.ParseDeclaredSymbolId(entry.DeclarationId);
+                if (parsed != null)
                 {
-                    foreach (var symbol in symbols)
+                    if (!result.TryGetValue(parsed.Value, out var existing))
                     {
-                        result.Add(symbol, entry);
+                        existing = new();
+                        result.Add(parsed.Value, existing);
                     }
+
+                    existing.Add(entry);
                 }
             }
 
-            return result;
+            return result.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/Microsoft.CodeAnalysis.Analyzers.csproj
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/Microsoft.CodeAnalysis.Analyzers.csproj
@@ -10,6 +10,7 @@
     <PackageId>*$(MSBuildProjectFile)*</PackageId>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\Microsoft.CodeAnalysis.BannedApiAnalyzers\Core\DocumentationCommentIdParser.cs" Link="DocumentationCommentIdParser.cs" />
     <Compile Include="..\..\Microsoft.CodeAnalysis.BannedApiAnalyzers\Core\SymbolIsBannedAnalyzerBase.cs" Link="SymbolIsBannedAnalyzerBase.cs" />
     <EmbeddedResource Include="AnalyzerBannedSymbols.txt" />
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -101,17 +101,10 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
         private static string DecodeName(string name)
             => name.IndexOf('#') >= 0 ? name.Replace('#', '.') : name;
 
-        private static int ReadNextInteger(string id, ref int index)
+        private static void ReadNextInteger(string id, ref int index)
         {
-            int n = 0;
-
             while (index < id.Length && char.IsDigit(id[index]))
-            {
-                n = n * 10 + (id[index] - '0');
                 index++;
-            }
-
-            return n;
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -2,6 +2,10 @@
 
 namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 {
+    /// <summary>
+    /// Stripped down port of the code in roslyn.  Responsible only for determining the <see cref="ISymbol.Name"/> and
+    /// name of the <see cref="ISymbol.ContainingSymbol"/> for a given xml doc comment symbol id.
+    /// </summary>
     internal static class DocumentationCommentIdParser
     {
         private static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -1,26 +1,22 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using Analyzer.Utilities.PooledObjects;
-
 namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 {
     internal static class DocumentationCommentIdParser
     {
-        public static bool ParseDeclaredSymbolId(string id, ArrayBuilder<(string ParentName, string SymbolName)> results)
+        public static (string ParentName, string SymbolName)? ParseDeclaredSymbolId(string id)
         {
             if (id == null)
-                return false;
+                return null;
 
             if (id.Length < 2)
-                return false;
+                return null;
 
             int index = 0;
-            results.Clear();
-            ParseDeclaredId(id, ref index, results);
-            return results.Count > 0;
+            return ParseDeclaredId(id, ref index);
         }
 
-        private static void ParseDeclaredId(string id, ref int index, ArrayBuilder<(string ParentName, string SymbolName)> results)
+        private static (string ParentName, string SymbolName)? ParseDeclaredId(string id, ref int index)
         {
             var kindChar = PeekNextChar(id, index);
 
@@ -36,7 +32,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 default:
                     // Documentation comment id must start with E, F, M, N, P or T. Note: we don't support banning full
                     // namespaces, so we bail in that case as well.
-                    return;
+                    return null;
             }
 
             index++;
@@ -70,7 +66,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 }
                 else
                 {
-                    results.Add((parentName, symbolName));
+                    return (parentName, symbolName);
                 }
             }
         }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Analyzer.Utilities.PooledObjects;
+
+namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
+{
+    internal static class DocumentationCommentIdParser
+    {
+        public static bool ParseDeclaredSymbolId(string id, ArrayBuilder<(string ParentName, string SymbolName)> results)
+        {
+            if (id == null)
+                return false;
+
+            if (id.Length < 2)
+                return false;
+
+            int index = 0;
+            results.Clear();
+            ParseDeclaredId(id, ref index, results);
+            return results.Count > 0;
+        }
+
+        private static void ParseDeclaredId(string id, ref int index, ArrayBuilder<(string ParentName, string SymbolName)> results)
+        {
+            var kindChar = PeekNextChar(id, index);
+
+            switch (kindChar)
+            {
+                case 'E': // Events
+                case 'F': // Fields
+                case 'M': // Methods
+                case 'P': // Properties
+                case 'T': // Types
+                    break;
+                case 'N': // Namespaces
+                default:
+                    // Documentation comment id must start with E, F, M, N, P or T. Note: we don't support banning full
+                    // namespaces, so we bail in that case as well.
+                    return;
+            }
+
+            index++;
+            if (PeekNextChar(id, index) == ':')
+                index++;
+
+            string parentName = "";
+
+            // process dotted names
+            while (true)
+            {
+                var symbolName = ParseName(id, ref index);
+
+                // has type parameters?
+                if (PeekNextChar(id, index) == '`')
+                {
+                    index++;
+
+                    // method type parameters?
+                    if (PeekNextChar(id, index) == '`')
+                        index++;
+
+                    ReadNextInteger(id, ref index);
+                }
+
+                if (PeekNextChar(id, index) == '.')
+                {
+                    index++;
+                    parentName = symbolName;
+                    continue;
+                }
+                else
+                {
+                    results.Add((parentName, symbolName));
+                }
+            }
+        }
+
+        private static char PeekNextChar(string id, int index)
+        {
+            return index >= id.Length ? '\0' : id[index];
+        }
+
+        private static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };
+
+        private static string ParseName(string id, ref int index)
+        {
+            string name;
+
+            int delimiterOffset = id.IndexOfAny(s_nameDelimiters, index);
+            if (delimiterOffset >= 0)
+            {
+                name = id[index..delimiterOffset];
+                index = delimiterOffset;
+            }
+            else
+            {
+                name = id[index..];
+                index = id.Length;
+            }
+
+            return DecodeName(name);
+        }
+
+        // undoes dot encodings within names...
+        private static string DecodeName(string name)
+            => name.IndexOf('#') >= 0 ? name.Replace('#', '.') : name;
+
+        private static int ReadNextInteger(string id, ref int index)
+        {
+            int n = 0;
+
+            while (index < id.Length && char.IsDigit(id[index]))
+            {
+                n = n * 10 + (id[index] - '0');
+                index++;
+            }
+
+            return n;
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/DocumentationCommentIdParser.cs
@@ -4,6 +4,8 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 {
     internal static class DocumentationCommentIdParser
     {
+        private static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };
+
         public static (string ParentName, string SymbolName)? ParseDeclaredSymbolId(string id)
         {
             if (id == null)
@@ -72,11 +74,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
         }
 
         private static char PeekNextChar(string id, int index)
-        {
-            return index >= id.Length ? '\0' : id[index];
-        }
-
-        private static readonly char[] s_nameDelimiters = { ':', '.', '(', ')', '{', '}', '[', ']', ',', '\'', '@', '*', '`', '~' };
+            => index >= id.Length ? '\0' : id[index];
 
         private static string ParseName(string id, ref int index)
         {
@@ -94,12 +92,8 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 index = id.Length;
             }
 
-            return DecodeName(name);
+            return name.Replace('#', '.');
         }
-
-        // undoes dot encodings within names...
-        private static string DecodeName(string name)
-            => name.IndexOf('#') >= 0 ? name.Replace('#', '.') : name;
 
         private static void ReadNextInteger(string id, ref int index)
         {

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             var errors = new List<Diagnostic>();
 
             // Report any duplicates.
-            var groups = entries.GroupBy(e => e.DeclarationId);
+            var groups = entries.GroupBy(e => TrimForErrorReporting(e.DeclarationId));
             foreach (var group in groups)
             {
                 if (group.Count() >= 2)
@@ -123,6 +123,18 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             }
 
             return result.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
+
+            static string TrimForErrorReporting(string declarationId)
+            {
+                return declarationId switch
+                {
+                    // Remove the prefix and colon if there.
+                    [_, ':', .. var rest] => rest,
+                    // Colon is technically optional.  So remove just the first character if not there.
+                    [_, .. var rest] => rest,
+                    _ => declarationId,
+                };
+            }
         }
     }
 }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -69,12 +69,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             var entries = query.ToList();
 
             if (entries.Count == 0)
-            {
                 return null;
-            }
 
             var errors = new List<Diagnostic>();
-
             var result = new Dictionary<ISymbol, BanFileEntry>(SymbolEqualityComparer.Default);
 
             foreach (var line in entries)
@@ -103,9 +100,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                     endContext =>
                     {
                         foreach (var error in errors)
-                        {
                             endContext.ReportDiagnostic(error);
-                        }
                     });
             }
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -76,16 +76,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             var errors = new List<Diagnostic>();
 
-            if (errors.Count != 0)
-            {
-                compilationContext.RegisterCompilationEndAction(
-                    endContext =>
-                    {
-                        foreach (var error in errors)
-                            endContext.ReportDiagnostic(error);
-                    });
-            }
-
             // Report any duplicates.
             var groups = entries.GroupBy(e => e.DeclarationId);
             foreach (var group in groups)
@@ -103,6 +93,16 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                             firstEntry.Symbols.FirstOrDefault()?.ToDisplayString() ?? ""));
                     }
                 }
+            }
+
+            if (errors.Count != 0)
+            {
+                compilationContext.RegisterCompilationEndAction(
+                    endContext =>
+                    {
+                        foreach (var error in errors)
+                            endContext.ReportDiagnostic(error);
+                    });
             }
 
             var result = new Dictionary<(string ContainerName, string SymbolName), List<BanFileEntry>>();

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
-using System;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
-using Microsoft.CodeAnalysis.Operations;
 using Analyzer.Utilities.Extensions;
-using Analyzer.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 {
     public abstract class SymbolIsBannedAnalyzerBase<TSyntaxKind> : DiagnosticAnalyzer
         where TSyntaxKind : struct
     {
-        protected abstract Dictionary<ISymbol, BanFileEntry>? ReadBannedApis(CompilationStartAnalysisContext compilationContext);
+        protected abstract Dictionary<(string ContainerName, string SymbolName), ImmutableArray<BanFileEntry>>? ReadBannedApis(CompilationStartAnalysisContext compilationContext);
 
         protected abstract DiagnosticDescriptor SymbolIsBannedRule { get; }
 
@@ -38,18 +38,11 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
         private void OnCompilationStart(CompilationStartAnalysisContext compilationContext)
         {
-            var entryBySymbol = ReadBannedApis(compilationContext);
-
-            if (entryBySymbol == null || entryBySymbol.Count == 0)
-            {
+            var bannedApis = ReadBannedApis(compilationContext);
+            if (bannedApis == null || bannedApis.Count == 0)
                 return;
-            }
 
-            Dictionary<ISymbol, BanFileEntry> entryByAttributeSymbol = entryBySymbol
-                .Where(pair => pair.Key is ITypeSymbol n && n.IsAttribute())
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
-
-            if (entryByAttributeSymbol.Count > 0)
+            if (ShouldAnalyzeAttributes())
             {
                 compilationContext.RegisterCompilationEndAction(
                     context =>
@@ -156,11 +149,53 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             return;
 
+            bool IsBannedSymbol([NotNullWhen(true)] ISymbol? symbol, [NotNullWhen(true)] out BanFileEntry? entry)
+            {
+                if (symbol is { ContainingSymbol.Name: string parentName } &&
+                    bannedApis.TryGetValue((parentName, symbol.Name), out var entries))
+                {
+                    foreach (var bannedFileEntry in entries)
+                    {
+                        foreach (var bannedSymbol in bannedFileEntry.Symbols)
+                        {
+                            if (SymbolEqualityComparer.Default.Equals(symbol, bannedSymbol))
+                            {
+                                entry = bannedFileEntry;
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                entry = null;
+                return false;
+            }
+
+            bool ShouldAnalyzeAttributes()
+            {
+                foreach (var kvp in bannedApis)
+                {
+                    if (!kvp.Key.SymbolName.EndsWith("Attribute", StringComparison.InvariantCulture))
+                        continue;
+
+                    foreach (var entry in kvp.Value)
+                    {
+                        if (entry.DeclarationId.StartsWith("T:", StringComparison.InvariantCulture) &&
+                            entry.Symbols.Any(s => s is INamedTypeSymbol namedType && namedType.IsAttribute()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
             void VerifyAttributes(Action<Diagnostic> reportDiagnostic, ImmutableArray<AttributeData> attributes, CancellationToken cancellationToken)
             {
                 foreach (var attribute in attributes)
                 {
-                    if (attribute.AttributeClass is { } attributeClass && entryByAttributeSymbol.TryGetValue(attributeClass, out var entry))
+                    if (IsBannedSymbol(attribute.AttributeClass, out var entry))
                     {
                         var node = attribute.ApplicationSyntaxReference?.GetSyntax(cancellationToken);
                         if (node != null)
@@ -168,7 +203,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                             reportDiagnostic(
                                 node.CreateDiagnostic(
                                     SymbolIsBannedRule,
-                                    attributeClass.ToDisplayString(),
+                                    attribute.AttributeClass.ToDisplayString(),
                                     string.IsNullOrWhiteSpace(entry.Message) ? "" : ": " + entry.Message));
                         }
                     }
@@ -177,8 +212,6 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             bool VerifyType(Action<Diagnostic> reportDiagnostic, ITypeSymbol? type, SyntaxNode syntaxNode)
             {
-                RoslynDebug.Assert(entryBySymbol != null);
-
                 do
                 {
                     if (!VerifyTypeArguments(reportDiagnostic, type, syntaxNode, out type))
@@ -192,7 +225,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                         return true;
                     }
 
-                    if (entryBySymbol.TryGetValue(type, out var entry))
+                    if (IsBannedSymbol(type, out var entry))
                     {
                         reportDiagnostic(
                             syntaxNode.CreateDiagnostic(
@@ -246,11 +279,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             void VerifySymbol(Action<Diagnostic> reportDiagnostic, ISymbol symbol, SyntaxNode syntaxNode)
             {
-                RoslynDebug.Assert(entryBySymbol != null);
-
                 foreach (var currentSymbol in GetSymbolAndOverridenSymbols(symbol))
                 {
-                    if (entryBySymbol.TryGetValue(currentSymbol, out var entry))
+                    if (IsBannedSymbol(currentSymbol, out var entry))
                     {
                         reportDiagnostic(
                             syntaxNode.CreateDiagnostic(
@@ -301,7 +332,10 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             public string DeclarationId { get; }
             public string Message { get; }
 
-            public BanFileEntry(string text, TextSpan span, SourceText sourceText, string path)
+            private readonly Lazy<ImmutableArray<ISymbol>> _lazySymbols;
+            public ImmutableArray<ISymbol> Symbols => _lazySymbols.Value;
+
+            public BanFileEntry(Compilation compilation, string text, TextSpan span, SourceText sourceText, string path)
             {
                 // Split the text on semicolon into declaration ID and message
                 var index = text.IndexOf(';');
@@ -325,6 +359,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 Span = span;
                 SourceText = sourceText;
                 Path = path;
+
+                _lazySymbols = new Lazy<ImmutableArray<ISymbol>>(
+                    () => DocumentationCommentId.GetSymbolsForDeclarationId(DeclarationId, compilation));
             }
 
             public Location Location => Location.Create(Path, Span, SourceText.Lines.GetLinePositionSpan(Span));

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
@@ -63,6 +63,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
             compilationContext.RegisterOperationAction(
                 context =>
                 {
+                    context.CancellationToken.ThrowIfCancellationRequested();
                     switch (context.Operation)
                     {
                         case IObjectCreationOperation objectCreation:
@@ -193,6 +194,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             void VerifyAttributes(Action<Diagnostic> reportDiagnostic, ImmutableArray<AttributeData> attributes, CancellationToken cancellationToken)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 foreach (var attribute in attributes)
                 {
                     if (IsBannedSymbol(attribute.AttributeClass, out var entry))

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzerBase.cs
@@ -174,6 +174,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
             bool ShouldAnalyzeAttributes()
             {
+                // We want to avoid realizing symbols here as that can be very expensive.  So we instead use a simple
+                // heuristic which works thanks to .net coding conventions.  Specifically, we look to see if the banned
+                // api is a type that ends in 'Attribute'.  In that case, we do the work to try to get the real symbol.
                 foreach (var kvp in bannedApis)
                 {
                     if (!kvp.Key.SymbolName.EndsWith("Attribute", StringComparison.InvariantCulture))
@@ -181,7 +184,7 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
 
                     foreach (var entry in kvp.Value)
                     {
-                        if (entry.DeclarationId.StartsWith("T:", StringComparison.InvariantCulture) &&
+                        if (entry.DeclarationId.StartsWith("T", StringComparison.InvariantCulture) &&
                             entry.Symbols.Any(s => s is INamedTypeSymbol namedType && namedType.IsAttribute()))
                         {
                             return true;


### PR DESCRIPTION
The core problem here is that hte BannedSymbols analyzer starts with a top down walk that attempts to find the corresponding ISymbol for a symbol in the symbol tree.  This can be quite expensive as the compiler has to realize all the symbols downwards (in order to look up those names), including walking into symbols that might be enormous (consider large namespaces, or types with 10s of thousands of members).

This PR flips the general idea of hte banned-analyzer around.  Instead of upfront computing the list of banned symbols, we instead look for the *names* (and container names) specified in BannedSymbols.txt.  Then, as we're analyzing, *only* if we hit a real symbol with those names, do we attempt to them go map the banned-symbol line back to actual ISymbols, which we then compare the current symbol being analyzed.

This means, if the code being analyzed never actually refers to the potential bad symbol, we don't pay any price looking it up.

Addresses 600 MB of allocations in a simple typing/lightbulb scenario:

![image](https://user-images.githubusercontent.com/4564579/229911596-f884f714-2042-4fdb-a8f1-7cc7ad47d75b.png)
