### PR TITLE
Improve performance of spell checking analyzer

### DIFF
--- a/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
+++ b/src/Text.Analyzers/Core/IdentifiersShouldBeSpelledCorrectly.cs
@@ -26,7 +26,7 @@ namespace Text.Analyzers
         private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyTitle));
         private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(IdentifiersShouldBeSpelledCorrectlyDescription));
 
-        private static readonly SourceTextValueProvider<(CodeAnalysisDictionary dictionary, Exception? exception)> s_xmlDictionaryProvider = new(static text => ParseDictionary(text, isXml: false));
+        private static readonly SourceTextValueProvider<(CodeAnalysisDictionary dictionary, Exception? exception)> s_xmlDictionaryProvider = new(static text => ParseDictionary(text, isXml: true));
         private static readonly SourceTextValueProvider<(CodeAnalysisDictionary dictionary, Exception? exception)> s_dicDictionaryProvider = new(static text => ParseDictionary(text, isXml: false));
         private static readonly CodeAnalysisDictionary s_mainDictionary = GetMainDictionary();
 


### PR DESCRIPTION
Addresses the enormous amount of dictionary allocations performed on every compilation start:

![image](https://user-images.githubusercontent.com/4564579/229929701-bb87ebf8-33a0-4748-a766-865d7b3e2444.png)
