### PR TITLE
Publish packages

### DIFF
--- a/nuget/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.Package.csproj
+++ b/nuget/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.Package.csproj
@@ -12,6 +12,7 @@
     <ReleaseNotes>Source generator for resource files</ReleaseNotes>
     <PackageTags>Microsoft.CodeAnalysis.ResxSourceGenerator, analyzers</PackageTags>
     <ReleaseTrackingOptOut>true</ReleaseTrackingOptOut>
+    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj
+++ b/nuget/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.Package.csproj
@@ -13,6 +13,7 @@
     <PackageTags>Roslyn CodeAnalysis Compiler CSharp Diagnostic Analyzers Syntax Semantics Performance</PackageTags>
     <AnalyzerDocumentationFileDir>$(RepoRoot)src\PerformanceSensitiveAnalyzers</AnalyzerDocumentationFileDir>
     <AnalyzerSarifFileDir>$(RepoRoot)src\PerformanceSensitiveAnalyzers</AnalyzerSarifFileDir>
+    <IsShippingPackage>true</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes a failure to publish ResxSourceGenerator and PerformanceSensitiveAnalyzers to any consumable package feed.