### PR TITLE
Only pack the non-stable artifacts in SB

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -4,6 +4,16 @@
     <GitHubRepositoryName>roslyn-analyzers</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
     <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
+    <!-- roslyn-analyzers produces stable release branded and stable pre-release branded artifacts in addition to the normal non-stable artifacts.
+         Only the non-stable artifacts should flow downstream in source build -->
+    <EnableDefaultSourceBuildIntermediateItems>false</EnableDefaultSourceBuildIntermediateItems>
   </PropertyGroup>
+
+  <Target Name="GetCustomIntermediateNupkgContents" BeforeTargets="GetCategorizedIntermediateNupkgContents">
+    <ItemGroup>
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)Shipping\**\*.nupkg" />
+      <IntermediateNupkgArtifactFile Include="$(CurrentRepoSourceBuildArtifactsPackagesDir)NonShipping\**\*.nupkg" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Avoid packing release, pre-release stable nupkgs

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
