### PR TITLE
Upgrade CA1812 and CA1852 to handle ivt

### DIFF
--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -875,7 +875,7 @@ Default Value: `false`
 
 Example: `dotnet_code_quality.CA1851.assume_method_enumerates_parameters = true`
 
-### Proceed with analysis event if InternalsVisibleTo is present
+### Proceed with analysis even if InternalsVisibleTo is present
 
 Option Name: `ignore_internalsvisibleto`
 

--- a/docs/Analyzer Configuration.md
+++ b/docs/Analyzer Configuration.md
@@ -874,3 +874,18 @@ If set to true, all IEnumerable type parameters would be assumed enumerated by t
 Default Value: `false`
 
 Example: `dotnet_code_quality.CA1851.assume_method_enumerates_parameters = true`
+
+### Proceed with analysis event if InternalsVisibleTo is present
+
+Option Name: `ignore_internalsvisibleto`
+
+Configurable Rules: [CA1812](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/CA1812), [CA1852](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/CA1852)
+
+Option Values: `true` or `false`
+Certain diagnostics are normally disabled if the assembly being analyzed used the InternalsVisibleTo attribute to
+expose the assembly's internal symbols. This option lets you override this behavior and proceed with analysis
+regardless of whether the attribute is present.
+
+Default Value: `false`
+
+Example: `dotnet_code_quality.CA1852.ignore_internalsvisibleto = false`

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -229,5 +229,10 @@ namespace Analyzer.Utilities
         /// String option to configure names of additional "None" enum case (separated by '|') for CA1008.
         /// </summary>
         public const string AdditionalEnumNoneNames = "additional_enum_none_names";
+
+        /// <summary>
+        /// Boolean option whether to perform the analysis even if the assembly exposes its internals.
+        /// </summary>
+        public const string IgnoreInternalsVisibleTo = "ignore_internalsvisibleto";
     }
 }


### PR DESCRIPTION
- Introduce the `ignore_internalsvisibleto` option to CA1812 and CA1852, enabling these rules to run even though an assembly has got InternalsVisibleTo definitions. The option defaults to `false` to maintain compatibility.

See https://github.com/dotnet/roslyn-analyzers/issues/5973

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
