### PR TITLE
Add check for interface implementations, CA1054

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
@@ -98,15 +98,15 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
-                if (method.ExplicitInterfaceImplementations.Length > 0)
-                {
-                    // should not warn for implementations of interfaces that may be out of our control
-                    return;
-                }
-
                 if (method.ContainingType.DerivesFrom(_attribute, baseTypesOnly: true))
                 {
                     // Attributes cannot accept System.Uri objects as positional or optional attributes
+                    return;
+                }
+
+                if (method.IsImplementationOfAnyInterfaceMember())
+                {
+                    // should not warn for implementations of interfaces that may be out of our control
                     return;
                 }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.cs
@@ -98,6 +98,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     return;
                 }
 
+                if (method.ExplicitInterfaceImplementations.Length > 0)
+                {
+                    // should not warn for implementations of interfaces that may be out of our control
+                    return;
+                }
+
                 if (method.ContainingType.DerivesFrom(_attribute, baseTypesOnly: true))
                 {
                     // Attributes cannot accept System.Uri objects as positional or optional attributes

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
 
         }
 
-        [Fact]
+        [Fact, WorkItem(6371, "https://github.com/dotnet/roslyn-analyzers/issues/6371")]
         public async Task CA1054NoWarningsForInterfaceImplementationsAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStringsTests.cs
@@ -154,6 +154,36 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         }
 
         [Fact]
+        public async Task CA1054NoWarningsForInterfaceImplementationsAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+    using System;
+
+    public interface IUrlInterface1
+    {
+        void Method(string url);
+    }
+
+    public interface IUrlInterface2
+    {
+        void Method(string url);
+    }
+
+    public class A : IUrlInterface1, IUrlInterface2
+    {
+        public void Method(string url) // Implements IUrlInterface1, implicitly
+        {
+        }
+
+        void IUrlInterface2.Method(string url) // Implements IUrlInterface2, explicitly
+        {
+        }
+    }
+", GetCA1054CSharpResultAt(6, 28, "url", "IUrlInterface1.Method(string)")
+ , GetCA1054CSharpResultAt(11, 28, "url", "IUrlInterface2.Method(string)"));
+        }
+
+        [Fact]
         public async Task CA1054NoWarningNotPublicAsync()
         {
             await VerifyCS.VerifyAnalyzerAsync(@"


### PR DESCRIPTION
## Summary

Adds check for interface implementations when checking for string URI parameters, as these can be out of the user's control.

Fixes #6371 