### PR TITLE
Emit CA1822 for recursive method.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -104,7 +104,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                     blockStartContext.RegisterOperationAction(operationContext =>
                     {
-                        if (((IInstanceReferenceOperation)operationContext.Operation).ReferenceKind == InstanceReferenceKind.ContainingTypeInstance)
+                        if (((IInstanceReferenceOperation)operationContext.Operation).ReferenceKind == InstanceReferenceKind.ContainingTypeInstance
+                            && (operationContext.Operation.Parent is not IInvocationOperation invocation || !invocation.TargetMethod.Equals(methodSymbol, SymbolEqualityComparer.Default)))
                         {
                             isInstanceReferenced = true;
                         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -1461,5 +1461,45 @@ Public Class C
         End Sub
 End Class");
         }
+
+        [Fact, WorkItem(6540, "https://github.com/dotnet/roslyn-analyzers/issues/6540")]
+        public Task RecursiveMethod_DiagnosticAsync()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using System;
+
+public class Test
+{
+    public void [|Recursive|](string argument)
+	{
+		if (argument.Length > 1)
+		{
+            Recursive(argument[1..]);
+		}
+
+		Console.WriteLine($""argument[-1]: {argument}"");
+    }
+}",
+                FixedCode = @"
+using System;
+
+public class Test
+{
+    public static void Recursive(string argument)
+	{
+		if (argument.Length > 1)
+		{
+            Recursive(argument[1..]);
+		}
+
+		Console.WriteLine($""argument[-1]: {argument}"");
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp8
+            }.RunAsync();
+        }
+
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.cs
@@ -1500,6 +1500,5 @@ public class Test
                 LanguageVersion = LanguageVersion.CSharp8
             }.RunAsync();
         }
-
     }
 }


### PR DESCRIPTION
The `MarkMembersAsStaticAnalyzer` currently checks if a method contains any instance reference operations. This PR adds an exclusion of the method itself, i.e. a recursive method, to that check.

Fixes #6540