### PR TITLE
Improve messaging of CA1861

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -220,11 +220,11 @@
     <value>Extract to static readonly field</value>
   </data>
   <data name="AvoidConstArraysDescription" xml:space="preserve">
-    <value>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</value>
+    <value>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</value>
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="AvoidConstArraysMessage" xml:space="preserve">
-    <value>Prefer 'static readonly' fields over local constant array arguments</value>
+    <value>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</value>
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="TestForEmptyStringsUsingStringLengthTitle" xml:space="preserve">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -224,7 +224,7 @@
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="AvoidConstArraysMessage" xml:space="preserve">
-    <value>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</value>
+    <value>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</value>
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="TestForEmptyStringsUsingStringLengthTitle" xml:space="preserve">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -220,11 +220,11 @@
     <value>Extract to static readonly field</value>
   </data>
   <data name="AvoidConstArraysDescription" xml:space="preserve">
-    <value>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</value>
+    <value>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</value>
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="AvoidConstArraysMessage" xml:space="preserve">
-    <value>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</value>
+    <value>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</value>
     <comment>{Locked="static readonly"}</comment>
   </data>
   <data name="TestForEmptyStringsUsingStringLengthTitle" xml:space="preserve">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Konstantní pole předaná jako argumenty se znovu nepoužívají, což znamená režijní výkon. Zvažte možnost extrahovat je do polí „static readonly“ pro zlepšení výkonu.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Konstantní pole předaná jako argumenty se znovu nepoužívají, což znamená režijní výkon. Zvažte možnost extrahovat je do polí „static readonly“ pro zlepšení výkonu.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Upřednostňujte pole „static readonly“ před argumenty místního konstantního pole.</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Upřednostňujte pole „static readonly“ před argumenty místního konstantního pole.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Konstantní pole předaná jako argumenty se znovu nepoužívají, což znamená režijní výkon. Zvažte možnost extrahovat je do polí „static readonly“ pro zlepšení výkonu.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Upřednostňujte pole „static readonly“ před argumenty místního konstantního pole.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Upřednostňujte pole „static readonly“ před argumenty místního konstantního pole.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Konstantenmatrizen, die als Argumente übergeben werden, werden nicht wiederverwendet, was einen Leistungsaufwand impliziert. Ziehen Sie in Betracht, sie in „static readonly“-Felder zu extrahieren, um die Leistung zu verbessern.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">„static readonly“-Felder lokalen Konstantenmatrizenargumenten vorziehen</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Konstantenmatrizen, die als Argumente übergeben werden, werden nicht wiederverwendet, was einen Leistungsaufwand impliziert. Ziehen Sie in Betracht, sie in „static readonly“-Felder zu extrahieren, um die Leistung zu verbessern.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Konstantenmatrizen, die als Argumente übergeben werden, werden nicht wiederverwendet, was einen Leistungsaufwand impliziert. Ziehen Sie in Betracht, sie in „static readonly“-Felder zu extrahieren, um die Leistung zu verbessern.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">„static readonly“-Felder lokalen Konstantenmatrizenargumenten vorziehen</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">„static readonly“-Felder lokalen Konstantenmatrizenargumenten vorziehen</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">„static readonly“-Felder lokalen Konstantenmatrizenargumenten vorziehen</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Las matrices constantes pasadas como argumentos no se reutilizan, lo que implica una sobrecarga de rendimiento. Considere la posibilidad de extraerlos en campos ''static readonly'' para mejorar el rendimiento.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Preferir los campos "static readonly" en lugar de los argumentos de matriz constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Las matrices constantes pasadas como argumentos no se reutilizan, lo que implica una sobrecarga de rendimiento. Considere la posibilidad de extraerlos en campos ''static readonly'' para mejorar el rendimiento.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Las matrices constantes pasadas como argumentos no se reutilizan, lo que implica una sobrecarga de rendimiento. Considere la posibilidad de extraerlos en campos ''static readonly'' para mejorar el rendimiento.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Preferir los campos "static readonly" en lugar de los argumentos de matriz constante local</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Preferir los campos "static readonly" en lugar de los argumentos de matriz constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Preferir los campos "static readonly" en lugar de los argumentos de matriz constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Préférer les champs ’static readonly’ aux arguments de tableau de constantes locaux</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Les tableaux de constantes passés en tant qu’arguments ne sont pas réutilisés, ce qui implique une surcharge du niveau de performance. Envisagez de les extraire dans ’static readonly’ champs pour améliorer le niveau de performance.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Les tableaux de constantes passés en tant qu’arguments ne sont pas réutilisés, ce qui implique une surcharge du niveau de performance. Envisagez de les extraire dans ’static readonly’ champs pour améliorer le niveau de performance.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Préférer les champs ’static readonly’ aux arguments de tableau de constantes locaux</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Préférer les champs ’static readonly’ aux arguments de tableau de constantes locaux</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Les tableaux de constantes passés en tant qu’arguments ne sont pas réutilisés, ce qui implique une surcharge du niveau de performance. Envisagez de les extraire dans ’static readonly’ champs pour améliorer le niveau de performance.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Préférer les champs ’static readonly’ aux arguments de tableau de constantes locaux</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Le matrici costanti passate come argomenti non vengono riutilizzate e ciò implica un sovraccarico delle prestazioni. È consigliabile estrarli in campi ‘static readonly' per migliorare le prestazioni.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Preferire i campi ‘static readonly' rispetto agli argomenti della matrice di costanti locali</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Le matrici costanti passate come argomenti non vengono riutilizzate e ciò implica un sovraccarico delle prestazioni. È consigliabile estrarli in campi ‘static readonly' per migliorare le prestazioni.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Le matrici costanti passate come argomenti non vengono riutilizzate e ciò implica un sovraccarico delle prestazioni. È consigliabile estrarli in campi ‘static readonly' per migliorare le prestazioni.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Preferire i campi ‘static readonly' rispetto agli argomenti della matrice di costanti locali</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Preferire i campi ‘static readonly' rispetto agli argomenti della matrice di costanti locali</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Preferire i campi ‘static readonly' rispetto agli argomenti della matrice di costanti locali</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">ローカルの定数配列引数よりも 'static readonly' フィールドを優先する</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">引数として渡された定数配列は再利用されません。これはパフォーマンスのオーバーヘッドを意味します。パフォーマンスを向上させるために、それらを 'static readonly' フィールドに抽出することを検討してください。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">ローカルの定数配列引数よりも 'static readonly' フィールドを優先する</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">引数として渡された定数配列は再利用されません。これはパフォーマンスのオーバーヘッドを意味します。パフォーマンスを向上させるために、それらを 'static readonly' フィールドに抽出することを検討してください。</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">引数として渡された定数配列は再利用されません。これはパフォーマンスのオーバーヘッドを意味します。パフォーマンスを向上させるために、それらを 'static readonly' フィールドに抽出することを検討してください。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">ローカルの定数配列引数よりも 'static readonly' フィールドを優先する</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">ローカルの定数配列引数よりも 'static readonly' フィールドを優先する</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">인수로 전달된 상수 배열은 재사용되지 않으므로 성능 오버헤드가 발생합니다. 성능을 향상시키려면 'static readonly' 필드로 추출하는 것이 좋습니다.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">로컬 상수 배열 인수보다 'static readonly' 필드 선호</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">인수로 전달된 상수 배열은 재사용되지 않으므로 성능 오버헤드가 발생합니다. 성능을 향상시키려면 'static readonly' 필드로 추출하는 것이 좋습니다.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">인수로 전달된 상수 배열은 재사용되지 않으므로 성능 오버헤드가 발생합니다. 성능을 향상시키려면 'static readonly' 필드로 추출하는 것이 좋습니다.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">로컬 상수 배열 인수보다 'static readonly' 필드 선호</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">로컬 상수 배열 인수보다 'static readonly' 필드 선호</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">로컬 상수 배열 인수보다 'static readonly' 필드 선호</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Preferuj pola „static readonly” niż argumenty lokalnej tablicy stałej</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Tablice stałe przekazywane jako argumenty nie są ponownie używane, co oznacza narzut na wydajność. Rozważ wyodrębnienie ich do pól „static readonly”, aby zwiększyć wydajność.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Preferuj pola „static readonly” niż argumenty lokalnej tablicy stałej</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Tablice stałe przekazywane jako argumenty nie są ponownie używane, co oznacza narzut na wydajność. Rozważ wyodrębnienie ich do pól „static readonly”, aby zwiększyć wydajność.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Tablice stałe przekazywane jako argumenty nie są ponownie używane, co oznacza narzut na wydajność. Rozważ wyodrębnienie ich do pól „static readonly”, aby zwiększyć wydajność.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Preferuj pola „static readonly” niż argumenty lokalnej tablicy stałej</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Preferuj pola „static readonly” niż argumenty lokalnej tablicy stałej</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Matrizes constantes passadas como argumentos não são reutilizadas, o que implica em uma sobrecarga de desempenho. Considere extraí-los para campos 'static readonly' para melhorar o desempenho.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Matrizes constantes passadas como argumentos não são reutilizadas, o que implica em uma sobrecarga de desempenho. Considere extraí-los para campos 'static readonly' para melhorar o desempenho.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Prefira campos 'static readonly' em vez de argumentos de matriz de constante local</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Prefira campos 'static readonly' em vez de argumentos de matriz de constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Matrizes constantes passadas como argumentos não são reutilizadas, o que implica em uma sobrecarga de desempenho. Considere extraí-los para campos 'static readonly' para melhorar o desempenho.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Prefira campos 'static readonly' em vez de argumentos de matriz de constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Prefira campos 'static readonly' em vez de argumentos de matriz de constante local</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Константные массивы, переданные в качестве аргументов, не используются повторно, что приводит к снижению производительности. Рассмотрите возможность извлечения их в статические поля "static readonly", чтобы повысить производительность.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">Отдавайте предпочтение полям "static readonly", а не аргументам локального константного массива</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">Отдавайте предпочтение полям "static readonly", а не аргументам локального константного массива</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Константные массивы, переданные в качестве аргументов, не используются повторно, что приводит к снижению производительности. Рассмотрите возможность извлечения их в статические поля "static readonly", чтобы повысить производительность.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Константные массивы, переданные в качестве аргументов, не используются повторно, что приводит к снижению производительности. Рассмотрите возможность извлечения их в статические поля "static readonly", чтобы повысить производительность.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">Отдавайте предпочтение полям "static readonly", а не аргументам локального константного массива</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">Отдавайте предпочтение полям "static readonly", а не аргументам локального константного массива</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">Bağımsız değişkenler olarak iletilen sabit diziler yeniden kullanılmaz ve bu durum, bir performans ek yüküne işaret eder. Performansı iyileştirmek için bunları 'static readonly' alanlara ayıklamayı deneyin.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">'static readonly' alanları yerel sabit dizi bağımsız değişkenlerine tercih edin</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">Bağımsız değişkenler olarak iletilen sabit diziler yeniden kullanılmaz ve bu durum, bir performans ek yüküne işaret eder. Performansı iyileştirmek için bunları 'static readonly' alanlara ayıklamayı deneyin.</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">Bağımsız değişkenler olarak iletilen sabit diziler yeniden kullanılmaz ve bu durum, bir performans ek yüküne işaret eder. Performansı iyileştirmek için bunları 'static readonly' alanlara ayıklamayı deneyin.</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">'static readonly' alanları yerel sabit dizi bağımsız değişkenlerine tercih edin</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">'static readonly' alanları yerel sabit dizi bağımsız değişkenlerine tercih edin</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">'static readonly' alanları yerel sabit dizi bağımsız değişkenlerine tercih edin</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">作为参数传递的常量数组未重复使用，这表示存在性能开销。请考虑将它们提取到 "static readonly" 字段来提高性能。</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">作为参数传递的常量数组未重复使用，这表示存在性能开销。请考虑将它们提取到 "static readonly" 字段来提高性能。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">首选 "static readonly" 字段而不是局部常量数组参数</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">首选 "static readonly" 字段而不是局部常量数组参数</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">作为参数传递的常量数组未重复使用，这表示存在性能开销。请考虑将它们提取到 "static readonly" 字段来提高性能。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">首选 "static readonly" 字段而不是局部常量数组参数</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">首选 "static readonly" 字段而不是局部常量数组参数</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -58,7 +58,7 @@
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array</source>
         <target state="needs-review-translation">優先使用 'static readonly' (「靜態唯讀」) 欄位而不是本機常數陣列引數</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -53,12 +53,12 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <source>Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
         <target state="needs-review-translation">不重複使用以引數傳遞的常數陣列，這表示效能額外負荷。請考慮將它們解壓縮至 'static readonly' (「靜態唯讀」) 欄位，以提升效能。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array and it is called repeatedly</source>
         <target state="needs-review-translation">優先使用 'static readonly' (「靜態唯讀」) 欄位而不是本機常數陣列引數</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -53,13 +53,13 @@
         <note />
       </trans-unit>
       <trans-unit id="AvoidConstArraysDescription">
-        <source>Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.</source>
-        <target state="translated">不重複使用以引數傳遞的常數陣列，這表示效能額外負荷。請考慮將它們解壓縮至 'static readonly' (「靜態唯讀」) 欄位，以提升效能。</target>
+        <source>Constant arrays passed as arguments are not reused which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.</source>
+        <target state="needs-review-translation">不重複使用以引數傳遞的常數陣列，這表示效能額外負荷。請考慮將它們解壓縮至 'static readonly' (「靜態唯讀」) 欄位，以提升效能。</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysMessage">
-        <source>Prefer 'static readonly' fields over local constant array arguments</source>
-        <target state="translated">優先使用 'static readonly' (「靜態唯讀」) 欄位而不是本機常數陣列引數</target>
+        <source>Prefer 'static readonly' fields over constant array arguments if the called method is not mutating the passed array</source>
+        <target state="needs-review-translation">優先使用 'static readonly' (「靜態唯讀」) 欄位而不是本機常數陣列引數</target>
         <note>{Locked="static readonly"}</note>
       </trans-unit>
       <trans-unit id="AvoidConstArraysTitle">

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1694,7 +1694,7 @@ Prefer using 'IsEmpty', 'Count' or 'Length' properties whichever available, rath
 
 ## [CA1861](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861): Avoid constant arrays as arguments
 
-Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.
+Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.
 
 |Item|Value|
 |-|-|

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3138,7 +3138,7 @@
         "CA1861": {
           "id": "CA1861",
           "shortDescription": "Avoid constant arrays as arguments",
-          "fullDescription": "Constant arrays passed as arguments are not reused which implies a performance overhead. Consider extracting them to 'static readonly' fields to improve performance.",
+          "fullDescription": "Constant arrays passed as arguments are not reused when called repeatedly, which implies a new array is created each time. Consider extracting them to 'static readonly' fields to improve performance if the passed array is not mutated within the called method.",
           "defaultLevel": "note",
           "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861",
           "properties": {

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -8,6 +8,4 @@ CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513> | Use ObjectDisposedException throw helper |
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
-CA1859 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1859> | Use concrete types when possible for improved performance |
-CA1861 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861> | Avoid constant arrays as arguments |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |


### PR DESCRIPTION
Updating messaging of CA1861 to apply the suggestion if the array argument is not mutated within the invoked method

Related to https://github.com/dotnet/runtime/pull/86229#issuecomment-1552360091 and https://github.com/dotnet/runtime/issues/86414
