### PR TITLE
Don't emit CA1861 for static ReadOnlyCollections

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.cs
@@ -37,12 +37,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
-            context.RegisterCompilationStartAction(static context =>
+            context.RegisterCompilationStartAction(context =>
             {
                 var knownTypeProvider = WellKnownTypeProvider.GetOrCreate(context.Compilation);
                 INamedTypeSymbol? readonlySpanType = knownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemReadOnlySpan1);
                 INamedTypeSymbol? functionType = knownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemFunc2);
-                INamedTypeSymbol? readOnlyCollectionType = knownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsObjectModelReadOnlyCollection1);
 
                 // Analyzes an argument operation
                 context.RegisterOperationAction(context =>
@@ -60,8 +59,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                         // If no argument, return
                         // If argument is passed as a params array but isn't itself an array, return
-                        // If argument is passed to a static ReadOnlyCollection<T>, return
-                        if (argumentOperation is null || (argumentOperation.Parameter.IsParams && arrayCreationOperation.IsImplicit) || IsPassedToStaticReadOnlyCollection(argumentOperation, readOnlyCollectionType))
+                        if (argumentOperation is null || (argumentOperation.Parameter.IsParams && arrayCreationOperation.IsImplicit))
                         {
                             return;
                         }
@@ -113,12 +111,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     string? paramName = null;
                     if (argumentOperation is not null)
                     {
-                        IFieldInitializerOperation? fieldInitializer = argumentOperation.GetAncestor<IFieldInitializerOperation>(
-                            OperationKind.FieldInitializer, f => f.InitializedFields.Any(x => x.IsReadOnly));
-                        IPropertyInitializerOperation? propertyInitializer = argumentOperation.GetAncestor<IPropertyInitializerOperation>(
-                            OperationKind.PropertyInitializer, p => p.InitializedProperties.Any(x => x.IsReadOnly));
-
-                        if (fieldInitializer is not null || propertyInitializer is not null)
+                        if (IsInitializingStaticOrReadOnlyFieldOrProperty(argumentOperation))
                         {
                             return;
                         }
@@ -153,12 +146,39 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             });
         }
 
-        private static bool IsPassedToStaticReadOnlyCollection(IArgumentOperation argument, INamedTypeSymbol? readOnlyCollectionType)
+        private static bool IsInitializingStaticOrReadOnlyFieldOrProperty(IOperation operation)
         {
-            return argument.Parent is IObjectCreationOperation objectCreation
-                   && objectCreation.Type.OriginalDefinition.Equals(readOnlyCollectionType, SymbolEqualityComparer.Default)
-                   && objectCreation.Parent is IAssignmentOperation { Target: IMemberReferenceOperation memberReference }
-                   && memberReference.Member.IsStatic;
+            var ancestor = operation;
+            do
+            {
+                ancestor = ancestor!.Parent;
+            } while (ancestor != null && !(ancestor.Kind == OperationKind.FieldInitializer || ancestor.Kind == OperationKind.PropertyInitializer ||
+                        ancestor.Kind == OperationKind.CoalesceAssignment || ancestor.Kind == OperationKind.SimpleAssignment));
+
+            if (ancestor != null)
+            {
+                switch (ancestor)
+                {
+                    case IFieldInitializerOperation fieldInitializer:
+                        return fieldInitializer.InitializedFields.Any(x => x.IsStatic || x.IsReadOnly);
+                    case IPropertyInitializerOperation propertyInitializer:
+                        return propertyInitializer.InitializedProperties.Any(x => x.IsStatic || x.IsReadOnly);
+                    case IAssignmentOperation assignmentOperation:
+                        if (assignmentOperation.Target is IFieldReferenceOperation fieldReference && fieldReference.Field.IsStatic)
+                        {
+                            return true;
+                        }
+
+                        if (assignmentOperation.Target is IPropertyReferenceOperation propertyReference && propertyReference.Property.IsStatic)
+                        {
+                            return true;
+                        }
+
+                        break;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.AvoidConstArraysAnalyzer,
@@ -778,6 +780,28 @@ public class A
     public A(string[] arr) { }
     private static List<string> GetValues(string[] arr) => null;
 }");
+        }
+
+        [Fact, WorkItem(6629, "https://github.com/dotnet/roslyn-analyzers/issues/6629")]
+        public Task StaticReadonlyCollection_NoDiagnostic()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+#nullable enable
+using System.Collections.ObjectModel;
+
+public class Test
+{
+    private static ReadOnlyCollection<string>? s_errorPayloadNames;
+
+    private void M(string eventName, string msg)
+    {
+        s_errorPayloadNames ??= new ReadOnlyCollection<string>(new string[] { ""message"" });
+    }
+}",
+                LanguageVersion = LanguageVersion.CSharp8
+            }.RunAsync();
         }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
@@ -768,6 +768,7 @@ using System.Collections.Generic;
 
 public class A
 {
+    public readonly List<string> Field1 = GetValues(new string[] { ""close"" });
     public static readonly A Field; 
     public static List<string> Property { get; } = GetValues(new string[] { ""close"" });
     public static string[] Property2 { get; } = new string[] { ""close"" };


### PR DESCRIPTION
This PR excludes `static readonly` ReadOnlyCollections from triggering CA1861. Fixes #6629.