### PR TITLE
User proper reference assemblies of `net6.0` instead of self-crafted release candidate ones

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.CSharp.NetAnalyzers.Microsoft.CodeQuality.Analyzers.QualityGuidelines.CSharpAvoidMultipleEnumerationsAnalyzer,
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.Microsoft.CodeQuality.An
 
             var test = new VerifyCS.Test()
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = CSharp.LanguageVersion.Latest,
                 TestState =
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.Microsoft.CodeQuality.An
             };
             var test = new VerifyVB.Test()
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = VisualBasic.LanguageVersion.Latest,
                 TestState =
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -4148,7 +4148,7 @@ class TestType
             var test = new VerifyCS.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { }
             };
@@ -4200,7 +4200,7 @@ class TestType
             var test = new VerifyVB.Test
             {
                 TestCode = sourceCode,
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 MarkupOptions = MarkupOptions.UseFirstDescriptor,
                 TestState = { },
             };

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Test.Utilities;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer,
@@ -18,7 +18,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         {
             return new VerifyCS.Test
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
                 TestState =
                 {
@@ -34,7 +34,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         {
             return new VerifyVB.Test
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = CodeAnalysis.VisualBasic.LanguageVersion.Latest,
                 TestState =
                 {
@@ -50,7 +50,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         {
             return new VerifyCS.Test
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp10,
                 TestState =
                 {
@@ -88,7 +88,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
                         csInput
                     }
                 },
-                ReferenceAssemblies = AdditionalMetadataReferences.Net60,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net60,
             };
         }
 

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
-using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
@@ -87,19 +85,6 @@ namespace Test.Utilities
         public static MetadataReference SystemWebExtensions { get; } = MetadataReference.CreateFromFile(typeof(System.Web.Script.Serialization.JavaScriptSerializer).Assembly.Location);
         public static MetadataReference SystemServiceModel { get; } = MetadataReference.CreateFromFile(typeof(System.ServiceModel.OperationContractAttribute).Assembly.Location);
 #endif
-
-        private static readonly Lazy<ReferenceAssemblies> _lazyNet60 =
-            new(() =>
-            {
-                return new ReferenceAssemblies(
-                    "net6.0",
-                    new PackageIdentity(
-                        "Microsoft.NETCore.App.Ref",
-                        "6.0.0-rc.1.21451.13"),
-                    Path.Combine("ref", "net6.0"));
-            });
-
-        public static ReferenceAssemblies Net60 => _lazyNet60.Value;
 
         private static ReferenceAssemblies CreateDefaultReferenceAssemblies()
         {


### PR DESCRIPTION
Just minor cleanup, nothing more