### PR TITLE
Fix analyzers/tests for non-local diagnostics

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     <!-- Versions for tests and general utility execution. -->
     <!-- This version is for utility and executable assemblies. The version here should not overlap with any of the surface
          area versions. -->
-    <MicrosoftCodeAnalysisVersionForTests>4.6.0-1.final</MicrosoftCodeAnalysisVersionForTests>
+    <MicrosoftCodeAnalysisVersionForTests>4.7.0-2.final</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForExecution>4.6.0-1.final</MicrosoftCodeAnalysisVersionForExecution>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,7 +74,7 @@
     <!-- Versions for tests and general utility execution. -->
     <!-- This version is for utility and executable assemblies. The version here should not overlap with any of the surface
          area versions. -->
-    <MicrosoftCodeAnalysisVersionForTests>4.7.0-2.final</MicrosoftCodeAnalysisVersionForTests>
+    <MicrosoftCodeAnalysisVersionForTests>4.7.0-3.23280.3</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForExecution>4.6.0-1.final</MicrosoftCodeAnalysisVersionForExecution>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>4.5.0</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseCancellationTokenThrowIfCancellationRequested.Fixer.cs
@@ -56,17 +56,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 createChangedDocument = async token =>
                 {
                     var editor = await DocumentEditor.CreateAsync(context.Document, token).ConfigureAwait(false);
-                    SyntaxNode expressionStatement = CreateThrowIfCancellationRequestedExpressionStatement(editor, conditional, propertyReference);
-                    editor.ReplaceNode(conditional.Syntax, expressionStatement);
 
                     if (conditional.WhenFalse is IBlockOperation block)
                     {
-                        editor.InsertAfter(expressionStatement, block.Operations.Select(x => x.Syntax.WithAdditionalAnnotations(Formatter.Annotation)));
+                        editor.InsertAfter(conditional.Syntax, block.Operations.Select(x => x.Syntax.WithAdditionalAnnotations(Formatter.Annotation)));
                     }
                     else if (conditional.WhenFalse is not null)
                     {
-                        editor.InsertAfter(expressionStatement, conditional.WhenFalse.Syntax);
+                        editor.InsertAfter(conditional.Syntax, conditional.WhenFalse.Syntax);
                     }
+
+                    SyntaxNode expressionStatement = CreateThrowIfCancellationRequestedExpressionStatement(editor, conditional, propertyReference);
+                    editor.ReplaceNode(conditional.Syntax, expressionStatement);
 
                     return editor.GetChangedDocument();
                 };
@@ -83,18 +84,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 {
                     var editor = await DocumentEditor.CreateAsync(context.Document, token).ConfigureAwait(false);
 
-                    SyntaxNode expressionStatement = CreateThrowIfCancellationRequestedExpressionStatement(editor, conditional, propertyReference)
-                        .WithAdditionalAnnotations(Formatter.Annotation);
-                    editor.ReplaceNode(conditional.Syntax, expressionStatement);
-
                     if (conditional.WhenTrue is IBlockOperation block)
                     {
-                        editor.InsertAfter(expressionStatement, block.Operations.Select(x => x.Syntax.WithAdditionalAnnotations(Formatter.Annotation)));
+                        editor.InsertAfter(conditional.Syntax, block.Operations.Select(x => x.Syntax.WithAdditionalAnnotations(Formatter.Annotation)));
                     }
                     else
                     {
-                        editor.InsertAfter(expressionStatement, conditional.WhenTrue.Syntax);
+                        editor.InsertAfter(conditional.Syntax, conditional.WhenTrue.Syntax);
                     }
+
+                    SyntaxNode expressionStatement = CreateThrowIfCancellationRequestedExpressionStatement(editor, conditional, propertyReference)
+                        .WithAdditionalAnnotations(Formatter.Annotation);
+                    editor.ReplaceNode(conditional.Syntax, expressionStatement);
 
                     return editor.GetChangedDocument();
                 };

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValueTests.Fixer.cs
@@ -281,6 +281,8 @@ End Enum
 ";
             await new VerifyVB.Test
             {
+                // TODO: Remove 'CodeFixTestBehaviors.SkipLocalDiagnosticCheck'
+                // Blocked by https://github.com/dotnet/roslyn/issues/68654
                 CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = code,
                 ExpectedDiagnostics =
@@ -354,6 +356,8 @@ End Enum
 ";
             await new VerifyVB.Test
             {
+                // TODO: Remove 'CodeFixTestBehaviors.SkipLocalDiagnosticCheck'
+                // Blocked by https://github.com/dotnet/roslyn/issues/68654
                 CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = code,
                 ExpectedDiagnostics =

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OperatorOverloadsHaveNamedAlternatesTests.Fixer.cs
@@ -1,7 +1,6 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.OperatorOverloadsHaveNamedAlternatesAnalyzer,
@@ -192,7 +191,6 @@ public class C
         {
             await new VerifyCS.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 public class C
 {
@@ -220,7 +218,6 @@ public class C
         {
             await new VerifyCS.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 public class C
 {
@@ -410,7 +407,6 @@ End Structure
         {
             await new VerifyVB.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 Public Class C
     Public Shared Operator +(left As C, right As C) As C
@@ -445,7 +441,6 @@ End Class
         {
             await new VerifyVB.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 Public Class C
     Public Shared Operator IsTrue(item As C) As Boolean

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEqualsTests.Fixer.cs
@@ -1,8 +1,7 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.Testing.EmptyDiagnosticAnalyzer, // Diagnostic is from the compiler
@@ -140,7 +139,6 @@ class {|CS0659:{|CS0661:C|}|}
         {
             await new VerifyVB.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 Class [|C|]
     Public Shared Operator =(c1 As C, c2 As C) As Boolean
@@ -183,7 +181,6 @@ End Class
         {
             await new VerifyVB.Test
             {
-                CodeFixTestBehaviors = CodeFixTestBehaviors.SkipLocalDiagnosticCheck,
                 TestCode = @"
 Imports System
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SealInternalTypesTests.cs
@@ -17,6 +17,14 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class SealInternalTypesTests
     {
+        // NOTE: 'SealInternalTypes' analyzer reports a compilation end diagnostic.
+        //       Code fixes are not yet supported for compilation end diagnostics,
+        //       hence 'SealInternalTypesFixer' is a no-op right now.
+        //       However, we have still implemented this fixer so that if code fix support
+        //       gets added for compilation end diagnostics in future, it should automatically light up.
+        //       All tests in this file are marked with 'CodeFixTestBehaviors.SkipLocalDiagnosticCheck'
+        //       as compilation end diagnostics are non-local diagnostics.
+
         #region Diagnostic
         [Theory]
         [InlineData("internal ")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseSpanBasedStringConcatTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseSpanBasedStringConcatTests.cs
@@ -268,7 +268,7 @@ var _ = {|#0:Fwd({|#1:foo.Substring(1) + bar.Substring(1)|}) + Fwd({|#2:foo.Subs
                     @"
 var _ = string.Concat(Fwd(string.Concat(foo.AsSpan(1), bar.AsSpan(1))), Fwd(string.Concat(foo.AsSpan(1), bar)).AsSpan(1), Fwd(string.Concat(foo, bar.AsSpan(1))));",
                     new[] { 0, 1, 2, 3 },
-                    4, 3, 3
+                    4, 2, 2
                 };
             }
         }
@@ -312,7 +312,7 @@ Dim s = {|#0:Fwd({|#1:foo.Substring(1) & bar.Substring(1)|}) & Fwd({|#2:foo.Subs
                     @"
 Dim s = String.Concat(Fwd(String.Concat(foo.AsSpan(1), bar.AsSpan(1))), Fwd(String.Concat(foo.AsSpan(1), bar)).AsSpan(1), Fwd(String.Concat(foo, bar.AsSpan(1))))",
                     new[] { 0, 1, 2, 3 },
-                    4, 3, 3
+                    4, 2, 2
                 };
             }
         }

--- a/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/BasicOverrideEqualsOnOverloadingOperatorEquals.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/BasicOverrideEqualsOnOverloadingOperatorEquals.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
 Imports Analyzer.Utilities
@@ -38,19 +38,10 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines
 
             context.RegisterSymbolAction(
                 Sub(symbolContext)
-                    Dim method = DirectCast(symbolContext.Symbol, IMethodSymbol)
-                    Debug.Assert(method.IsDefinition)
+                    Dim type = DirectCast(symbolContext.Symbol, INamedTypeSymbol)
 
-                    Dim type = method.ContainingType
                     If type.TypeKind = TypeKind.Interface OrElse type.IsImplicitClass OrElse type.SpecialType = SpecialType.System_Object Then
                         ' Don't apply this rule to interfaces, the implicit class (i.e. error case), or System.Object.
-                        Return
-                    End If
-
-                    ' If there's a = operator...
-                    If method.MethodKind <> MethodKind.UserDefinedOperator OrElse
-                        Not CaseInsensitiveComparison.Equals(method.Name, WellKnownMemberNames.EqualityOperatorName) Then
-
                         Return
                     End If
 
@@ -59,9 +50,26 @@ Namespace Microsoft.CodeQuality.VisualBasic.Analyzers.ApiDesignGuidelines
                         Return
                     End If
 
+                    ' If there's a = operator...
+                    If Not HasEqualityOperator(type) Then
+                        Return
+                    End If
+
                     symbolContext.ReportDiagnostic(type.CreateDiagnostic(Rule))
                 End Sub,
-                SymbolKind.Method)
+                SymbolKind.NamedType)
         End Sub
+
+        Private Shared Function HasEqualityOperator(type As INamedTypeSymbol) As Boolean
+            For Each method In type.GetMembers().OfType(Of IMethodSymbol)
+                If method.MethodKind = MethodKind.UserDefinedOperator AndAlso
+                    CaseInsensitiveComparison.Equals(method.Name, WellKnownMemberNames.EqualityOperatorName) Then
+
+                    Return True
+                End If
+            Next
+
+            Return False
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #6598

_Recommended to review ignoring whitespace differences_

- Move to latest Microsoft.CodeAnalysis package for unit tests
- Fix analyzers reporting non-local diagnostics
- Add comments to tests where `CodeFixTestBehaviors.SkipLocalDiagnosticCheck` cannot be removed
- Also fixed a code fixer relying on implicit tracking node functionality, which fails after moving to latest MS.CA bits.
