### PR TITLE
Fix RS0033 and RS0034 in the presence of primary constructors

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ExportedPartsShouldHaveImportingConstructor.cs
@@ -100,7 +100,9 @@ namespace Roslyn.Diagnostics.Analyzers
                     continue;
                 }
 
-                if (constructor.IsImplicitlyDeclared)
+                // See if there's a synthesized parameterless constructor (for example, for a struct with no explicit
+                // constructors at all).
+                if (constructor.IsImplicitlyDeclared && constructor.DeclaringSyntaxReferences.IsEmpty)
                 {
                     if (exportAttributeApplication.ApplicationSyntaxReference is object)
                     {

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -84,6 +84,7 @@ namespace Roslyn.Diagnostics.Analyzers
 
             foreach (var constructor in namedType.Constructors)
             {
+                // Ignore parameterless struct constructors.
                 if (constructor.IsImplicitlyDeclared && constructor.DeclaringSyntaxReferences.IsEmpty)
                 {
                     continue;

--- a/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/ImportingConstructorShouldBeObsolete.cs
@@ -84,7 +84,7 @@ namespace Roslyn.Diagnostics.Analyzers
 
             foreach (var constructor in namedType.Constructors)
             {
-                if (constructor.IsImplicitlyDeclared)
+                if (constructor.IsImplicitlyDeclared && constructor.DeclaringSyntaxReferences.IsEmpty)
                 {
                     continue;
                 }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/ExportedPartsShouldHaveImportingConstructorTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/ExportedPartsShouldHaveImportingConstructorTests.cs
@@ -42,6 +42,35 @@ class C {{
         [Theory]
         [InlineData("System.Composition")]
         [InlineData("System.ComponentModel.Composition")]
+        public async Task SingleExpectedConstructor_PrimaryConstructors_CSharpAsync(string mefNamespace)
+        {
+            var source = $$"""
+using {{mefNamespace}};
+using System.Diagnostics.CodeAnalysis;
+
+[Export]
+[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
+class C(string s)
+{
+    [ImportingConstructor]
+    public C() : this("") { }
+}
+""";
+
+            await new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalReferences = { AdditionalMetadataReferences.SystemComponentModelCompositionReference },
+                },
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.Preview,
+            }.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("System.Composition")]
+        [InlineData("System.ComponentModel.Composition")]
         public async Task SingleExpectedConstructor_VisualBasicAsync(string mefNamespace)
         {
             var source = $@"

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/ExportedPartsShouldHaveImportingConstructorTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/ExportedPartsShouldHaveImportingConstructorTests.cs
@@ -45,17 +45,17 @@ class C {{
         public async Task SingleExpectedConstructor_PrimaryConstructors_CSharpAsync(string mefNamespace)
         {
             var source = $$"""
-using {{mefNamespace}};
-using System.Diagnostics.CodeAnalysis;
+                using {{mefNamespace}};
+                using System.Diagnostics.CodeAnalysis;
 
-[Export]
-[method: SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
-class C(string s)
-{
-    [ImportingConstructor]
-    public C() : this("") { }
-}
-""";
+                [Export]
+                [method: SuppressMessage("RoslynDiagnosticsReliability", "RS0034:Exported parts should have [ImportingConstructor]", Justification = "Used incorrectly by tests")]
+                class C(string s)
+                {
+                    [ImportingConstructor]
+                    public C() : this("") { }
+                }
+                """;
 
             await new VerifyCS.Test
             {


### PR DESCRIPTION
Depends on https://github.com/dotnet/roslyn-analyzers/pull/6690 going in to update hte version of Roslyn we support.