### PR TITLE
Prevent surfacing OperationCanceledException as diagnostic

### DIFF
--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -179,6 +179,10 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                             context.AddSource(impl.OutputTextHintName, impl.OutputText);
                         }
                     }
+                    catch (OperationCanceledException)
+                    {
+                        throw;
+                    }
                     catch (Exception ex)
                     {
                         var exceptionLines = ex.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                             context.AddSource(impl.OutputTextHintName, impl.OutputText);
                         }
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
                     {
                         throw;
                     }


### PR DESCRIPTION
I haven't seen the exception being surfaced as a diagnostic, but from reading the code, it seems possible.