### PR TITLE
Remove error when targeting net8.0-browser1.0 TFM

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformString.cs
@@ -27,6 +27,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         private const string IsPrefix = "Is";
         private const string VersionSuffix = "VersionAtLeast";
         private const string macOS = nameof(macOS);
+        private const string Browser = nameof(Browser);
 
         private static readonly LocalizableString s_localizableTitle = CreateLocalizableResourceString(nameof(UseValidPlatformStringTitle));
         private static readonly LocalizableString s_localizableDescription = CreateLocalizableResourceString(nameof(UseValidPlatformStringDescription));
@@ -82,6 +83,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 if (knownPlatforms.TryGetValue(macOS, out var versions))
                 {
                     knownPlatforms.Add("OSX", versions);
+                }
+
+                if (knownPlatforms.TryGetValue(Browser, out versions) && versions == 0)
+                {
+                    // Browser is a special case, we don't have a version guard method for it but we need to support a browser1.0 target platform
+                    knownPlatforms[Browser] = 2;
                 }
 
                 context.RegisterOperationAction(context => AnalyzeOperation(context.Operation, context, knownPlatforms), OperationKind.Invocation);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/UseValidPlatformStringTest.cs
@@ -123,7 +123,7 @@ public class Test
     [{|#3:SupportedOSPlatform(""watchOs7.1.0.2"")|}] // Version '7.1.0.2' is not valid for platform 'watchOs'. Use a version with 2-3 parts for this platform.
     public static void InvalidVersion2() { }
 
-    [{|#4:UnsupportedOSPlatform(""browser1.0."")|}] // Version '1.0.' is not valid for platform 'browser'. Do not use versions for this platform.
+    [{|#4:UnsupportedOSPlatform(""linux1.0."")|}] // Version '1.0.' is not valid for platform 'linux'. Do not use versions for this platform.
     public static void InvalidVersion3() { }
 }";
             await VerifyAnalyzerCsAsync(csSource,
@@ -131,7 +131,7 @@ public class Test
                 VerifyCS.Diagnostic(UseValidPlatformString.UnknownPlatform).WithLocation(1).WithArguments("watch"),
                 VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(2).WithArguments("7", "windows", "-4"),
                 VerifyCS.Diagnostic(UseValidPlatformString.InvalidVersion).WithLocation(3).WithArguments("7.1.0.2", "watchOs", "-3"),
-                VerifyCS.Diagnostic(UseValidPlatformString.NoVersion).WithLocation(4).WithArguments("1.0.", "browser"));
+                VerifyCS.Diagnostic(UseValidPlatformString.NoVersion).WithLocation(4).WithArguments("1.0.", "linux"));
         }
 
         [Fact]
@@ -157,7 +157,7 @@ Public Class Test
     Public Shared Sub InvalidVersion2()
     End Sub
 
-    <[|UnsupportedOSPlatform(""browser1.0."")|]>
+    <[|UnsupportedOSPlatform(""linux1.0."")|]>
     Public Shared Sub InvalidVersion3()
     End Sub
 End Class";
@@ -413,7 +413,7 @@ public class Test
     [{|#0:SupportedOSPlatform(""MacOS1.2.3.4"")|}] // Version '1.2.3.4' is not valid for platform 'MacOS'. Use a version with 2-3 parts for this platform.
     [SupportedOSPlatform(""Osx2.3"")]
     [SupportedOSPlatform(""Linux"")]
-    [[|SupportedOSPlatform(""Browser4.3"")|]] // Browser should not have a version
+    [[|SupportedOSPlatform(""Linux4.3"")|]] // Linux should not have a version
     public void SupportedOSPlatformMac4PartsInvalid() { }
 
     [SupportedOSPlatform(""MacOS1.2"")]


### PR DESCRIPTION
We're adding support for the `net8.0-browser` TFM (see https://github.com/dotnet/runtime/issues/85333) and noticed the platform analyzer complains because we're using version 1.0 but there is no `IsBrowserVersionAtLeast()` method.

As far as I know we don't plan to add one (at least right now) which makes Browser a special case.

/cc @lewing @steveisok