### PR TITLE
CA1861: Do not warn if not an array initializer.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.cs
@@ -103,7 +103,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
 
                     // Must be literal array
-                    if (arrayCreationOperation.Initializer is { } initializer &&
+                    if (arrayCreationOperation.Initializer is not { } initializer ||
                         initializer.ElementValues.Any(x => x is not ILiteralOperation))
                     {
                         return;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
@@ -806,28 +806,34 @@ public class Test
         }
 
         [Fact, WorkItem(6686, "https://github.com/dotnet/roslyn-analyzers/issues/6686")]
-        public Task ArrayWithoutInitializer_Diagnostic()
+        public Task ArrayWithoutInitializer_NoDiagnostic()
         {
-            var source = @"using System.Collections.Generic;
-
-public class MyClass
-{
-    public List<object> Cases => new() { {|CA1861:new object[0]|} };
-}";
-            var fixedSource = @"using System.Collections.Generic;
-
-public class MyClass
-{
-    public List<object> Cases => new() { item };
-
-    private static readonly object[] item = new object[0];
-}";
             return new VerifyCS.Test
             {
-                TestCode = source,
-                FixedCode = fixedSource,
+                TestCode = @"using System.Collections.Generic;
+
+public class MyClass
+{
+    public List<object> Cases => new() { new object[0] };
+}",
                 LanguageVersion = LanguageVersion.CSharp10
             }.RunAsync();
+        }
+
+        [Fact, WorkItem(6686, "https://github.com/dotnet/roslyn-analyzers/issues/6697")]
+        public async Task ArrayWithoutInitializer_NoDiagnostic2()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+using System;
+
+public class MyClass
+{
+    public void M1(Type[] types) { }
+    public void M2(int length)
+    {
+         M1(new Type[length]);
+    }
+}");
         }
     }
 }


### PR DESCRIPTION
CA1861: `Avoid constant arrays as arguments` analyzer should not warn when the array creation has no array initializer.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/6697
Related to https://github.com/dotnet/runtime/pull/87768#issuecomment-1602508045