### PR TITLE
Don't emit CA1849 for DbContext methods

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -188,19 +188,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static ImmutableArray<IMethodSymbol> GetExcludedMethods(WellKnownTypeProvider wellKnownTypeProvider)
         {
-            var methods = ImmutableArray<IMethodSymbol>.Empty;
+            var methodsBuilder = ImmutableArray.CreateBuilder<IMethodSymbol>();
             if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbContext, out INamedTypeSymbol? dbContextType))
             {
-                var addMethods = dbContextType
-                    .GetMembers("Add")
-                    .OfType<IMethodSymbol>();
-                var addRangeMethods = dbContextType
-                    .GetMembers("AddRange")
-                    .OfType<IMethodSymbol>();
-                methods = methods.AddRange(addMethods.Concat(addRangeMethods));
+                foreach (var method in dbContextType.GetMembers().OfType<IMethodSymbol>())
+                {
+                    if (method.Name is "Add" or "AddRange")
+                    {
+                        methodsBuilder.Add(method);
+                    }
+                }
             }
-
-            return methods;
+            return methodsBuilder.ToImmutable();
         }
 
         /// <summary>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -199,6 +199,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
                 }
             }
+            
             return methodsBuilder.ToImmutable();
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -199,7 +199,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
                 }
             }
-            
+
             return methodsBuilder.ToImmutable();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
 {
     public class UseAsyncMethodInAsyncContextTests
     {
+        private static readonly ImmutableArray<PackageIdentity> EntityFrameworkPackages = ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8"));
+
         [Fact]
         public async Task TaskWaitInTaskReturningMethodGeneratesWarning()
         {
@@ -1259,7 +1261,7 @@ class Test {
         ctx.Add(1);
     }
 }",
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(EntityFrameworkPackages)
             }.RunAsync();
         }
 
@@ -1278,7 +1280,7 @@ class Test {
         ctx.AddRange(1, 2);
     }
 }",
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(EntityFrameworkPackages)
             }.RunAsync();
         }
 
@@ -1298,7 +1300,7 @@ class Test {
     }
 }",
                 ExpectedDiagnostics = { new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor).WithLocation(0).WithArguments("IDbContextFactory<DbContext>.CreateDbContext()", "IDbContextFactory<DbContext>.CreateDbContextAsync(CancellationToken)") },
-                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(EntityFrameworkPackages)
             }.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
@@ -1241,6 +1242,64 @@ Module Program
 End Module
 ";
             await CreateVBTestAndRunAsync(testVB);
+        }
+
+        [Fact]
+        [WorkItem(6684, "https://github.com/dotnet/roslyn-analyzers/issues/6684")]
+        public Task DbContextAdd_NoDiagnostic()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+class Test {
+    public async Task RunAsync(DbContext ctx) {
+        ctx.Add(1);
+    }
+}",
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(6684, "https://github.com/dotnet/roslyn-analyzers/issues/6684")]
+        public Task DbContextAddRange_NoDiagnostic()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+class Test {
+    public async Task RunAsync(DbContext ctx) {
+        ctx.AddRange(1, 2);
+    }
+}",
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+            }.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(6684, "https://github.com/dotnet/roslyn-analyzers/issues/6684")]
+        public Task DbContextFactoryCreateDbContext_Diagnostic()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+class Test {
+    public async Task RunAsync(IDbContextFactory<DbContext> factory) {
+        var context = {|#0:factory.CreateDbContext()|};
+    }
+}",
+                ExpectedDiagnostics = { new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor).WithLocation(0).WithArguments("IDbContextFactory<DbContext>.CreateDbContext()", "IDbContextFactory<DbContext>.CreateDbContextAsync(CancellationToken)") },
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.EntityFrameworkCore", "7.0.8")))
+            }.RunAsync();
         }
 
         private static async Task CreateCSTestAndRunAsync(string testCS)

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -64,6 +64,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftCodeAnalysisVisualBasicExtensions = "Microsoft.CodeAnalysis.VisualBasicExtensions";
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicCompilation = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation";
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicExtensions = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions";
+        public const string MicrosoftEntityFrameworkCoreDbContext = "Microsoft.EntityFrameworkCore.DbContext";
         public const string MicrosoftEntityFrameworkCoreEntityFrameworkQueryableExtensions = "Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions";
         public const string MicrosoftEntityFrameworkCoreRelationalQueryableExtensions = "Microsoft.EntityFrameworkCore.RelationalQueryableExtensions";
         public const string MicrosoftExtensionsLoggingILogger = "Microsoft.Extensions.Logging.ILogger";


### PR DESCRIPTION
This PR adds exclusions for the `DbContext.Add()` and `DbContext.AddRange()` methods and fixes a false negative for `IDbContextFactory<DbContext>.CreateDbContext()` in the `UseAsyncMethodInAsyncContext` analyzer.

Fixes #6684.