### PR TITLE
Recommend using Equals with StringComparison instead of string.ToLower() == otherString.ToLower()

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpRecommendCaseInsensitiveStringComparisonFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpRecommendCaseInsensitiveStringComparisonFixer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpRecommendCaseInsensitiveStringComparisonFixer : RecommendCaseInsensitiveStringComparisonFixer
     {
-        protected override List<SyntaxNode> GetNewArguments(SyntaxGenerator generator, string caseChangingApproachValue, IInvocationOperation mainInvocationOperation,
+        protected override IEnumerable<SyntaxNode> GetNewArgumentsForInvocation(SyntaxGenerator generator, string caseChangingApproachValue, IInvocationOperation mainInvocationOperation,
             INamedTypeSymbol stringComparisonType, out SyntaxNode? mainInvocationInstance)
         {
             List<SyntaxNode> arguments = new();
@@ -80,7 +80,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     newArgumentNode = node;
                 }
 
-                arguments.Add(newArgumentNode);
+                arguments.Add(newArgumentNode.WithTriviaFrom(node));
             }
 
             Debug.Assert(mainInvocationInstance != null);
@@ -91,5 +91,12 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
 
             return arguments;
         }
+
+        protected override IEnumerable<SyntaxNode> GetNewArgumentsForBinary(SyntaxGenerator generator, SyntaxNode rightNode, SyntaxNode typeMemberAccess) =>
+            new List<SyntaxNode>()
+            {
+                generator.Argument(rightNode),
+                generator.Argument(typeMemberAccess)
+            };
     }
 }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpRecommendCaseInsensitiveStringComparisonFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpRecommendCaseInsensitiveStringComparisonFixer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
     [ExportCodeFixProvider(LanguageNames.CSharp), Shared]
     public sealed class CSharpRecommendCaseInsensitiveStringComparisonFixer : RecommendCaseInsensitiveStringComparisonFixer
     {
-        protected override List<SyntaxNode> GetNewArguments(SyntaxGenerator generator, IInvocationOperation mainInvocationOperation,
+        protected override List<SyntaxNode> GetNewArguments(SyntaxGenerator generator, string caseChangingApproachValue, IInvocationOperation mainInvocationOperation,
             INamedTypeSymbol stringComparisonType, out SyntaxNode? mainInvocationInstance)
         {
             List<SyntaxNode> arguments = new();
@@ -25,14 +25,12 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
 
             InvocationExpressionSyntax invocationExpression = (InvocationExpressionSyntax)mainInvocationOperation.Syntax;
 
-            string? caseChangingApproachName = null;
             bool isChangingCaseInArgument = false;
-
             mainInvocationInstance = null;
 
             if (invocationExpression.Expression is MemberAccessExpressionSyntax memberAccessExpression)
             {
-                var internalExpression = memberAccessExpression.Expression is ParenthesizedExpressionSyntax parenthesizedExpression ?
+                ExpressionSyntax internalExpression = memberAccessExpression.Expression is ParenthesizedExpressionSyntax parenthesizedExpression ?
                     parenthesizedExpression.Expression :
                     memberAccessExpression.Expression;
 
@@ -40,7 +38,6 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     internalInvocationExpression.Expression is MemberAccessExpressionSyntax internalMemberAccessExpression)
                 {
                     mainInvocationInstance = internalMemberAccessExpression.Expression;
-                    caseChangingApproachName = GetCaseChangingApproach(internalMemberAccessExpression.Name.Identifier.ValueText);
                 }
                 else
                 {
@@ -59,10 +56,9 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     node.Expression;
 
                 MemberAccessExpressionSyntax? argumentMemberAccessExpression = null;
-                if (argumentExpression is InvocationExpressionSyntax argumentInvocationExpression &&
-                    (argumentMemberAccessExpression = argumentInvocationExpression.Expression as MemberAccessExpressionSyntax) != null)
+                if (argumentExpression is InvocationExpressionSyntax argumentInvocationExpression)
                 {
-                    caseChangingApproachName = GetCaseChangingApproach(argumentMemberAccessExpression.Name.Identifier.ValueText);
+                    argumentMemberAccessExpression = argumentInvocationExpression.Expression as MemberAccessExpressionSyntax;
                 }
 
                 SyntaxNode newArgumentNode;
@@ -87,11 +83,9 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                 arguments.Add(newArgumentNode);
             }
 
-            Debug.Assert(caseChangingApproachName != null);
             Debug.Assert(mainInvocationInstance != null);
 
-            SyntaxNode stringComparisonArgument = GetNewStringComparisonArgument(generator,
-                stringComparisonType, caseChangingApproachName!, isAnyArgumentNamed);
+            SyntaxNode stringComparisonArgument = GetNewStringComparisonArgument(generator, stringComparisonType, caseChangingApproachValue, isAnyArgumentNamed);
 
             arguments.Add(stringComparisonArgument);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -2066,6 +2066,9 @@ Widening and user defined conversions are not supported with generic types.</val
   <data name="RecommendCaseInsensitiveStringComparerStringComparisonCodeFixTitle" xml:space="preserve">
     <value>Use the 'string.{0}(string, StringComparison)' overload</value>
   </data>
+  <data name="RecommendCaseInsensitiveStringEqualsCodeFixTitle" xml:space="preserve">
+    <value>Use 'string.Equals(string, StringComparison)'</value>
+  </data>
   <data name="RecommendCaseInsensitiveStringComparerTitle" xml:space="preserve">
     <value>Prefer using 'StringComparer' to perform case-insensitive string comparisons</value>
   </data>
@@ -2074,6 +2077,15 @@ Widening and user defined conversions are not supported with generic types.</val
   </data>
   <data name="RecommendCaseInsensitiveStringComparerMessage" xml:space="preserve">
     <value>Prefer using 'StringComparer' to perform a case-insensitive comparison</value>
+  </data>
+    <data name="RecommendCaseInsensitiveStringEqualsTitle" xml:space="preserve">
+    <value>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</value>
+  </data>
+    <data name="RecommendCaseInsensitiveStringEqualsDescription" xml:space="preserve">
+    <value>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</value>
+  </data>
+    <data name="RecommendCaseInsensitiveStringEqualsMessage" xml:space="preserve">
+    <value>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</value>
   </data>
   <data name="RecommendCaseInsensitiveStringComparisonTitle" xml:space="preserve">
     <value>Prefer the 'StringComparison' method overloads to perform case-insensitive string comparisons</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -2069,17 +2069,11 @@ Widening and user defined conversions are not supported with generic types.</val
   <data name="RecommendCaseInsensitiveStringEqualsCodeFixTitle" xml:space="preserve">
     <value>Use 'string.Equals(string, StringComparison)'</value>
   </data>
-  <data name="RecommendCaseInsensitiveStringComparerTitle" xml:space="preserve">
-    <value>Prefer using 'StringComparer' to perform case-insensitive string comparisons</value>
-  </data>
   <data name="RecommendCaseInsensitiveStringComparerDescription" xml:space="preserve">
     <value>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons when using 'CompareTo', because they lead to an allocation. Instead, use 'StringComparer' to perform case-insensitive comparisons.</value>
   </data>
   <data name="RecommendCaseInsensitiveStringComparerMessage" xml:space="preserve">
     <value>Prefer using 'StringComparer' to perform a case-insensitive comparison</value>
-  </data>
-    <data name="RecommendCaseInsensitiveStringEqualsTitle" xml:space="preserve">
-    <value>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</value>
   </data>
     <data name="RecommendCaseInsensitiveStringEqualsDescription" xml:space="preserve">
     <value>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</value>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
@@ -32,8 +35,13 @@ namespace Microsoft.NetCore.Analyzers.Performance
         internal const string StringStartsWithMethodName = "StartsWith";
         internal const string StringCompareToMethodName = "CompareTo";
         internal const string StringComparerCompareMethodName = "Compare";
+        internal const string StringEqualsMethodName = "Equals";
         internal const string StringParameterName = "value";
         internal const string StringComparisonParameterName = "comparisonType";
+        internal const string CaseChangingApproachName = "CaseChangingApproach";
+        internal const string OffendingMethodName = "OffendingMethodName";
+        internal const string LeftOffendingMethodName = "LeftOffendingMethodName";
+        internal const string RightOffendingMethodName = "RightOffendingMethodName";
 
         internal static readonly DiagnosticDescriptor RecommendCaseInsensitiveStringComparisonRule = DiagnosticDescriptorHelper.Create(
             RuleId,
@@ -115,18 +123,12 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 ParameterInfo.GetParameterInfo(stringType)
             };
 
-            ParameterInfo[] stringInt32Parameters = new[]
+            // Equals(string)
+            IMethodSymbol? stringEqualsStringMethod = stringType.GetMembers(StringEqualsMethodName).OfType<IMethodSymbol>().GetFirstOrDefaultMemberWithParameterInfos(stringParameter);
+            if (stringEqualsStringMethod == null)
             {
-                ParameterInfo.GetParameterInfo(stringType),
-                ParameterInfo.GetParameterInfo(int32Type)
-            };
-
-            ParameterInfo[] stringInt32Int32Parameters = new[]
-            {
-                ParameterInfo.GetParameterInfo(stringType),
-                ParameterInfo.GetParameterInfo(int32Type),
-                ParameterInfo.GetParameterInfo(int32Type)
-            };
+                return;
+            }
 
             // Retrieve the diagnosable string overload methods: Contains, IndexOf (3 overloads), StartsWith, CompareTo
 
@@ -153,12 +155,25 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 return;
             }
 
+            ParameterInfo[] stringInt32Parameters = new[]
+            {
+                ParameterInfo.GetParameterInfo(stringType),
+                ParameterInfo.GetParameterInfo(int32Type)
+            };
+
             // IndexOf(string, int startIndex)
             IMethodSymbol? indexOfStringInt32Method = indexOfMethods.GetFirstOrDefaultMemberWithParameterInfos(stringInt32Parameters);
             if (indexOfStringInt32Method == null)
             {
                 return;
             }
+
+            ParameterInfo[] stringInt32Int32Parameters = new[]
+            {
+                ParameterInfo.GetParameterInfo(stringType),
+                ParameterInfo.GetParameterInfo(int32Type),
+                ParameterInfo.GetParameterInfo(int32Type)
+            };
 
             // IndexOf(string, int startIndex, int count)
             IMethodSymbol? indexOfStringInt32Int32Method = indexOfMethods.GetFirstOrDefaultMemberWithParameterInfos(stringInt32Int32Parameters);
@@ -190,49 +205,165 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
             context.RegisterOperationAction(context =>
             {
-                IInvocationOperation caseChangingInvocation = (IInvocationOperation)context.Operation;
-                IMethodSymbol caseChangingMethod = caseChangingInvocation.TargetMethod;
+                if (context.Operation is IInvocationOperation caseChangingInvocation)
+                {
+                    AnalyzeInvocation(context, caseChangingInvocation, stringType,
+                        containsStringMethod, startsWithStringMethod, compareToStringMethod,
+                        indexOfStringMethod, indexOfStringInt32Method, indexOfStringInt32Int32Method);
+                }
+                else if (context.Operation is IBinaryOperation binaryOperation)
+                {
+                    AnalyzeBinaryOperation(context, binaryOperation, stringType);
+                }
+            },
+                OperationKind.Invocation, // a.ToLower().Method()
+                OperationKind.Binary // a.ToLower() == b.ToLower()
+            );
+        }
 
-                if (!caseChangingMethod.Equals(toLowerParameterlessMethod) &&
-                    !caseChangingMethod.Equals(toLowerInvariantParameterlessMethod) &&
-                    !caseChangingMethod.Equals(toUpperParameterlessMethod) &&
-                    !caseChangingMethod.Equals(toUpperInvariantParameterlessMethod))
-                {
-                    return;
-                }
+        private static void AnalyzeInvocation(OperationAnalysisContext context, IInvocationOperation caseChangingInvocation, INamedTypeSymbol stringType,
+            IMethodSymbol containsStringMethod, IMethodSymbol startsWithStringMethod, IMethodSymbol compareToStringMethod,
+            IMethodSymbol indexOfStringMethod, IMethodSymbol indexOfStringInt32Method, IMethodSymbol indexOfStringInt32Int32Method)
+        {
+            if (!IsOffendingMethod(caseChangingInvocation, stringType, out string? offendingMethodName))
+            {
+                return;
+            }
 
-                // Ignore parenthesized operations
-                IOperation? ancestor = caseChangingInvocation.WalkUpParentheses().WalkUpConversion().Parent;
+            if (!TryGetInvocationWithoutParentheses(caseChangingInvocation, out IInvocationOperation? diagnosableInvocation))
+            {
+                return;
+            }
 
-                IInvocationOperation diagnosableInvocation;
-                if (ancestor is IInvocationOperation invocationAncestor)
-                {
-                    diagnosableInvocation = invocationAncestor;
-                }
-                else if (ancestor is IArgumentOperation argumentAncestor && argumentAncestor.Parent is IInvocationOperation argumentInvocationAncestor)
-                {
-                    diagnosableInvocation = argumentInvocationAncestor;
-                }
-                else
-                {
-                    return;
-                }
+            string caseChangingApproach = GetCaseChangingApproach(offendingMethodName);
 
-                IMethodSymbol diagnosableMethod = diagnosableInvocation.TargetMethod;
+            ImmutableDictionary<string, string?> dict = new Dictionary<string, string?>()
+            {
+                { CaseChangingApproachName, caseChangingApproach }
+            }.ToImmutableDictionary();
 
-                if (diagnosableMethod.Equals(containsStringMethod) ||
-                    diagnosableMethod.Equals(startsWithStringMethod) ||
-                    diagnosableMethod.Equals(indexOfStringMethod) ||
-                    diagnosableMethod.Equals(indexOfStringInt32Method) ||
-                    diagnosableMethod.Equals(indexOfStringInt32Int32Method))
+            IMethodSymbol diagnosableMethod = diagnosableInvocation.TargetMethod;
+
+            if (diagnosableMethod.Equals(containsStringMethod) ||
+                diagnosableMethod.Equals(startsWithStringMethod) ||
+                diagnosableMethod.Equals(indexOfStringMethod) ||
+                diagnosableMethod.Equals(indexOfStringInt32Method) ||
+                diagnosableMethod.Equals(indexOfStringInt32Int32Method))
+            {
+                context.ReportDiagnostic(diagnosableInvocation.CreateDiagnostic(RecommendCaseInsensitiveStringComparisonRule, dict, diagnosableMethod.Name));
+            }
+            else if (diagnosableMethod.Equals(compareToStringMethod))
+            {
+                context.ReportDiagnostic(diagnosableInvocation.CreateDiagnostic(RecommendCaseInsensitiveStringComparerRule, dict));
+            }
+        }
+
+        private static void AnalyzeBinaryOperation(OperationAnalysisContext context, IBinaryOperation binaryOperation, INamedTypeSymbol stringType)
+        {
+            if (binaryOperation.OperatorKind is not BinaryOperatorKind.Equals and not BinaryOperatorKind.NotEquals)
+            {
+                return;
+            }
+
+            bool atLeastOneOffendingInvocation = false;
+
+            string? leftOffendingMethodName = null;
+            if (TryGetInvocationWithoutParentheses(binaryOperation.LeftOperand, out IInvocationOperation? leftInvocation))
+            {
+                atLeastOneOffendingInvocation = IsOffendingMethod(leftInvocation, stringType, out leftOffendingMethodName);
+            }
+
+            string? rightOffendingMethodName = null;
+            if (TryGetInvocationWithoutParentheses(binaryOperation.RightOperand, out IInvocationOperation? rightInvocation))
+            {
+                atLeastOneOffendingInvocation = IsOffendingMethod(rightInvocation, stringType, out rightOffendingMethodName);
+            }
+
+            if (atLeastOneOffendingInvocation)
+            {
+                string caseChangingApproachValue = GetPreferredCaseChangingApproach(leftOffendingMethodName, rightOffendingMethodName);
+
+                ImmutableDictionary<string, string?> dict = new Dictionary<string, string?>()
                 {
-                    context.ReportDiagnostic(diagnosableInvocation.CreateDiagnostic(RecommendCaseInsensitiveStringComparisonRule, diagnosableMethod.Name));
-                }
-                else if (diagnosableMethod.Equals(compareToStringMethod))
-                {
-                    context.ReportDiagnostic(diagnosableInvocation.CreateDiagnostic(RecommendCaseInsensitiveStringComparerRule));
-                }
-            }, OperationKind.Invocation);
+                    { CaseChangingApproachName, caseChangingApproachValue }
+                }.ToImmutableDictionary();
+
+                context.ReportDiagnostic(
+                    binaryOperation.CreateDiagnostic(RecommendCaseInsensitiveStringComparerRule, dict));
+            }
+        }
+
+        private static bool TryGetInvocationWithoutParentheses(IOperation operation,
+            [NotNullWhen(returnValue: true)] out IInvocationOperation? diagnosableInvocation)
+        {
+            diagnosableInvocation = null;
+            if (operation is not IInvocationOperation invocationOperation)
+            {
+                return false;
+            }
+
+            IOperation? ancestor = invocationOperation.WalkUpParentheses().WalkUpConversion().Parent;
+
+            if (ancestor is IInvocationOperation invocationAncestor)
+            {
+                diagnosableInvocation = invocationAncestor;
+            }
+            else if (ancestor is IArgumentOperation argumentAncestor && argumentAncestor.Parent is IInvocationOperation argumentInvocationAncestor)
+            {
+                diagnosableInvocation = argumentInvocationAncestor;
+            }
+            else
+            {
+                diagnosableInvocation = invocationOperation;
+            }
+
+            return diagnosableInvocation != null;
+        }
+
+        private static bool IsOffendingMethod(IInvocationOperation invocation, ITypeSymbol stringType,
+            [NotNullWhen(returnValue: true)] out string? offendingMethodName)
+        {
+            offendingMethodName = null;
+
+            if (!invocation.Instance.Type.Equals(stringType))
+            {
+                return false;
+            }
+
+            if (!invocation.TargetMethod.Name.Equals(StringToLowerMethodName, StringComparison.Ordinal) &&
+                !invocation.TargetMethod.Name.Equals(StringToLowerInvariantMethodName, StringComparison.Ordinal) &&
+                !invocation.TargetMethod.Name.Equals(StringToUpperMethodName, StringComparison.Ordinal) &&
+                !invocation.TargetMethod.Name.Equals(StringToUpperInvariantMethodName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            offendingMethodName = invocation.TargetMethod.Name;
+            return true;
+        }
+
+        private static string GetCaseChangingApproach(string methodName)
+        {
+            if (methodName is StringToLowerMethodName or StringToUpperMethodName)
+            {
+                return StringComparisonCurrentCultureIgnoreCaseName;
+            }
+
+            Debug.Assert(methodName is StringToLowerInvariantMethodName or StringToUpperInvariantMethodName);
+            return StringComparisonInvariantCultureIgnoreCaseName;
+        }
+
+        private static string GetPreferredCaseChangingApproach(string? leftOffendingMethodName, string? rightOffendingMethodName)
+        {
+            if (leftOffendingMethodName is StringToLowerMethodName or StringToUpperMethodName ||
+                rightOffendingMethodName is StringToLowerMethodName or StringToUpperMethodName)
+            {
+                return StringComparisonCurrentCultureIgnoreCaseName;
+            }
+
+            Debug.Assert(leftOffendingMethodName is StringToLowerInvariantMethodName or StringToUpperInvariantMethodName ||
+                         rightOffendingMethodName is StringToLowerInvariantMethodName or StringToUpperInvariantMethodName);
+            return StringComparisonInvariantCultureIgnoreCaseName;
         }
     }
 }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
@@ -63,8 +63,18 @@ namespace Microsoft.NetCore.Analyzers.Performance
             isPortedFxCopRule: false,
             isDataflowRule: false);
 
+        internal static readonly DiagnosticDescriptor RecommendCaseInsensitiveStringEqualsRule = DiagnosticDescriptorHelper.Create(
+            RuleId,
+            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringEqualsTitle)),
+            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringEqualsMessage)),
+            DiagnosticCategory.Performance,
+            RuleLevel.IdeSuggestion,
+            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringEqualsDescription)),
+            isPortedFxCopRule: false,
+            isDataflowRule: false);
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
-            RecommendCaseInsensitiveStringComparisonRule, RecommendCaseInsensitiveStringComparerRule);
+            RecommendCaseInsensitiveStringComparisonRule, RecommendCaseInsensitiveStringComparerRule, RecommendCaseInsensitiveStringEqualsRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -288,8 +298,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     { CaseChangingApproachName, caseChangingApproachValue }
                 }.ToImmutableDictionary();
 
-                context.ReportDiagnostic(
-                    binaryOperation.CreateDiagnostic(RecommendCaseInsensitiveStringComparerRule, dict));
+                context.ReportDiagnostic(binaryOperation.CreateDiagnostic(RecommendCaseInsensitiveStringEqualsRule, dict));
             }
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
         internal static readonly DiagnosticDescriptor RecommendCaseInsensitiveStringComparerRule = DiagnosticDescriptorHelper.Create(
             RuleId,
-            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringComparerTitle)),
+            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringComparisonTitle)),
             CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringComparerMessage)),
             DiagnosticCategory.Performance,
             RuleLevel.IdeSuggestion,
@@ -65,7 +65,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
         internal static readonly DiagnosticDescriptor RecommendCaseInsensitiveStringEqualsRule = DiagnosticDescriptorHelper.Create(
             RuleId,
-            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringEqualsTitle)),
+            CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringComparisonTitle)),
             CreateLocalizableResourceString(nameof(RecommendCaseInsensitiveStringEqualsMessage)),
             DiagnosticCategory.Performance,
             RuleLevel.IdeSuggestion,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
@@ -325,6 +325,11 @@ namespace Microsoft.NetCore.Analyzers.Performance
         {
             offendingMethodName = null;
 
+            if (invocation.Instance == null || invocation.Instance.Type == null)
+            {
+                return false;
+            }
+
             if (!invocation.Instance.Type.Equals(stringType))
             {
                 return false;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Analyzer.cs
@@ -203,22 +203,22 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 return;
             }
 
+            // a.ToLower().Method()
             context.RegisterOperationAction(context =>
             {
-                if (context.Operation is IInvocationOperation caseChangingInvocation)
-                {
-                    AnalyzeInvocation(context, caseChangingInvocation, stringType,
-                        containsStringMethod, startsWithStringMethod, compareToStringMethod,
-                        indexOfStringMethod, indexOfStringInt32Method, indexOfStringInt32Int32Method);
-                }
-                else if (context.Operation is IBinaryOperation binaryOperation)
-                {
-                    AnalyzeBinaryOperation(context, binaryOperation, stringType);
-                }
-            },
-                OperationKind.Invocation, // a.ToLower().Method()
-                OperationKind.Binary // a.ToLower() == b.ToLower()
-            );
+                IInvocationOperation caseChangingInvocation = (IInvocationOperation)context.Operation;
+                AnalyzeInvocation(context, caseChangingInvocation, stringType,
+                    containsStringMethod, startsWithStringMethod, compareToStringMethod,
+                    indexOfStringMethod, indexOfStringInt32Method, indexOfStringInt32Int32Method);
+            }, OperationKind.Invocation);
+
+            // a.ToLower() == b.ToLower()
+            context.RegisterOperationAction(context =>
+            {
+                IBinaryOperation binaryOperation = (IBinaryOperation)context.Operation;
+                AnalyzeBinaryOperation(context, binaryOperation, stringType);
+
+            }, OperationKind.Binary);
         }
 
         private static void AnalyzeInvocation(OperationAnalysisContext context, IInvocationOperation caseChangingInvocation, INamedTypeSymbol stringType,

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
@@ -52,7 +52,11 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 return;
             }
 
-            IOperation operation = model.GetOperation(node, ct);
+            IOperation? operation = model.GetOperation(node, ct);
+            if (operation == null)
+            {
+                return;
+            }
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(doc);
 
@@ -77,7 +81,8 @@ namespace Microsoft.NetCore.Analyzers.Performance
                         equivalenceKey: nameof(MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringComparerStringComparisonCodeFixTitle)),
                     context.Diagnostics);
             }
-            else if (operation is IBinaryOperation binaryOperation)
+            else if (operation is IBinaryOperation binaryOperation &&
+                     binaryOperation.LeftOperand != null && binaryOperation.RightOperand != null)
             {
                 Task<Document> createChangedDocument(CancellationToken _) => FixBinaryAsync(generator, doc, root, binaryOperation, stringComparisonType, caseChangingApproachValue);
 
@@ -138,11 +143,11 @@ namespace Microsoft.NetCore.Analyzers.Performance
             INamedTypeSymbol stringComparisonType, string caseChangingApproachValue)
         {
             SyntaxNode leftNode = binaryOperation.LeftOperand is IInvocationOperation leftInvocation ?
-                leftInvocation.Instance.Syntax :
+                leftInvocation.Instance!.Syntax :
                 binaryOperation.LeftOperand.Syntax;
 
             SyntaxNode rightNode = binaryOperation.RightOperand is IInvocationOperation rightInvocation ?
-                rightInvocation.Instance.Syntax :
+                rightInvocation.Instance!.Syntax :
                 binaryOperation.RightOperand.Syntax;
 
             SyntaxNode memberAccess = generator.MemberAccessExpression(leftNode, RCISCAnalyzer.StringEqualsMethodName).WithTriviaFrom(leftNode);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
@@ -86,14 +86,13 @@ namespace Microsoft.NetCore.Analyzers.Performance
             {
                 Task<Document> createChangedDocument(CancellationToken _) => FixBinaryAsync(generator, doc, root, binaryOperation, stringComparisonType, caseChangingApproachValue);
 
-                string title = string.Format(System.Globalization.CultureInfo.CurrentCulture,
-                    MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringComparerStringComparisonCodeFixTitle, RCISCAnalyzer.StringEqualsMethodName);
+                string title = MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringEqualsCodeFixTitle;
 
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         title,
                         createChangedDocument,
-                        equivalenceKey: nameof(MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringComparerStringComparisonCodeFixTitle)),
+                        equivalenceKey: nameof(MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringEqualsCodeFixTitle)),
                     context.Diagnostics);
             }
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Fixer.cs
@@ -58,7 +58,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
             Task<Document> createChangedDocument(CancellationToken _) => FixInvocationAsync(doc, root,
                 invocation, stringComparisonType, invocation.TargetMethod.Name);
 
-            string title = string.Format(
+            string title = string.Format(System.Globalization.CultureInfo.CurrentCulture,
                 MicrosoftNetCoreAnalyzersResources.RecommendCaseInsensitiveStringComparerStringComparisonCodeFixTitle, invocation.TargetMethod.Name);
 
             context.RegisterCodeFix(

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2353,6 +2353,26 @@ Obecné přetypování (IL unbox.any) používané sekvencí vrácenou metodou E
         <target state="translated">Preferovat přetížení metody StringComparison pro porovnávání řetězců bez ohledu na velikost písmen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Odebrat redundantní volání</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2333,11 +2333,6 @@ Obecné přetypování (IL unbox.any) používané sekvencí vrácenou metodou E
         <target state="translated">Použijte přetížení string.{0}(string, StringComparison)</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Preferovat použití StringComparer pro porovnávání řetězců bez rozlišení velikosti písmen</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Vyhněte se volání ToLower, ToUpper, ToLowerInvariant a ToUpperInvariant pro porovnávání řetězců bez ohledu na velikost písmen, protože vedou k alokaci. Místo toho raději volejte přetížení metod Contains, IndexOf a StartsWith, které přebírají hodnotu výčtu StringComparison, aby se provedlo porovnání bez ohledu na velikost písmen.</target>
@@ -2366,11 +2361,6 @@ Obecné přetypování (IL unbox.any) používané sekvencí vrácenou metodou E
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2333,11 +2333,6 @@ Erweiterungen und benutzerdefinierte Konvertierungen werden bei generischen Type
         <target state="translated">Verwenden Sie die "string.{0}(string, StringComparison)"-Überladung</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">"StringComparer" bevorzugen, um Zeichenfolgenvergleiche ohne Beachtung der Groß-/Kleinschreibung durchzuführen.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Vermeiden Sie das Aufrufen von "ToLower", "ToUpper", "ToLowerInvariant" und "ToUpperInvariant", um Zeichenfolgenvergleiche ohne Beachtung der Groß-/Kleinschreibung durchzuführen, da sie zu einer Zuordnung führen. Rufen Sie stattdessen lieber die Methodenüberladungen von "Contains", "IndexOf" und "StartsWith" auf, die einen StringComparison-Enumerationswert verwenden, um Vergleiche ohne Beachtung der Groß-/Kleinschreibung durchzuführen.</target>
@@ -2366,11 +2361,6 @@ Erweiterungen und benutzerdefinierte Konvertierungen werden bei generischen Type
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2353,6 +2353,26 @@ Erweiterungen und benutzerdefinierte Konvertierungen werden bei generischen Type
         <target state="translated">"StringComparison"-Methodenüberladungen bevorzugen, um Zeichenfolgenvergleiche ohne Beachtung der Groß-/Kleinschreibung durchzuführen</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Redundanten Aufruf entfernen</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2333,11 +2333,6 @@ La ampliación y las conversiones definidas por el usuario no se admiten con tip
         <target state="translated">Usar la sobrecarga "string.{0}(string, StringComparison)"</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Preferir el uso de "StringComparer" para realizar comparaciones de cadenas sin distinción de mayúsculas y minúsculas</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Evite llamar a "ToLower", "ToUpper", "ToLowerInvariant" y "ToUpperInvariant" para realizar comparaciones de cadenas sin distinción de mayúsculas y minúsculas porque dan lugar a una asignación. En su lugar, es preferible llamar a las sobrecargas de método de "Contains", "IndexOf" y "StartsWith" que toman un valor de enumeración "StringComparison" para realizar comparaciones sin distinción de mayúsculas y minúsculas.</target>
@@ -2366,11 +2361,6 @@ La ampliación y las conversiones definidas por el usuario no se admiten con tip
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2353,6 +2353,26 @@ La ampliación y las conversiones definidas por el usuario no se admiten con tip
         <target state="translated">Preferir las sobrecargas del método "StringComparison" para realizar comparaciones de cadenas sin distinción de mayúsculas y minúsculas</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Quitar llamada redundante</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2333,11 +2333,6 @@ Les conversions étendues et définies par l’utilisateur ne sont pas prises en
         <target state="translated">Utiliser la surcharge « string.{0}(string, StringComparison) »</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Préférer l’utilisation de « StringComparer » pour effectuer des comparaisons de chaînes qui ne respectent pas la casse</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Évitez d’appeler 'ToLower', 'ToUpper', 'ToLowerInvariant' et 'ToUpperInvariant' pour effectuer des comparaisons de chaînes qui ne respectent pas la casse, car elles entraînent une allocation. Préférez plutôt appeler les surcharges de méthode de 'Contains', 'IndexOf' et 'StartsWith' qui acceptent une valeur enum 'StringComparison' pour effectuer des comparaisons qui ne respectent pas la casse.</target>
@@ -2366,11 +2361,6 @@ Les conversions étendues et définies par l’utilisateur ne sont pas prises en
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2353,6 +2353,26 @@ Les conversions étendues et définies par l’utilisateur ne sont pas prises en
         <target state="translated">Préférer les surcharges de méthode 'StringComparison' pour effectuer des comparaisons de chaînes qui ne respectent pas la casse</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Supprimer un appel redondant</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2333,11 +2333,6 @@ L'ampliamento e le conversioni definite dall'utente non sono supportate con tipi
         <target state="translated">Usare l'overload “string.{0}(string, StringComparison)"</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Preferire l'uso di “StringComparer” per eseguire confronti di stringhe senza distinzione tra maiuscole e minuscole</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Evitare di chiamare “ToLower”, “ToUpper”, “ToLowerInvariant” e “ToUpperInvariant” per eseguire confronti di stringhe senza distinzione tra maiuscole e minuscole, perché comportano un'allocazione. Preferire invece chiamare i sovraccarichi dei metodi “Contains”, “IndexOf” e “StartsWith” che accettano un valore dell'enumerazione “StringComparison” per eseguire confronti senza distinzione tra maiuscole e minuscole.</target>
@@ -2366,11 +2361,6 @@ L'ampliamento e le conversioni definite dall'utente non sono supportate con tipi
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2353,6 +2353,26 @@ L'ampliamento e le conversioni definite dall'utente non sono supportate con tipi
         <target state="translated">Preferire gli overload di metodo “StringComparison” per eseguire confronti tra stringhe senza distinzione tra maiuscole e minuscole</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Rimuovi la chiamata ridondante</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2353,6 +2353,26 @@ Enumerable.OfType&lt;T&gt; で使用されるジェネリック型チェック (
         <target state="translated">大文字と小文字を区別しない文字列比較を実行するには、'StringComparison' メソッド オーバーロードをお勧めします</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">冗長な呼び出しを削除する</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2333,11 +2333,6 @@ Enumerable.OfType&lt;T&gt; で使用されるジェネリック型チェック (
         <target state="translated">'string.{0}(string, StringComparison)' オーバーロードを使用してください</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">大文字と小文字を区別しない文字列比較を実行するには、'StringComparer' を使用することをお勧めします</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">大文字と小文字を区別しない文字列比較を実行するために、'ToLower'、'ToUpper'、'ToLowerInvariant'、および 'ToUpperInvariant' を呼び出さないようにしてください。これは、割り当てにつながるためです。代わりに、'StringComparison' 列挙型の値を取る 'Contains'、'IndexOf'、'StartsWith' のメソッド オーバーロードを呼び出して、大文字と小文字を区別しない比較を実行することをお勧めします。</target>
@@ -2366,11 +2361,6 @@ Enumerable.OfType&lt;T&gt; で使用されるジェネリック型チェック (
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2353,6 +2353,26 @@ Enumerable.OfType&lt;T&gt;에서 사용하는 제네릭 형식 검사(C# 'is' �
         <target state="translated">대소문자를 구분하지 않는 문자열 비교를 수행하려면 'StringComparison' 메서드 오버로드를 선호합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">중복 호출 제거</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2333,11 +2333,6 @@ Enumerable.OfType&lt;T&gt;에서 사용하는 제네릭 형식 검사(C# 'is' �
         <target state="translated">'string.{0}(string, StringComparison)' 오버로드 사용</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">대소문자를 구분하지 않는 문자열 비교를 수행하려면 'StringComparer' 사용을 선호합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">대/소문자를 구분하지 않는 문자열 비교를 수행하기 위해 'ToLower', 'ToUpper', 'ToLowerInvariant' 및 'ToUpperInvariant'를 호출하지 마세요. 대신 대/소문자를 구분하지 않는 비교를 수행하기 위해 'StringComparison' 열거형 값을 사용하는 'Contains', 'IndexOf' 및 'StartsWith'의 메서드 오버로드를 호출하는 것이 좋습니다.</target>
@@ -2366,11 +2361,6 @@ Enumerable.OfType&lt;T&gt;에서 사용하는 제네릭 형식 검사(C# 'is' �
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2353,6 +2353,26 @@ Konwersje poszerzane i zdefiniowane przez użytkownika nie są obsługiwane w pr
         <target state="translated">Preferuj przeciążenia metody „StringComparison”, aby wykonywać porównania ciągów bez uwzględniania wielkości liter</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Usuń nadmiarowe wywołanie</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2333,11 +2333,6 @@ Konwersje poszerzane i zdefiniowane przez użytkownika nie są obsługiwane w pr
         <target state="translated">Użyj obciążenia „string.{0}(string, StringComparison)”</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Preferuj używanie elementu „StringComparer” do wykonywania porównań ciągów bez uwzględniania wielkości liter</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Unikaj wywoływania elementów „ToLower”, „ToUpper”, „ToLowerInvariant” i „ToUpperInvariant”, aby przeprowadzać porównania ciągów bez uwzględniania wielkości liter, ponieważ prowadzą do alokacji. Zamiast tego preferuj wywoływanie przeciążeń metod „Contains”, „IndexOf” i „StartsWith”, które przyjmują wartość wyliczenia „StringComparison”, aby wykonać porównania bez uwzględniania wielkości liter.</target>
@@ -2366,11 +2361,6 @@ Konwersje poszerzane i zdefiniowane przez użytkownika nie są obsługiwane w pr
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2333,11 +2333,6 @@ Ampliação e conversões definidas pelo usuário não são compatíveis com tip
         <target state="translated">Use a 'cadeia de caracteres.{0}(cadeia de caracteres, StringComparison)' sobrecarga</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Prefira usar 'StringComparer' para realizar comparações de cadeia de caracteres que não diferenciam maiúsculas de minúsculas</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Evite chamar 'ToLower', 'ToUpper', 'ToLowerInvariant' e 'ToUpperInvariant' para executar comparações de cadeia de caracteres que não diferenciam maiúsculas de minúsculas porque elas levam a uma alocação. Em vez disso, prefira chamar as sobrecargas de método de 'Contains', 'IndexOf' e 'StartsWith' que usam um valor de enumeração 'StringComparison' para executar comparações que não diferenciam maiúsculas de minúsculas.</target>
@@ -2366,11 +2361,6 @@ Ampliação e conversões definidas pelo usuário não são compatíveis com tip
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2353,6 +2353,26 @@ Ampliação e conversões definidas pelo usuário não são compatíveis com tip
         <target state="translated">Prefira as sobrecargas do método 'StringComparison' para executar comparações de cadeia de caracteres que não diferenciam maiúsculas de minúsculas</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Remova a chamada redundante</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2333,11 +2333,6 @@ Widening and user defined conversions are not supported with generic types.</sou
         <target state="translated">Используйте перегрузку "string.{0}(string, StringComparison)"</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Используйте StringComparer для сравнения строк без учета регистра</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Избегайте вызова ToLower, ToUpper, ToLowerInvariant и ToUpperInvariant для сравнения строк без учета регистра, так как они приведут к выделению. Вместо этого вызывайте перегрузки методов Contains, IndexOf и StartsWith, которые принимают значение перечисления StringComparison для сравнения без учета регистра.</target>
@@ -2366,11 +2361,6 @@ Widening and user defined conversions are not supported with generic types.</sou
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2353,6 +2353,26 @@ Widening and user defined conversions are not supported with generic types.</sou
         <target state="translated">Используйте перегрузки метода StringComparison для сравнения строк без учета регистра</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Удалить избыточный вызов</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2353,6 +2353,26 @@ Genel türlerde genişletme ve kullanıcı tanımlı dönüştürmeler desteklen
         <target state="translated">Büyük/küçük harfe duyarsız dize karşılaştırmaları gerçekleştirmek için 'StringComparison' metodu aşırı yüklemelerini tercih edin</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">Gereksiz çağrıyı kaldır</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2333,11 +2333,6 @@ Genel türlerde genişletme ve kullanıcı tanımlı dönüştürmeler desteklen
         <target state="translated">'string.{0}(string, StringComparison)' aşırı yüklemesini kullan</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">Büyük/küçük harfe duyarsız dize karşılaştırmaları gerçekleştirmek için 'StringComparer' kullanmayı tercih edin</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">Bir ayırmaya yol açtıkları için büyük/küçük harfe duyarsız dize karşılaştırmaları gerçekleştirmek için 'ToLower', 'ToUpper', 'ToLowerInvariant' ve 'ToUpperInvariant' aramaktan kaçının. Bunun yerine, büyük/küçük harfe duyarsız karşılaştırmalar gerçekleştirmek için bir 'StringComparison' enum değeri alan 'Contains', 'IndexOf' ve 'StartsWith' yöntem aşırı yüklemelerini aramayı tercih edin.</target>
@@ -2366,11 +2361,6 @@ Genel türlerde genişletme ve kullanıcı tanımlı dönüştürmeler desteklen
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2353,6 +2353,26 @@ Enumerable.OfType&lt;T&gt; 使用的泛型类型检查 (C# 'is' operator/IL 'isi
         <target state="translated">首选 "StringComparison" 方法重载来执行不区分大小写的字符串比较</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">删除冗余的调用</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2333,11 +2333,6 @@ Enumerable.OfType&lt;T&gt; 使用的泛型类型检查 (C# 'is' operator/IL 'isi
         <target state="translated">使用 "string.{0}(string, StringComparison)" 重载</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">首选使用 "StringComparer" 执行不区分大小写的字符串比较</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">避免调用 "ToLower"、"ToUpper"、"ToLowerInvariant" 和 "ToUpperInvariant" 来执行不区分大小写的字符串比较，因为它们会导致分配。相反，首选调用采用 "StringComparison" 枚举值的 "Contains"、"IndexOf" 和 "StartsWith" 的方法重载来执行不区分大小写的比较。</target>
@@ -2366,11 +2361,6 @@ Enumerable.OfType&lt;T&gt; 使用的泛型类型检查 (C# 'is' operator/IL 'isi
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2353,6 +2353,26 @@ Enumerable.OfType&lt;T&gt; 使用的一般型別檢查 (C# 'is' operator/IL 'isi
         <target state="translated">偏好使用 'StringComparison' 方法多載來執行不區分大小寫的字串比較</target>
         <note />
       </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsCodeFixTitle">
+        <source>Use 'string.Equals(string, StringComparison)'</source>
+        <target state="new">Use 'string.Equals(string, StringComparison)'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsDescription">
+        <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</source>
+        <target state="new">Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
+        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
+        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RemoveRedundantCall">
         <source>Remove redundant call</source>
         <target state="translated">移除冗餘的呼叫</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2333,11 +2333,6 @@ Enumerable.OfType&lt;T&gt; 使用的一般型別檢查 (C# 'is' operator/IL 'isi
         <target state="translated">使用 'string.{0}(string, StringComparison)' 多載</target>
         <note />
       </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringComparerTitle">
-        <source>Prefer using 'StringComparer' to perform case-insensitive string comparisons</source>
-        <target state="translated">偏好使用 'StringComparer' 來執行不區分大小寫的字串比較</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RecommendCaseInsensitiveStringComparisonDescription">
         <source>Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons because they lead to an allocation. Instead, prefer calling the method overloads of 'Contains', 'IndexOf' and 'StartsWith' that take a 'StringComparison' enum value to perform case-insensitive comparisons.</source>
         <target state="translated">避免呼叫 'ToLower'、'ToUpper'、'ToLowerInvariant' 和 'ToUpperInvariant' 來執行不區分大小寫的字串比較，因為它們會導致配置。相反地，偏好呼叫採用 'StringComparison' 列舉值的 'Contains'、'IndexOf' 和 'StartsWith' 方法多載，以執行不區分大小寫的比較。</target>
@@ -2366,11 +2361,6 @@ Enumerable.OfType&lt;T&gt; 使用的一般型別檢查 (C# 'is' operator/IL 'isi
       <trans-unit id="RecommendCaseInsensitiveStringEqualsMessage">
         <source>Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</source>
         <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RecommendCaseInsensitiveStringEqualsTitle">
-        <source>Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</source>
-        <target state="new">Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons</target>
         <note />
       </trans-unit>
       <trans-unit id="RemoveRedundantCall">

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1704,9 +1704,9 @@ Constant arrays passed as arguments are not reused when called repeatedly, which
 |CodeFix|True|
 ---
 
-## [CA1862](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862): Prefer using 'StringComparer' to perform case-insensitive string comparisons
+## [CA1862](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862): Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons
 
-Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons when using 'CompareTo', because they lead to an allocation. Instead, use 'StringComparer' to perform case-insensitive comparisons.
+Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.
 
 |Item|Value|
 |-|-|

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md
@@ -1704,7 +1704,7 @@ Constant arrays passed as arguments are not reused when called repeatedly, which
 |CodeFix|True|
 ---
 
-## [CA1862](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862): Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons
+## [CA1862](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862): Prefer the 'StringComparison' method overloads to perform case-insensitive string comparisons
 
 Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3158,7 +3158,7 @@
         },
         "CA1862": {
           "id": "CA1862",
-          "shortDescription": "Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons",
+          "shortDescription": "Prefer the 'StringComparison' method overloads to perform case-insensitive string comparisons",
           "fullDescription": "Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.",
           "defaultLevel": "note",
           "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862",

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -3158,8 +3158,8 @@
         },
         "CA1862": {
           "id": "CA1862",
-          "shortDescription": "Prefer using 'StringComparer' to perform case-insensitive string comparisons",
-          "fullDescription": "Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons when using 'CompareTo', because they lead to an allocation. Instead, use 'StringComparer' to perform case-insensitive comparisons.",
+          "shortDescription": "Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons",
+          "fullDescription": "Avoid calling 'ToLower', 'ToUpper', 'ToLowerInvariant' and 'ToUpperInvariant' to perform case-insensitive string comparisons, as in 'string.ToLower() == string.ToLower()', because they lead to an allocation. Instead, use 'string.Equals(string, StringComparison)' to perform case-insensitive comparisons.",
           "defaultLevel": "note",
           "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862",
           "properties": {

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -8,7 +8,7 @@ CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513> | Use ObjectDisposedException throw helper |
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
-CA1862 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862> | Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons |
+CA1862 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862> | Prefer the 'StringComparison' method overloads to perform case-insensitive string comparisons |
 CA1863 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1863> | Use 'CompositeFormat' |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |
 CA2261 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2261> | Do not use ConfigureAwaitOptions.SuppressThrowing with Task\<TResult> |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -8,7 +8,7 @@ CA1512 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1513 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1513> | Use ObjectDisposedException throw helper |
 CA1856 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1856> | Incorrect usage of ConstantExpected attribute |
 CA1857 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1857> | A constant is expected for the parameter |
-CA1862 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862> | Prefer using 'StringComparer' to perform case-insensitive string comparisons |
+CA1862 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862> | Prefer using 'string.Equals(string, StringComparison)' to perform case-insensitive string comparisons |
 CA1863 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1863> | Use 'CompositeFormat' |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |
 CA2261 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2261> | Do not use ConfigureAwaitOptions.SuppressThrowing with Task\<TResult> |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
@@ -353,8 +353,18 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     yield return new object[] { $"a {before} b.To{casing}()",          $"{after}a.Equals(b, StringComparison.CurrentCultureIgnoreCase)" };
                     yield return new object[] { $"a {before} b.To{casing}Invariant()", $"{after}a.Equals(b, StringComparison.InvariantCultureIgnoreCase)" };
 
-                    yield return new object[] { $"\"abc\" {before} b.To{casing}()",          $"{after}\"abc\".Equals(b, StringComparison.CurrentCultureIgnoreCase)" };
-                    yield return new object[] { $"\"abc\" {before} b.To{casing}Invariant()", $"{after}\"abc\".Equals(b, StringComparison.InvariantCultureIgnoreCase)" };
+                    yield return new object[] { $"\"abc\" {before} b.To{casing}()",                                $"{after}\"abc\".Equals(b, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"\"abc\" {before} b.To{casing}Invariant()",                       $"{after}\"abc\".Equals(b, StringComparison.InvariantCultureIgnoreCase)" };
+                    yield return new object[] { $"\"abc\".To{casing}() {before} b.To{casing}()",                   $"{after}\"abc\".Equals(b, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"\"abc\".To{casing}() {before} b.To{casing}Invariant()",          $"{after}\"abc\".Equals(b, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"\"abc\".To{casing}Invariant() {before} b.To{casing}Invariant()", $"{after}\"abc\".Equals(b, StringComparison.InvariantCultureIgnoreCase)" };
+
+                    yield return new object[] { $"GetString().To{casing}() {before} a.To{casing}()",          $"{after}GetString().Equals(a, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"GetString().To{casing}() {before} a.To{casing}Invariant()", $"{after}GetString().Equals(a, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"GetString().To{casing}Invariant() {before} a.To{casing}()", $"{after}GetString().Equals(a, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"GetString().To{casing}() {before} a",                       $"{after}GetString().Equals(a, StringComparison.CurrentCultureIgnoreCase)" };
+                    yield return new object[] { $"GetString().To{casing}Invariant() {before} a",              $"{after}GetString().Equals(a, StringComparison.InvariantCultureIgnoreCase)" };
+                    yield return new object[] { $"GetString().To{casing}Invariant() {before} \"abc\"",        $"{after}GetString().Equals(\"abc\", StringComparison.InvariantCultureIgnoreCase)" };
                 }
             }
 #pragma warning restore format

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
@@ -391,6 +391,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 yield return new object[] { $"\"aBc\".ToLowerInvariant().{method}(ch, StringComparison.CurrentCulture)" };
             }
 
+            // CompareTo
             yield return new object[] { "\"aBc\".CompareTo(obj)" };
             yield return new object[] { "\"aBc\".ToLower().CompareTo(obj)" };
             yield return new object[] { "\"aBc\".CompareTo(\"cDe\")" };
@@ -405,6 +406,25 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 yield return new object[] { $"\"aBc\".{caseChanging}().CompareTo(\"CdE\")" };
                 yield return new object[] { $"GetStringA().{caseChanging}().CompareTo(GetStringB())" };
                 yield return new object[] { $"(\"aBc\".{caseChanging}()).CompareTo(\"CdE\")" };
+            }
+        }
+
+        public static IEnumerable<object[]> CSharpDiagnosticNoFixEqualsData() => DiagnosticNoFixEqualsData(CSharpComparisonOperators);
+        public static IEnumerable<object[]> VisualBasicDiagnosticNoFixEqualsData() => DiagnosticNoFixEqualsData(VisualBasicComparisonOperators);
+
+        private static IEnumerable<object[]> DiagnosticNoFixEqualsData(Tuple<string, string>[] ops)
+        {
+            foreach ((string op, _) in ops)
+            {
+                yield return new object[] { $"\"aBc\".ToLower() {op} \"cDe\".ToLowerInvariant()" };
+                yield return new object[] { $"\"aBc\".ToLower() {op} \"cDe\".ToUpperInvariant()" };
+                yield return new object[] { $"\"aBc\".ToUpper() {op} \"cDe\".ToLowerInvariant()" };
+                yield return new object[] { $"\"aBc\".ToUpper() {op} \"cDe\".ToUpperInvariant()" };
+
+                yield return new object[] { $"\"aBc\".ToLowerInvariant() {op} \"cDe\".ToLower()" };
+                yield return new object[] { $"\"aBc\".ToLowerInvariant() {op} \"cDe\".ToUpper()" };
+                yield return new object[] { $"\"aBc\".ToUpperInvariant() {op} \"cDe\".ToLower()" };
+                yield return new object[] { $"\"aBc\".ToUpperInvariant() {op} \"cDe\".ToUpper()" };
             }
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
@@ -7,23 +7,23 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 {
     public abstract class RecommendCaseInsensitiveStringComparison_Base_Tests
     {
-        private static readonly ValueTuple<string, string>[] Cultures = new[] {
-            ValueTuple.Create("ToLower", "CurrentCultureIgnoreCase"),
-            ValueTuple.Create("ToUpper", "CurrentCultureIgnoreCase"),
-            ValueTuple.Create("ToLowerInvariant", "InvariantCultureIgnoreCase"),
-            ValueTuple.Create("ToUpperInvariant", "InvariantCultureIgnoreCase")
+        private static readonly (string, string)[] Cultures = new[] {
+            ("ToLower", "CurrentCultureIgnoreCase"),
+            ("ToUpper", "CurrentCultureIgnoreCase"),
+            ("ToLowerInvariant", "InvariantCultureIgnoreCase"),
+            ("ToUpperInvariant", "InvariantCultureIgnoreCase")
         };
 
         private static readonly string[] ContainsStartsWith = new[] { "Contains", "StartsWith" };
         private static readonly string[] UnnamedArgs = new[] { "", ", 1", ", 1, 1" };
 
-        private static readonly ValueTuple<string, string>[] CSharpComparisonOperators = new[] {
-            ValueTuple.Create("==", ""),
-            ValueTuple.Create("!=", "!")
+        private static readonly (string, string)[] CSharpComparisonOperators = new[] {
+            ("==", ""),
+            ("!=", "!")
         };
-        private static readonly ValueTuple<string, string>[] VisualBasicComparisonOperators = new[] {
-            ValueTuple.Create("=", ""),
-            ValueTuple.Create("<>", "Not ")
+        private static readonly (string, string)[] VisualBasicComparisonOperators = new[] {
+            ("=", ""),
+            ("<>", "Not ")
         };
 
         private const string CSharpSeparator = ": ";

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.Base.Tests.cs
@@ -7,23 +7,23 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 {
     public abstract class RecommendCaseInsensitiveStringComparison_Base_Tests
     {
-        private static readonly Tuple<string, string>[] Cultures = new[] {
-            Tuple.Create("ToLower", "CurrentCultureIgnoreCase"),
-            Tuple.Create("ToUpper", "CurrentCultureIgnoreCase"),
-            Tuple.Create("ToLowerInvariant", "InvariantCultureIgnoreCase"),
-            Tuple.Create("ToUpperInvariant", "InvariantCultureIgnoreCase")
+        private static readonly ValueTuple<string, string>[] Cultures = new[] {
+            ValueTuple.Create("ToLower", "CurrentCultureIgnoreCase"),
+            ValueTuple.Create("ToUpper", "CurrentCultureIgnoreCase"),
+            ValueTuple.Create("ToLowerInvariant", "InvariantCultureIgnoreCase"),
+            ValueTuple.Create("ToUpperInvariant", "InvariantCultureIgnoreCase")
         };
 
         private static readonly string[] ContainsStartsWith = new[] { "Contains", "StartsWith" };
         private static readonly string[] UnnamedArgs = new[] { "", ", 1", ", 1, 1" };
 
-        private static readonly Tuple<string, string>[] CSharpComparisonOperators = new[] {
-            Tuple.Create("==", ""),
-            Tuple.Create("!=", "!")
+        private static readonly ValueTuple<string, string>[] CSharpComparisonOperators = new[] {
+            ValueTuple.Create("==", ""),
+            ValueTuple.Create("!=", "!")
         };
-        private static readonly Tuple<string, string>[] VisualBasicComparisonOperators = new[] {
-            Tuple.Create("=", ""),
-            Tuple.Create("<>", "Not ")
+        private static readonly ValueTuple<string, string>[] VisualBasicComparisonOperators = new[] {
+            ValueTuple.Create("=", ""),
+            ValueTuple.Create("<>", "Not ")
         };
 
         private const string CSharpSeparator = ": ";
@@ -333,7 +333,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
             DiagnosedAndFixedEqualityToEqualsData(CSharpComparisonOperators);
         public static IEnumerable<object[]> VisualBasicDiagnosedAndFixedEqualityToEqualsData() =>
             DiagnosedAndFixedEqualityToEqualsData(VisualBasicComparisonOperators);
-        private static IEnumerable<object[]> DiagnosedAndFixedEqualityToEqualsData(Tuple<string, string>[] comparisonOperators)
+        private static IEnumerable<object[]> DiagnosedAndFixedEqualityToEqualsData(ValueTuple<string, string>[] comparisonOperators)
         {
 #pragma warning disable format
             foreach (string casing in new[]{ "Lower", "Upper" })
@@ -412,7 +412,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static IEnumerable<object[]> CSharpDiagnosticNoFixEqualsData() => DiagnosticNoFixEqualsData(CSharpComparisonOperators);
         public static IEnumerable<object[]> VisualBasicDiagnosticNoFixEqualsData() => DiagnosticNoFixEqualsData(VisualBasicComparisonOperators);
 
-        private static IEnumerable<object[]> DiagnosticNoFixEqualsData(Tuple<string, string>[] ops)
+        private static IEnumerable<object[]> DiagnosticNoFixEqualsData(ValueTuple<string, string>[] ops)
         {
             foreach ((string op, _) in ops)
             {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.CSharp.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.CSharp.Tests.cs
@@ -212,6 +212,33 @@ class C
         }
 
         [Theory]
+        [MemberData(nameof(CSharpDiagnosedAndFixedEqualityToEqualsData))]
+        public async Task Diagnostic_Equality_To_Equals(string diagnosedLine, string fixedLine)
+        {
+            string originalCode = $@"using System;
+class C
+{{
+    bool M(string a, string b)
+    {{
+        bool result = [|{diagnosedLine}|];
+        if ([|{diagnosedLine}|]) return result;
+        return [|{diagnosedLine}|];
+    }}
+}}";
+            string fixedCode = $@"using System;
+class C
+{{
+    bool M(string a, string b)
+    {{
+        bool result = {fixedLine};
+        if ({fixedLine}) return result;
+        return {fixedLine};
+    }}
+}}";
+            await VerifyFixCSharpAsync(originalCode, fixedCode);
+        }
+
+        [Theory]
         [MemberData(nameof(NoDiagnosticData))]
         [InlineData("\"aBc\".CompareTo(null)")]
         [InlineData("\"aBc\".ToUpperInvariant().CompareTo((object)null)")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.CSharp.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.CSharp.Tests.cs
@@ -318,6 +318,22 @@ class C
             await VerifyDiagnosticOnlyCSharpAsync(originalCode);
         }
 
+        [Theory]
+        [MemberData(nameof(CSharpDiagnosticNoFixEqualsData))]
+        public async Task Diagnostic_NoFix_Equals(string diagnosedLine)
+        {
+            string originalCode = $@"using System;
+class C
+{{
+    bool M()
+    {{
+        return [|{diagnosedLine}|];
+    }}
+}}";
+
+            await VerifyDiagnosticOnlyCSharpAsync(originalCode);
+        }
+
         private async Task VerifyNoDiagnosticCSharpAsync(string originalSource)
         {
             VerifyCS.Test test = new()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
@@ -219,6 +219,33 @@ End Class";
         }
 
         [Theory]
+        [MemberData(nameof(VisualBasicDiagnosedAndFixedEqualityToEqualsData))]
+        public async Task Diagnostic_Equality_To_Equals(string diagnosedLine, string fixedLine)
+        {
+            string originalCode = $@"Imports System
+Class C
+    Function M(a As String, b As String) As Boolean
+        Dim result As Boolean = [|{diagnosedLine}|]
+        If [|{diagnosedLine}|] Then
+            Return result
+        End If
+        Return [|{diagnosedLine}|]
+    End Function
+End Class";
+            string fixedCode = $@"Imports System
+Class C
+    Function M(a As String, b As String) As Boolean
+        Dim result As Boolean = {fixedLine}
+        If {fixedLine} Then
+            Return result
+        End If
+        Return {fixedLine}
+    End Function
+End Class";
+            await VerifyFixVisualBasicAsync(originalCode, fixedCode);
+        }
+
+        [Theory]
         [MemberData(nameof(NoDiagnosticData))]
         [InlineData("\"aBc\".CompareTo(Nothing)")]
         [InlineData("\"aBc\".ToUpperInvariant().CompareTo(CObj(Nothing))")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
@@ -245,6 +245,44 @@ End Class";
             await VerifyFixVisualBasicAsync(originalCode, fixedCode);
         }
 
+        [Fact]
+        public async Task Diagnostic_Equality_To_Equals_Trivia()
+        {
+            string originalCode = $@"Imports System
+Class C
+    Function M(a As String, b As String) As Boolean
+        ' Trivia1
+        Dim result As Boolean = [|a.ToLower() = b.ToLowerInvariant()|] ' Trivia2
+        ' Trivia3
+        If [|a.ToLowerInvariant() <> b.ToLower()|] Then ' Trivia4
+            ' Trivia5
+            Return [|b <> a.ToLowerInvariant()|] ' Trivia6
+            ' Trivia7
+        End If
+        ' Trivia8
+        Return [|""abc"" = a.ToUpperInvariant()|] ' Trivia9
+        ' Trivia10
+    End Function
+End Class";
+            string fixedCode = $@"Imports System
+Class C
+    Function M(a As String, b As String) As Boolean
+        ' Trivia1
+        Dim result As Boolean = a.Equals(b, StringComparison.CurrentCultureIgnoreCase) ' Trivia2
+        ' Trivia3
+        If Not a.Equals(b, StringComparison.CurrentCultureIgnoreCase) Then ' Trivia4
+            ' Trivia5
+            Return Not b.Equals(a, StringComparison.InvariantCultureIgnoreCase) ' Trivia6
+            ' Trivia7
+        End If
+        ' Trivia8
+        Return ""abc"".Equals(a, StringComparison.InvariantCultureIgnoreCase) ' Trivia9
+        ' Trivia10
+    End Function
+End Class";
+            await VerifyFixVisualBasicAsync(originalCode, fixedCode);
+        }
+
         [Theory]
         [MemberData(nameof(NoDiagnosticData))]
         [InlineData("\"aBc\".CompareTo(Nothing)")]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
@@ -332,6 +332,20 @@ End Class";
             await VerifyDiagnosticOnlyVisualBasicAsync(originalCode);
         }
 
+        [Theory]
+        [MemberData(nameof(VisualBasicDiagnosticNoFixEqualsData))]
+        public async Task Diagnostic_NoFix_Equals(string diagnosedLine)
+        {
+            string originalCode = $@"Imports System
+Class C
+    Public Function M() As Boolean
+        Return [|{diagnosedLine}|]
+    End Function
+End Class";
+
+            await VerifyDiagnosticOnlyVisualBasicAsync(originalCode);
+        }
+
         private async Task VerifyNoDiagnosticVisualBasicAsync(string originalSource)
         {
             VerifyVB.Test test = new()

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/RecommendCaseInsensitiveStringComparison.VisualBasic.Tests.cs
@@ -224,6 +224,9 @@ End Class";
         {
             string originalCode = $@"Imports System
 Class C
+    Function GetString() As String
+        Return ""cde""
+    End Function
     Function M(a As String, b As String) As Boolean
         Dim result As Boolean = [|{diagnosedLine}|]
         If [|{diagnosedLine}|] Then
@@ -234,6 +237,9 @@ Class C
 End Class";
             string fixedCode = $@"Imports System
 Class C
+    Function GetString() As String
+        Return ""cde""
+    End Function
     Function M(a As String, b As String) As Boolean
         Dim result As Boolean = {fixedLine}
         If {fixedLine} Then

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicRecommendCaseInsensitiveStringComparisonFixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicRecommendCaseInsensitiveStringComparisonFixer.vb
@@ -14,9 +14,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
     Public NotInheritable Class BasicRecommendCaseInsensitiveStringComparisonFixer
         Inherits RecommendCaseInsensitiveStringComparisonFixer
 
-        Protected Overrides Function GetNewArguments(generator As SyntaxGenerator, caseChangingApproachValue As String,
+        Protected Overrides Function GetNewArgumentsForInvocation(generator As SyntaxGenerator, caseChangingApproachValue As String,
                 mainInvocationOperation As IInvocationOperation, stringComparisonType As INamedTypeSymbol,
-                ByRef mainInvocationInstance As SyntaxNode) As List(Of SyntaxNode)
+                ByRef mainInvocationInstance As SyntaxNode) As IEnumerable(Of SyntaxNode)
 
             Dim paramName As String = RecommendCaseInsensitiveStringComparisonAnalyzer.StringParameterName
 
@@ -93,7 +93,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                 End If
 
-                arguments.Add(newArgumentNode)
+                arguments.Add(newArgumentNode.WithTriviaFrom(node))
 
             Next
 
@@ -107,6 +107,15 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
         End Function
 
+        Protected Overrides Function GetNewArgumentsForBinary(generator As SyntaxGenerator, rightNode As SyntaxNode, typeMemberAccess As SyntaxNode) As IEnumerable(Of SyntaxNode)
+
+            Return New List(Of SyntaxNode) From
+            {
+                generator.Argument(rightNode.WithoutTrivia()),' Need To remove any trivia because otherwise an unexpected newline is added
+                generator.Argument(typeMemberAccess)
+            }
+
+        End Function
     End Class
 
 End Namespace

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicRecommendCaseInsensitiveStringComparisonFixer.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicRecommendCaseInsensitiveStringComparisonFixer.vb
@@ -14,8 +14,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
     Public NotInheritable Class BasicRecommendCaseInsensitiveStringComparisonFixer
         Inherits RecommendCaseInsensitiveStringComparisonFixer
 
-        Protected Overrides Function GetNewArguments(generator As SyntaxGenerator, mainInvocationOperation As IInvocationOperation,
-            stringComparisonType As INamedTypeSymbol, ByRef mainInvocationInstance As SyntaxNode) As List(Of SyntaxNode)
+        Protected Overrides Function GetNewArguments(generator As SyntaxGenerator, caseChangingApproachValue As String,
+                mainInvocationOperation As IInvocationOperation, stringComparisonType As INamedTypeSymbol,
+                ByRef mainInvocationInstance As SyntaxNode) As List(Of SyntaxNode)
 
             Dim paramName As String = RecommendCaseInsensitiveStringComparisonAnalyzer.StringParameterName
 
@@ -24,8 +25,8 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
             Dim invocationExpression As InvocationExpressionSyntax = DirectCast(mainInvocationOperation.Syntax, InvocationExpressionSyntax)
 
-            Dim caseChangingApproachName As String = ""
             Dim isChangingCaseInArgument As Boolean = False
+            mainInvocationInstance = Nothing
 
             Dim memberAccessExpression As MemberAccessExpressionSyntax = TryCast(invocationExpression.Expression, MemberAccessExpressionSyntax)
 
@@ -48,7 +49,6 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                 If internalMemberAccessExpression IsNot Nothing Then
                     mainInvocationInstance = internalMemberAccessExpression.Expression
-                    caseChangingApproachName = GetCaseChangingApproach(internalMemberAccessExpression.Name.Identifier.ValueText)
                 Else
                     mainInvocationInstance = memberAccessExpression.Expression
                     isChangingCaseInArgument = True
@@ -72,9 +72,6 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
                 If argumentInvocationExpression IsNot Nothing Then
                     argumentMemberAccessExpression = TryCast(argumentInvocationExpression.Expression, MemberAccessExpressionSyntax)
-                    If argumentMemberAccessExpression IsNot Nothing Then
-                        caseChangingApproachName = GetCaseChangingApproach(argumentMemberAccessExpression.Name.Identifier.ValueText)
-                    End If
                 End If
 
                 Dim newArgumentNode As SyntaxNode
@@ -100,10 +97,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
 
             Next
 
-            Debug.Assert(caseChangingApproachName IsNot Nothing)
             Debug.Assert(mainInvocationInstance IsNot Nothing)
 
-            Dim stringComparisonArgument As SyntaxNode = GetNewStringComparisonArgument(generator, stringComparisonType, caseChangingApproachName, isAnyArgumentNamed)
+            Dim stringComparisonArgument As SyntaxNode = GetNewStringComparisonArgument(generator, stringComparisonType, caseChangingApproachValue, isAnyArgumentNamed)
 
             arguments.Add(stringComparisonArgument)
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78607

Follow up of https://github.com/dotnet/runtime/issues/78606 

- Made sure it handles both `==`/`=` and `!=`/`<>` (C#/VB)
- Moved some code from the fixer to the analyzer and passed the result in the immutable dictionary (follow up of a suggestion by @Youssef1313)
- Added trivia support for both this new case and the original