### PR TITLE
Don't emit CA1002 when type is sealed

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotExposeGenericLists.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotExposeGenericLists.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     // FxCop compat: only analyze externally visible symbols by default.
                     if (!context.Options.MatchesConfiguredVisibility(Rule, field, context.Compilation) ||
-                        field.ContainingType.IsSealed)
+                        field.ContainingType is { TypeKind: TypeKind.Class, IsSealed: true })
                     {
                         return;
                     }
@@ -67,7 +67,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     if (property.IsOverride ||
                         property.IsImplementationOfAnyInterfaceMember() ||
-                        property.ContainingType.IsSealed)
+                        property.ContainingType is { TypeKind: TypeKind.Class, IsSealed: true })
                     {
                         return;
                     }
@@ -98,7 +98,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                     if (methodSymbol.IsOverride ||
                         methodSymbol.IsImplementationOfAnyInterfaceMember() ||
-                        methodSymbol.ContainingType.IsSealed)
+                        methodSymbol.ContainingType is { TypeKind: TypeKind.Class, IsSealed: true })
                     {
                         return;
                     }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotExposeGenericLists.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DoNotExposeGenericLists.cs
@@ -47,7 +47,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     var field = (IFieldSymbol)context.Symbol;
 
                     // FxCop compat: only analyze externally visible symbols by default.
-                    if (!context.Options.MatchesConfiguredVisibility(Rule, field, context.Compilation))
+                    if (!context.Options.MatchesConfiguredVisibility(Rule, field, context.Compilation) ||
+                        field.ContainingType.IsSealed)
                     {
                         return;
                     }
@@ -65,7 +66,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     var property = (IPropertySymbol)context.Symbol;
 
                     if (property.IsOverride ||
-                        property.IsImplementationOfAnyInterfaceMember())
+                        property.IsImplementationOfAnyInterfaceMember() ||
+                        property.ContainingType.IsSealed)
                     {
                         return;
                     }
@@ -95,7 +97,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     }
 
                     if (methodSymbol.IsOverride ||
-                        methodSymbol.IsImplementationOfAnyInterfaceMember())
+                        methodSymbol.IsImplementationOfAnyInterfaceMember() ||
+                        methodSymbol.ContainingType.IsSealed)
                     {
                         return;
                     }


### PR DESCRIPTION
Fixes dotnet/runtime#88310