### PR TITLE
Improve PropertiesShouldNotBeWriteOnly performance

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/PropertiesShouldNotBeWriteOnly.cs
@@ -70,25 +70,26 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 return;
             }
 
-            // Only analyze externally visible properties by default
-            if (!context.Options.MatchesConfiguredVisibility(AddGetterRule, property, context.Compilation))
-            {
-                Debug.Assert(!context.Options.MatchesConfiguredVisibility(MakeMoreAccessibleRule, property, context.Compilation));
-                return;
-            }
-
-            Debug.Assert(context.Options.MatchesConfiguredVisibility(MakeMoreAccessibleRule, property, context.Compilation));
+            Debug.Assert(context.Options.MatchesConfiguredVisibility(MakeMoreAccessibleRule, property, context.Compilation) == context.Options.MatchesConfiguredVisibility(AddGetterRule, property, context.Compilation));
 
             // We handled the non-CA1044 cases earlier.  Now, we handle CA1044 cases
             // If there is no getter then it is not accessible
             if (property.IsWriteOnly)
             {
-                context.ReportDiagnostic(property.CreateDiagnostic(AddGetterRule, property.Name));
+                // Only analyze externally visible properties by default
+                if (context.Options.MatchesConfiguredVisibility(AddGetterRule, property, context.Compilation))
+                {
+                    context.ReportDiagnostic(property.CreateDiagnostic(AddGetterRule, property.Name));
+                }
             }
             // Otherwise if there is a setter, check for its relative accessibility
             else if (!property.IsReadOnly && (property.GetMethod!.DeclaredAccessibility < property.SetMethod!.DeclaredAccessibility))
             {
-                context.ReportDiagnostic(property.CreateDiagnostic(MakeMoreAccessibleRule, property.Name));
+                // Only analyze externally visible properties by default
+                if (context.Options.MatchesConfiguredVisibility(MakeMoreAccessibleRule, property, context.Compilation))
+                {
+                    context.ReportDiagnostic(property.CreateDiagnostic(MakeMoreAccessibleRule, property.Name));
+                }
             }
         }
     }


### PR DESCRIPTION
This ends up allocating `Location[]` here:

https://github.com/dotnet/roslyn-analyzers/blob/9653f963f44ab15d64e8131ed8240c249d3cb84d/src/Utilities/Compiler/Options/AnalyzerOptionsExtensions.cs#L34

and `MatchesConfiguredVisibility` might be generally slow. So we avoid calling it until we are about to issue a diagnostic.

In the trace I'm looking at currently, there is not so much allocations, but still an improvement.

![image](https://github.com/dotnet/roslyn-analyzers/assets/31348972/e9143a5d-e889-4e20-82ce-6b30492fe5ea)
