### PR TITLE
Check method name for CA1305

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProvider.cs
@@ -246,9 +246,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                             && x.ArgumentKind == ArgumentKind.DefaultValue);
 
                         var nullableType = invocationExpression.Instance?.Type.GetNullableValueTypeUnderlyingType();
-                        var isNullableNumberInvocation = numberTypes.Contains(nullableType, SymbolEqualityComparer.Default);
+                        var isDefaultToStringInvocation = invocationExpression.TargetMethod is { Name: nameof(object.ToString), Parameters.Length: 0 };
+                        var isNullableNumberToStringInvocation = isDefaultToStringInvocation && numberTypes.Contains(nullableType, SymbolEqualityComparer.Default);
 
-                        if (currentCallHasNullFormatProvider || isNullableNumberInvocation)
+                        if (currentCallHasNullFormatProvider || isNullableNumberToStringInvocation)
                         {
                             oaContext.ReportDiagnostic(invocationExpression.CreateDiagnostic(IFormatProviderOptionalRule,
                                 targetMethod.ToDisplayString(SymbolDisplayFormats.ShortSymbolDisplayFormat)));

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/SpecifyIFormatProviderTests.cs
@@ -1611,6 +1611,47 @@ public class Test {{
             return VerifyCS.VerifyAnalyzerAsync(code, new DiagnosticResult(SpecifyIFormatProviderAnalyzer.IFormatProviderOptionalRule).WithLocation(0).WithArguments($"{valueType}?.ToString()"));
         }
 
+        [Theory, WorkItem(6746, "https://github.com/dotnet/roslyn-analyzers/issues/6586")]
+        [InlineData("int")]
+        [InlineData("uint")]
+        [InlineData("long")]
+        [InlineData("ulong")]
+        [InlineData("short")]
+        [InlineData("ushort")]
+        [InlineData("double")]
+        [InlineData("float")]
+        [InlineData("decimal")]
+        public Task FormatProviderForNullableValueTypesAlreadyProvided_NoDiagnostic(string valueType)
+        {
+            var code = $@"
+using System.Globalization;
+
+public class Test {{
+    public void M({valueType}? x) {{
+        var y = x?.ToString(CultureInfo.CurrentCulture);
+    }}
+}}";
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Theory, WorkItem(6746, "https://github.com/dotnet/roslyn-analyzers/issues/6746")]
+        [CombinatorialData]
+        public Task FormatProviderForNullableValueTypes_NoDiagnostic(
+            [CombinatorialValues("int", "uint", "long", "ulong", "short", "ushort", "double", "float", "decimal")] string valueType,
+            [CombinatorialValues("GetHashCode", "GetValueOrDefault")] string methodName
+        )
+        {
+            var code = $@"
+public class Test {{
+    public void M({valueType}? x) {{
+        var y = x.{methodName}();
+    }}
+}}";
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
         private DiagnosticResult GetIFormatProviderAlternateStringRuleCSharpResultAt(int line, int column, string arg1, string arg2, string arg3) =>
 #pragma warning disable RS0030 // Do not use banned APIs
             VerifyCS.Diagnostic(SpecifyIFormatProviderAnalyzer.IFormatProviderAlternateStringRule)


### PR DESCRIPTION
This PR fixes an issue where CA1305 is reported on nullable value types on any method invocation, when it should just be reporting on `ToString()` invocations. This was introduced by #6730.

Sorry about that!

Fixes #6745 and #6746