### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.1.2-beta1.23357.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -88,7 +88,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftVisualStudioThreadingAnalyzersVersion>17.0.26-alpha</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <!-- Roslyn Testing -->
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23322.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23357.1</MicrosoftCodeAnalysisTestingVersion>
     <!-- Libs -->
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
-using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -59,20 +57,6 @@ namespace Test.Utilities
                 var compilationOptions = base.CreateCompilationOptions();
                 return compilationOptions.WithSpecificDiagnosticOptions(
                     compilationOptions.SpecificDiagnosticOptions.SetItems(NullableWarnings));
-            }
-
-            protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics(IEnumerable<(Project project, Diagnostic diagnostic)> diagnostics)
-            {
-                var baseResult = base.SortDistinctDiagnostics(diagnostics);
-                if (typeof(DiagnosticSuppressor).IsAssignableFrom(typeof(TAnalyzer)))
-                {
-                    // Include suppressed diagnostics when testing diagnostic suppressors
-                    return baseResult;
-                }
-
-                // Treat suppressed diagnostics as non-existent. Normally this wouldn't be necessary, but some of the
-                // tests include diagnostics reported in code wrapped in '#pragma warning disable'.
-                return baseResult.WhereAsArray(diagnostic => !diagnostic.diagnostic.IsSuppressed);
             }
 
             protected override ParseOptions CreateParseOptions()

--- a/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/VisualBasicCodeFixVerifier`2+Test.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -28,20 +25,6 @@ namespace Test.Utilities
             protected override ParseOptions CreateParseOptions()
             {
                 return ((VisualBasicParseOptions)base.CreateParseOptions()).WithLanguageVersion(LanguageVersion);
-            }
-
-            protected override ImmutableArray<(Project project, Diagnostic diagnostic)> SortDistinctDiagnostics(IEnumerable<(Project project, Diagnostic diagnostic)> diagnostics)
-            {
-                var baseResult = base.SortDistinctDiagnostics(diagnostics);
-                if (typeof(DiagnosticSuppressor).IsAssignableFrom(typeof(TAnalyzer)))
-                {
-                    // Include suppressed diagnostics when testing diagnostic suppressors
-                    return baseResult;
-                }
-
-                // Treat suppressed diagnostics as non-existent. Normally this wouldn't be necessary, but some of the
-                // tests include diagnostics reported in code wrapped in '#Disable Warning'.
-                return baseResult.WhereAsArray(diagnostic => !diagnostic.diagnostic.IsSuppressed);
             }
         }
     }


### PR DESCRIPTION
Removes workarounds from #6711 which are no longer necessary.