### PR TITLE
Include delegate 'Invoke' method in public API

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -759,6 +759,11 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
 
                     if (methodSymbol is { MethodKind: MethodKind.Constructor, ContainingType.TypeKind: TypeKind.Enum })
                         return false;
+
+                    // include a delegate's 'Invoke' method so we encode its signature (it would be a breaking change to
+                    // change that). All other delegate methods can be ignored though.
+                    if (methodSymbol is { ContainingType.TypeKind: TypeKind.Delegate, MethodKind: not MethodKind.DelegateInvoke })
+                        return false;
                 }
 
                 // We don't consider properties to be public APIs. Instead, property getters and setters

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -2050,6 +2050,25 @@ C<T>.field2 -> C<T>.Nested";
             await VerifyCSharpAsync(source, shippedText, unshippedText);
         }
 
+        [Fact]
+        public async Task ShippedTextWithMissingDelegate()
+        {
+            var source = $$"""
+                #nullable enable
+                {{EnabledModifierCSharp}} delegate void D(int X, string Y);
+                """;
+
+            var shippedText = """
+                #nullable enable
+                D
+                virtual D.Invoke(int X, string! Y) -> void
+                """;
+
+            var unshippedText = string.Empty;
+
+            await VerifyCSharpAsync(source, shippedText, unshippedText);
+        }
+
         #endregion
 
         #region Fix tests


### PR DESCRIPTION
The delegate 'Invoke' signature defines the shape of the delegate, and is needed in teh public API file so that if it changes it is blocked.