### PR TITLE
Do not report RS0041 or RS0057 for implicitly-declared symbols

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -247,7 +247,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 if (_useNullability)
                 {
                     symbolUsesOblivious = UsesOblivious(symbol);
-                    if (symbolUsesOblivious)
+                    if (symbolUsesOblivious && !symbol.IsImplicitlyDeclared)
                     {
                         reportObliviousApi(symbol);
                     }


### PR DESCRIPTION
I wasn't able to reproduce the errors from Roslyn.sln in a unit testing configuration, so this is implementation-only.