### PR TITLE
CA1853: Fix incorrect code fixes

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpDoNotGuardDictionaryRemoveByContainsKeyFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpDoNotGuardDictionaryRemoveByContainsKeyFixer.cs
@@ -4,6 +4,7 @@ using System.Composition;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
@@ -16,11 +17,11 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
     {
         protected override bool SyntaxSupportedByFixer(SyntaxNode conditionalSyntax)
         {
-            if (conditionalSyntax is ConditionalExpressionSyntax conditionalExpressionSyntax)
-                return conditionalExpressionSyntax.WhenTrue.ChildNodes().Count() == 1;
-
-            if (conditionalSyntax is IfStatementSyntax)
-                return true;
+            if (conditionalSyntax is IfStatementSyntax ifStatementSyntax)
+            {
+                return ifStatementSyntax.Condition.RawKind != (int)SyntaxKind.LogicalNotExpression &&
+                    ifStatementSyntax.Statement.ChildNodes().Count() == 1;
+            }
 
             return false;
         }

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpDoNotGuardDictionaryRemoveByContainsKeyFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpDoNotGuardDictionaryRemoveByContainsKeyFixer.cs
@@ -19,6 +19,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
         {
             if (conditionalSyntax is IfStatementSyntax ifStatementSyntax)
             {
+                // The analyzer also reports a diagnostic when the condition is negated.
+                // Applying the fix in this case would lead to wrong code.
                 return ifStatementSyntax.Condition.RawKind != (int)SyntaxKind.LogicalNotExpression &&
                     ifStatementSyntax.Statement.ChildNodes().Count() == 1;
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKeyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKeyTests.cs
@@ -164,6 +164,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        [WorkItem(6274, "https://github.com/dotnet/roslyn-analyzers/issues/6274")]
         public async Task NegatedCondition_ReportsDiagnostic_CS()
         {
             string source = CSUsings + CSNamespaceAndClassStart + @"
@@ -175,7 +176,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 MyDictionary.Remove(""Key"");
         }" + CSNamespaceAndClassEnd;
 
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]
@@ -242,6 +243,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        [WorkItem(6274, "https://github.com/dotnet/roslyn-analyzers/issues/6274")]
         public async Task AdditionalStatements_ReportsDiagnostic_CS()
         {
             string source = CSUsings + CSNamespaceAndClassStart + @"
@@ -257,7 +259,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
         " + CSNamespaceAndClassEnd;
 
-            await VerifyCS.VerifyAnalyzerAsync(source);
+            await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKeyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKeyTests.cs
@@ -106,6 +106,21 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         }
 
         [Fact]
+        [WorkItem(6274, "https://github.com/dotnet/roslyn-analyzers/issues/6274")]
+        public async Task RemoveIsTheOnlyStatementInTernaryOperator_NoDiagnostic_CS()
+        {
+            string source = CSUsings + CSNamespaceAndClassStart + @"
+        private readonly Dictionary<string, string> MyDictionary = new Dictionary<string, string>();
+
+        public MyClass()
+        {
+            bool test = MyDictionary.ContainsKey(""Key"") ? MyDictionary.Remove(""Key"") : false;
+        }" + CSNamespaceAndClassEnd;
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact]
         public async Task HasElseBlock_OffersFixer_CS()
         {
             string source = CSUsings + CSNamespaceAndClassStart + @"
@@ -349,6 +364,25 @@ Namespace Testopolis
 End Namespace";
 
             await VerifyVB.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact]
+        [WorkItem(6274, "https://github.com/dotnet/roslyn-analyzers/issues/6274")]
+        public async Task RemoveIsTheOnlyStatementInTernaryOperator_NoDiagnostic_VB()
+        {
+            string source = @"
+" + VBUsings + @"
+Namespace Testopolis
+    Public Class SomeClass
+        Public MyDictionary As New Dictionary(Of String, String)()
+
+        Public Sub New()
+            Dim test As Boolean = If(MyDictionary.ContainsKey(""Key""), MyDictionary.Remove(""Key""), False)
+        End Sub
+    End Class
+End Namespace";
+
+            await VerifyVB.VerifyCodeFixAsync(source, source);
         }
 
         [Fact]

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotGuardDictionaryRemoveByContainsKey.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotGuardDictionaryRemoveByContainsKey.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.NetCore.Analyzers.Performance
 
@@ -14,12 +15,13 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
         Inherits DoNotGuardDictionaryRemoveByContainsKeyFixer
 
         Protected Overrides Function SyntaxSupportedByFixer(conditionalSyntax As SyntaxNode) As Boolean
-            If TypeOf conditionalSyntax Is IfStatementSyntax Then
-                Return True
+            If TypeOf conditionalSyntax Is SingleLineIfStatementSyntax Then
+                Return CType(conditionalSyntax, SingleLineIfStatementSyntax).Condition.RawKind <> SyntaxKind.NotExpression
             End If
 
             If TypeOf conditionalSyntax Is MultiLineIfBlockSyntax Then
-                Return CType(conditionalSyntax, MultiLineIfBlockSyntax).IfStatement.ChildNodes().Count() = 1
+                Return CType(conditionalSyntax, MultiLineIfBlockSyntax).IfStatement.Condition.RawKind <> SyntaxKind.NotExpression And
+                    CType(conditionalSyntax, MultiLineIfBlockSyntax).Statements.Count() = 1
             End If
 
             Return False

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotGuardDictionaryRemoveByContainsKey.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Performance/BasicDoNotGuardDictionaryRemoveByContainsKey.vb
@@ -15,6 +15,9 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Performance
         Inherits DoNotGuardDictionaryRemoveByContainsKeyFixer
 
         Protected Overrides Function SyntaxSupportedByFixer(conditionalSyntax As SyntaxNode) As Boolean
+            ' The analyzer also reports a diagnostic when the condition is negated.
+            ' Applying the fix in this case would lead to wrong code.
+
             If TypeOf conditionalSyntax Is SingleLineIfStatementSyntax Then
                 Return CType(conditionalSyntax, SingleLineIfStatementSyntax).Condition.RawKind <> SyntaxKind.NotExpression
             End If


### PR DESCRIPTION
This PR will fix missing and incorrectly applied code fixes and adds additional tests to cover these cases.
The following has been changed:

1. Negated `dictionary.ContainsKey` calls now only report a diagnostic (added a wrong fix before). See `NegatedCondition_ReportsDiagnostic_CS` and `NegatedCondition_ReportsDiagnostic_VB`.
2. Additional statements in the if block now only report a diagnostic (added a wrong fix before). See `AdditionalStatements_ReportsDiagnostic_CS` and `AdditionalStatements_ReportsDiagnostic_VB`.
3. Fixer for single statement ifs in VB (did not work before). See `HasElseStatement_OffersFixer_VB`.
4. Add missing tests for VB, see `TriviaIsPreserved_VB` and `RemoveIsTheOnlyStatementInABlock_OffersFixer_VB`.
5. Remove `ConditionalExpressionSyntax` check for CS fixer as conditional expressions are not reported by the analyzer.

Fixes #6274