### PR TITLE
Prevent RS0031 for message only lines

### DIFF
--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Core/SymbolIsBannedAnalyzer.cs
@@ -67,7 +67,9 @@ namespace Microsoft.CodeAnalysis.BannedApiAnalyzers
                 where !string.IsNullOrWhiteSpace(textWithoutComment)
                 let trimmedTextWithoutComment = textWithoutComment.TrimEnd()
                 let span = commentIndex == -1 ? line.Span : new Text.TextSpan(line.Span.Start, trimmedTextWithoutComment.Length)
-                select new BanFileEntry(compilation, trimmedTextWithoutComment, span, sourceText, additionalFile.Path);
+                let entry = new BanFileEntry(compilation, trimmedTextWithoutComment, span, sourceText, additionalFile.Path)
+                where !string.IsNullOrWhiteSpace(entry.DeclarationId)
+                select entry;
 
             var entries = query.ToList();
 

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -95,6 +95,18 @@ End Class");
         }
 
         [Fact]
+        public async Task NoDiagnosticReportedForMultilineMessageOnlyBannedTextAsync()
+        {
+            var source = @"";
+            var bannedText = @"
+;first
+  ;second
+;third // comment";
+
+            await VerifyCSharpAnalyzerAsync(source, bannedText);
+        }
+
+        [Fact]
         public async Task DiagnosticReportedForDuplicateBannedApiLinesAsync()
         {
             var source = @"";


### PR DESCRIPTION
This commit will filter out entries of banned symbols files that only contain a message and no declaration ID to prevent false RS0031.

Fixes #6633