### PR TITLE
Remove unnecessary pragma

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseStringEqualsOverStringCompare.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseStringEqualsOverStringCompare.cs
@@ -291,10 +291,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 invocation.TargetMethod.Equals(symbols.CompareStringStringStringComparison, SymbolEqualityComparer.Default);
         }
 
-        //  No IOperation instances are being stored here.
-#pragma warning disable RS1008 // Avoid storing per-compilation data into the fields of a diagnostic analyzer
         private static readonly ImmutableArray<Func<IOperation, RequiredSymbols, bool>> CaseSelectors =
-#pragma warning restore RS1008 // Avoid storing per-compilation data into the fields of a diagnostic analyzer
             ImmutableArray.Create<Func<IOperation, RequiredSymbols, bool>>(
                 IsStringStringCase,
                 IsStringStringBoolCase,


### PR DESCRIPTION
Since #6724 has been merged, this `pragma` directive can be removed.