### PR TITLE
CA2249: Also trigger on `String.IndexOf() != -1`

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOf.Fixer.cs
@@ -120,9 +120,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
                 }
 
-                SyntaxNode newIfCondition = (int)otherOperation.ConstantValue.Value! != -1 ?
-                                            containsInvocation :
-                                            generator.LogicalNotExpression(containsInvocation);
+                // We first check for "IndexOf() == -1" which translates to "!Contains()". All other covered cases do not need negation.
+                SyntaxNode newIfCondition = binaryOperation.OperatorKind == BinaryOperatorKind.Equals && (int)otherOperation.ConstantValue.Value! == -1 ?
+                                            generator.LogicalNotExpression(containsInvocation) :
+                                            containsInvocation;
                 newIfCondition = newIfCondition.WithTriviaFrom(binaryOperation.Syntax);
                 editor.ReplaceNode(binaryOperation.Syntax, newIfCondition);
                 var newRoot = editor.GetChangedRoot();

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfAnalyzer.cs
@@ -176,7 +176,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         if (otherOperand.ConstantValue.HasValue && otherOperand.ConstantValue.Value is int intValue)
                         {
                             if ((operatorKind == BinaryOperatorKind.Equals && intValue < 0) ||
-                                (operatorKind == BinaryOperatorKind.GreaterThanOrEqual && intValue == 0))
+                                (operatorKind == BinaryOperatorKind.GreaterThanOrEqual && intValue == 0) ||
+                                (operatorKind == BinaryOperatorKind.NotEquals && intValue < 0))
                             {
                                 // This is the only case we are targeting in this analyzer
                                 return true;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/PreferStringContainsOverIndexOfTests.cs
@@ -20,6 +20,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         [InlineData("a", true, " == ", " -1")]
         [InlineData("This", false, " >= ", " 0")]
         [InlineData("a", true, " >= ", " 0")]
+        [InlineData("This", false, " != ", " -1")]
+        [InlineData("a", true, " != ", " -1")]
         public async Task TestStringAndCharAsync(string input, bool isCharTest, string operatorKind, string value)
         {
             string startQuote = isCharTest ? "'" : "\"";
@@ -50,7 +52,7 @@ namespace TestNamespace
             startQuote = "\"";
             string vbCharLiteral = isCharTest ? "c" : "";
             string stringComparison = isCharTest ? "" : ", System.StringComparison.Ordinal";
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
 
             string vbInput = @"
 Public Class StringOf
@@ -77,6 +79,7 @@ End Class
         [Theory]
         [InlineData(" == ", " -1")]
         [InlineData(" >= ", " 0")]
+        [InlineData(" != ", " -1")]
         public async Task TestStringNoComparisonArgumentAsync(string operatorKind, string value)
         {
             string csInput = @"
@@ -102,7 +105,7 @@ namespace TestNamespace
             };
             await testOrdinal.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -128,6 +131,7 @@ End Class
         [Theory]
         [InlineData(" == ", " -1")]
         [InlineData(" >= ", " 0")]
+        [InlineData(" != ", " -1")]
         public async Task TestCharAndOrdinalAsync(string operatorKind, string value)
         {
             string csInput = @"
@@ -153,7 +157,7 @@ namespace TestNamespace
             };
             await testOrdinal.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -895,7 +899,6 @@ namespace TestNamespace
         }
 
         [Theory]
-        [InlineData(" != ", "-1")]
         [InlineData(" != ", "3")]
         [InlineData(" > ", "2")]
         [InlineData(" >= ", "2")]
@@ -981,6 +984,7 @@ namespace TestNamespace
         [Theory]
         [InlineData(" == ", " -1", "!")]
         [InlineData(" >= ", " 0", "")]
+        [InlineData(" != ", " -1", "")]
         public async Task TestFunctionParameterAsync(string operatorKind, string value, string notString)
         {
             string csInput = @"
@@ -1017,7 +1021,7 @@ namespace TestNamespace
             };
             await testCulture.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
@@ -1053,6 +1057,7 @@ End Class
         [Theory]
         [InlineData(" == ", " -1", "!")]
         [InlineData(" >= ", " 0", "")]
+        [InlineData(" != ", " -1", "")]
         public async Task TestFunctionParameterWithStringComparisonArgumentAsync(string operatorKind, string value, string notString)
         {
             string csInput = @"
@@ -1089,7 +1094,7 @@ namespace TestNamespace
             };
             await testCulture.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             notString = notString == "!" ? " Not" : notString;
             string vbInput = @"
 Public Class StringOf
@@ -1125,6 +1130,7 @@ End Class
         [Theory]
         [InlineData(" == ", " -1")]
         [InlineData(" >= ", " 0")]
+        [InlineData(" != ", " -1")]
         public async Task TestReversedMultipleDeclarationsAsync(string operatorKind, string value)
         {
             string csInput = @"
@@ -1150,7 +1156,7 @@ namespace TestNamespace
             };
             await testOrdinal.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -1176,6 +1182,7 @@ End Class
         [Theory]
         [InlineData(" == ", " -1")]
         [InlineData(" >= ", " 0")]
+        [InlineData(" != ", " -1")]
         public async Task TestMultipleDeclarationsAsync(string operatorKind, string value)
         {
             string csInput = @"
@@ -1201,7 +1208,7 @@ namespace TestNamespace
             };
             await testOrdinal.RunAsync();
 
-            operatorKind = operatorKind == " == " ? " = " : operatorKind;
+            operatorKind = ToBasicOperator(operatorKind);
             string vbInput = @"
 Public Class StringOf
     Class TestClass
@@ -1223,5 +1230,19 @@ End Class
             };
             await testOrdinal_vb.RunAsync();
         }
+
+        #region Helpers
+
+        private string ToBasicOperator(string op)
+        {
+            return op switch
+            {
+                " == " => " = ",
+                " != " => " <> ",
+                _ => op
+            };
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Ran the new version against `dotnet/runtime` and found one new case:
[runtime/src/coreclr/tools/Common/Compiler/ProcessLinkerXmlBase.cs#L214](https://github.com/dotnet/runtime/blob/44c46e181a2a6f23a66f10924d8b7840150f18b7/src/coreclr/tools/Common/Compiler/ProcessLinkerXmlBase.cs#L214)

Also ran it against `dotnet/roslyn` -- found multiple `CA2249`, but most of them were already covered before this PR:
<details>

<summary>Paths</summary>

```
W:\roslyn\src\Compilers\Core\CodeAnalysisTest\Diagnostics\AnalysisContextInfoTests.cs(50,25): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\CanonicalError.cs(273,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\CanonicalError.cs(273,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\CanonicalError.cs(274,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\CanonicalError.cs(274,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\Vbc.cs(636,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\Vbc.cs(636,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\Vbc.cs(637,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\MSBuildTask\Vbc.cs(637,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\DocumentationCommentId.cs(263,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\DocumentationCommentId.cs(263,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\DocumentationCommentId.cs(1502,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\DocumentationCommentId.cs(1502,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\FileUtilities.cs(214,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\FileUtilities.cs(214,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\FileUtilities.cs(214,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\FileUtilities.cs(214,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(76,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(76,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(76,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(76,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(77,33): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(77,33): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(77,33): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(77,33): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(499,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(499,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(499,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(499,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(500,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(500,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(500,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(500,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(722,37): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(722,37): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(722,37): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(722,37): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(723,41): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(723,41): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(723,41): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\FileSystem\PathUtilities.cs(723,41): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs(100,57): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs(100,57): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs(100,57): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\InternalUtilities\StringExtensions.cs(100,57): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataHelpers.cs(155,66): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataHelpers.cs(155,66): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataHelpers.cs(947,80): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataHelpers.cs(947,80): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataTypeName.cs(154,84): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReader\MetadataTypeName.cs(154,84): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReference\AssemblyIdentity.DisplayName.cs(221,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReference\AssemblyIdentity.DisplayName.cs(221,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReference\AssemblyIdentity.DisplayName.cs(449,26): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\MetadataReference\AssemblyIdentity.DisplayName.cs(449,26): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\PEWriter\TypeNameSerializer.cs(221,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Core\Portable\PEWriter\TypeNameSerializer.cs(221,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Portable\Symbols\AssemblySymbol.cs(684,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Portable\Symbols\AssemblySymbol.cs(684,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNames.cs(223,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Portable\Symbols\Synthesized\GeneratedNames.cs(223,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Emit\CodeGen\CodeGenDynamicTests.cs(137,118): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SemanticModelGetDeclaredSymbolAPITests.cs(4324,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(157,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(158,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(159,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(160,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(161,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(162,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(163,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(165,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\CSharp\Test\Symbol\Compilation\SymbolSearchTests.cs(190,36): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\ClrGlobalAssemblyCache.cs(250,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\ClrGlobalAssemblyCache.cs(250,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(345,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(345,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(345,30): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(442,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(442,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(442,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(467,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(467,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(467,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(502,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(502,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Shared\GlobalAssemblyCacheHelpers\FusionAssemblyIdentity.cs(502,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Test\Core\Compilation\CompilationTestDataExtensions.cs(33,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\Test\Core\Compilation\CompilationTestDataExtensions.cs(33,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\VisualBasic\Test\Emit\CodeGen\CodeGenAsyncTests.vb(5380,20): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\VisualBasic\Test\Semantic\Semantics\MyBaseMyClassTests.vb(3991,28): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Compilers\VisualBasic\Test\Symbol\SymbolsTests\AnonymousTypes\AnonymousTypesEmittedSymbolsTests.vb(578,28): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\EditorFeatures\Core.Cocoa\Snippets\AbstractSnippetExpansionClient.cs(191,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\EditorFeatures\Core.Cocoa\Snippets\AbstractSnippetExpansionClient.cs(370,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\EditorFeatures\Core.Cocoa\Snippets\AbstractSnippetExpansionClient.cs(371,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Features\Core\Portable\PdbSourceDocument\SourceLinkMap.cs(146,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Features\Core\Portable\PdbSourceDocument\SourceLinkMap.cs(146,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Features\Core\Portable\PdbSourceDocument\SourceLinkMap.cs(180,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Features\Core\Portable\PdbSourceDocument\SourceLinkMap.cs(180,17): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Tools\BuildValidator\Program.cs(187,43): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\CoreTestUtilities\MEF\TestComposition.cs(201,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\Core\Portable\Rename\ConflictEngine\ConflictResolver.cs(515,16): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\Core\Portable\Rename\ConflictEngine\ConflictResolver.cs(515,16): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Formatting\Engine\TreeData.Node.cs(40,25): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Formatting\Engine\TreeData.Node.cs(40,25): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Utilities\WordSimilarityChecker.cs(117,46): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\Core\Utilities\WordSimilarityChecker.cs(117,46): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.cs(52,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.cs(52,29): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.cs(144,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\SharedUtilitiesAndExtensions\Compiler\CSharp\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.cs(144,21): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\VisualBasic\Portable\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.vb(49,28): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
W:\roslyn\src\Workspaces\VisualBasic\Portable\Formatting\Engine\Trivia\TriviaDataFactory.CodeShapeAnalyzer.vb(49,28): info CA2249: Use 'string.Contains' instead of 'string.IndexOf' to improve readability
```

</details>

I did not manage to run it against `dotnet/roslyn-analyzers`.
The rule did not trigger at all, even if I added a already covered case, e.g. `var test = "str".IndexOf('a') == -1`.
I tried it again with `dotnet_diagnostic.CA2249.severity = warning` added to the `.editorconfig` with no luck.

Fixes #6587