### PR TITLE
CA2208: Find incorrect paramName in derived

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -105,7 +103,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             }
             else
             {
-                List<Diagnostic> diagnostics = new();
+                Diagnostic? diagnosticFound = null;
                 foreach (IArgumentOperation argument in creation.Arguments)
                 {
                     if (argument.Parameter?.Type.SpecialType != SpecialType.System_String)
@@ -123,21 +121,18 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                     if (diagnostic != null)
                     {
+                        diagnosticFound = diagnostic;
                         // RuleIncorrectMessage is the highest priority rule, no need to check other rules
                         if (diagnostic.Descriptor.Equals(RuleIncorrectMessage))
                         {
-                            context.ReportDiagnostic(diagnostic);
-                            return;
+                            break;
                         }
-
-                        diagnostics.Add(diagnostic);
                     }
                 }
 
-                if (diagnostics.Count != 0)
+                if (diagnosticFound != null)
                 {
-                    // Report the last found diagnostic otherwise
-                    context.ReportDiagnostic(diagnostics.Last());
+                    context.ReportDiagnostic(diagnosticFound);
                 }
             }
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
@@ -1091,6 +1091,20 @@ dotnet_code_quality.CA2208.api_surface = public") }
                         }
                     }
                 }");
+        }
+
+        [Fact, WorkItem(6580, "https://github.com/dotnet/roslyn-analyzers/issues/6580")]
+        public async Task ArgumentNullException_Test()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test(string name)
+                    {
+                        if (name is null) throw new System.ArgumentNullException(""not name"", ""Must not be null."");
+                    }
+                }",
+                GetCSharpIncorrectParameterNameExpectedResult(6, 49, "Test", "not name", "paramName", "ArgumentNullException"));
         }
 
         private static DiagnosticResult GetCSharpNoArgumentsExpectedResult(int line, int column, string typeName) =>


### PR DESCRIPTION
This PR fixes a bug where diagnostics for all but the last arguments were not reported.
See also: https://github.com/dotnet/roslyn-analyzers/issues/6580#issuecomment-1637200714

I ran the analyzer against `dotnet/runtime` (no findings) and `dotnet/roslyn` (lots of CA2208, but none relate to the issue).

Fixes #6580
