### PR TITLE
Improve handling of indexed array access in flow analysis

### DIFF
--- a/src/Microsoft.CodeAnalysis.AnalyzerUtilities/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.CodeAnalysis.AnalyzerUtilities/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeEqualsByHashCodeParts(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData!, TAnalysisContext!, TAnalysisResult!, TAbstractAnalysisValue>! obj) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractDataFlowAnalysisContext<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.ComputeHashCodePartsSpecific(ref Analyzer.Utilities.RoslynHashCode hashCode) -> void
+abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AnalysisEntityBasedPredicateAnalysisData<TValue>.ValueDomain.get -> Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.AbstractValueDomain<TValue>!
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeEqualsByHashCodeParts(Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T!>! obj) -> bool
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CacheBasedEquatable<T>.ComputeHashCodeParts(ref Analyzer.Utilities.RoslynHashCode hashCode) -> void
 abstract Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.DataFlowOperationVisitor<TAnalysisData, TAnalysisContext, TAnalysisResult, TAbstractAnalysisValue>.GetAbstractDefaultValue(Microsoft.CodeAnalysis.ITypeSymbol? type) -> TAbstractAnalysisValue

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysis.cs
@@ -16,6 +16,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
     /// </summary>
     public partial class CopyAnalysis : ForwardDataFlowAnalysis<CopyAnalysisData, CopyAnalysisContext, CopyAnalysisResult, CopyBlockAnalysisResult, CopyAbstractValue>
     {
+        internal static readonly AbstractValueDomain<CopyAbstractValue> ValueDomainInstance = CopyAbstractValueDomain.Default;
+
         private CopyAnalysis(CopyDataFlowOperationVisitor operationVisitor)
             : base(operationVisitor.AnalysisDomain, operationVisitor)
         {
@@ -43,7 +45,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
                     wellKnownTypeProvider, pointsToAnalysisKind, interproceduralAnalysisConfig,
                     interproceduralAnalysisPredicate, pessimisticAnalysis, performCopyAnalysis: false, exceptionPathsAnalysis) :
                 null;
-            var analysisContext = CopyAnalysisContext.Create(CopyAbstractValueDomain.Default, wellKnownTypeProvider,
+            var analysisContext = CopyAnalysisContext.Create(ValueDomainInstance, wellKnownTypeProvider,
                 cfg, owningSymbol, analyzerOptions, interproceduralAnalysisConfig, pessimisticAnalysis, exceptionPathsAnalysis, pointsToAnalysisResult,
                 TryGetOrComputeResultForAnalysisContext, interproceduralAnalysisPredicate);
             return TryGetOrComputeResultForAnalysisContext(analysisContext);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/CopyAnalysis/CopyAnalysisData.cs
@@ -7,6 +7,7 @@ using System.Linq;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
 {
+    using static Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis.CopyAnalysis;
     using CoreCopyAnalysisData = DictionaryAnalysisData<AnalysisEntity, CopyAbstractValue>;
 
     /// <summary>
@@ -38,6 +39,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.CopyAnalysis
             AssertValidCopyAnalysisData();
         }
 
+        protected override AbstractValueDomain<CopyAbstractValue> ValueDomain => ValueDomainInstance;
         public override AnalysisEntityBasedPredicateAnalysisData<CopyAbstractValue> Clone() => new CopyAnalysisData(this);
 
         public override int Compare(AnalysisEntityBasedPredicateAnalysisData<CopyAbstractValue> other, MapAbstractDomain<AnalysisEntity, CopyAbstractValue> coreDataAnalysisDomain)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAnalysisDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAnalysisDomain.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         private sealed class PointsToAnalysisDomain : PredicatedAnalysisDataDomain<PointsToAnalysisData, PointsToAbstractValue>
         {
             public PointsToAnalysisDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator)
-                : base(new CorePointsToAnalysisDataDomain(defaultPointsToValueGenerator, PointsToAbstractValueDomainInstance))
+                : base(new CorePointsToAnalysisDataDomain(defaultPointsToValueGenerator, ValueDomainInstance))
             {
             }
 

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
     /// </summary>
     public partial class PointsToAnalysis : ForwardDataFlowAnalysis<PointsToAnalysisData, PointsToAnalysisContext, PointsToAnalysisResult, PointsToBlockAnalysisResult, PointsToAbstractValue>
     {
-        internal static readonly AbstractValueDomain<PointsToAbstractValue> PointsToAbstractValueDomainInstance = PointsToAbstractValueDomain.Default;
+        internal static readonly AbstractValueDomain<PointsToAbstractValue> ValueDomainInstance = PointsToAbstractValueDomain.Default;
 
         private PointsToAnalysis(PointsToAnalysisDomain analysisDomain, PointsToDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             AssertValidPointsToAnalysisData();
         }
 
+        protected override AbstractValueDomain<PointsToAbstractValue> ValueDomain => PointsToAnalysis.ValueDomainInstance;
         public override AnalysisEntityBasedPredicateAnalysisData<PointsToAbstractValue> Clone() => new PointsToAnalysisData(this);
 
         public override int Compare(AnalysisEntityBasedPredicateAnalysisData<PointsToAbstractValue> other, MapAbstractDomain<AnalysisEntity, PointsToAbstractValue> coreDataAnalysisDomain)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.cs
@@ -16,6 +16,8 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
 
     internal partial class TaintedDataAnalysis : ForwardDataFlowAnalysis<TaintedDataAnalysisData, TaintedDataAnalysisContext, TaintedDataAnalysisResult, TaintedDataBlockAnalysisResult, TaintedDataAbstractValue>
     {
+        internal static readonly AbstractValueDomain<TaintedDataAbstractValue> ValueDomainInstance = TaintedDataAbstractValueDomain.Default;
+
         private TaintedDataAnalysis(TaintedDataAnalysisDomain analysisDomain, TaintedDataOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
         {
@@ -94,7 +96,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
             }
 
             TaintedDataAnalysisContext analysisContext = TaintedDataAnalysisContext.Create(
-                TaintedDataAbstractValueDomain.Default,
+                ValueDomainInstance,
                 wellKnownTypeProvider,
                 cfg,
                 containingMethod,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysisData.cs
@@ -29,6 +29,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
         {
         }
 
+        protected override AbstractValueDomain<TaintedDataAbstractValue> ValueDomain => TaintedDataAnalysis.ValueDomainInstance;
         public override AnalysisEntityBasedPredicateAnalysisData<TaintedDataAbstractValue> Clone()
         {
             return new TaintedDataAnalysisData(this);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysis.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
     /// </summary>
     public partial class ValueContentAnalysis : ForwardDataFlowAnalysis<ValueContentAnalysisData, ValueContentAnalysisContext, ValueContentAnalysisResult, ValueContentBlockAnalysisResult, ValueContentAbstractValue>
     {
+        internal static readonly AbstractValueDomain<ValueContentAbstractValue> ValueDomainInstance = ValueContentAbstractValueDomain.Default;
+
         private ValueContentAnalysis(ValueContentAnalysisDomain analysisDomain, ValueContentDataFlowOperationVisitor operationVisitor)
             : base(analysisDomain, operationVisitor)
         {
@@ -98,7 +100,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
                 null;
 
             var analysisContext = ValueContentAnalysisContext.Create(
-                ValueContentAbstractValueDomain.Default, wellKnownTypeProvider, cfg, owningSymbol, analyzerOptions,
+                ValueDomainInstance, wellKnownTypeProvider, cfg, owningSymbol, analyzerOptions,
                 interproceduralAnalysisConfig, pessimisticAnalysis, copyAnalysisResult,
                 pointsToAnalysisResult, TryGetOrComputeResultForAnalysisContext,
                 additionalSupportedValueTypes, getValueContentValueForAdditionalSupportedValueTypeOperation,

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/ValueContentAnalysis/ValueContentAnalysisData.cs
@@ -42,6 +42,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.ValueContentAnalysis
         {
         }
 
+        protected override AbstractValueDomain<ValueContentAbstractValue> ValueDomain => ValueContentAnalysis.ValueDomainInstance;
         public override AnalysisEntityBasedPredicateAnalysisData<ValueContentAbstractValue> Clone() => new ValueContentAnalysisData(this);
 
         public override int Compare(AnalysisEntityBasedPredicateAnalysisData<ValueContentAbstractValue> other, MapAbstractDomain<AnalysisEntity, ValueContentAbstractValue> coreDataAnalysisDomain)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AbstractIndex.cs
@@ -11,5 +11,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public static AbstractIndex Create(int index) => new ConstantValueIndex(index);
         public static AbstractIndex Create(AnalysisEntity analysisEntity) => new AnalysisEntityBasedIndex(analysisEntity);
         public static AbstractIndex Create(IOperation operation) => new OperationBasedIndex(operation);
+
+        internal bool IsConstant() => this is ConstantValueIndex;
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             Debug.Assert(EqualsIgnoringInstanceLocation(analysisEntityToMerge));
             Debug.Assert(!InstanceLocation.Equals(analysisEntityToMerge.InstanceLocation));
 
-            var mergedInstanceLocation = PointsToAnalysis.PointsToAnalysis.PointsToAbstractValueDomainInstance.Merge(InstanceLocation, analysisEntityToMerge.InstanceLocation);
+            var mergedInstanceLocation = PointsToAnalysis.PointsToAnalysis.ValueDomainInstance.Merge(InstanceLocation, analysisEntityToMerge.InstanceLocation);
             return new AnalysisEntity(Symbol, Indices, InstanceReferenceOperationSyntax, CaptureId, mergedInstanceLocation, Type, Parent, IsThisOrMeInstance);
         }
 
@@ -203,6 +203,30 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         };
 
         public bool IsLValueFlowCaptureEntity => CaptureId.HasValue && CaptureId.Value.IsLValueFlowCapture;
+
+        public bool EqualsIgnoringIndices(AnalysisEntity? other)
+        {
+            // Perform fast equality checks first.
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other == null ||
+                EqualsIgnoringInstanceLocationId != other.EqualsIgnoringInstanceLocationId)
+            {
+                return false;
+            }
+
+            // Now perform slow check that compares individual hash code parts sequences.
+            return Symbol.GetHashCodeOrDefault() == other.Symbol.GetHashCodeOrDefault()
+                && InstanceLocation.GetHashCode() == other.InstanceLocation.GetHashCode()
+                && InstanceReferenceOperationSyntax.GetHashCodeOrDefault() == other.InstanceReferenceOperationSyntax.GetHashCodeOrDefault()
+                && CaptureId.GetHashCodeOrDefault() == other.CaptureId.GetHashCodeOrDefault()
+                && Type.GetHashCodeOrDefault() == other.Type.GetHashCodeOrDefault()
+                && Parent.GetHashCodeOrDefault() == other.Parent.GetHashCodeOrDefault()
+                && IsThisOrMeInstance.GetHashCode() == other.IsThisOrMeInstance.GetHashCode();
+        }
 
         public bool EqualsIgnoringInstanceLocation(AnalysisEntity? other)
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public bool IsLValueFlowCaptureEntity => CaptureId.HasValue && CaptureId.Value.IsLValueFlowCapture;
 
-        public bool EqualsIgnoringIndices(AnalysisEntity? other)
+        internal bool EqualsIgnoringIndices(AnalysisEntity? other)
         {
             // Perform fast equality checks first.
             if (ReferenceEquals(this, other))

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -204,29 +204,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public bool IsLValueFlowCaptureEntity => CaptureId.HasValue && CaptureId.Value.IsLValueFlowCapture;
 
-        internal bool EqualsIgnoringIndices(AnalysisEntity? other)
-        {
-            // Perform fast equality checks first.
-            if (ReferenceEquals(this, other))
-            {
-                return true;
-            }
-
-            if (other == null ||
-                EqualsIgnoringInstanceLocationId != other.EqualsIgnoringInstanceLocationId)
-            {
-                return false;
-            }
-
-            // Now perform slow check that compares individual hash code parts sequences.
-            return Symbol.GetHashCodeOrDefault() == other.Symbol.GetHashCodeOrDefault()
-                && InstanceLocation.GetHashCode() == other.InstanceLocation.GetHashCode()
-                && InstanceReferenceOperationSyntax.GetHashCodeOrDefault() == other.InstanceReferenceOperationSyntax.GetHashCodeOrDefault()
-                && CaptureId.GetHashCodeOrDefault() == other.CaptureId.GetHashCodeOrDefault()
-                && Type.GetHashCodeOrDefault() == other.Type.GetHashCodeOrDefault()
-                && Parent.GetHashCodeOrDefault() == other.Parent.GetHashCodeOrDefault()
-                && IsThisOrMeInstance.GetHashCode() == other.IsThisOrMeInstance.GetHashCode();
-        }
+        internal AnalysisEntity WithIndices(ImmutableArray<AbstractIndex> indices)
+            => new(Symbol, indices, InstanceReferenceOperationSyntax, CaptureId, InstanceLocation, Type, Parent, IsThisOrMeInstance);
 
         public bool EqualsIgnoringInstanceLocation(AnalysisEntity? other)
         {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 }
 
                 if (canOverlap &&
-                    entity.EqualsIgnoringIndices(analysisEntity) &&
+                    entity.WithIndices(analysisEntity.Indices).Equals(analysisEntity) &&
                     CoreAnalysisData.TryGetValue(entity, out var existingValue))
                 {
                     var mergedValue = ValueDomain.Merge(value, existingValue);

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -58,6 +59,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public virtual bool HasAnyAbstractValue => CoreAnalysisData.Count > 0 || HasPredicatedData;
 
+        protected abstract AbstractValueDomain<TValue> ValueDomain { get; }
         public abstract AnalysisEntityBasedPredicateAnalysisData<TValue> Clone();
         public abstract AnalysisEntityBasedPredicateAnalysisData<TValue> WithMergedData(AnalysisEntityBasedPredicateAnalysisData<TValue> data, MapAbstractDomain<AnalysisEntity, TValue> coreDataAnalysisDomain);
         public abstract int Compare(AnalysisEntityBasedPredicateAnalysisData<TValue> other, MapAbstractDomain<AnalysisEntity, TValue> coreDataAnalysisDomain);
@@ -100,6 +102,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
 
             CoreAnalysisData[key] = value;
+
+            ClearOverlappingAnalysisDataForIndexedEntity(key, value);
         }
 
         public void RemoveEntries(AnalysisEntity key)
@@ -158,6 +162,46 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         public void AddTrackedEntities(HashSet<AnalysisEntity> builder) => builder.UnionWith(CoreAnalysisData.Keys);
+
+        private void ClearOverlappingAnalysisDataForIndexedEntity(AnalysisEntity analysisEntity, TValue value)
+        {
+            if (!analysisEntity.Indices.Any(index => !index.IsConstant()))
+            {
+                return;
+            }
+
+            foreach (var entity in CoreAnalysisData.Keys)
+            {
+                if (entity.Indices.Length != analysisEntity.Indices.Length ||
+                    entity == analysisEntity)
+                {
+                    continue;
+                }
+
+                var canOverlap = true;
+                for (var i = 0; i < entity.Indices.Length; i++)
+                {
+                    if (entity.Indices[i].IsConstant() &&
+                        analysisEntity.Indices[i].IsConstant() &&
+                        !entity.Indices[i].Equals(analysisEntity.Indices[i]))
+                    {
+                        canOverlap = false;
+                        break;
+                    }
+                }
+
+                if (canOverlap &&
+                    entity.EqualsIgnoringIndices(analysisEntity) &&
+                    CoreAnalysisData.TryGetValue(entity, out var existingValue))
+                {
+                    var mergedValue = ValueDomain.Merge(value, existingValue);
+                    if (!existingValue!.Equals(mergedValue))
+                    {
+                        SetAbstractValue(entity, mergedValue);
+                    }
+                }
+            }
+        }
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Fixes #6616

We now ensure that setting an abstract value for an indexed access entity with any non-constant index clears out the existing value for entities that can overlap the indexed location
