### PR TITLE
Fix handling of array creation.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.Collector.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.Collector.cs
@@ -454,6 +454,17 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
                             return;
                         }
+
+                    case OperationKind.ArrayCreation:
+                        {
+                            var arrayOp = (IArrayCreationOperation)op;
+                            if (arrayOp.Type != null)
+                            {
+                                values.Add(arrayOp.Type);
+                            }
+
+                            break;
+                        }
                 }
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
@@ -13,6 +13,39 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
     public static partial class UseConcreteTypeTests
     {
         [Fact]
+        [WorkItem(6751, "https://github.com/dotnet/roslyn-analyzers/issues/6751")]
+        public static async Task MultipleReturns()
+        {
+            await TestCSAsync(@"
+                using System;
+                using System.Collections.Generic;
+
+                public abstract class Base { }
+                public sealed class Derived1 : Base { }
+                public sealed class Derived2 : Base { }
+
+                internal sealed class Test
+                {
+                    private static IEnumerable<Base> M(int i)
+                    {
+                        try
+                        {
+                            switch (i)
+                            {
+                                case 0: return new Derived1[1];
+                                case 1: return new Derived2[1];
+                                default: throw new ArgumentException();
+                            }
+                        }
+                        finally
+                        {
+                        }
+                    }
+                }
+            ");
+        }
+
+        [Fact]
         [WorkItem(6565, "https://github.com/dotnet/roslyn-analyzers/issues/6565")]
         public static async Task DiscoverArrayUpgrades()
         {


### PR DESCRIPTION
- The USeConcreteType analyzer didn't recognize array creation sequences which causes some analysis errors.

This fixes #6751

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
