### PR TITLE
Track all disposable types in PointsToAnalysis

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -2208,6 +2208,11 @@ class Test
 
         // https://github.com/dotnet/roslyn-analyzers/issues/6512
         await using var e3 = new AsyncDisposableAndDisposable().ConfigureAwait(false);
+
+        foreach (var x in new[] { 1, 2 })
+        {
+            await using var e4 = new AsyncDisposableAndDisposable().ConfigureAwait(false);
+        }
     }
 }
 "

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScopeTests.cs
@@ -2169,6 +2169,99 @@ End Class",
             }.RunAsync();
         }
 
+        [Fact, WorkItem(6765, "https://github.com/dotnet/roslyn-analyzers/issues/6765")]
+        public async Task LocalWithAsyncDisposableAndAwaitUsingStatement_Disposed_NoDiagnosticAsync()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                LanguageVersion = CSharpLanguageVersion.CSharp10,
+                TestCode = @"
+using System;
+using System.Threading.Tasks;
+
+class AsyncDisposableAndDisposable : IAsyncDisposable, IDisposable
+{
+    public ValueTask DisposeAsync()
+    {
+        return default(ValueTask);
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public static async Task M1()
+    {
+        // https://github.com/dotnet/roslyn-analyzers/issues/6765
+        var e1 = new AsyncDisposableAndDisposable();
+        await using (e1.ConfigureAwait(false))
+        {
+        }
+
+        var e2 = new AsyncDisposableAndDisposable();
+        var x2 = e2.ConfigureAwait(false);
+        await x2.DisposeAsync();
+
+        // https://github.com/dotnet/roslyn-analyzers/issues/6512
+        await using var e3 = new AsyncDisposableAndDisposable().ConfigureAwait(false);
+    }
+}
+"
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(6765, "https://github.com/dotnet/roslyn-analyzers/issues/6765")]
+        public async Task LocalWithAsyncDisposableAndAwaitUsingStatement_NotDisposed_DiagnosticAsync()
+        {
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithAsyncInterfaces,
+                LanguageVersion = CSharpLanguageVersion.CSharp10,
+                TestCode = @"
+using System;
+using System.Threading.Tasks;
+
+class AsyncDisposableAndDisposable : IAsyncDisposable, IDisposable
+{
+    public ValueTask DisposeAsync()
+    {
+        return default(ValueTask);
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+class Test
+{
+    public static async Task M1()
+    {
+        var e1 = new AsyncDisposableAndDisposable();
+        
+        var e2 = new AsyncDisposableAndDisposable();
+        var x2 = e2.ConfigureAwait(false);
+
+        var e3 = new AsyncDisposableAndDisposable().ConfigureAwait(false);
+    }
+}
+",
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(21,18): warning CA2000: Call System.IDisposable.Dispose on object created by 'new AsyncDisposableAndDisposable()' before all references to it are out of scope
+                    GetCSharpResultAt(21, 18, "new AsyncDisposableAndDisposable()"),
+                    // /0/Test0.cs(23,18): warning CA2000: Call System.IDisposable.Dispose on object created by 'new AsyncDisposableAndDisposable()' before all references to it are out of scope
+                    GetCSharpResultAt(23, 18, "new AsyncDisposableAndDisposable()"),
+                    // /0/Test0.cs(26,18): warning CA2000: Call System.IDisposable.Dispose on object created by 'new AsyncDisposableAndDisposable()' before all references to it are out of scope
+                    GetCSharpResultAt(26, 18, "new AsyncDisposableAndDisposable()")
+                }
+            }.RunAsync();
+        }
+
         [Fact, WorkItem(3305, "https://github.com/dotnet/roslyn-analyzers/issues/3305")]
         public async Task LocalWithRefStructDisposableAssignment_NotDisposed_DiagnosticAsync()
         {

--- a/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ITypeSymbolExtensions.cs
@@ -140,12 +140,17 @@ namespace Analyzer.Utilities.Extensions
         /// </summary>
         public static bool IsDisposable(this ITypeSymbol type,
             INamedTypeSymbol? iDisposable,
-            INamedTypeSymbol? iAsyncDisposable)
+            INamedTypeSymbol? iAsyncDisposable,
+            INamedTypeSymbol? configuredAsyncDisposable)
         {
             if (type.IsReferenceType)
             {
                 return IsInterfaceOrImplementsInterface(type, iDisposable)
                     || IsInterfaceOrImplementsInterface(type, iAsyncDisposable);
+            }
+            else if (SymbolEqualityComparer.Default.Equals(type, configuredAsyncDisposable))
+            {
+                return true;
             }
 
 #if CODEANALYSIS_V3_OR_BETTER

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -302,6 +302,7 @@ namespace Analyzer.Utilities
         public const string SystemRuntimeCompilerServicesCallerArgumentExpressionAttribute = "System.Runtime.CompilerServices.CallerArgumentExpressionAttribute";
         public const string SystemRuntimeCompilerServicesCompilerGeneratedAttribute = "System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string SystemRuntimeCompilerServicesConfiguredAsyncDisposable = "System.Runtime.CompilerServices.ConfiguredAsyncDisposable";
+        public const string SystemRuntimeCompilerServicesConfiguredValueTaskAwaitable = "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable";
         public const string SystemRuntimeCompilerServicesConfiguredValueTaskAwaitable1 = "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1";
         public const string SystemRuntimeCompilerServicesDisableRuntimeMarshallingAttribute = "System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute";
         public const string SystemRuntimeCompilerServicesICriticalNotifyCompletion = "System.Runtime.CompilerServices.ICriticalNotifyCompletion";
@@ -408,6 +409,7 @@ namespace Analyzer.Utilities
         public const string SystemThreadingMonitor = "System.Threading.Monitor";
         public const string SystemThreadingSpinLock = "System.Threading.SpinLock";
         public const string SystemThreadingTasksConfigureAwaitOptions = "System.Threading.Tasks.ConfigureAwaitOptions";
+        public const string SystemThreadingTasksTaskAsyncEnumerableExtensions = "System.Threading.Tasks.TaskAsyncEnumerableExtensions";
         public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";
         public const string SystemThreadingTasksTask1 = "System.Threading.Tasks.Task`1";
         public const string SystemThreadingTasksTaskCompletionSource = "System.Threading.Tasks.TaskCompletionSource";

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.CorePointsToAnalysisDataDomain.cs
@@ -17,10 +17,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         /// </summary>
         private sealed class CorePointsToAnalysisDataDomain : AnalysisEntityMapAbstractDomain<PointsToAbstractValue>
         {
-            public CorePointsToAnalysisDataDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator, AbstractValueDomain<PointsToAbstractValue> valueDomain)
+            private readonly Func<ITypeSymbol?, bool> _isDisposable;
+
+            public CorePointsToAnalysisDataDomain(
+                DefaultPointsToValueGenerator defaultPointsToValueGenerator,
+                AbstractValueDomain<PointsToAbstractValue> valueDomain,
+                Func<ITypeSymbol?, bool> isDisposable)
                 : base(valueDomain, defaultPointsToValueGenerator.IsTrackedEntity, defaultPointsToValueGenerator.IsTrackedPointsToValue)
             {
                 DefaultPointsToValueGenerator = defaultPointsToValueGenerator;
+                this._isDisposable = isDisposable;
             }
 
             public DefaultPointsToValueGenerator DefaultPointsToValueGenerator { get; }
@@ -36,12 +42,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             protected override void AssertValidEntryForMergedMap(AnalysisEntity analysisEntity, PointsToAbstractValue value)
             {
-                PointsToAnalysisData.AssertValidPointsToAnalysisKeyValuePair(analysisEntity, value);
+                PointsToAnalysisData.AssertValidPointsToAnalysisKeyValuePair(analysisEntity, value, _isDisposable);
             }
 
             protected override void AssertValidAnalysisData(CorePointsToAnalysisData map)
             {
-                PointsToAnalysisData.AssertValidPointsToAnalysisData(map);
+                PointsToAnalysisData.AssertValidPointsToAnalysisData(map, _isDisposable);
             }
 
             public CorePointsToAnalysisData MergeCoreAnalysisDataForBackEdge(

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAnalysisDomain.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToAnalysisDomain.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         /// </summary>
         private sealed class PointsToAnalysisDomain : PredicatedAnalysisDataDomain<PointsToAnalysisData, PointsToAbstractValue>
         {
-            public PointsToAnalysisDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator)
-                : base(new CorePointsToAnalysisDataDomain(defaultPointsToValueGenerator, ValueDomainInstance))
+            public PointsToAnalysisDomain(DefaultPointsToValueGenerator defaultPointsToValueGenerator, Func<ITypeSymbol?, bool> isDisposable)
+                : base(new CorePointsToAnalysisDataDomain(defaultPointsToValueGenerator, ValueDomainInstance, isDisposable))
             {
             }
 
@@ -22,7 +22,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 PointsToAnalysisData forwardEdgeAnalysisData,
                 PointsToAnalysisData backEdgeAnalysisData,
                 Func<PointsToAbstractValue, ImmutableHashSet<AnalysisEntity>> getChildAnalysisEntities,
-                Action<AnalysisEntity, PointsToAnalysisData> resetAbstractValue)
+                Action<AnalysisEntity, PointsToAnalysisData> resetAbstractValue,
+                Func<ITypeSymbol?, bool> isDisposable)
             {
                 if (!forwardEdgeAnalysisData.IsReachableBlockData && backEdgeAnalysisData.IsReachableBlockData)
                 {
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                     getChildAnalysisEntities,
                     resetAbstractValue);
                 return new PointsToAnalysisData(mergedCoreAnalysisData, forwardEdgeAnalysisData,
-                    backEdgeAnalysisData, forwardEdgeAnalysisData.IsReachableBlockData, CoreDataAnalysisDomain);
+                    backEdgeAnalysisData, forwardEdgeAnalysisData.IsReachableBlockData, CoreDataAnalysisDomain, isDisposable);
             }
         }
     }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.PointsToDataFlowOperationVisitor.cs
@@ -81,13 +81,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             }
 
             private bool ShouldBeTracked(AnalysisEntity analysisEntity)
-                => PointsToAnalysis.ShouldBeTracked(analysisEntity, DataFlowAnalysisContext.PointsToAnalysisKind);
+                => PointsToAnalysis.ShouldBeTracked(analysisEntity, DataFlowAnalysisContext.PointsToAnalysisKind, IsDisposable);
             private PointsToAbstractValue GetValueForEntityThatShouldNotBeTracked(AnalysisEntity analysisEntity)
             {
                 Debug.Assert(!ShouldBeTracked(analysisEntity));
                 Debug.Assert(!CurrentAnalysisData.TryGetValue(analysisEntity, out var existingValue) || existingValue == PointsToAbstractValue.NoLocation);
 
-                return !PointsToAnalysis.ShouldBeTracked(analysisEntity.Type) ?
+                return !PointsToAnalysis.ShouldBeTracked(analysisEntity.Type, IsDisposable) ?
                     PointsToAbstractValue.NoLocation :
                     _defaultPointsToValueGenerator.GetOrCreateDefaultValue(analysisEntity);
             }
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             protected override PointsToAbstractValue GetPointsToAbstractValue(IOperation operation) => base.GetCachedAbstractValue(operation);
 
-            protected override PointsToAbstractValue GetAbstractDefaultValue(ITypeSymbol? type) => !PointsToAnalysis.ShouldBeTracked(type) ? PointsToAbstractValue.NoLocation : PointsToAbstractValue.NullLocation;
+            protected override PointsToAbstractValue GetAbstractDefaultValue(ITypeSymbol? type) => !PointsToAnalysis.ShouldBeTracked(type, IsDisposable) ? PointsToAbstractValue.NoLocation : PointsToAbstractValue.NullLocation;
 
             protected override bool HasAnyAbstractValue(PointsToAnalysisData data) => data.HasAnyAbstractValue;
 
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             // Create a dummy PointsTo value for each reference type parameter.
             protected override PointsToAbstractValue GetDefaultValueForParameterOnEntry(IParameterSymbol parameter, AnalysisEntity analysisEntity)
-                => PointsToAnalysis.ShouldBeTracked(parameter.Type) ?
+                => PointsToAnalysis.ShouldBeTracked(parameter.Type, IsDisposable) ?
                     PointsToAbstractValue.Create(
                         AbstractLocation.CreateSymbolLocation(parameter, DataFlowAnalysisContext.InterproceduralAnalysisData?.CallStack),
                         mayBeNull: true) :
@@ -268,7 +268,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             protected override PointsToAbstractValue ComputeAnalysisValueForReferenceOperation(IOperation operation, PointsToAbstractValue defaultValue)
             {
-                if (PointsToAnalysis.ShouldBeTracked(operation.Type) &&
+                if (PointsToAnalysis.ShouldBeTracked(operation.Type, IsDisposable) &&
                     AnalysisEntityFactory.TryCreate(operation, out var analysisEntity))
                 {
                     return GetAbstractValue(analysisEntity);
@@ -412,14 +412,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                         foreach (var analysisEntity in copyValue.AnalysisEntities)
                         {
                             SetValueForNullCompareFromPredicate(analysisEntity, value, targetEntity.Type, equals, inferInTargetAnalysisData,
-                                ref predicateValueKind, _defaultPointsToValueGenerator, WellKnownTypeProvider.Compilation,
+                                ref predicateValueKind, _defaultPointsToValueGenerator, WellKnownTypeProvider.Compilation, IsDisposable,
                                 sourceAnalysisData: CurrentAnalysisData, targetAnalysisData: targetAnalysisData);
                         }
                     }
                     else
                     {
                         SetValueForNullCompareFromPredicate(targetEntity, value, targetEntity.Type, equals, inferInTargetAnalysisData,
-                            ref predicateValueKind, _defaultPointsToValueGenerator, WellKnownTypeProvider.Compilation,
+                            ref predicateValueKind, _defaultPointsToValueGenerator, WellKnownTypeProvider.Compilation, IsDisposable,
                             sourceAnalysisData: CurrentAnalysisData, targetAnalysisData: targetAnalysisData);
                     }
 
@@ -438,10 +438,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
                 ref PredicateValueKind predicateValueKind,
                 DefaultPointsToValueGenerator defaultPointsToValueGenerator,
                 Compilation compilation,
+                Func<ITypeSymbol?, bool> isDisposable,
                 PointsToAnalysisData sourceAnalysisData,
                 PointsToAnalysisData targetAnalysisData)
             {
-                if (!PointsToAnalysis.ShouldBeTracked(key, defaultPointsToValueGenerator.PointsToAnalysisKind))
+                if (!PointsToAnalysis.ShouldBeTracked(key, defaultPointsToValueGenerator.PointsToAnalysisKind, isDisposable))
                 {
                     Debug.Assert(!targetAnalysisData.HasAbstractValue(key));
                     Debug.Assert(!sourceAnalysisData.HasAbstractValue(key));
@@ -571,15 +572,15 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             protected override PointsToAnalysisData MergeAnalysisData(PointsToAnalysisData value1, PointsToAnalysisData value2)
                 => _pointsToAnalysisDomain.Merge(value1, value2);
             protected override PointsToAnalysisData MergeAnalysisDataForBackEdge(PointsToAnalysisData value1, PointsToAnalysisData value2, BasicBlock forBlock)
-                => _pointsToAnalysisDomain.MergeAnalysisDataForBackEdge(value1, value2, GetChildAnalysisEntities, ResetAbstractValueIfTracked);
+                => _pointsToAnalysisDomain.MergeAnalysisDataForBackEdge(value1, value2, GetChildAnalysisEntities, ResetAbstractValueIfTracked, IsDisposable);
             protected override void UpdateValuesForAnalysisData(PointsToAnalysisData targetAnalysisData)
                 => UpdateValuesForAnalysisData(targetAnalysisData.CoreAnalysisData, CurrentAnalysisData.CoreAnalysisData);
             protected override PointsToAnalysisData GetClonedAnalysisData(PointsToAnalysisData analysisData)
                 => (PointsToAnalysisData)analysisData.Clone();
             public override PointsToAnalysisData GetEmptyAnalysisData()
-                => new();
+                => new(IsDisposable);
             protected override PointsToAnalysisData GetExitBlockOutputData(PointsToAnalysisResult analysisResult)
-                => new(analysisResult.ExitBlockOutput.Data);
+                => new(analysisResult.ExitBlockOutput.Data, IsDisposable);
             protected override void ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(PointsToAnalysisData dataAtException, ThrownExceptionInfo throwBranchWithExceptionType)
                 => ApplyMissingCurrentAnalysisDataForUnhandledExceptionData(dataAtException.CoreAnalysisData, CurrentAnalysisData.CoreAnalysisData, throwBranchWithExceptionType);
             protected override void AssertValidAnalysisData(PointsToAnalysisData analysisData)
@@ -915,7 +916,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             private PointsToAbstractValue VisitInvocationCommon(IOperation operation, IOperation? instance)
             {
-                if (PointsToAnalysis.ShouldBeTracked(operation.Type))
+                if (PointsToAnalysis.ShouldBeTracked(operation.Type, IsDisposable))
                 {
                     if (TryGetInterproceduralAnalysisResult(operation, out var interproceduralResult))
                     {
@@ -1166,7 +1167,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
                 ConversionInference? inference = null;
                 if (operandValue.NullState == NullAbstractValue.NotNull &&
-                    PointsToAnalysis.ShouldBeTracked(operation.Value.Type))
+                    PointsToAnalysis.ShouldBeTracked(operation.Value.Type, IsDisposable))
                 {
                     if (TryInferConversion(operation, out var conversionInference))
                     {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysis.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Analyzer.Utilities;
@@ -81,22 +82,24 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         {
             using var trackedEntitiesBuilder = new TrackedEntitiesBuilder(analysisContext.PointsToAnalysisKind);
             var defaultPointsToValueGenerator = new DefaultPointsToValueGenerator(trackedEntitiesBuilder);
-            var analysisDomain = new PointsToAnalysisDomain(defaultPointsToValueGenerator);
+            var isDisposable = DisposeAnalysisHelper.GetIsDisposableDelegate(analysisContext.ControlFlowGraph.OriginalOperation.SemanticModel!.Compilation);
+            var analysisDomain = new PointsToAnalysisDomain(defaultPointsToValueGenerator, isDisposable);
             var operationVisitor = new PointsToDataFlowOperationVisitor(trackedEntitiesBuilder, defaultPointsToValueGenerator, analysisDomain, analysisContext);
             var pointsToAnalysis = new PointsToAnalysis(analysisDomain, operationVisitor);
             return pointsToAnalysis.TryGetOrComputeResultCore(analysisContext, cacheResult: true);
         }
 
-        internal static bool ShouldBeTracked([NotNullWhen(returnValue: true)] ITypeSymbol? typeSymbol)
+        internal static bool ShouldBeTracked([NotNullWhen(returnValue: true)] ITypeSymbol? typeSymbol, Func<ITypeSymbol?, bool> isDisposable)
             => typeSymbol.IsReferenceTypeOrNullableValueType() ||
                typeSymbol?.IsRefLikeType == true ||
-               typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.IsValueType;
+               typeSymbol is ITypeParameterSymbol typeParameter && !typeParameter.IsValueType ||
+               isDisposable(typeSymbol);
 
-        internal static bool ShouldBeTracked(AnalysisEntity analysisEntity, PointsToAnalysisKind pointsToAnalysisKind)
+        internal static bool ShouldBeTracked(AnalysisEntity analysisEntity, PointsToAnalysisKind pointsToAnalysisKind, Func<ITypeSymbol?, bool> isDisposable)
         {
             Debug.Assert(pointsToAnalysisKind != PointsToAnalysisKind.None);
 
-            if (!ShouldBeTracked(analysisEntity.Type) &&
+            if (!ShouldBeTracked(analysisEntity.Type, isDisposable) &&
                 !analysisEntity.IsLValueFlowCaptureEntity &&
                 !analysisEntity.IsThisOrMeInstance)
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -15,14 +15,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
     /// </summary>
     public sealed class PointsToAnalysisData : AnalysisEntityBasedPredicateAnalysisData<PointsToAbstractValue>
     {
-        internal PointsToAnalysisData()
+        private readonly Func<ITypeSymbol?, bool> _isDisposable;
+
+        internal PointsToAnalysisData(Func<ITypeSymbol?, bool> isDisposable)
         {
+            _isDisposable = isDisposable;
         }
 
-        internal PointsToAnalysisData(IDictionary<AnalysisEntity, PointsToAbstractValue> fromData)
+        internal PointsToAnalysisData(IDictionary<AnalysisEntity, PointsToAbstractValue> fromData, Func<ITypeSymbol?, bool> isDisposable)
             : base(fromData)
         {
-            AssertValidPointsToAnalysisData(fromData);
+            AssertValidPointsToAnalysisData(fromData, isDisposable);
+
+            _isDisposable = isDisposable;
         }
 
         internal PointsToAnalysisData(
@@ -30,17 +35,22 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             PredicatedAnalysisData<AnalysisEntity, PointsToAbstractValue> predicatedData1,
             PredicatedAnalysisData<AnalysisEntity, PointsToAbstractValue> predicatedData2,
             bool isReachableData,
-            MapAbstractDomain<AnalysisEntity, PointsToAbstractValue> coreDataAnalysisDomain)
+            MapAbstractDomain<AnalysisEntity, PointsToAbstractValue> coreDataAnalysisDomain,
+            Func<ITypeSymbol?, bool> isDisposable)
             : base(mergedCoreAnalysisData, predicatedData1, predicatedData2, isReachableData, coreDataAnalysisDomain)
         {
-            AssertValidPointsToAnalysisData(mergedCoreAnalysisData);
+            AssertValidPointsToAnalysisData(mergedCoreAnalysisData, isDisposable);
             AssertValidPointsToAnalysisData();
+
+            _isDisposable = isDisposable;
         }
 
         private PointsToAnalysisData(PointsToAnalysisData fromData)
             : base(fromData)
         {
             fromData.AssertValidPointsToAnalysisData();
+
+            _isDisposable = fromData._isDisposable;
         }
 
         private PointsToAnalysisData(PointsToAnalysisData data1, PointsToAnalysisData data2, MapAbstractDomain<AnalysisEntity, PointsToAbstractValue> coreDataAnalysisDomain)
@@ -49,6 +59,8 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             data1.AssertValidPointsToAnalysisData();
             data2.AssertValidPointsToAnalysisData();
             AssertValidPointsToAnalysisData();
+
+            _isDisposable = data1._isDisposable;
         }
 
         protected override AbstractValueDomain<PointsToAbstractValue> ValueDomain => PointsToAnalysis.ValueDomainInstance;
@@ -67,7 +79,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
         public override void SetAbstractValue(AnalysisEntity key, PointsToAbstractValue value)
         {
-            AssertValidPointsToAnalysisKeyValuePair(key, value);
+            AssertValidPointsToAnalysisKeyValuePair(key, value, _isDisposable);
             base.SetAbstractValue(key, value);
         }
 
@@ -98,14 +110,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         [Conditional("DEBUG")]
         internal void AssertValidPointsToAnalysisData()
         {
-            AssertValidPointsToAnalysisData(CoreAnalysisData);
+            AssertValidPointsToAnalysisData(CoreAnalysisData, _isDisposable);
 #pragma warning disable IDE0200 // Remove unnecessary lambda expression - https://github.com/dotnet/roslyn/issues/63464
-            AssertValidPredicatedAnalysisData(map => AssertValidPointsToAnalysisData(map));
+            AssertValidPredicatedAnalysisData(map => AssertValidPointsToAnalysisData(map, _isDisposable));
 #pragma warning restore IDE0200 // Remove unnecessary lambda expression
         }
 
         [Conditional("DEBUG")]
-        internal static void AssertValidPointsToAnalysisData(IDictionary<AnalysisEntity, PointsToAbstractValue> map)
+        internal static void AssertValidPointsToAnalysisData(IDictionary<AnalysisEntity, PointsToAbstractValue> map, Func<ITypeSymbol?, bool> isDisposable)
         {
             if (map is CorePointsToAnalysisData corePointsToAnalysisData)
             {
@@ -114,18 +126,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
 
             foreach (var kvp in map)
             {
-                AssertValidPointsToAnalysisKeyValuePair(kvp.Key, kvp.Value);
+                AssertValidPointsToAnalysisKeyValuePair(kvp.Key, kvp.Value, isDisposable);
             }
         }
 
         [Conditional("DEBUG")]
         internal static void AssertValidPointsToAnalysisKeyValuePair(
             AnalysisEntity key,
-            PointsToAbstractValue value)
+            PointsToAbstractValue value,
+            Func<ITypeSymbol?, bool> isDisposable)
         {
             Debug.Assert(value.Kind != PointsToAbstractValueKind.Undefined);
             Debug.Assert(!key.IsLValueFlowCaptureEntity || value.Kind == PointsToAbstractValueKind.KnownLValueCaptures);
-            Debug.Assert(PointsToAnalysis.ShouldBeTracked(key, PointsToAnalysisKind.Complete));
+            Debug.Assert(PointsToAnalysis.ShouldBeTracked(key, PointsToAnalysisKind.Complete, isDisposable));
         }
     }
 }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/PointsToAnalysis/PointsToAnalysisData.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
         internal PointsToAnalysisData(IDictionary<AnalysisEntity, PointsToAbstractValue> fromData, Func<ITypeSymbol?, bool> isDisposable)
             : base(fromData)
         {
-            AssertValidPointsToAnalysisData(fromData, isDisposable);
-
             _isDisposable = isDisposable;
+
+            AssertValidPointsToAnalysisData(fromData, isDisposable);
         }
 
         internal PointsToAnalysisData(
@@ -39,28 +39,28 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow.PointsToAnalysis
             Func<ITypeSymbol?, bool> isDisposable)
             : base(mergedCoreAnalysisData, predicatedData1, predicatedData2, isReachableData, coreDataAnalysisDomain)
         {
+            _isDisposable = isDisposable;
+
             AssertValidPointsToAnalysisData(mergedCoreAnalysisData, isDisposable);
             AssertValidPointsToAnalysisData();
-
-            _isDisposable = isDisposable;
         }
 
         private PointsToAnalysisData(PointsToAnalysisData fromData)
             : base(fromData)
         {
-            fromData.AssertValidPointsToAnalysisData();
-
             _isDisposable = fromData._isDisposable;
+
+            fromData.AssertValidPointsToAnalysisData();
         }
 
         private PointsToAnalysisData(PointsToAnalysisData data1, PointsToAnalysisData data2, MapAbstractDomain<AnalysisEntity, PointsToAbstractValue> coreDataAnalysisDomain)
             : base(data1, data2, coreDataAnalysisDomain)
         {
+            _isDisposable = data1._isDisposable;
+
             data1.AssertValidPointsToAnalysisData();
             data2.AssertValidPointsToAnalysisData();
             AssertValidPointsToAnalysisData();
-
-            _isDisposable = data1._isDisposable;
         }
 
         protected override AbstractValueDomain<PointsToAbstractValue> ValueDomain => PointsToAnalysis.ValueDomainInstance;

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -4049,7 +4049,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// </summary>
         protected INamedTypeSymbol? TaskNamedType { get; }
 
-
 #pragma warning disable CA1200 // Avoid using cref tags with a prefix - cref prefix required for one of the project contexts
         /// <summary>
         /// <see cref="INamedTypeSymbol"/> for <see cref="T:System.Threading.Tasks.TaskAsyncEnumerableExtensions"/>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -4049,10 +4049,13 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         /// </summary>
         protected INamedTypeSymbol? TaskNamedType { get; }
 
+
+#pragma warning disable CA1200 // Avoid using cref tags with a prefix - cref prefix required for one of the project contexts
         /// <summary>
-        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions"/>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="T:System.Threading.Tasks.TaskAsyncEnumerableExtensions"/>
         /// </summary>
         private INamedTypeSymbol? TaskAsyncEnumerableExtensions { get; }
+#pragma warning restore CA1200 // Avoid using cref tags with a prefix
 
         /// <summary>
         /// <see cref="INamedTypeSymbol"/> for <see cref="System.IO.MemoryStream"/>

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -249,7 +249,10 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             ContractNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticContractsContract);
             IDisposableNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable);
             IAsyncDisposableNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIAsyncDisposable);
+            ConfiguredAsyncDisposable = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesConfiguredAsyncDisposable);
+            ConfiguredValueTaskAwaitable = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeCompilerServicesConfiguredValueTaskAwaitable);
             TaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask);
+            TaskAsyncEnumerableExtensions = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTaskAsyncEnumerableExtensions);
             MemoryStreamNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIOMemoryStream);
             ValueTaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksValueTask);
             GenericTaskNamedType = WellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingTasksTask1);
@@ -3107,20 +3110,33 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 value = VisitInvocation_NonLambdaOrDelegateOrLocalFunction(operation, argument);
                 CacheAbstractValue(operation, value);
 
-                if (operation.Arguments.Length == 1 &&
-                    operation.Instance != null &&
-                    operation.TargetMethod.IsTaskConfigureAwaitMethod(GenericTaskNamedType))
+                switch (operation.Arguments.Length)
                 {
-                    // ConfigureAwait invocation - just return the abstract value of the visited instance on which it is invoked.
-                    value = GetCachedAbstractValue(operation.Instance);
-                }
-                else if (operation.Arguments.Length == 1 &&
-                   operation.TargetMethod.IsTaskFromResultMethod(TaskNamedType))
-                {
-                    // Result wrapped within a task.
-                    var wrappedOperationValue = GetCachedAbstractValue(operation.Arguments[0].Value);
-                    var pointsToValueOfTask = GetPointsToAbstractValue(operation);
-                    SetTaskWrappedValue(pointsToValueOfTask, wrappedOperationValue);
+                    case 1:
+                        if (operation.Instance != null && operation.TargetMethod.IsTaskConfigureAwaitMethod(GenericTaskNamedType))
+                        {
+                            // ConfigureAwait invocation - just return the abstract value of the visited instance on which it is invoked.
+                            value = GetCachedAbstractValue(operation.Instance);
+                        }
+                        else if (operation.TargetMethod.IsTaskFromResultMethod(TaskNamedType))
+                        {
+                            // Result wrapped within a task.
+                            var wrappedOperationValue = GetCachedAbstractValue(operation.Arguments[0].Value);
+                            var pointsToValueOfTask = GetPointsToAbstractValue(operation);
+                            SetTaskWrappedValue(pointsToValueOfTask, wrappedOperationValue);
+                        }
+
+                        break;
+
+                    case 2:
+                        if (operation.Instance == null &&
+                            operation.TargetMethod.IsAsyncDisposableConfigureAwaitMethod(IAsyncDisposableNamedType, TaskAsyncEnumerableExtensions))
+                        {
+                            // ConfigureAwait invocation - just return the abstract value of the visited instance on which it is invoked.
+                            value = GetCachedAbstractValue(operation.Arguments.GetArgumentForParameterAtIndex(0));
+                        }
+
+                        break;
                 }
 
                 PostVisitInvocation(operation.TargetMethod, operation.Arguments);
@@ -4019,9 +4035,24 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         private INamedTypeSymbol? IAsyncDisposableNamedType { get; }
 
         /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for "System.Runtime.CompilerServices.ConfiguredAsyncDisposable"
+        /// </summary>
+        private INamedTypeSymbol? ConfiguredAsyncDisposable { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"
+        /// </summary>
+        private INamedTypeSymbol? ConfiguredValueTaskAwaitable { get; }
+
+        /// <summary>
         /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Tasks.Task"/>
         /// </summary>
         protected INamedTypeSymbol? TaskNamedType { get; }
+
+        /// <summary>
+        /// <see cref="INamedTypeSymbol"/> for <see cref="System.Threading.Tasks.TaskAsyncEnumerableExtensions"/>
+        /// </summary>
+        private INamedTypeSymbol? TaskAsyncEnumerableExtensions { get; }
 
         /// <summary>
         /// <see cref="INamedTypeSymbol"/> for <see cref="System.IO.MemoryStream"/>
@@ -4103,9 +4134,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         }
 
         private protected bool IsDisposable([NotNullWhen(returnValue: true)] ITypeSymbol? type)
-            => type != null && type.IsDisposable(IDisposableNamedType, IAsyncDisposableNamedType);
+            => type != null && type.IsDisposable(IDisposableNamedType, IAsyncDisposableNamedType, ConfiguredAsyncDisposable);
 
         private protected DisposeMethodKind GetDisposeMethodKind(IMethodSymbol method)
-            => method.GetDisposeMethodKind(IDisposableNamedType, IAsyncDisposableNamedType, TaskNamedType, ValueTaskNamedType);
+            => method.GetDisposeMethodKind(IDisposableNamedType, IAsyncDisposableNamedType, ConfiguredAsyncDisposable, TaskNamedType, ValueTaskNamedType, ConfiguredValueTaskAwaitable);
     }
 }


### PR DESCRIPTION
We used to only track reference types and strings in PointsToAnalysis, which in turns leads to `ConfiguredAsyncDisposable` struct type returned from `TaskAsyncEnumerableExtensions.ConfigureAwait(this IAsyncDisposable, bool)` not being tracked, and hence the `await using` statement doesn't mark the original disposable object as being disposed.

Fixes #6765
Fixes #6512