### PR TITLE
Move to latest source build reference packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>ae1fff344d46976624e68ae17164e0607ab68b10</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23330.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23374.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>c7e229b7e8cd71c8479e236ae1efff3ad1d740f9</Sha>
+      <Sha>e798ac579db6cdcb2505e6cf39141fd508e407d1</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.23214.1">


### PR DESCRIPTION
This should hopefully address [compliance warnings](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-roslyn-analyzers?_a=alerts&typeId=6265215&alerts-view-option=active) on the repo

See https://github.com/dotnet/source-build-reference-packages/pull/750 and https://github.com/dotnet/source-build-reference-packages/pull/747 for reference
