### PR TITLE
Include parameters for CA1864

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.cs
@@ -343,7 +343,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                         case IInvocationOperation invocation when searchContext == SearchContext.AddMethod:
                             if (DoesSignatureMatch(invocation.TargetMethod, usageContext.AddSymbol)
                                 && IsSameConstantOrReferenceOperation(invocation.Arguments[0].Value, usageContext.ContainsKeyArgumentReference)
-                                && invocation.Arguments[1].Value.Kind is OperationKind.Literal or OperationKind.LocalReference or OperationKind.FieldReference or OperationKind.ConstantPattern
+                                && invocation.Arguments[1].Value.Kind is OperationKind.Literal or OperationKind.LocalReference or OperationKind.FieldReference or OperationKind.ParameterReference or OperationKind.ConstantPattern
                                 && !AddArgumentIsDeclaredInBlock(invocation))
                             {
                                 usageContext.UsageLocations.Add(invocation.Syntax.GetLocation());

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -13,6 +13,5 @@ CA1863 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1865 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865> | Use char overload |
 CA1866 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1866> | Use char overload |
 CA1867 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1867> | Use char overload |
-CA1868 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1868> | Unnecessary call to 'Contains(item)' |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |
 CA2261 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2261> | Do not use ConfigureAwaitOptions.SuppressThrowing with Task\<TResult> |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
@@ -542,8 +542,7 @@ public class Test
                 {
                     VerifyCS.Diagnostic(PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryAddRuleId).WithLocation(0).WithLocation(1),
                     VerifyCS.Diagnostic(PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryAddRuleId).WithLocation(2).WithLocation(3)
-                },
-                DisabledDiagnostics = { PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryGetValueRuleId }
+                }
             }.RunAsync();
         }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
@@ -3,6 +3,8 @@
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Performance.PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer,
@@ -485,6 +487,62 @@ namespace UnitTests {
             return new VerifyVB.Test
             {
                 TestCode = testCode,
+                DisabledDiagnostics = { PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryGetValueRuleId }
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(6824, "https://github.com/dotnet/roslyn-analyzers/issues/6824")]
+        public Task WhenArgumentIsAParameter()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using System.Collections.Generic;
+
+public class Test
+{
+    private readonly Dictionary<string, int> _data;
+
+    public void Diagnostic1(string key)
+    {
+        int value = 42;
+        if (!{|#0:_data.ContainsKey(key)|})
+        {
+            {|#1:_data.Add(key, value)|};
+        }
+    }
+
+    public void Diagnostic2(string key, int value)
+    {
+        if (!{|#2:_data.ContainsKey(key)|})
+        {
+            {|#3:_data.Add(key, value)|};
+        }
+    }
+}",
+                FixedCode = @"
+using System.Collections.Generic;
+
+public class Test
+{
+    private readonly Dictionary<string, int> _data;
+
+    public void Diagnostic1(string key)
+    {
+        int value = 42;
+        _data.TryAdd(key, value);
+    }
+
+    public void Diagnostic2(string key, int value)
+    {
+        _data.TryAdd(key, value);
+    }
+}",
+                ExpectedDiagnostics =
+                {
+                    VerifyCS.Diagnostic(PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryAddRuleId).WithLocation(0).WithLocation(1),
+                    VerifyCS.Diagnostic(PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryAddRuleId).WithLocation(2).WithLocation(3)
+                },
                 DisabledDiagnostics = { PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.PreferTryGetValueRuleId }
             }.RunAsync();
         }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryAddOverGuardedAddTests.cs
@@ -3,7 +3,6 @@
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<


### PR DESCRIPTION
CA1864 now also triggers if the `value` argument passed to the `Add` method is a parameter.

Fixes #6824