### PR TITLE
Perform exceptions path analysis for all flow analyses

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidDeadConditionalCode_NullAnalysis.cs
@@ -7762,5 +7762,73 @@ internal class SerialPort
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8,
             }.RunAsync();
         }
+
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.PointsToAnalysis)]
+        [Trait(Traits.DataflowAnalysis, Traits.Dataflow.NullAnalysis)]
+        [Fact, WorkItem(4984, "https://github.com/dotnet/roslyn-analyzers/issues/4984")]
+        public async Task NullCoalescingOperatorInsideCatchBlock_WithinLoop_NoDiagnosticsAsync()
+        {
+            await new VerifyCS.Test
+            {
+                TestCode = @"
+namespace Ca1508FalsePositive
+{
+    using System;
+    using System.Collections.Generic;
+
+    class Program
+    {
+        private static object AutoDetectAndConnect(string host)
+        {
+            List<Exception> exceptions = null;
+            foreach (string registeredScheduler in s_schedulers)
+            {
+                try
+                {
+                    object conn = Connect(registeredScheduler, host);
+                    if (conn != null)
+                        return conn;
+                }
+                catch (Exception ex)
+                {
+                    // warning CA1508: 'exceptions' is always 'null'. Remove or refactor the condition(s) to avoid dead code.
+                    (exceptions ??= new List<Exception>()).Add(ex);
+                }
+            }
+
+            // Commenting out this code block will ""resolve"" CA1508 above
+            if (exceptions == null)
+            {
+                throw new NotSupportedException(host);
+            }
+
+            throw new AggregateException(exceptions);
+
+            static object Connect(string a, string b) => throw new NotImplementedException($""{a}{b}"");
+        }
+
+        static List<string> s_schedulers = new List<string>();
+        static void Register(string scheduler) => s_schedulers.Add(scheduler);
+
+        static void Main(string[] args)
+        {
+            Register(""abc"");
+            Register(""def"");
+
+            try
+            {
+                var conn = AutoDetectAndConnect(args.Length > 0 ? args[0] : args.GetHashCode().ToString());
+                Console.WriteLine(conn);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+    }
+}",
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8,
+            }.RunAsync();
+        }
     }
 }

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/AvoidMultipleEnumerationsTests.cs
@@ -181,7 +181,7 @@ End Namespace
             await VerifyVisualBasicAsync(vbCode);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/6830")]
         public async Task TestInvocationsInForEachLoop()
         {
             var csharpCode = @"
@@ -4067,7 +4067,7 @@ End Module
                 customizedLinqChainMethods: editorConfig);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn-analyzers/issues/6830")]
         public async Task TestDomainMerge()
         {
             var csharpCode1 = @"

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             // i.e. for every '{key, value}' pair in the dictionary, 'key' is the destination of at least one back edge
             // and 'value' is the minimum ordinal such that there is no back edge to 'key' from any basic block with ordinal > 'value'.
             using var loopRangeMap = PooledDictionary<int, int>.GetInstance();
-            ComputeLoopRangeMap(cfg, loopRangeMap);
+            var hasAnyTryBlock = ComputeLoopRangeMap(cfg, loopRangeMap);
 
             TAnalysisData? normalPathsExitBlockData = null, exceptionPathsExitBlockData = null;
 
@@ -115,7 +115,12 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     blockToUniqueInputFlowMap, loopRangeMap, exceptionPathsAnalysisPostPass: false);
                 normalPathsExitBlockData = resultBuilder.ExitBlockOutputData;
 
-                if (analysisContext.ExceptionPathsAnalysis)
+                // If we are executing exception paths analysis OR have at least one try/catch/finally block
+                // in the method, execute an exception path analysis post pass.
+                // This post pass will handle all possible operations within the control flow graph that can
+                // throw an exception and merge analysis data after all such operation analyses into the
+                // catch blocks reachable from those operations.
+                if (analysisContext.ExceptionPathsAnalysis || hasAnyTryBlock)
                 {
                     RoslynDebug.Assert(normalPathsExitBlockData != null);
 
@@ -286,11 +291,9 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
                 // Check if we are starting a try region which has one or more associated catch/filter regions.
                 // If so, we conservatively merge the input data for try region into the input data for the associated catch/filter regions.
-#pragma warning disable CA1508 // Avoid dead conditional code - https://github.com/dotnet/roslyn-analyzers/issues/4408
                 if (block.EnclosingRegion?.Kind == ControlFlowRegionKind.Try &&
                     block.EnclosingRegion.EnclosingRegion?.Kind == ControlFlowRegionKind.TryAndCatch &&
                     block.EnclosingRegion.EnclosingRegion.FirstBlockOrdinal == block.Ordinal)
-#pragma warning restore CA1508 // Avoid dead conditional code
                 {
                     MergeIntoCatchInputData(block.EnclosingRegion.EnclosingRegion, input, block);
                 }
@@ -791,14 +794,19 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             }
         }
 
-        private static void ComputeLoopRangeMap(ControlFlowGraph cfg, PooledDictionary<int, int> loopRangeMap)
+        private static bool ComputeLoopRangeMap(ControlFlowGraph cfg, PooledDictionary<int, int> loopRangeMap)
         {
+            var hasAnyTryBlock = false;
             for (int i = cfg.Blocks.Length - 1; i > 0; i--)
             {
                 var block = cfg.Blocks[i];
                 HandleBranch(block.FallThroughSuccessor);
                 HandleBranch(block.ConditionalSuccessor);
+
+                hasAnyTryBlock |= block.EnclosingRegion.Kind == ControlFlowRegionKind.Try;
             }
+
+            return hasAnyTryBlock;
 
             void HandleBranch(ControlFlowBranch? branch)
             {

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -923,7 +923,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected virtual TAnalysisData GetMergedAnalysisDataForPossibleThrowingOperation(TAnalysisData? existingData, IOperation operation)
         {
-            Debug.Assert(DataFlowAnalysisContext.ExceptionPathsAnalysis);
             Debug.Assert(ExecutingExceptionPathsAnalysisPostPass);
 
             return existingData == null ?

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -844,7 +844,6 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         protected virtual void HandlePossibleThrowingOperation(IOperation operation)
         {
-            Debug.Assert(DataFlowAnalysisContext.ExceptionPathsAnalysis);
             Debug.Assert(ExecutingExceptionPathsAnalysisPostPass);
 
             // Bail out if we are not analyzing an interprocedural call and there is no


### PR DESCRIPTION
Fixes #5199
Fixes #5160
Fixes #4984

We already had implementation and option based support to perform exception path analysis to handle all operations that can potentially throw an exception, and hence need flow analysis data at the point of operation to be merged with analysis data at start of reachable catch blocks from that operation. However, we were only performing this analysis post pass when flow analysis is looking at exceptions data. Now we do it for all analysis as this is required for more accurate input analysis data at start of catch and finally blocks.

**NOTE:** Fixing this issue led to an assert firing in CodeAnalysis dataflow operation visitor for an existing unit test, which has also been fixed in this PR

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
