### PR TITLE
Don´t emit CA1849 when using DbSet.Add and DbSet.AddRange EntityFramework Methods

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -191,7 +191,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             var entityFrameworkTypeNames = new[]
             {
                 WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbContext,
-                WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbSet
+                WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbSet1
             };
 
             var methodsBuilder = ImmutableArray.CreateBuilder<IMethodSymbol>();

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -188,14 +188,24 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static ImmutableArray<IMethodSymbol> GetExcludedMethods(WellKnownTypeProvider wellKnownTypeProvider)
         {
-            var methodsBuilder = ImmutableArray.CreateBuilder<IMethodSymbol>();
-            if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbContext, out INamedTypeSymbol? dbContextType))
+            var entityFrameworkTypeNames = new[]
             {
-                foreach (var method in dbContextType.GetMembers().OfType<IMethodSymbol>())
+                WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbContext,
+                WellKnownTypeNames.MicrosoftEntityFrameworkCoreDbSet
+            };
+
+            var methodsBuilder = ImmutableArray.CreateBuilder<IMethodSymbol>();
+
+            foreach (var entityFrameworkTypeName in entityFrameworkTypeNames)
+            {
+                if (wellKnownTypeProvider.TryGetOrCreateTypeByMetadataName(entityFrameworkTypeName, out INamedTypeSymbol? entityFrameworkType))
                 {
-                    if (method.Name is "Add" or "AddRange")
+                    foreach (var method in entityFrameworkType.GetMembers().OfType<IMethodSymbol>())
                     {
-                        methodsBuilder.Add(method);
+                        if (method.Name is "Add" or "AddRange")
+                        {
+                            methodsBuilder.Add(method);
+                        }
                     }
                 }
             }

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1294,7 +1294,7 @@ using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 
 class Test {
-    public async Task RunAsync(DbSet set) {
+    public async Task RunAsync(DbSet<object> set) {
         set.AddRange(1, 2);
     }
 }",

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1285,6 +1285,24 @@ class Test {
         }
 
         [Fact]
+        public Task DbSetAddRange_NoDiagnostic()
+        {
+            return new VerifyCS.Test
+            {
+                TestCode = @"
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+class Test {
+    public async Task RunAsync(DbSet set) {
+        ctx.AddRange(1, 2);
+    }
+}",
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(EntityFrameworkPackages)
+            }.RunAsync();
+        }
+
+        [Fact]
         [WorkItem(6684, "https://github.com/dotnet/roslyn-analyzers/issues/6684")]
         public Task DbContextFactoryCreateDbContext_Diagnostic()
         {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1295,7 +1295,7 @@ using System.Threading.Tasks;
 
 class Test {
     public async Task RunAsync(DbSet set) {
-        ctx.AddRange(1, 2);
+        set.AddRange(1, 2);
     }
 }",
                 ReferenceAssemblies = ReferenceAssemblies.Net.Net70.WithPackages(EntityFrameworkPackages)

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -65,7 +65,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicCompilation = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation";
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicExtensions = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions";
         public const string MicrosoftEntityFrameworkCoreDbContext = "Microsoft.EntityFrameworkCore.DbContext";
-        public const string MicrosoftEntityFrameworkCoreDbSet = "Microsoft.EntityFrameworkCore.DbSet";
+        public const string MicrosoftEntityFrameworkCoreDbSet1 = "Microsoft.EntityFrameworkCore.DbSet`1";
         public const string MicrosoftEntityFrameworkCoreEntityFrameworkQueryableExtensions = "Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions";
         public const string MicrosoftEntityFrameworkCoreRelationalQueryableExtensions = "Microsoft.EntityFrameworkCore.RelationalQueryableExtensions";
         public const string MicrosoftExtensionsLoggingILogger = "Microsoft.Extensions.Logging.ILogger";

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -65,6 +65,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicCompilation = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation";
         public const string MicrosoftCodeAnalysisVisualBasicVisualBasicExtensions = "Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions";
         public const string MicrosoftEntityFrameworkCoreDbContext = "Microsoft.EntityFrameworkCore.DbContext";
+        public const string MicrosoftEntityFrameworkCoreDbSet = "Microsoft.EntityFrameworkCore.DbSet";
         public const string MicrosoftEntityFrameworkCoreEntityFrameworkQueryableExtensions = "Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions";
         public const string MicrosoftEntityFrameworkCoreRelationalQueryableExtensions = "Microsoft.EntityFrameworkCore.RelationalQueryableExtensions";
         public const string MicrosoftExtensionsLoggingILogger = "Microsoft.Extensions.Logging.ILogger";


### PR DESCRIPTION
fixes https://github.com/dotnet/efcore/issues/31431

Ignores DbSet.Add and DbSet.AddRange in CA1849 analyzer as well..

This currently generated a false positive if you call for example Add on a DbSet

```
myDbContext.Users.Add(new User("John Doe"));
```