### PR TITLE
[Performance] Improve AvoidUninstantiatedInternalClasses performance

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -119,7 +119,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                         {
                             foreach (var (_, findTypeOrDefault) in applicableAttributes)
                             {
-                                if (findTypeOrDefault(attribute, context.Compilation) is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(context.ContainingSymbol.ContainingAssembly))
+                                if (findTypeOrDefault(attribute, context.Compilation) is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(type.ContainingAssembly))
                                 {
                                     instantiatedTypes.TryAdd(namedType, null);
                                     break;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                 startContext.RegisterOperationAction(context =>
                 {
                     var expr = (IObjectCreationOperation)context.Operation;
-                    if (expr.Type is INamedTypeSymbol namedType)
+                    if (expr.Type is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(context.ContainingSymbol.ContainingAssembly))
                     {
                         instantiatedTypes.TryAdd(namedType, null);
                     }
@@ -119,7 +119,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
                         {
                             foreach (var (_, findTypeOrDefault) in applicableAttributes)
                             {
-                                if (findTypeOrDefault(attribute, context.Compilation) is INamedTypeSymbol namedType)
+                                if (findTypeOrDefault(attribute, context.Compilation) is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(context.ContainingSymbol.ContainingAssembly))
                                 {
                                     instantiatedTypes.TryAdd(namedType, null);
                                     break;


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn-analyzers/issues/6301

I'm not marking this PR as a fix for #6301 as I think there may be a room for more performance improvements. This is only a quick pass.