### PR TITLE
[Performance] Use Length property instead of Count()

### DIFF
--- a/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IEnumerableOfIMethodSymbolExtensions.cs
@@ -44,7 +44,7 @@ namespace Analyzer.Utilities.Extensions
         {
             return methods.Where(candidateMethod =>
             {
-                if (!System.Collections.Immutable.ImmutableArrayExtensions.HasExactly(candidateMethod.Parameters, selectedOverload.Parameters.Count() + 1))
+                if (!System.Collections.Immutable.ImmutableArrayExtensions.HasExactly(candidateMethod.Parameters, selectedOverload.Parameters.Length + 1))
                 {
                     return false;
                 }
@@ -70,7 +70,7 @@ namespace Analyzer.Utilities.Extensions
                     }
                 }
 
-                for (int i = 0; i < selectedOverload.Parameters.Count(); i++, j++)
+                for (int i = 0; i < selectedOverload.Parameters.Length; i++, j++)
                 {
                     if (!selectedOverload.Parameters[i].Type.Equals(candidateMethod.Parameters[j].Type) ||
                         selectedOverload.Parameters[i].IsParams != candidateMethod.Parameters[j].IsParams ||
@@ -140,7 +140,7 @@ namespace Analyzer.Utilities.Extensions
             var expectedParameterCount = expectedParameterTypesInOrder.Length;
             return members?.FirstOrDefault(member =>
             {
-                if (member.Parameters.Count() != expectedParameterCount)
+                if (member.Parameters.Length != expectedParameterCount)
                 {
                     return false;
                 }


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
