### PR TITLE
Write CA1824 as non-compilation-end

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Resources/CSharpMarkAssembliesWithNeutralResourcesLanguage.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Resources/CSharpMarkAssembliesWithNeutralResourcesLanguage.cs
@@ -15,10 +15,15 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Resources
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpMarkAssembliesWithNeutralResourcesLanguageAnalyzer : MarkAssembliesWithNeutralResourcesLanguageAnalyzer
     {
-        protected override void RegisterAttributeAnalyzer(CompilationStartAnalysisContext context, Action onResourceFound, INamedTypeSymbol generatedCode)
+        protected override void RegisterAttributeAnalyzer(CompilationStartAnalysisContext context, Func<bool> shouldAnalyze, Action<SyntaxNodeAnalysisContext> onResourceFound, INamedTypeSymbol generatedCode)
         {
             context.RegisterSyntaxNodeAction(context =>
             {
+                if (!shouldAnalyze())
+                {
+                    return;
+                }
+
                 var attributeSyntax = (AttributeSyntax)context.Node;
                 if (!CheckAttribute(attributeSyntax))
                 {
@@ -30,7 +35,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Resources
                     return;
                 }
 
-                onResourceFound();
+                onResourceFound(context);
             }, SyntaxKind.Attribute);
         }
 

--- a/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -203,8 +203,7 @@
             "tags": [
               "PortedFromFxCop",
               "Telemetry",
-              "EnabledRuleInAggressiveMode",
-              "CompilationEnd"
+              "EnabledRuleInAggressiveMode"
             ]
           }
         },
@@ -6387,8 +6386,7 @@
             "tags": [
               "PortedFromFxCop",
               "Telemetry",
-              "EnabledRuleInAggressiveMode",
-              "CompilationEnd"
+              "EnabledRuleInAggressiveMode"
             ]
           }
         },

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguageTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Resources/MarkAssembliesWithNeutralResourcesLanguageTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
@@ -18,12 +18,26 @@ namespace Microsoft.NetCore.Analyzers.Resources.UnitTests
 namespace DesignerFile {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")]
     internal class Resource1 { }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")]
+    internal class Resource2 { }
+
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")]
+    internal class Resource3 { }
 }";
 
         private const string BasicDesignerFile = @"
 Namespace My.Resources
     <Global.System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")> _
     Friend Class Resource1
+    End Class
+
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")> _
+    Friend Class Resource2
+    End Class
+
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Resources.Tools.StronglyTypedResourceBuilder"", ""4.0.0.0"")> _
+    Friend Class Resource3
     End Class
 End Namespace";
 

--- a/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Resources/BasicMarkAssembliesWithNeutralResourcesLanguage.vb
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.NetCore.Analyzers/Resources/BasicMarkAssembliesWithNeutralResourcesLanguage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 Imports Microsoft.NetCore.Analyzers.Resources
 Imports Microsoft.CodeAnalysis
@@ -13,9 +13,13 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Resources
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicMarkAssembliesWithNeutralResourcesLanguageAnalyzer
         Inherits MarkAssembliesWithNeutralResourcesLanguageAnalyzer
-        Protected Overrides Sub RegisterAttributeAnalyzer(context As CompilationStartAnalysisContext, onResourceFound As Action, generatedCode As INamedTypeSymbol)
+        Protected Overrides Sub RegisterAttributeAnalyzer(context As CompilationStartAnalysisContext, shouldAnalyze As Func(Of Boolean), onResourceFound As Action(Of SyntaxNodeAnalysisContext), generatedCode As INamedTypeSymbol)
             context.RegisterSyntaxNodeAction(
                 Sub(nc)
+                    If Not shouldAnalyze() Then
+                        Return
+                    End If
+
                     Dim attributeSyntax = DirectCast(nc.Node, AttributeSyntax)
                     If Not CheckBasicAttribute(attributeSyntax) Then
                         Return
@@ -25,7 +29,7 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Resources
                         Return
                     End If
 
-                    onResourceFound()
+                    onResourceFound(nc)
                 End Sub, SyntaxKind.Attribute)
         End Sub
 

--- a/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/DiagnosticExtensions.cs
@@ -170,6 +170,12 @@ namespace Analyzer.Utilities.Extensions
             => context.Compilation.ReportNoLocationDiagnostic(rule, context.ReportDiagnostic, properties: null, args);
 
         public static void ReportNoLocationDiagnostic(
+            this SyntaxNodeAnalysisContext context,
+            DiagnosticDescriptor rule,
+            params object[] args)
+            => context.Compilation.ReportNoLocationDiagnostic(rule, context.ReportDiagnostic, properties: null, args);
+
+        public static void ReportNoLocationDiagnostic(
             this Compilation compilation,
             DiagnosticDescriptor rule,
             Action<Diagnostic> addDiagnostic,


### PR DESCRIPTION
The intent of this change is two things:

1. Avoid analyzing more attributes if we already found a matching attribute.
2. Having this analyzer not be a compilation end analyzer.

@mavasani @sharwell Do you think it's worth changing this analyzer to not be non-compilation-end (which will make it available in IDE live diagnostics)?

Is there a better than what I did here?