### PR TITLE
Use direct cast instead of type checking when type is known

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
@@ -54,7 +54,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             void visitEnumSymbol(SymbolStartAnalysisContext context)
             {
-                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumSymbol)
+                var enumSymbol = (INamedTypeSymbol)context.Symbol;
+                if (enumSymbol.TypeKind != TypeKind.Enum)
                 {
                     return;
                 }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol equatableType)
         {
-            if (context.Symbol is not INamedTypeSymbol namedType
-                || (namedType.TypeKind != TypeKind.Struct && namedType.TypeKind != TypeKind.Class)
+            var namedType = (INamedTypeSymbol)context.Symbol;
+            if ((namedType.TypeKind != TypeKind.Struct && namedType.TypeKind != TypeKind.Class)
                 || (namedType.TypeKind == TypeKind.Struct && namedType.IsRefLikeType))
             {
                 return;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementIDisposableCorrectly.cs
@@ -182,10 +182,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             private void AnalyzeNamedTypeSymbol(SymbolAnalysisContext context)
             {
+                var type = (INamedTypeSymbol)context.Symbol;
                 // Note all the descriptors/rules for this analyzer have the same ID and category and hence
                 // will always have identical configured visibility.
-                if (context.Symbol is INamedTypeSymbol type &&
-                    type.TypeKind == TypeKind.Class &&
+                if (type.TypeKind == TypeKind.Class &&
                     context.Options.MatchesConfiguredVisibility(IDisposableReimplementationRule, type, context.Compilation))
                 {
                     bool implementsDisposableInBaseType = ImplementsDisposableInBaseType(type);

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.cs
@@ -103,7 +103,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                     context.RegisterOperationAction(context =>
                     {
-                        if (context.Operation is IInstanceReferenceOperation { ReferenceKind: InstanceReferenceKind.ContainingTypeInstance }
+                        var operation = (IInstanceReferenceOperation)context.Operation;
+                        if (operation.ReferenceKind == InstanceReferenceKind.ContainingTypeInstance
                             && (context.Operation.Parent is not IInvocationOperation invocation || !invocation.TargetMethod.Equals(methodSymbol, SymbolEqualityComparer.Default)))
                         {
                             isInstanceReferenced = true;
@@ -121,7 +122,8 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
 
                     context.RegisterOperationAction(context =>
                     {
-                        if (context.Operation is IParameterReferenceOperation { Parameter.ContainingSymbol: IMethodSymbol { MethodKind: MethodKind.Constructor } })
+                        var operation = (IParameterReferenceOperation)context.Operation;
+                        if (operation.Parameter.ContainingSymbol is IMethodSymbol { MethodKind: MethodKind.Constructor })
                         {
                             // we're referencing a parameter not from our actual method, but from a type constructor.
                             // This must be a primary constructor scenario, and we're capturing the parameter here.  

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/ImplementGenericMathInterfacesCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/ImplementGenericMathInterfacesCorrectly.cs
@@ -51,10 +51,8 @@ namespace Microsoft.NetCore.Analyzers.Usage
 
                 context.RegisterSymbolAction(context =>
                 {
-                    if (context.Symbol is INamedTypeSymbol ntSymbol)
-                    {
-                        AnalyzeSymbol(context, ntSymbol, iParsableInterface.ContainingNamespace, iNumberInterface.ContainingNamespace);
-                    }
+                    var symbol = (INamedTypeSymbol)context.Symbol;
+                    AnalyzeSymbol(context, symbol, iParsableInterface.ContainingNamespace, iNumberInterface.ContainingNamespace);
                 }, SymbolKind.NamedType);
             });
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetFramework.Analyzers/MarkVerbHandlersWithValidateAntiforgeryTokenAnalyzer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using Analyzer.Utilities;
@@ -96,9 +96,10 @@ namespace Microsoft.NetFramework.Analyzers
                     compilationStartContext.RegisterSymbolAction(
                         (SymbolAnalysisContext symbolContext) =>
                         {
+                            var methodSymbol = (IMethodSymbol)symbolContext.Symbol;
+
                             // TODO enhancements: Consider looking at IAsyncResult-based action methods.
-                            if (symbolContext.Symbol is not IMethodSymbol methodSymbol
-                                || methodSymbol.MethodKind != MethodKind.Ordinary
+                            if (methodSymbol.MethodKind != MethodKind.Ordinary
                                 || methodSymbol.IsStatic
                                 || !methodSymbol.IsPublic()
                                 || !(methodSymbol.ReturnType.Inherits(actionResultSymbol)  // FxCop implementation only looked at ActionResult-derived return types.


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
