### PR TITLE
Fix IndexOfOfRangeException for non-formatting methods.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -415,6 +415,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return false;
                 }
 
+                if (formatIndex == method.Parameters.Length - 1)
+                {
+                    // format specification is the last parameter (e.g. CompositeFormat.Parse)
+                    // this is therefore not a formatting method.
+                    return false;
+                }
+
                 int expectedArguments = GetExpectedNumberOfArguments(method.Parameters, formatIndex);
                 formatInfo = new Info(formatIndex, expectedArguments);
                 _map.TryAdd(method, formatInfo);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -573,6 +573,36 @@ End Class"
             await basicTest.RunAsync();
         }
 
+        [Fact]
+        [WorkItem(90357, "https://github.com/dotnet/runtime/issues/90357")]
+        public async Task CA2241CSharpPassingMethodWithNoPossibleArguments()
+        {
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using System.Diagnostics.CodeAnalysis;
+
+class Test
+{
+    public static int Parse([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format) => -1;
+
+    void M1(string param)
+    {
+        var a = Parse(""{0} {1}"");
+    }
+}"
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+                }
+            };
+
+            await csharpTest.RunAsync();
+        }
+
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90357

Excludes non-formatting method from checks as it is impossible to ever pass the correct number of arguments.
