### PR TITLE
Runtime90357 6012

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -290,12 +290,6 @@
   <data name="ProvideCorrectArgumentsToFormattingMethodsMessage" xml:space="preserve">
     <value>Provide correct arguments to formatting methods</value>
   </data>
-  <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle" xml:space="preserve">
-    <value>Provide correct format specification to formatting methods</value>
-  </data>
-  <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription" xml:space="preserve">
-    <value>The format argument that is passed to System.String.Format is not properly formatted.</value>
-  </data>
   <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage" xml:space="preserve">
     <value>The format argument is not a valid format string</value>
   </data>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/MicrosoftNetCoreAnalyzersResources.resx
@@ -290,6 +290,15 @@
   <data name="ProvideCorrectArgumentsToFormattingMethodsMessage" xml:space="preserve">
     <value>Provide correct arguments to formatting methods</value>
   </data>
+  <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle" xml:space="preserve">
+    <value>Provide correct format specification to formatting methods</value>
+  </data>
+  <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription" xml:space="preserve">
+    <value>The format argument that is passed to System.String.Format is not properly formatted.</value>
+  </data>
+  <data name="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage" xml:space="preserve">
+    <value>The format argument is not a valid format string</value>
+  </data>
   <data name="TestForNaNCorrectlyTitle" xml:space="preserve">
     <value>Test for NaN correctly</value>
   </data>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -332,7 +332,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
             } // end of main loop
 
-            return uniqueNumbers.Count;
+            return uniqueNumbers.Count == 0 ? 0 : uniqueNumbers.Max() + 1;
         }
 
         private class StringFormatInfo

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -41,7 +41,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             DiagnosticCategory.Usage,
             RuleLevel.BuildWarningCandidate,
             description: CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsDescription)),
-            isPortedFxCopRule: false,
+            isPortedFxCopRule: true,
             isDataflowRule: false);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -415,6 +415,13 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return false;
                 }
 
+                if (formatIndex == method.Parameters.Length - 1)
+                {
+                    // format specification is the last parameter (e.g. CompositeFormat.Parse)
+                    // this is therefore not a formatting method.
+                    return false;
+                }
+
                 int expectedArguments = GetExpectedNumberOfArguments(method.Parameters, formatIndex);
                 formatInfo = new Info(formatIndex, expectedArguments);
                 _map.TryAdd(method, formatInfo);

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethods.cs
@@ -36,11 +36,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         internal static readonly DiagnosticDescriptor InvalidFormatRule = DiagnosticDescriptorHelper.Create(
             RuleId,
-            CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle)),
+            CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsTitle)),
             CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage)),
             DiagnosticCategory.Usage,
             RuleLevel.BuildWarningCandidate,
-            description: CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription)),
+            description: CreateLocalizableResourceString(nameof(ProvideCorrectArgumentsToFormattingMethodsDescription)),
             isPortedFxCopRule: false,
             isDataflowRule: false);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2288,6 +2288,21 @@ Obecné přetypování (IL unbox.any) používané sekvencí vrácenou metodou E
         <target state="translated">Argument formátu, který se předává do System.String.Format, neobsahuje položku formátování, která odpovídá jednotlivým argumentům objektů, nebo naopak.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Poskytněte metodám formátování správné argumenty</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.cs.xlf
@@ -2288,19 +2288,9 @@ Obecné přetypování (IL unbox.any) používané sekvencí vrácenou metodou E
         <target state="translated">Argument formátu, který se předává do System.String.Format, neobsahuje položku formátování, která odpovídá jednotlivým argumentům objektů, nebo naopak.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2288,19 +2288,9 @@ Erweiterungen und benutzerdefinierte Konvertierungen werden bei generischen Type
         <target state="translated">Das an "System.String.Format" übergebene Formatargument enthält kein Formatelement, das den einzelnen Objektargumenten entspricht bzw. umgekehrt.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.de.xlf
@@ -2288,6 +2288,21 @@ Erweiterungen und benutzerdefinierte Konvertierungen werden bei generischen Type
         <target state="translated">Das an "System.String.Format" übergebene Formatargument enthält kein Formatelement, das den einzelnen Objektargumenten entspricht bzw. umgekehrt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Geeignete Argumente für Formatierungsmethoden angeben</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2288,6 +2288,21 @@ La ampliación y las conversiones definidas por el usuario no se admiten con tip
         <target state="translated">El argumento de cadena format pasado a System.String.Format no contiene un elemento de formato que corresponda a cada argumento de objeto o viceversa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Proporcionar argumentos correctos para los métodos de formato</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.es.xlf
@@ -2288,19 +2288,9 @@ La ampliación y las conversiones definidas por el usuario no se admiten con tip
         <target state="translated">El argumento de cadena format pasado a System.String.Format no contiene un elemento de formato que corresponda a cada argumento de objeto o viceversa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2288,19 +2288,9 @@ Les conversions étendues et définies par l’utilisateur ne sont pas prises en
         <target state="translated">L'argument de mise en forme passé à System.String.Format ne contient aucun élément de mise en forme pour chaque argument d'objet correspondant, ou vice versa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.fr.xlf
@@ -2288,6 +2288,21 @@ Les conversions étendues et définies par l’utilisateur ne sont pas prises en
         <target state="translated">L'argument de mise en forme passé à System.String.Format ne contient aucun élément de mise en forme pour chaque argument d'objet correspondant, ou vice versa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Indiquer le nombre correct d'arguments dans les méthodes de mise en forme</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2288,6 +2288,21 @@ L'ampliamento e le conversioni definite dall'utente non sono supportate con tipi
         <target state="translated">L'argomento format passato a System.String.Format non contiene un elemento di formato corrispondente a ogni argomento dell'oggetto o viceversa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Fornire gli argomenti corretti ai metodi di formattazione</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.it.xlf
@@ -2288,19 +2288,9 @@ L'ampliamento e le conversioni definite dall'utente non sono supportate con tipi
         <target state="translated">L'argomento format passato a System.String.Format non contiene un elemento di formato corrispondente a ogni argomento dell'oggetto o viceversa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2288,19 +2288,9 @@ Enumerable.OfType&lt;T&gt; で使用されるジェネリック型チェック (
         <target state="translated">System.String.Format に渡される書式引数には、各オブジェクト引数に対応する書式項目が含まれていないか、各書式項目に対応するオブジェクト引数が含まれていません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ja.xlf
@@ -2288,6 +2288,21 @@ Enumerable.OfType&lt;T&gt; で使用されるジェネリック型チェック (
         <target state="translated">System.String.Format に渡される書式引数には、各オブジェクト引数に対応する書式項目が含まれていないか、各書式項目に対応するオブジェクト引数が含まれていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">書式設定メソッドに正しい引数を指定します</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2288,6 +2288,21 @@ Enumerable.OfType&lt;T&gt;에서 사용하는 제네릭 형식 검사(C# 'is' �
         <target state="translated">System.String.Format으로 전달된 format 인수에 각 개체 인수에 해당하는 format 항목이 포함되지 않으며 그 반대의 경우도 마찬가지입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">서식 지정 메서드에 올바른 인수를 제공하세요.</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ko.xlf
@@ -2288,19 +2288,9 @@ Enumerable.OfType&lt;T&gt;에서 사용하는 제네릭 형식 검사(C# 'is' �
         <target state="translated">System.String.Format으로 전달된 format 인수에 각 개체 인수에 해당하는 format 항목이 포함되지 않으며 그 반대의 경우도 마찬가지입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2288,19 +2288,9 @@ Konwersje poszerzane i zdefiniowane przez użytkownika nie są obsługiwane w pr
         <target state="translated">Argument formatu przekazywany do metody System.String.Format nie zawiera elementu formatu odpowiadającego każdemu argumentowi obiektu lub odwrotnie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pl.xlf
@@ -2288,6 +2288,21 @@ Konwersje poszerzane i zdefiniowane przez użytkownika nie są obsługiwane w pr
         <target state="translated">Argument formatu przekazywany do metody System.String.Format nie zawiera elementu formatu odpowiadającego każdemu argumentowi obiektu lub odwrotnie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Określ poprawne argumenty dla metod formatujących</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2288,19 +2288,9 @@ Ampliação e conversões definidas pelo usuário não são compatíveis com tip
         <target state="translated">O argumento de formato passado para System.String.Format não contém um item de formato correspondente a cada argumento de objeto ou vice-versa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.pt-BR.xlf
@@ -2288,6 +2288,21 @@ Ampliação e conversões definidas pelo usuário não são compatíveis com tip
         <target state="translated">O argumento de formato passado para System.String.Format não contém um item de formato correspondente a cada argumento de objeto ou vice-versa.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Fornecer os argumentos corretos para métodos de formatação</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2288,6 +2288,21 @@ Widening and user defined conversions are not supported with generic types.</sou
         <target state="translated">Передаваемый в System.String.Format аргумент формата не содержит элемент формата, соответствующий каждому из аргументов объекта, или наоборот.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Задайте правильные аргументы для методов форматирования</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.ru.xlf
@@ -2288,19 +2288,9 @@ Widening and user defined conversions are not supported with generic types.</sou
         <target state="translated">Передаваемый в System.String.Format аргумент формата не содержит элемент формата, соответствующий каждому из аргументов объекта, или наоборот.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2288,19 +2288,9 @@ Genel türlerde genişletme ve kullanıcı tanımlı dönüştürmeler desteklen
         <target state="translated">System.String.Format’a geçirilen biçim bağımsız değişkeni, her nesne bağımsız değişkenine karşılık gelen bir biçim öğesi içermiyor ve tersi için de aynısı geçerli.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.tr.xlf
@@ -2288,6 +2288,21 @@ Genel türlerde genişletme ve kullanıcı tanımlı dönüştürmeler desteklen
         <target state="translated">System.String.Format’a geçirilen biçim bağımsız değişkeni, her nesne bağımsız değişkenine karşılık gelen bir biçim öğesi içermiyor ve tersi için de aynısı geçerli.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">Biçimlendirme yöntemlerine doğru bağımsız değişkenleri sağlayın</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2288,6 +2288,21 @@ Enumerable.OfType&lt;T&gt; 使用的泛型类型检查 (C# 'is' operator/IL 'isi
         <target state="translated">传递到 System.String.Format 的 format 参数不包含与各对象参数相对应的格式项，反之亦然。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">为格式化方法提供正确的参数</target>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hans.xlf
@@ -2288,19 +2288,9 @@ Enumerable.OfType&lt;T&gt; 使用的泛型类型检查 (C# 'is' operator/IL 'isi
         <target state="translated">传递到 System.String.Format 的 format 参数不包含与各对象参数相对应的格式项，反之亦然。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2288,19 +2288,9 @@ Enumerable.OfType&lt;T&gt; 使用的一般型別檢查 (C# 'is' operator/IL 'isi
         <target state="translated">傳遞給 System.String.Format 的格式化引數，並未包含與每個物件引數相對應的格式項目，反之亦然。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
-        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
-        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
         <source>The format argument is not a valid format string</source>
         <target state="new">The format argument is not a valid format string</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
-        <source>Provide correct format specification to formatting methods</source>
-        <target state="new">Provide correct format specification to formatting methods</target>
         <note />
       </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/xlf/MicrosoftNetCoreAnalyzersResources.zh-Hant.xlf
@@ -2288,6 +2288,21 @@ Enumerable.OfType&lt;T&gt; 使用的一般型別檢查 (C# 'is' operator/IL 'isi
         <target state="translated">傳遞給 System.String.Format 的格式化引數，並未包含與每個物件引數相對應的格式項目，反之亦然。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatDescription">
+        <source>The format argument that is passed to System.String.Format is not properly formatted.</source>
+        <target state="new">The format argument that is passed to System.String.Format is not properly formatted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatMessage">
+        <source>The format argument is not a valid format string</source>
+        <target state="new">The format argument is not a valid format string</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsInvalidFormatTitle">
+        <source>Provide correct format specification to formatting methods</source>
+        <target state="new">Provide correct format specification to formatting methods</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProvideCorrectArgumentsToFormattingMethodsMessage">
         <source>Provide correct arguments to formatting methods</source>
         <target state="translated">為格式化方法提供正確的引數</target>

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -13,6 +13,5 @@ CA1863 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-
 CA1865 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865> | Use char overload |
 CA1866 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1866> | Use char overload |
 CA1867 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1867> | Use char overload |
-CA1869 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1869> | Cache and reuse 'JsonSerializerOptions' instances |
 CA2021 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2021> | Do not call Enumerable.Cast\<T> or Enumerable.OfType\<T> with incompatible types |
 CA2261 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2261> | Do not use ConfigureAwaitOptions.SuppressThrowing with Task\<TResult> |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -119,6 +119,7 @@ public class C
         var c = String.Format(""{0} {1} {2}"", 1, 2, 3);
         var d = String.Format(""{0} {1} {2} {3}"", 1, 2, 3, 4);
         var e = String.Format(""{0} {1} {2} {0}"", 1, 2, 3);
+        var f = String.Format(""{0} {0} {0} {0}"", 1);
 
         Console.Write(""{0}"", 1);
         Console.Write(""{0} {1}"", 1, 2);
@@ -126,6 +127,7 @@ public class C
         Console.Write(""{0} {1} {2} {3}"", 1, 2, 3, 4);
         Console.Write(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
         Console.Write(""{0} {1} {2} {3} {0}"", 1, 2, 3, 4);
+        Console.Write(""{0} {0} {0} {0} {0}"", 1);
 
         Console.WriteLine(""{0}"", 1);
         Console.WriteLine(""{0} {1}"", 1, 2);
@@ -133,6 +135,7 @@ public class C
         Console.WriteLine(""{0} {1} {2} {3}"", 1, 2, 3, 4);
         Console.WriteLine(""{0} {1} {2} {3} {4}"", 1, 2, 3, 4, 5);
         Console.WriteLine(""{0} {1} {2} {3} {0}"", 1, 2, 3, 4);
+        Console.WriteLine(""{0} {0} {0} {0} {0}"", 1);
     }
 }
 ");

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -573,6 +573,36 @@ End Class"
             await basicTest.RunAsync();
         }
 
+        [Fact]
+        [WorkItem(90357, "https://github.com/dotnet/runtime/issues/90357")]
+        public async Task CA2241CSharpPassingMethodWithNoPossibleArguments()
+        {
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using System.Diagnostics.CodeAnalysis;
+
+class Test
+{
+    public static int Parse([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format) => -1;
+
+    void M1(string param)
+    {
+        var a = Parse(""{0} {1}"");
+    }
+}"
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+                }
+            };
+
+            await csharpTest.RunAsync();
+        }
+
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/ProvideCorrectArgumentsToFormattingMethodsTests.cs
@@ -603,6 +603,40 @@ class Test
             await csharpTest.RunAsync();
         }
 
+        [Fact]
+        [WorkItem(90357, "https://github.com/dotnet/runtime/issues/90357")]
+        public async Task CA2241CSharpFailingMethodWithNoPossibleArgumentsButInValidFormat()
+        {
+            var csharpTest = new VerifyCS.Test
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"
+using System.Diagnostics.CodeAnalysis;
+
+class Test
+{
+    public static int Parse([StringSyntax(StringSyntaxAttribute.CompositeFormat)] string format) => -1;
+
+    void M1(string param)
+    {
+        var a = Parse(""{0 {1}"");
+    }
+}"
+                    },
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+                }
+            };
+
+            csharpTest.ExpectedDiagnostics.Add(
+                // Test0.cs(10,17): warning CA2241: Provide correct arguments to formatting methods
+                GetBasicResultAt(10, 17));
+
+            await csharpTest.RunAsync();
+        }
+
         #endregion
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column)


### PR DESCRIPTION
Fixes #6012 
See also https://github.com/dotnet/runtime/issues/90357

Prevents IndexOutOfRangeException, but also checks formats of non-formatting methods.