### PR TITLE
Change localization branch to release/8.0.1xx temporarily

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -24,10 +24,11 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0.1xx') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: roslyn-analyzers
+        MirrorBranch: release/8.0.1xx
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-ROSANLZR'
   - template: /eng/common/templates/jobs/jobs.yml
@@ -95,7 +96,7 @@ stages:
       - name: Codeql.Cadence
         value: 0
       - name: Codeql.TSAEnabled
-        value: true 
+        value: true
       steps:
         - task: UseDotNet@2
           inputs:


### PR DESCRIPTION
Similar to the change we did in dotnet/runtime (https://github.com/dotnet/runtime/pull/90812), we need to temporarily switch the OneLocBuild MirrorBranch to point to the release/8.0.1xx branch to ensure all localization changes go there until we ship. This change will be reverted after we ship, so that we point to main again. We need to backport this to the [release/8.0.1xx](https://github.com/dotnet/roslyn-analyzers/tree/release/8.0.1xx) branch as well (like in https://github.com/dotnet/runtime/pull/90813).

@mavasani @sharwell @cristianosuzuki77 @buyaa-n @ericstj @ViktorHofer

