### PR TITLE
Bump Microsoft.CodeAnalysis to 4.6.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="$(SourceBuildPackageVersionPropsPath)" Condition="'$(SourceBuildPackageVersionPropsPath)' != ''" />
   <PropertyGroup>
-    <VersionPrefix>3.11.0</VersionPrefix>
+    <VersionPrefix>4.6.0</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <NetAnalyzersVersionPrefix>9.0.0</NetAnalyzersVersionPrefix>
     <NetAnalyzersPreReleaseVersionLabel>preview</NetAnalyzersPreReleaseVersionLabel>
@@ -61,18 +61,18 @@
     -->
     <!-- Microsoft.CodeAnalysis versions for different purposes. -->
     <!-- Surface area that various projects compile against. These should have source-build reference packages -->
-    <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>3.11.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
+    <MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>4.6.0</MicrosoftCodeAnalysisForRoslynDiagnosticsAnalyzersVersion>
     <MicrosoftCodeAnalysisVersionForPublicApiAnalyzers>1.2.1</MicrosoftCodeAnalysisVersionForPublicApiAnalyzers>
-    <MicrosoftCodeAnalysisVersionForBannedApiAnalyzers>3.11.0</MicrosoftCodeAnalysisVersionForBannedApiAnalyzers>
-    <MicrosoftCodeAnalysisVersionForBannedApiAnalyzersTests>3.11.0</MicrosoftCodeAnalysisVersionForBannedApiAnalyzersTests>
-    <MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzers>3.11.0</MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzers>
-    <MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzersTests>3.11.0</MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzersTests>
-    <MicrosoftCodeAnalysisVersionForResxSourceGenerators>4.0.1</MicrosoftCodeAnalysisVersionForResxSourceGenerators>
-    <MicrosoftCodeAnalysisVersionForNetAnalyzers>3.11.0</MicrosoftCodeAnalysisVersionForNetAnalyzers>
-    <MicrosoftCodeAnalysisVersionForTextAnalyzers>3.11.0</MicrosoftCodeAnalysisVersionForTextAnalyzers>
-    <MicrosoftCodeAnalysisVersionForCodeAnalysisAnalyzers>3.11.0</MicrosoftCodeAnalysisVersionForCodeAnalysisAnalyzers>
-    <MicrosoftCodeAnalysisVersionForToolsAndUtilities>3.11.0</MicrosoftCodeAnalysisVersionForToolsAndUtilities>
-    <MicrosoftCodeAnalysisVersionForMetrics>4.0.1</MicrosoftCodeAnalysisVersionForMetrics>
+    <MicrosoftCodeAnalysisVersionForBannedApiAnalyzers>4.6.0</MicrosoftCodeAnalysisVersionForBannedApiAnalyzers>
+    <MicrosoftCodeAnalysisVersionForBannedApiAnalyzersTests>4.6.0</MicrosoftCodeAnalysisVersionForBannedApiAnalyzersTests>
+    <MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzers>4.6.0</MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzers>
+    <MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzersTests>4.6.0</MicrosoftCodeAnalysisVersionForPerfSensitiveAnalyzersTests>
+    <MicrosoftCodeAnalysisVersionForResxSourceGenerators>4.6.0</MicrosoftCodeAnalysisVersionForResxSourceGenerators>
+    <MicrosoftCodeAnalysisVersionForNetAnalyzers>4.6.0</MicrosoftCodeAnalysisVersionForNetAnalyzers>
+    <MicrosoftCodeAnalysisVersionForTextAnalyzers>4.6.0</MicrosoftCodeAnalysisVersionForTextAnalyzers>
+    <MicrosoftCodeAnalysisVersionForCodeAnalysisAnalyzers>4.6.0</MicrosoftCodeAnalysisVersionForCodeAnalysisAnalyzers>
+    <MicrosoftCodeAnalysisVersionForToolsAndUtilities>4.6.0</MicrosoftCodeAnalysisVersionForToolsAndUtilities>
+    <MicrosoftCodeAnalysisVersionForMetrics>4.6.0</MicrosoftCodeAnalysisVersionForMetrics>
     <!-- Versions for tests and general utility execution. -->
     <!-- This version is for utility and executable assemblies. The version here should not overlap with any of the surface
          area versions. -->

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             }
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
-            SyntaxNode classDecl = generator.GetDeclaration(token.Parent);
+            SyntaxNode? classDecl = generator.GetDeclaration(token.Parent);
             if (classDecl == null)
             {
                 return;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/ApplyDiagnosticAnalyzerAttributeFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/ApplyDiagnosticAnalyzerAttributeFix.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             }
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
-            SyntaxNode classDecl = generator.GetDeclaration(token.Parent);
+            SyntaxNode? classDecl = generator.GetDeclaration(token.Parent);
             if (classDecl == null)
             {
                 return;

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                 IObjectCreationOperation objectCreation =>
                     await CallOverloadWithEqualityComparerAsync(
                         document, objectCreation.Syntax, objectCreation.Constructor, objectCreation.Arguments, isUsedAsExtensionMethod: false,
-                        (generator, args) => generator.ObjectCreationExpression(objectCreation.Type, args), iEqualityComparer, cancellationToken)
+                        (generator, args) => generator.ObjectCreationExpression(objectCreation.Type!, args), iEqualityComparer, cancellationToken)
                     .ConfigureAwait(false),
 
                 IInvocationOperation invocation =>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -675,7 +675,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -874,7 +874,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/Microsoft.CodeAnalysis.BannedApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -77,7 +77,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/InteropServices/CSharpDisableRuntimeMarshalling.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/InteropServices/CSharpDisableRuntimeMarshalling.Fixer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Analyzer.Utilities;
@@ -201,14 +202,15 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
         {
             var enclosingMethod = FindEnclosingMethod(syntax);
 
-            static BaseMethodDeclarationSyntax? FindEnclosingMethod(SyntaxNode syntax)
+            static BaseMethodDeclarationSyntax FindEnclosingMethod(SyntaxNode syntax)
             {
                 while (syntax.Parent is not (null or BaseMethodDeclarationSyntax))
                 {
                     syntax = syntax.Parent;
                 }
 
-                return (BaseMethodDeclarationSyntax?)syntax.Parent;
+                Debug.Assert(syntax.Parent is BaseMethodDeclarationSyntax);
+                return (BaseMethodDeclarationSyntax)syntax.Parent!;
             }
 
             editor.SetModifiers(enclosingMethod, editor.Generator.GetModifiers(enclosingMethod).WithIsUnsafe(true));

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/InteropServices/CSharpDynamicInterfaceCastableImplementation.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/InteropServices/CSharpDynamicInterfaceCastableImplementation.Fixer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.InteropServices
                         {
                             generatedMembers.Add(generator.AsPrivateInterfaceImplementation(
                                 implementation,
-                                generator.NameExpression(member.ContainingType)));
+                                generator.NameExpression(member.ContainingType))!);
                         }
                     }
                 }
@@ -161,8 +161,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.InteropServices
                     SyntaxFactory.List(
                 new[]
                 {
-                        (AccessorDeclarationSyntax)generator.WithStatements(generator.GetAccessor(eventDeclaration, DeclarationKind.AddAccessor), defaultMethodBodyStatements),
-                        (AccessorDeclarationSyntax)generator.WithStatements(generator.GetAccessor(eventDeclaration, DeclarationKind.RemoveAccessor), defaultMethodBodyStatements),
+                        (AccessorDeclarationSyntax)generator.WithStatements(generator.GetAccessor(eventDeclaration, DeclarationKind.AddAccessor)!, defaultMethodBodyStatements),
+                        (AccessorDeclarationSyntax)generator.WithStatements(generator.GetAccessor(eventDeclaration, DeclarationKind.RemoveAccessor)!, defaultMethodBodyStatements),
                 })));
         }
 

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpPreferDictionaryTryMethodsOverContainsKeyGuardFixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpPreferDictionaryTryMethodsOverContainsKeyGuardFixer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -125,14 +126,15 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                         SingleVariableDesignation(Identifier(Value))
                     )
                 );
-                var tryGetValueInvocation = generator.InvocationExpression(tryGetValueAccess, keyArgument, outArgument);
+                Debug.Assert(keyArgument is not null);
+                var tryGetValueInvocation = generator.InvocationExpression(tryGetValueAccess, keyArgument!, outArgument);
                 editor.ReplaceNode(containsKeyInvocation, tryGetValueInvocation);
 
                 var identifierName = (IdentifierNameSyntax)generator.IdentifierName(Value);
                 if (addStatementNode != null)
                 {
                     editor.InsertBefore(addStatementNode,
-                        generator.ExpressionStatement(generator.AssignmentStatement(identifierName, changedValueNode)));
+                        generator.ExpressionStatement(generator.AssignmentStatement(identifierName, changedValueNode!)));
                     editor.ReplaceNode(changedValueNode!, identifierName);
                 }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/DefineAccessorsForAttributeArguments.Fixer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                     switch (fixCase)
                     {
                         case DefineAccessorsForAttributeArgumentsAnalyzer.AddAccessorCase:
-                            SyntaxNode parameter = generator.GetDeclaration(node, DeclarationKind.Parameter);
+                            SyntaxNode? parameter = generator.GetDeclaration(node, DeclarationKind.Parameter);
                             if (parameter != null)
                             {
                                 title = MicrosoftCodeQualityAnalyzersResources.CreatePropertyAccessorForParameter;
@@ -46,7 +46,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                             return;
 
                         case DefineAccessorsForAttributeArgumentsAnalyzer.MakePublicCase:
-                            SyntaxNode property = generator.GetDeclaration(node, DeclarationKind.Property);
+                            SyntaxNode? property = generator.GetDeclaration(node, DeclarationKind.Property);
                             if (property != null)
                             {
                                 title = MicrosoftCodeQualityAnalyzersResources.MakeGetterPublic;
@@ -100,7 +100,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                                                                                       editor.Generator.TypeExpression(parameterSymbol.Type),
                                                                                                                       Accessibility.Public,
                                                                                                                       DeclarationModifiers.ReadOnly);
-                                                               newProperty = editor.Generator.WithGetAccessorStatements(newProperty, null);
+                                                               newProperty = editor.Generator.WithGetAccessorStatements(newProperty, null!);
                                                                editor.AddMember(typeDeclaration, newProperty);
                                                            },
                                                            cancellationToken).ConfigureAwait(false);
@@ -133,7 +133,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                 // Having just made the property public, if it has a setter with no Accessibility set, then we've just made the setter public.
                 // Instead restore the setter's original accessibility so that we don't fire a violation with the generated code.
-                SyntaxNode setter = editor.Generator.GetAccessor(property, DeclarationKind.SetAccessor);
+                SyntaxNode? setter = editor.Generator.GetAccessor(property, DeclarationKind.SetAccessor);
                 if (setter != null)
                 {
                     Accessibility setterAccessibility = editor.Generator.GetAccessibility(setter);

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumShouldNotHaveDuplicatedValues.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
                                 break;
                             default:
-                                foreach (var childOperation in operation.Children)
+                                foreach (var childOperation in operation.ChildOperations)
                                 {
                                     visitInitializerValue(childOperation);
                                 }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumStorageShouldBeInt32.Fixer.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editing;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeActions;
 using Analyzer.Utilities;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 {
@@ -51,9 +52,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var diagnosticSpan = diagnostic.Location.SourceSpan;
             var node = root.FindNode(diagnosticSpan);
             var enumDeclarationNode = generator.GetDeclaration(node, DeclarationKind.Enum);
+            Debug.Assert(enumDeclarationNode is not null);
 
             // Find the target syntax node to replace. Was not able to find a language neutral way of doing this. So using the language specific methods
-            var targetNode = GetTargetNode(enumDeclarationNode);
+            var targetNode = GetTargetNode(enumDeclarationNode!);
             if (targetNode == null)
             {
                 return document;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EnumsShouldHaveZeroValue.Fixer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static SyntaxNode GetExplicitlyAssignedField(IFieldSymbol originalField, SyntaxNode declaration, SyntaxGenerator generator)
         {
-            SyntaxNode originalInitializer = generator.GetExpression(declaration);
+            SyntaxNode? originalInitializer = generator.GetExpression(declaration);
             if (originalInitializer != null || !originalField.HasConstantValue)
             {
                 return declaration;
@@ -94,7 +94,9 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static async Task<Document> GetUpdatedDocumentForRuleNameRenameAsync(Document document, IFieldSymbol field, CancellationToken cancellationToken)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Solution newSolution = await CodeAnalysis.Rename.Renamer.RenameSymbolAsync(document.Project.Solution, field, "None", document.Project.Solution.Options, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
             return newSolution.GetDocument(document.Id)!;
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzer.Fixer.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode declaration = root.FindNode(context.Span);
+            SyntaxNode? declaration = root.FindNode(context.Span);
             declaration = generator.GetDeclaration(declaration);
             if (declaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/IdentifiersShouldNotContainUnderscores.Fixer.cs
@@ -58,10 +58,12 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             string title = MicrosoftCodeQualityAnalyzersResources.IdentifiersShouldNotContainUnderscoresCodeFixTitle;
+#pragma warning disable CS0618 // Type or member is obsolete
             context.RegisterCodeFix(CodeAction.Create(title,
                                         ct => Renamer.RenameSymbolAsync(context.Document.Project.Solution, symbol, newName, context.Document.Project.Solution.Options, ct),
                                         equivalenceKey: title),
                                     context.Diagnostics);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         protected static string RemoveUnderscores(string name)

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementStandardExceptionConstructors.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ImplementStandardExceptionConstructors.Fixer.cs
@@ -59,8 +59,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
             CodeAnalysis.Text.TextSpan diagnosticSpan = diagnostics.First().Location.SourceSpan; // All the diagnostics are reported at the same location -- the name of the declared class -- so it doesn't matter which one we pick
             SyntaxNode node = root.FindNode(diagnosticSpan);
-            SyntaxNode targetNode = editor.Generator.GetDeclaration(node, DeclarationKind.Class);
-            if (model.GetDeclaredSymbol(targetNode, cancellationToken) is not INamedTypeSymbol typeSymbol)
+            SyntaxNode? targetNode = editor.Generator.GetDeclaration(node, DeclarationKind.Class);
+            if (targetNode is null || model.GetDeclaredSymbol(targetNode, cancellationToken) is not INamedTypeSymbol typeSymbol)
             {
                 return document;
             }
@@ -98,7 +98,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                                                     parameters: new[]
                                                     {
                                                     generator.ParameterDeclaration("message", generator.TypeExpression(editor.SemanticModel.Compilation.GetSpecialType(SpecialType.System_String))),
-                                                    generator.ParameterDeclaration("innerException", generator.TypeExpression(editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemException)))
+                                                    generator.ParameterDeclaration("innerException", generator.TypeExpression(editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemException)!))
                                                     },
                                                     accessibility: Accessibility.Public,
                                                     baseConstructorArguments: new[]

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/InterfaceMethodsShouldBeCallableByChildTypes.Fixer.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -45,7 +46,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             }
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
-            SyntaxNode declaration = generator.GetDeclaration(nodeToFix);
+            SyntaxNode? declaration = generator.GetDeclaration(nodeToFix);
             if (declaration == null)
             {
                 return;
@@ -170,7 +171,8 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
                 foreach (ISymbol implementedMember in explicitImplementations)
                 {
                     SyntaxNode interfaceTypeNode = docEditor.Generator.TypeExpression(implementedMember.ContainingType);
-                    newDeclaration = docEditor.Generator.AsPublicInterfaceImplementation(newDeclaration, interfaceTypeNode);
+                    newDeclaration = docEditor.Generator.AsPublicInterfaceImplementation(newDeclaration!, interfaceTypeNode)!;
+                    Debug.Assert(newDeclaration is not null);
                 }
 
                 docEditor.ReplaceNode(declaration, newDeclaration);

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverloadOperatorEqualsOnOverridingValueTypeEquals.Fixer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode declaration = root.FindNode(context.Span);
+            SyntaxNode? declaration = root.FindNode(context.Span);
             declaration = generator.GetDeclaration(declaration);
             if (declaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsAndOperatorEqualsOnValueTypes.Fixer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
             SyntaxNode enclosingNode = root.FindNode(context.Span);
-            SyntaxNode declaration = generator.GetDeclaration(enclosingNode);
+            SyntaxNode? declaration = generator.GetDeclaration(enclosingNode);
             if (declaration == null)
             {
                 return;

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideEqualsOnOverloadingOperatorEquals.Fixer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode typeDeclaration = root.FindNode(context.Span);
+            SyntaxNode? typeDeclaration = root.FindNode(context.Span);
             typeDeclaration = SyntaxGenerator.GetGenerator(context.Document).GetDeclaration(typeDeclaration);
             if (typeDeclaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideGetHashCodeOnOverridingEquals.Fixer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
         {
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode typeDeclaration = root.FindNode(context.Span);
+            SyntaxNode? typeDeclaration = root.FindNode(context.Span);
             typeDeclaration = SyntaxGenerator.GetGenerator(context.Document).GetDeclaration(typeDeclaration);
             if (typeDeclaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/OverrideMethodsOnComparableTypes.Fixer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode declaration = root.FindNode(context.Span);
+            SyntaxNode? declaration = root.FindNode(context.Span);
             declaration = generator.GetDeclaration(declaration);
             if (declaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.Fixer.cs
@@ -56,7 +56,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
 
         private static async Task<Document> GetUpdatedDocumentForParameterRenameAsync(Document document, ISymbol parameter, string newName, CancellationToken cancellationToken)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Solution newSolution = await Renamer.RenameSymbolAsync(document.Project.Solution, parameter, newName, document.Project.Solution.Options, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
+
             return newSolution.GetDocument(document.Id)!;
         }
     }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/TypesThatOwnDisposableFieldsShouldBeDisposable.Fixer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode declaration = root.FindNode(context.Span);
+            SyntaxNode? declaration = root.FindNode(context.Span);
             declaration = generator.GetDeclaration(declaration);
 
             if (declaration == null)
@@ -49,7 +49,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             SemanticModel model = editor.SemanticModel;
 
             // Add the interface to the baselist.
-            SyntaxNode interfaceType = generator.TypeExpression(model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable));
+            SyntaxNode interfaceType = generator.TypeExpression(model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIDisposable)!);
             editor.AddInterfaceType(declaration, interfaceType);
 
             // Find a Dispose method. If one exists make that implement IDisposable, else generate a new method.
@@ -58,14 +58,14 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             if (disposeMethod != null && disposeMethod.DeclaringSyntaxReferences.Length == 1)
             {
                 SyntaxNode memberPartNode = await disposeMethod.DeclaringSyntaxReferences.Single().GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
-                memberPartNode = generator.GetDeclaration(memberPartNode);
-                editor.ReplaceNode(memberPartNode, generator.AsPublicInterfaceImplementation(memberPartNode, interfaceType));
+                memberPartNode = generator.GetDeclaration(memberPartNode)!;
+                editor.ReplaceNode(memberPartNode, generator.AsPublicInterfaceImplementation(memberPartNode, interfaceType)!);
             }
             else
             {
-                SyntaxNode throwStatement = generator.ThrowStatement(generator.ObjectCreationExpression(model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException)));
+                SyntaxNode throwStatement = generator.ThrowStatement(generator.ObjectCreationExpression(model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNotImplementedException)!));
                 SyntaxNode member = generator.MethodDeclaration(TypesThatOwnDisposableFieldsShouldBeDisposableAnalyzer.Dispose, statements: new[] { throwStatement });
-                member = generator.AsPublicInterfaceImplementation(member, interfaceType);
+                member = generator.AsPublicInterfaceImplementation(member, interfaceType)!;
                 editor.AddMember(declaration, member);
             }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/UriParametersShouldNotBeStrings.Fixer.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             var originalParameter = generator.ParameterDeclaration(methodSymbol.Parameters[parameterIndex]);
 
             // replace original parameter type to System.Uri
-            var newParameter = generator.ReplaceNode(originalParameter, generator.GetType(originalParameter), generator.TypeExpression(uriType));
+            var newParameter = generator.ReplaceNode(originalParameter, generator.GetType(originalParameter)!, generator.TypeExpression(uriType));
 
             // create original method decl
             var original = generator.MethodDeclaration(methodSymbol, generator.DefaultMethodBody(compilation));

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUnusedPrivateFields.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUnusedPrivateFields.Fixer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.CodeActions;
 using Analyzer.Utilities;
+using System.Diagnostics;
 
 namespace Microsoft.CodeQuality.Analyzers.Maintainability
 {
@@ -50,8 +51,9 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private static async Task<Document> RemoveFieldAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
         {
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            node = editor.Generator.GetDeclaration(node);
-            editor.RemoveNode(node);
+            node = editor.Generator.GetDeclaration(node)!;
+            Debug.Assert(node is not null);
+            editor.RemoveNode(node!);
             return editor.GetChangedDocument();
         }
     }

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStatic.Fixer.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
                 var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
                 // Compute replacements
-                var editor = new SyntaxEditor(root, solution.Workspace);
+                var editor = new SyntaxEditor(root, solution.Workspace.Services);
                 foreach (var referenceLocation in referenceLocationGroup)
                 {
                     cancellationToken.ThrowIfCancellationRequested();

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RemoveEmptyFinalizers.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/RemoveEmptyFinalizers.Fixer.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Composition;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Analyzer.Utilities;
@@ -43,8 +44,9 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
             // Get the declaration so that we step up to the methodblocksyntax and not the methodstatementsyntax for VB.
-            node = editor.Generator.GetDeclaration(node);
-            editor.RemoveNode(node);
+            node = editor.Generator.GetDeclaration(node)!;
+            Debug.Assert(node is not null);
+            editor.RemoveNode(node!);
             return editor.GetChangedDocument();
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/QualityGuidelines/UseLiteralsWhereAppropriate.Fixer.cs
@@ -29,8 +29,13 @@ namespace Microsoft.CodeQuality.Analyzers.QualityGuidelines
         {
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            SyntaxNode declaration = root.FindNode(context.Span);
+            SyntaxNode? declaration = root.FindNode(context.Span);
             declaration = SyntaxGenerator.GetGenerator(context.Document).GetDeclaration(declaration, DeclarationKind.Field);
+            if (declaration is null)
+            {
+                return;
+            }
+
             var fieldFeclaration = GetFieldDeclaration(declaration);
             if (fieldFeclaration == null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.Fixer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
             SyntaxNode enclosingNode = root.FindNode(context.Span, getInnermostNodeForTie: true);
-            SyntaxNode declaration = generator.GetDeclaration(enclosingNode);
+            SyntaxNode? declaration = generator.GetDeclaration(enclosingNode);
             if (declaration == null || !CodeFixSupportsDeclaration(declaration))
             {
                 return;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/ProvidePublicParameterlessSafeHandleConstructor.Fixer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
             SyntaxNode enclosingNode = root.FindNode(context.Span);
-            SyntaxNode declaration = generator.GetDeclaration(enclosingNode);
+            SyntaxNode? declaration = generator.GetDeclaration(enclosingNode);
             if (declaration == null)
             {
                 return;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptions.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptions.cs
@@ -290,7 +290,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 {
                     if (operation.Parent is IAssignmentOperation assignment)
                     {
-                        foreach (IOperation children in assignment.Children)
+                        foreach (IOperation children in assignment.ChildOperations)
                         {
                             if (children is IFieldReferenceOperation or IPropertyReferenceOperation)
                             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKey.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardDictionaryRemoveByContainsKey.cs
@@ -75,12 +75,12 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     return;
                 }
 
-                if (conditionalOperation.WhenTrue.Children.Any())
+                if (conditionalOperation.WhenTrue.ChildOperations.Any())
                 {
                     using var additionalLocation = ArrayBuilder<Location>.GetInstance(2);
                     additionalLocation.Add(conditionalOperation.Syntax.GetLocation());
 
-                    switch (conditionalOperation.WhenTrue.Children.First())
+                    switch (conditionalOperation.WhenTrue.ChildOperations.First())
                     {
                         case IInvocationOperation childInvocationOperation:
                             if ((childInvocationOperation.TargetMethod.OriginalDefinition.Equals(remove1Param, SymbolEqualityComparer.Default) ||
@@ -98,7 +98,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                              * However, a fixer is only offered if there is a single method in the block.
                              */
 
-                            var nestedInvocationOperation = childStatementOperation.Children.OfType<IInvocationOperation>()
+                            var nestedInvocationOperation = childStatementOperation.ChildOperations.OfType<IInvocationOperation>()
                                                             .FirstOrDefault(op => op.TargetMethod.OriginalDefinition.Equals(remove1Param, SymbolEqualityComparer.Default) ||
                                                                                   op.TargetMethod.OriginalDefinition.Equals(remove2Param, SymbolEqualityComparer.Default));
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardSetAddOrRemoveByContains.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/DoNotGuardSetAddOrRemoveByContains.cs
@@ -288,7 +288,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     }
                 }
 
-                var firstChildOperation = operation?.Children.FirstOrDefault();
+                var firstChildOperation = operation?.ChildOperations.FirstOrDefault();
 
                 switch (firstChildOperation)
                 {
@@ -303,7 +303,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
 
                     case ISimpleAssignmentOperation:
                     case IExpressionStatementOperation:
-                        var firstChildAddOrRemove = firstChildOperation.Children
+                        var firstChildAddOrRemove = firstChildOperation.ChildOperations
                             .OfType<IInvocationOperation>()
                             .FirstOrDefault(i => extractAdd ?
                                 IsAnyAddMethod(i.TargetMethod) :

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/PreferDictionaryTryMethodsOverContainsKeyGuardAnalyzer.cs
@@ -493,7 +493,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
         private static void FindUsageInOperationsAfterConditionBlock(IOperation sourceOperation, ref DictionaryUsageContext context, SearchContext searchContext)
         {
             var testOperation = false;
-            foreach (var operation in sourceOperation.Parent!.Children)
+            foreach (var operation in sourceOperation.Parent!.ChildOperations)
             {
                 if (!testOperation)
                 {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseAsSpanInsteadOfRangeIndexer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
@@ -130,7 +129,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                             return;
                         }
 
-                        IEnumerator<IOperation> enumerator = operationContext.Operation.Children.GetEnumerator();
+                        var enumerator = operationContext.Operation.ChildOperations.GetEnumerator();
 
                         if (!enumerator.MoveNext())
                         {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidUnsealedAttributes.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidUnsealedAttributes.Fixer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             DocumentEditor editor = await DocumentEditor.CreateAsync(context.Document, context.CancellationToken).ConfigureAwait(false);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             SyntaxNode node = root.FindNode(context.Span);
-            SyntaxNode declaration = editor.Generator.GetDeclaration(node);
+            SyntaxNode? declaration = editor.Generator.GetDeclaration(node);
 
             if (declaration != null)
             {

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ImplementSerializationConstructors.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/ImplementSerializationConstructors.Fixer.cs
@@ -72,8 +72,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                                     typeSymbol.Name,
                                     new[]
                                     {
-                                            generator.ParameterDeclaration("serializationInfo", generator.TypeExpression(docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationSerializationInfo))),
-                                            generator.ParameterDeclaration("streamingContext", generator.TypeExpression(docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationStreamingContext)))
+                                            generator.ParameterDeclaration("serializationInfo", generator.TypeExpression(docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationSerializationInfo)!)),
+                                            generator.ParameterDeclaration("streamingContext", generator.TypeExpression(docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeSerializationStreamingContext)!))
                                     },
                                     typeSymbol.IsSealed ? Accessibility.Private : Accessibility.Protected,
                                     statements: new[] { throwStatement });

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectly.Fixer.cs
@@ -73,6 +73,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static async Task<Document> SwapArgumentsOrderAsync(Document document, IObjectCreationOperation creation, int paramPosition, int argumentCount, CancellationToken token)
         {
+            Debug.Assert(creation.Type is not null);
+
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, token).ConfigureAwait(false);
             SyntaxNode parameter = AddNameOfIfLiteral(creation.Arguments[paramPosition].Value, editor.Generator);
             SyntaxNode newCreation;
@@ -80,11 +82,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 if (paramPosition == 0)
                 {
-                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type, creation.Arguments[1].Syntax, parameter);
+                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type!, creation.Arguments[1].Syntax, parameter);
                 }
                 else
                 {
-                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type, parameter, creation.Arguments[0].Syntax);
+                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type!, parameter, creation.Arguments[0].Syntax);
                 }
             }
             else
@@ -92,11 +94,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 Debug.Assert(argumentCount == 3);
                 if (paramPosition == 0)
                 {
-                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type, creation.Arguments[1].Syntax, parameter, creation.Arguments[2].Syntax);
+                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type!, creation.Arguments[1].Syntax, parameter, creation.Arguments[2].Syntax);
                 }
                 else
                 {
-                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type, parameter, creation.Arguments[1].Syntax, creation.Arguments[0].Syntax);
+                    newCreation = editor.Generator.ObjectCreationExpression(creation.Type!, parameter, creation.Arguments[1].Syntax, creation.Arguments[0].Syntax);
                 }
             }
 
@@ -106,9 +108,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static async Task<Document> AddNullMessageToArgumentListAsync(Document document, IObjectCreationOperation creation, CancellationToken token)
         {
+            Debug.Assert(creation.Type is not null);
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, token).ConfigureAwait(false);
             SyntaxNode argument = AddNameOfIfLiteral(creation.Arguments[0].Value, editor.Generator);
-            SyntaxNode newCreation = editor.Generator.ObjectCreationExpression(creation.Type, editor.Generator.Argument(editor.Generator.NullLiteralExpression()), argument);
+            SyntaxNode newCreation = editor.Generator.ObjectCreationExpression(creation.Type!, editor.Generator.Argument(editor.Generator.NullLiteralExpression()), argument);
             editor.ReplaceNode(creation.Syntax, newCreation);
             return editor.GetChangedDocument();
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/MarkAllNonSerializableFields.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/MarkAllNonSerializableFields.Fixer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             SyntaxNode attr = editor.Generator.Attribute(editor.Generator.TypeExpression(
-                editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNonSerializedAttribute)));
+                editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemNonSerializedAttribute)!));
             editor.AddAttribute(fieldNode, attr);
             return editor.GetChangedDocument();
         }
@@ -66,7 +66,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             await editor.EditOneDeclarationAsync(type, (docEditor, declaration) =>
             {
                 SyntaxNode serializableAttr = docEditor.Generator.Attribute(docEditor.Generator.TypeExpression(
-                    docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemSerializableAttribute)));
+                    docEditor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemSerializableAttribute)!));
                 docEditor.AddAttribute(declaration, serializableAttr);
             }, cancellationToken).ConfigureAwait(false);
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/MarkISerializableTypesWithSerializable.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/MarkISerializableTypesWithSerializable.Fixer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(context.Document);
             SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            SyntaxNode node = root.FindNode(context.Span);
+            SyntaxNode? node = root.FindNode(context.Span);
             node = generator.GetDeclaration(node);
             if (node == null)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
         {
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             SyntaxNode attr = editor.Generator.Attribute(editor.Generator.TypeExpression(
-                editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemSerializableAttribute)));
+                editor.SemanticModel.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemSerializableAttribute)!));
             editor.AddAttribute(node, attr);
             return editor.GetChangedDocument();
         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseExceptionThrowHelpers.cs
@@ -163,7 +163,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     IConditionalOperation? condition = throwOperation.Parent as IConditionalOperation;
                     if (condition is null)
                     {
-                        if (throwOperation.Parent is IBlockOperation parentBlock && parentBlock.Children.Count() == 1)
+                        if (throwOperation.Parent is IBlockOperation parentBlock && parentBlock.ChildOperations.Count == 1)
                         {
                             condition = parentBlock.Parent as IConditionalOperation;
                         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotCallDangerousMethodsInDeserialization.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;
@@ -24,7 +24,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     {
         internal const string DiagnosticId = "CA5360";
 
-        private ImmutableArray<(string, string[])> DangerousCallable = ImmutableArray.Create<(string, string[])>
+        private readonly ImmutableArray<(string, string[])> DangerousCallable = ImmutableArray.Create<(string, string[])>
             (
                 (WellKnownTypeNames.SystemIOFile, new[] { "WriteAllBytes", "WriteAllLines", "WriteAllText", "Copy", "Move", "AppendAllLines", "AppendAllText", "AppendText", "Delete" }),
                 (WellKnownTypeNames.SystemIODirectory, new[] { "Delete" }),

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Security/DoNotDisableTokenValidationChecks.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
 using Analyzer.Utilities;
@@ -18,7 +18,7 @@ namespace Microsoft.NetCore.Analyzers.Security
     public sealed class DoNotDisableTokenValidationChecks : DiagnosticAnalyzer
     {
         // Set of properties on Microsoft.IdentityModel.Tokens.TokenValidationParameters which shouldn't be set to false.
-        private ImmutableArray<string> PropertiesWhichShouldNotBeFalse = ImmutableArray.Create(
+        private readonly ImmutableArray<string> PropertiesWhichShouldNotBeFalse = ImmutableArray.Create(
             "RequireExpirationTime",
             "ValidateAudience",
             "ValidateIssuer",

--- a/src/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
+++ b/src/PerformanceSensitiveAnalyzers/Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -184,7 +184,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.PerformanceSensitiveAnalyzers.CodeFixes",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -193,7 +193,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PerformanceSensitiveAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
+++ b/src/PublicApiAnalyzers/Microsoft.CodeAnalysis.PublicApiAnalyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -460,7 +460,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.PublicApiAnalyzers.CodeFixes",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpAvoidOptSuffixForNullableEnableCodeCodeFixProvider.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpAvoidOptSuffixForNullableEnableCodeCodeFixProvider.cs
@@ -59,7 +59,9 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
         }
 
         private static async Task<Solution> RemoveOptSuffixOnVariableAsync(Document document, ISymbol variableSymbol, string newName, CancellationToken cancellationToken)
+#pragma warning disable CS0618 // Type or member is obsolete
             => await Renamer.RenameSymbolAsync(document.Project.Solution, variableSymbol, newName, document.Project.Solution.Options, cancellationToken)
                 .ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -157,7 +157,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.CSharp.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -269,7 +269,7 @@
     {
       "tool": {
         "name": "Roslyn.Diagnostics.VisualBasic.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/Text.Analyzers/Text.Analyzers.sarif
+++ b/src/Text.Analyzers/Text.Analyzers.sarif
@@ -5,7 +5,7 @@
     {
       "tool": {
         "name": "Humanizer",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -14,7 +14,7 @@
     {
       "tool": {
         "name": "Text.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -86,7 +86,7 @@
     {
       "tool": {
         "name": "Text.CSharp.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {
@@ -95,7 +95,7 @@
     {
       "tool": {
         "name": "Text.VisualBasic.Analyzers",
-        "version": "3.11.0",
+        "version": "4.6.0",
         "language": "en-US"
       },
       "rules": {

--- a/src/Utilities.UnitTests/Lightup/LightupHelpersTests.cs
+++ b/src/Utilities.UnitTests/Lightup/LightupHelpersTests.cs
@@ -151,6 +151,11 @@ namespace Analyzer.Utilities.UnitTests.Lightup
 
             public bool Equals(ISymbol? other, SymbolEqualityComparer equalityComparer)
                 => throw new NotImplementedException();
+
+            public TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
+                throw new NotImplementedException();
+
+            public int MetadataToken => throw new NotImplementedException();
         }
     }
 }

--- a/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IOperationExtensions.cs
@@ -177,7 +177,7 @@ namespace Analyzer.Utilities.Extensions
                 }
                 else
                 {
-                    foreach (var child in operation.Children)
+                    foreach (var child in operation.ChildOperations)
                     {
                         operationsToProcess.Enqueue(child);
                     }
@@ -796,8 +796,8 @@ namespace Analyzer.Utilities.Extensions
 
         public static bool HasAnyExplicitDescendant(this IOperation operation, Func<IOperation, bool>? descendIntoOperation = null)
         {
-            using var stack = ArrayBuilder<IEnumerator<IOperation>>.GetInstance();
-            stack.Add(operation.Children.GetEnumerator());
+            using var stack = ArrayBuilder<IOperation.OperationList.Enumerator>.GetInstance();
+            stack.Add(operation.ChildOperations.GetEnumerator());
 
             while (stack.Any())
             {
@@ -818,7 +818,7 @@ namespace Analyzer.Utilities.Extensions
                             return true;
                         }
 
-                        stack.Add(current.Children.GetEnumerator());
+                        stack.Add(current.ChildOperations.GetEnumerator());
                     }
                 }
             }

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Analysis/TaintedDataAnalysis/TaintedDataAnalysis.TaintedDataOperationVisitor.cs
@@ -179,7 +179,7 @@ namespace Analyzer.Utilities.FlowAnalysis.Analysis.TaintedDataAnalysis
                 // - instantiating an object with tainted data makes the new object tainted
 
                 List<TaintedDataAbstractValue>? taintedValues = null;
-                foreach (IOperation childOperation in operation.Children)
+                foreach (IOperation childOperation in operation.ChildOperations)
                 {
                     TaintedDataAbstractValue childValue = Visit(childOperation, argument);
                     if (childValue.Kind == TaintedDataAbstractValueKind.Tainted)

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowOperationVisitor.cs
@@ -2764,7 +2764,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public override TAbstractAnalysisValue DefaultVisit(IOperation operation, object? argument)
         {
-            return VisitArray(operation.Children, argument);
+            return VisitArray(operation.ChildOperations, argument);
         }
 
         public override TAbstractAnalysisValue VisitSimpleAssignment(ISimpleAssignmentOperation operation, object? argument)

--- a/src/Utilities/Workspaces/SyntaxGeneratorExtensions.cs
+++ b/src/Utilities/Workspaces/SyntaxGeneratorExtensions.cs
@@ -431,7 +431,7 @@ namespace Analyzer.Utilities
         {
             return generator.ThrowStatement(generator.ObjectCreationExpression(
                 generator.TypeExpression(
-                    compilation.GetOrCreateTypeByMetadataName(SystemNotImplementedExceptionTypeName))));
+                    compilation.GetOrCreateTypeByMetadataName(SystemNotImplementedExceptionTypeName)!)));
         }
 
         public static SyntaxNode? TryGetContainingDeclaration(this SyntaxGenerator generator, SyntaxNode? node, DeclarationKind kind)


### PR DESCRIPTION
I was writing the analyzer/fixer for https://github.com/dotnet/runtime/issues/78587 and I ran into an issue where I couldn't make use of `Utf8StringLiteralExpression`/`IUtf8StringOperation` APIs because the `Microsoft.CodeAnalysis` package version used by this repo is `3.11.0`, and the APIs are available in newer `4.*` versions.

I bumped the version in `Versions.props` to `4.6.0` and then fixed the issues / added suppressions / `!`s until I was able to build the repo.

(not really familiar with this repo so please do let me know if this is completely off)