### PR TITLE
Add/improve descriptions

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -356,8 +356,8 @@
     <value>Configure generated code analysis</value>
   </data>
   <data name="ConfigureGeneratedCodeAnalysisDescription" xml:space="preserve">
-    <value>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</value>
-    <comment>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</comment>
+    <value>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</value>
+    <comment>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</comment>
   </data>
   <data name="EnableConcurrentExecutionMessage" xml:space="preserve">
     <value>Enable concurrent execution</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -355,6 +355,10 @@
   <data name="ConfigureGeneratedCodeAnalysisTitle" xml:space="preserve">
     <value>Configure generated code analysis</value>
   </data>
+  <data name="ConfigureGeneratedCodeAnalysisDescription" xml:space="preserve">
+    <value>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</value>
+    <comment>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</comment>
+  </data>
   <data name="EnableConcurrentExecutionMessage" xml:space="preserve">
     <value>Enable concurrent execution</value>
   </data>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -556,7 +556,7 @@
     <value>Do not use APIs banned for analyzers</value>
   </data>
   <data name="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription" xml:space="preserve">
-    <value>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</value>
+    <value>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</value>
   </data>
   <data name="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage" xml:space="preserve">
     <value>'{0}': A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'</value>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -365,6 +365,10 @@
   <data name="EnableConcurrentExecutionTitle" xml:space="preserve">
     <value>Enable concurrent execution</value>
   </data>
+  <data name="EnabledConcurrentExecutionDescription" xml:space="preserve">
+    <value>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</value>
+    <comment>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</comment>
+  </data>
   <data name="ConfigureGeneratedCodeAnalysisFix" xml:space="preserve">
     <value>Configure generated code analysis</value>
   </data>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ConfigureGeneratedCodeAnalysisAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ConfigureGeneratedCodeAnalysisAnalyzer.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             DiagnosticCategory.MicrosoftCodeAnalysisCorrectness,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
+            description: CreateLocalizableResourceString(nameof(ConfigureGeneratedCodeAnalysisDescription)),
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/EnableConcurrentExecutionAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/EnableConcurrentExecutionAnalyzer.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             DiagnosticCategory.MicrosoftCodeAnalysisCorrectness,
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
+            description: CreateLocalizableResourceString(nameof(EnabledConcurrentExecutionDescription)),
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Povolit souběžné provádění</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Neplatná položka v souboru vydané verze analyzátoru</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Projekt obsahující analyzátory nebo zdrojové generátory by měl určovat vlastnost &lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Projekt obsahující analyzátory nebo zdrojové generátory by měl určovat vlastnost &lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Symboly by se měly porovnat podle rovnosti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Nakonfigurovat analýzu vygenerovaného kódu</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Ein Projekt, das Analysetools oder Quellgeneratoren enthält, muss die Eigenschaft "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;" angeben.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Ein Projekt, das Analysetools oder Quellgeneratoren enthält, muss die Eigenschaft "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;" angeben.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Symbole sollten auf Gleichheit verglichen werden</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Konfigurieren der Analyse von generiertem Code</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Gleichzeitige Ausführung aktivieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Ungültiger Eintrag in Analysetool-Releasedatei.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Habilitar la ejecución simultánea</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrada no válida en el archivo de versión del analizador.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Un proyecto que contenga analizadores o generadores de origen debe especificar la propiedad "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;".</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Un proyecto que contenga analizadores o generadores de origen debe especificar la propiedad "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;".</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Se debe comparar la igualdad de los símbolos</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Configurar análisis de código generado</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Un projet contenant des analyseurs ou des générateurs sources doit spécifier la propriété ' &lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Un projet contenant des analyseurs ou des générateurs sources doit spécifier la propriété ' &lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">La comparaison des symboles doit porter sur l'égalité.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Configurer l'analyse du code générée</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Activer l'exécution simultanée</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrée non valide dans le fichier de version d'analyseur.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Un progetto contenente analizzatori o generatori di origine deve specificare la proprietà '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Un progetto contenente analizzatori o generatori di origine deve specificare la proprietà '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">È necessario confrontare i simboli per verificarne l'uguaglianza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Configura Code Analysis per file generati</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Abilita l'esecuzione simultanea</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Voce non valida nel file di versione dell'analizzatore.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">シンボルは等しいかどうかを比較する必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">生成されたコード分析を構成します</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">アナライザーまたはソース ジェネレーターを含むプロジェクトでは、プロパティ '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;' を指定する必要があります。</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">アナライザーまたはソース ジェネレーターを含むプロジェクトでは、プロパティ '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;' を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -207,6 +207,11 @@
         <target state="translated">同時実行を有効にします</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">アナライザー リリース ファイルに無効なエントリがあります。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -207,6 +207,11 @@
         <target state="translated">동시 실행 사용</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">분석기 릴리스 파일에 잘못된 항목이 있습니다.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">분석기 또는 원본 생성기를 포함하는 프로젝트는 속성 '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'을(를) 지정해야 합니다.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">분석기 또는 원본 생성기를 포함하는 프로젝트는 속성 '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'을(를) 지정해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">기호는 동등성을 위해 비교되어야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">생성된 코드 분석 구성</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Włącz wykonywanie współbieżne</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Nieprawidłowy wpis w pliku wydania analizatora.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Projekt zawierający analizatory lub generatory źródeł powinien określać właściwość „&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;”</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Projekt zawierający analizatory lub generatory źródeł powinien określać właściwość „&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;”</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Symbole powinny być porównywane pod kątem równości</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Konfigurowanie analizy wygenerowanego kodu</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Os símbolos devem ser comparados quanto à igualdade</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Configurar análise de código gerado</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Um projeto que contém analisadores ou geradores de origem deve especificar a propriedade '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Um projeto que contém analisadores ou geradores de origem deve especificar a propriedade '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Habilitar execução simultânea</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrada inválida no arquivo de versão do analisador.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Проект, содержащий анализаторы или исходные генераторы, должен указывать свойство "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;"</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Проект, содержащий анализаторы или исходные генераторы, должен указывать свойство "&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Символы следует сравнивать на равенство</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Настройка анализа созданного кода</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Включение параллельного выполнения</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Недопустимая запись в файле выпуска анализатора.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Semboller eşitlik bakımından karşılaştırılmalıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">Oluşturulan kod analizini yapılandır</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -207,6 +207,11 @@
         <target state="translated">Eşzamanlı yürütmeyi etkinleştir</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Çözümleyici yayın dosyasında geçersiz girdi.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">Çözümleyiciler veya kaynak oluşturucular içeren bir proje '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;' özelliğini belirtilmelidir.</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">Çözümleyiciler veya kaynak oluşturucular içeren bir proje '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;' özelliğini belirtilmelidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -207,6 +207,11 @@
         <target state="translated">启用并发执行</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">分析器版本文件中的条目无效。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">应比较符号是否相等</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">配置生成的代码分析</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">包含分析器或源生成器的项目应指定属性“&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;”。</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">包含分析器或源生成器的项目应指定属性“&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;”。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -308,8 +308,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersDescription">
-        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'.</source>
-        <target state="translated">包含分析器或來源產生器的專案應該指定屬性 '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'。</target>
+        <source>A project containing analyzers or source generators should specify the property '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'. This will flag the use of APIs that are problematic in analyzers/source generators and should be avoided.</source>
+        <target state="needs-review-translation">包含分析器或來源產生器的專案應該指定屬性 '&lt;EnforceExtendedAnalyzerRules&gt;true&lt;/EnforceExtendedAnalyzerRules&gt;'。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoSettingSpecifiedSymbolIsBannedInAnalyzersMessage">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -207,6 +207,11 @@
         <target state="translated">啟用同時執行</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnabledConcurrentExecutionDescription">
+        <source>Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</source>
+        <target state="new">Call the 'AnalysisContext.EnableConcurrentExecution' method to enable concurrent execution of analyzer actions registered by this analyzer. An analyzer that registers for concurrent execution can have better performance than a non-concurrent analyzer. However, such an analyzer must ensure that its actions can execute correctly in parallel.</target>
+        <note>Do not localize 'AnalysisContext.EnableConcurrentExecution'.</note>
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">分析器版本檔案中的項目無效。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -58,9 +58,9 @@
         <note />
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
-        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
-        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
-        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+        <source>Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalysisContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalysisContext.ConfigureGeneratedCodeAnalysis'.</note>
       </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">應比較符號是否相等</target>
         <note />
       </trans-unit>
+      <trans-unit id="ConfigureGeneratedCodeAnalysisDescription">
+        <source>Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</source>
+        <target state="new">Call the 'AnalyzerContext.ConfigureGeneratedCodeAnalysis' method to configure the handling of generated code for this analyzer. Non-configured analyzers will default to an appropriate default mode for generated code.</target>
+        <note>Do not localize 'AnalyzerContext.ConfigureGeneratedCodeAnalysis'.</note>
+      </trans-unit>
       <trans-unit id="ConfigureGeneratedCodeAnalysisFix">
         <source>Configure generated code analysis</source>
         <target state="translated">設定產生的程式碼分析</target>


### PR DESCRIPTION
In the course of writing an analyzer I encountered the RS1025, RS1026, and RS1036 diagnostics. Based on the existing messages and/or descriptions I couldn't immediately figure out what I was doing wrong or why it mattered. This change adds or updates the associated descriptions to provide some guidance about what the user should do and why.