### PR TITLE
Update AnalyzerBannedSymbols.txt

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
@@ -1,13 +1,15 @@
+T:System.Diagnostics.Process; Analyzers should not inspect or create processes
+T:System.Diagnostics.ProcessStartInfo; Analyzers should not inspect or create processes
+T:System.Environment; Analyzers should not read their settings directly from environment variables
+P:System.Globalization.CultureInfo.CurrentCulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture
+P:System.Globalization.CultureInfo.CurrentUICulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentUICulture
 T:System.IO.File; Do not do file IO in analyzers
 T:System.IO.Directory; Do not do file IO in analyzers
 M:System.IO.Path.GetTempPath; Do not do file IO in analyzers
-T:System.Environment; Analyzers should not read their settings directly from environment variables
 T:System.Random; Analyzers should be deterministic
 M:System.Reflection.Assembly.Load(System.Byte[]); Analyzers should only load their dependencies via standard runtime mechanisms
 M:System.Reflection.Assembly.Load(System.String); Analyzers should only load their dependencies via standard runtime mechanisms
 M:System.Reflection.Assembly.Load(System.Reflection.AssemblyName); Analyzers should only load their dependencies via standard runtime mechanisms
 M:System.Reflection.Assembly.Load(System.Byte[],System.Byte[]); Analyzers should only load their dependencies via standard runtime mechanisms
-P:System.Globalization.CultureInfo.CurrentCulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture
-P:System.Globalization.CultureInfo.CurrentUICulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentUICulture
 T:Microsoft.CodeAnalysis.GeneratorInitializationContext; Non-incremental source generators should not be used, implement IIncrementalGenerator instead
 T:Microsoft.CodeAnalysis.GeneratorExecutionContext; Non-incremental source generators should not be used, implement IIncrementalGenerator instead


### PR DESCRIPTION
Two changes here: 

- Added `Process` and `ProcessStartInfo` to the banned API list
- Sorted the list

