### PR TITLE
Avoid 'Collection was modified' InvalidOperationException

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntityBasedPredicateAnalysisData.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Analyzer.Utilities.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 {
@@ -170,6 +171,11 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 return;
             }
 
+            // Collect all the overlapping indexed entities whose value needs to be updated into a builder.
+            // Ensure that we perform these state updates after the foreach loop to avoid modifying the
+            // underlying CoreAnalysisData within the loop.
+            // See https://github.com/dotnet/roslyn-analyzers/issues/6929 for more details.
+            using var builder = ArrayBuilder<(AnalysisEntity, TValue)>.GetInstance(CoreAnalysisData.Count);
             foreach (var entity in CoreAnalysisData.Keys)
             {
                 if (entity.Indices.Length != analysisEntity.Indices.Length ||
@@ -197,9 +203,14 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                     var mergedValue = ValueDomain.Merge(value, existingValue);
                     if (!existingValue!.Equals(mergedValue))
                     {
-                        SetAbstractValue(entity, mergedValue);
+                        builder.Add((entity, mergedValue));
                     }
                 }
+            }
+
+            foreach (var (entity, newValue) in builder.AsEnumerable())
+            {
+                SetAbstractValue(entity, newValue);
             }
         }
 


### PR DESCRIPTION
Fixes #6929

Ensure that we do not perform any state updates to the dataflow CoreAnalysisData inside the loop for the method `ClearOverlappingAnalysisDataForIndexedEntity`. We instead collect the key-value pairs to be updated in the loop, and perform these updates after the loop.

I haven't been able to come up with a minimal repro case that reproduces this exception, but the loop for which exception was generated can no longer perform any state updates, so we can be quite certain the underlying exception can no longer be thrown.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
