### PR TITLE
Use ExportCodeFixProviderAttribute to trigger RS1016

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.Fixer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
             var model = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var typeIsSealed = ((INamedTypeSymbol)model.GetDeclaredSymbol(classDecl, cancellationToken)!).IsSealed;
 
-            INamedTypeSymbol? codeFixProviderSymbol = model.Compilation.GetOrCreateTypeByMetadataName(FixerWithFixAllAnalyzer.CodeFixProviderMetadataName);
+            INamedTypeSymbol? codeFixProviderSymbol = model.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisCodeFixesCodeFixProvider);
             IMethodSymbol? getFixAllProviderMethod = codeFixProviderSymbol?.GetMembers(FixerWithFixAllAnalyzer.GetFixAllProviderMethodName).OfType<IMethodSymbol>().FirstOrDefault();
             if (getFixAllProviderMethod == null)
             {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/FixAnalyzers/FixerWithFixAllAnalyzer.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -24,12 +25,9 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     public sealed class FixerWithFixAllAnalyzer : DiagnosticAnalyzer
     {
-        private const string CodeActionMetadataName = "Microsoft.CodeAnalysis.CodeActions.CodeAction";
         private const string CreateMethodName = "Create";
         private const string EquivalenceKeyPropertyName = "EquivalenceKey";
         private const string EquivalenceKeyParameterName = "equivalenceKey";
-        internal const string CodeFixProviderMetadataName = "Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider";
-        private const string ExportCodeFixProviderAttributeMetadataName = "Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute";
         internal const string GetFixAllProviderMethodName = "GetFixAllProvider";
 
         private static readonly LocalizableString s_localizableCodeActionNeedsEquivalenceKeyDescription = CreateLocalizableResourceString(nameof(CodeActionNeedsEquivalenceKeyDescription));
@@ -81,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            INamedTypeSymbol? codeFixProviderSymbol = context.Compilation.GetOrCreateTypeByMetadataName(CodeFixProviderMetadataName);
+            INamedTypeSymbol? codeFixProviderSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisCodeFixesCodeFixProvider);
             if (codeFixProviderSymbol == null)
             {
                 return;
@@ -93,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                 return;
             }
 
-            INamedTypeSymbol? codeActionSymbol = context.Compilation.GetOrCreateTypeByMetadataName(CodeActionMetadataName);
+            INamedTypeSymbol? codeActionSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisCodeActionsCodeAction);
             if (codeActionSymbol == null)
             {
                 return;
@@ -105,7 +103,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.FixAnalyzers
                 return;
             }
 
-            INamedTypeSymbol? exportCodeFixProviderAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(ExportCodeFixProviderAttributeMetadataName);
+            INamedTypeSymbol? exportCodeFixProviderAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisCodeFixesExportCodeFixProviderAttribute);
             if (exportCodeFixProviderAttributeSymbol == null)
             {
                 return;

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.Fixer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.Fixer.cs
@@ -22,9 +22,11 @@ namespace Microsoft.CodeAnalysis.Analyzers.UnitTests.FixAnalyzers
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class {|RS1016:C1|} : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -46,9 +48,11 @@ class {|RS1016:C1|} : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -82,9 +86,11 @@ class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 sealed class {|RS1016:C1|} : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -106,9 +112,11 @@ sealed class {|RS1016:C1|} : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 sealed class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -142,9 +150,11 @@ sealed class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -167,6 +177,7 @@ class C1 : CodeFixProvider
     }
 }
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C2))]
 class C2 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -199,9 +210,11 @@ class C2 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 sealed class {|RS1016:C1|} : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -219,6 +232,7 @@ sealed class {|RS1016:C1|} : CodeFixProvider
     }
 }
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C2))]
 sealed class {|RS1016:C2|} : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -240,9 +254,11 @@ sealed class {|RS1016:C2|} : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 sealed class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -265,6 +281,7 @@ sealed class C1 : CodeFixProvider
     }
 }
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C2))]
 sealed class C2 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -295,17 +312,19 @@ sealed class C2 : CodeFixProvider
 
         #region VisualBasic tests
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/23410")]
+        [Fact()]
         public async Task VisualBasic_VerifyFix_NonSealedTypeAsync()
         {
             var source = @"
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
-Class C1
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
+Class {|RS1016:C1|}
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
 		Get
@@ -315,22 +334,20 @@ Class C1
 
 	Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
 		' Regular cases.
-		Dim codeAction1_1 = {|RS1010:CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))|}
+		Dim codeAction1_1 = CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))
 		Return Nothing
 	End Function
-
-    Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
-    End Function
 End Class
 ";
             var fixedSource = @"
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -346,7 +363,7 @@ Class C1
 	End Function
 
     Public NotOverridable Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
+        Return WellKnownFixAllProviders.BatchFixer
     End Function
 End Class
 ";
@@ -360,10 +377,12 @@ End Class
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
-NotInheritable Class C1
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
+NotInheritable Class {|RS1016:C1|}
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
 		Get
@@ -373,22 +392,20 @@ NotInheritable Class C1
 
 	Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
 		' Regular cases.
-		Dim codeAction1_1 = {|RS1010:CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))|}
+		Dim codeAction1_1 = CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))
 		Return Nothing
 	End Function
-
-    Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
-    End Function
 End Class
 ";
             var fixedSource = @"
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 NotInheritable Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -404,7 +421,7 @@ NotInheritable Class C1
 	End Function
 
     Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
+        Return WellKnownFixAllProviders.BatchFixer
     End Function
 End Class
 ";
@@ -418,9 +435,11 @@ End Class
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -440,6 +459,7 @@ Class C1
     End Function
 End Class
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C2))>
 Class C2
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -469,10 +489,12 @@ End Class
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
-NotInheritable Class C1
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
+NotInheritable Class {|RS1016:C1|}
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
 		Get
@@ -482,16 +504,13 @@ NotInheritable Class C1
 
 	Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
 		' Regular cases.
-		Dim codeAction1_1 = {|RS1010:CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))|}
+		Dim codeAction1_1 = CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))
 		Return Nothing
 	End Function
-
-    Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
-    End Function
 End Class
 
-NotInheritable Class C2
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C2))>
+NotInheritable Class {|RS1016:C2|}
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
 		Get
@@ -501,22 +520,20 @@ NotInheritable Class C2
 
 	Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
 		' Regular cases.
-		Dim codeAction1_1 = {|RS1010:CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))|}
+		Dim codeAction1_1 = CodeAction.Create(""Title1_1"", Function(x) Task.FromResult(context.Document))
 		Return Nothing
 	End Function
-
-    Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
-    End Function
 End Class
 ";
             var fixedSource = @"
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 NotInheritable Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -532,10 +549,11 @@ NotInheritable Class C1
 	End Function
 
     Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
+        Return WellKnownFixAllProviders.BatchFixer
     End Function
 End Class
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C2))>
 NotInheritable Class C2
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -551,7 +569,7 @@ NotInheritable Class C2
 	End Function
 
     Public Overrides Function GetFixAllProvider() As FixAllProvider
-	    Return WellKnownFixAllProviders.BatchFixer
+        Return WellKnownFixAllProviders.BatchFixer
     End Function
 End Class
 ";

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/FixAnalyzers/FixerWithFixAllAnalyzerTests.cs
@@ -105,9 +105,11 @@ public class MyDerivedCodeActionWithEquivalenceKey : MyAbstractCodeActionWithEqu
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -136,22 +138,22 @@ class C1 : CodeFixProvider
 
             var expected = new[]
             {
-                // Test0.cs(21,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(21, 29),
-                // Test0.cs(22,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(22, 29),
                 // Test0.cs(23,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
                 GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(23, 29),
-                // Test0.cs(26,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(26, 29),
-                // Test0.cs(27,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(27, 29),
+                // Test0.cs(24,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(24, 29),
+                // Test0.cs(25,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(25, 29),
                 // Test0.cs(28,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(28, 29)
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(28, 29),
+                // Test0.cs(29,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(29, 29),
+                // Test0.cs(30,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(30, 29)
             };
 
-            // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.cs(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
             await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
 
@@ -162,9 +164,11 @@ class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -211,60 +215,24 @@ class C1 : CodeFixProvider
     }
 ";
 
-            // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.cs(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic);
         }
 
         [Fact]
-        public async Task CSharp_CodeActionCreate_NoDiagnosticsOnSubTypeAsync()
+        public async Task CSharp_CodeActionCreate_DiagnosticsOnExportedCodeFixProviderTypeAsync()
         {
             var source = @"
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
-class C2 : C1
-{
-}
-
-class C1 : CodeFixProvider
-{
-    public override ImmutableArray<string> FixableDiagnosticIds
-    {
-        get
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    public override Task RegisterCodeFixesAsync(CodeFixContext context)
-    {
-        var equivalenceKey = ""equivalenceKey"";
-        var codeAction2_1 = CodeAction.Create(""Title2_1"", _ => Task.FromResult(context.Document), equivalenceKey);
-        return null;
-    }
-";
-
-            // Test0.cs(12,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(12, 7, "C1");
-
-            await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic);
-        }
-
-        [Fact]
-        public async Task CSharp_CodeActionCreate_DiagnosticsOnAbstractTypeAsync()
-        {
-            var source = @"
-using System;
-using System.Collections.Immutable;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CodeActions;
-
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C2))]
 class C2 : C1
 {
 }
@@ -287,12 +255,12 @@ abstract class C1 : CodeFixProvider
 ";
             var expected = new[]
             {
-                // Test0.cs(24,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(24, 29)
+                // Test0.cs(26,29): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetCSharpCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(26, 29)
             };
 
-            // Test0.cs(12,16): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(12, 16, "C1");
+            // Test0.cs(10,16): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C2");
 
             await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
@@ -304,9 +272,11 @@ abstract class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -326,12 +296,12 @@ class C1 : CodeFixProvider
 
             var expected = new[]
             {
-                // Test0.cs(20,26): warning RS1011: 'MyCodeActionNoEquivalenceKey' has the default value of 'null' for property 'EquivalenceKey'. Either override this property on 'MyCodeActionNoEquivalenceKey' to return a non-null and unique value across all code actions per-fixer or use such an existing code action.
-                GetCSharpOverrideCodeActionEquivalenceKeyExpectedDiagnostic(20, 26, "MyCodeActionNoEquivalenceKey")
+                // Test0.cs(22,26): warning RS1011: 'MyCodeActionNoEquivalenceKey' has the default value of 'null' for property 'EquivalenceKey'. Either override this property on 'MyCodeActionNoEquivalenceKey' to return a non-null and unique value across all code actions per-fixer or use such an existing code action.
+                GetCSharpOverrideCodeActionEquivalenceKeyExpectedDiagnostic(22, 26, "MyCodeActionNoEquivalenceKey")
             };
 
-            // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.cs(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true, expected: expected);
         }
@@ -343,9 +313,11 @@ class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -371,8 +343,8 @@ class C1 : CodeFixProvider
         return null;
     }
 ";
-            // Test0.cs(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.cs(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetCSharpOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestCSharpCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true);
         }
@@ -387,9 +359,11 @@ class C1 : CodeFixProvider
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
 
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(C1))]
 class C1 : CodeFixProvider
 {
     public override ImmutableArray<string> FixableDiagnosticIds
@@ -515,9 +489,11 @@ End Class
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -543,22 +519,22 @@ Class C1
 
             var expected = new[]
             {
-                // Test0.vb(18,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(18, 23),
-                // Test0.vb(19,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(19, 23),
                 // Test0.vb(20,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
                 GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(20, 23),
-                // Test0.vb(23,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(23, 23),
-                // Test0.vb(24,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(24, 23),
+                // Test0.vb(21,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(21, 23),
+                // Test0.vb(22,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(22, 23),
                 // Test0.vb(25,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(25, 23)
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(25, 23),
+                // Test0.vb(26,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(26, 23),
+                // Test0.vb(27,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(27, 23)
             };
 
-            // Test0.vb(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.vb(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
@@ -570,9 +546,11 @@ Class C1
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -614,60 +592,24 @@ Class C1
 		Return Nothing
 	End Function
 ";
-            // Test0.vb(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.vb(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic);
         }
 
         [Fact]
-        public async Task VisualBasic_CodeActionCreate_NoDiagnosticsOnSubTypeAsync()
+        public async Task VisualBasic_CodeActionCreate_DiagnosticsOnExportedCodeFixProviderTypeAsync()
         {
             var source = @"
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
-Class C2
-    Inherits C1
-End Class
-
-Class C1
-	Inherits CodeFixProvider
-	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
-		Get
-			Throw New NotImplementedException()
-		End Get
-	End Property
-
-	Public Overrides Function RegisterCodeFixesAsync(context As CodeFixContext) As Task
-		Dim equivalenceKey = ""equivalenceKey""
-		Dim codeAction2_1 = CodeAction.Create(""Title2_1"", Function(x) Task.FromResult(context.Document), equivalenceKey)
-		Return Nothing
-	End Function
-
-	Private Function GetKey() As String
-		Return Nothing
-	End Function
-";
-            // Test0.vb(12,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(12, 7, "C1");
-
-            await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic);
-        }
-
-        [Fact]
-        public async Task VisualBasic_CodeActionCreate_DiagnosticsOnAbstractTypeAsync()
-        {
-            var source = @"
-Imports System
-Imports System.Collections.Immutable
-Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.CodeFixes
-Imports Microsoft.CodeAnalysis.CodeActions
-
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C2))>
 Class C2
     Inherits C1
 End Class
@@ -691,12 +633,12 @@ MustInherit Class C1
 ";
             var expected = new[]
             {
-                // Test0.vb(21,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
-                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(21, 23)
+                // Test0.vb(23,23): warning RS1010: Provide an explicit argument for optional parameter 'equivalenceKey', which is non-null and unique across all code actions created by this fixer.
+                GetBasicCreateCodeActionWithEquivalenceKeyExpectedDiagnostic(23, 23)
             };
 
-            // Test0.vb(12,19): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(12, 19, "C1");
+            // Test0.vb(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C2");
 
             await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, expected: expected);
         }
@@ -708,9 +650,11 @@ MustInherit Class C1
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -727,12 +671,12 @@ Class C1
 
             var expected = new[]
             {
-                // Test0.vb(17,20): warning RS1011: 'MyCodeActionNoEquivalenceKey' has the default value of 'null' for property 'EquivalenceKey'. Either override this property on 'MyCodeActionNoEquivalenceKey' to return a non-null and unique value across all code actions per-fixer or use such an existing code action.
-                GetBasicOverrideCodeActionEquivalenceKeyExpectedDiagnostic(17, 20, "MyCodeActionNoEquivalenceKey")
+                // Test0.vb(19,20): warning RS1011: 'MyCodeActionNoEquivalenceKey' has the default value of 'null' for property 'EquivalenceKey'. Either override this property on 'MyCodeActionNoEquivalenceKey' to return a non-null and unique value across all code actions per-fixer or use such an existing code action.
+                GetBasicOverrideCodeActionEquivalenceKeyExpectedDiagnostic(19, 20, "MyCodeActionNoEquivalenceKey")
             };
 
-            // Test0.vb(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.vb(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true, expected: expected);
         }
@@ -744,9 +688,11 @@ Class C1
 Imports System
 Imports System.Collections.Immutable
 Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.CodeActions
 
+<ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=NameOf(C1))>
 Class C1
 	Inherits CodeFixProvider
 	Public Overrides ReadOnly Property FixableDiagnosticIds() As ImmutableArray(Of String)
@@ -769,8 +715,8 @@ Class C1
 		Return Nothing
 	End Function
 ";
-            // Test0.vb(8,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
-            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(8, 7, "C1");
+            // Test0.vb(10,7): warning RS1016: 'C1' registers one or more code fixes, but does not override the method 'CodeFixProvider.GetFixAllProvider'. Override this method and provide a non-null FixAllProvider for FixAll support, potentially 'WellKnownFixAllProviders.BatchFixer', or 'null' to explicitly disable FixAll support.
+            var missingGetFixAllProviderOverrideDiagnostic = GetBasicOverrideGetFixAllProviderExpectedDiagnostic(10, 7, "C1");
 
             await TestBasicCoreAsync(source, missingGetFixAllProviderOverrideDiagnostic, withCustomCodeActions: true);
         }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -32,6 +32,9 @@ namespace Analyzer.Utilities
         public const string MicrosoftAspNetCoreMvcRouteAttribute = "Microsoft.AspNetCore.Mvc.RouteAttribute";
         public const string MicrosoftAspNetCoreMvcRoutingHttpMethodAttribute = "Microsoft.AspNetCore.Mvc.Routing.HttpMethodAttribute";
         public const string MicrosoftAspNetCoreRazorHostingRazorCompiledItemAttribute = "Microsoft.AspNetCore.Razor.Hosting.RazorCompiledItemAttribute";
+        public const string MicrosoftCodeAnalysisCodeActionsCodeAction = "Microsoft.CodeAnalysis.CodeActions.CodeAction";
+        public const string MicrosoftCodeAnalysisCodeFixesCodeFixProvider = "Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider";
+        public const string MicrosoftCodeAnalysisCodeFixesExportCodeFixProviderAttribute = "Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute";
         public const string MicrosoftCodeAnalysisCompilation = "Microsoft.CodeAnalysis.Compilation";
         public const string MicrosoftCodeAnalysisCSharpCSharpCompilation = "Microsoft.CodeAnalysis.CSharp.CSharpCompilation";
         public const string MicrosoftCodeAnalysisCSharpCSharpExtensions = "Microsoft.CodeAnalysis.CSharp.CSharpExtensions";


### PR DESCRIPTION
Fixes #5818

I've used the suggestion from @Youssef1313 to use the `ExportCodeFixProvider` attribute to decide whether to report RS1016 instead of looking at the base type of the code fix provider.

This change means that RS1016 will now _only_ report a diagnostic on a code fix provider that is exported.

I have also fixed up some of the VB.NET tests:
* The test `VisualBasic_VerifyFix_NonSealedTypeAsync` was skipped because of dotnet/roslyn#23410. That bug was fixed quite a while ago, so I've stopped skipping it and fixed the code so that it passes.
* Most of the other VB.NET tests in `FixerWithFixAllAnalyzerTests.Fixer.cs` weren't actually testing anything. The original source code did not produce RS1016, and the "fixed" code was the same as the original code.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
