### PR TITLE
Fix false-flag of CompareExchange and re-usage with loops

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptions.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptions.cs
@@ -103,7 +103,8 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     continue;
                 }
 
-                // Symbol is declared in a parent scope, so this implies that options are re-used.
+                // Symbol is declared in a parent scope and referenced inside a loop,
+                // this implies that options are used more than once.
                 if (IsLocalReferenceInsideChildLoop(localRefOperation, localBlock!))
                 {
                     return false;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptionsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/AvoidSingleUseOfLocalJsonSerializerOptionsTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                     static void Main(string[] args)
                     {
                         JsonSerializerOptions options = {|CA1869:new JsonSerializerOptions()|};
-                        options.AllowTrailingCommas = true;        
+                        options.AllowTrailingCommas = true;
 
                         string json = JsonSerializer.Serialize(args, options);
                         Console.WriteLine(json);
@@ -370,7 +370,6 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
                 }
                 """);
 
-
         [Fact]
         public Task CS_UseNewOptionsAsArgument_InterlockedCompareExchange_NoWarn()
             => VerifyCS.VerifyAnalyzerAsync("""
@@ -633,7 +632,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                 class Program
                 {
-                    static JsonSerializerOptions s_options;    
+                    static JsonSerializerOptions s_options;
 
                     static string Serialize<T>(T value)
                     {
@@ -642,7 +641,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                         s_options = {{expression}};
 
-                        return JsonSerializer.Serialize(value, opt1);   
+                        return JsonSerializer.Serialize(value, opt1);
                     }
                 }
                 """);
@@ -657,14 +656,14 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 
                 class Program
                 {
-                    static JsonSerializerOptions s_options;    
+                    static JsonSerializerOptions s_options;
 
                     static string Serialize<T>(T value)
                     {
                         JsonSerializerOptions opt1, opt2;
                         {{expression}} = new JsonSerializerOptions();
 
-                        return JsonSerializer.Serialize(value, opt1);   
+                        return JsonSerializer.Serialize(value, opt1);
                     }
                 }
                 """);


### PR DESCRIPTION
<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->


Fixes https://github.com/dotnet/roslyn-analyzers/issues/6957