### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.1.2-beta1.23509.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,7 +90,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftVisualStudioThreadingAnalyzersVersion>17.0.26-alpha</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <!-- Roslyn Testing -->
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23357.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23509.1</MicrosoftCodeAnalysisTestingVersion>
     <!-- Libs -->
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>


### PR DESCRIPTION
Allows testing fixers without an analyzer, e.g. when testing a diagnostic generated from an `ObsoleteAttribute`.
See dotnet/roslyn-sdk#1117 for more information.