### PR TITLE
Replace explicit richCodeNavigationEnvironment in azure-pipelines-richnav.yml

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -10,7 +10,6 @@ stages:
     - template: /eng/common/templates/jobs/jobs.yml
       parameters:
         enableRichCodeNavigation: true
-        richCodeNavigationEnvironment: "production"
         richCodeNavigationLanguage: "csharp"
         jobs:
         - job: Debug_Build


### PR DESCRIPTION
This is managed by the arcade defaults, we should be using the "internal" environment as requested by the RichNav team.
