### PR TITLE
Revert "[release/8.0] Stabilize package versions for .NET 8"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>


### PR DESCRIPTION
Reverts dotnet/roslyn-analyzers#7002

Stabilizing packages in roslyn-analyzers isn't required for the .NET 8 release.