### PR TITLE
Don't emit CA1849 for nameof expressions

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -137,7 +137,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         }
                         else
                         {
-                            InspectAndReportBlockingMemberAccess(context, ((IPropertyReferenceOperation)context.Operation).Property, syncBlockingSymbols, SymbolKind.Property);
+                            var propertyReferenceOperation = (IPropertyReferenceOperation)context.Operation;
+                            if (propertyReferenceOperation.Parent is not INameOfOperation)
+                            {
+                                InspectAndReportBlockingMemberAccess(context, propertyReferenceOperation.Property, syncBlockingSymbols, SymbolKind.Property);
+                            }
                         }
                     }
                 }, OperationKind.Invocation, OperationKind.PropertyReference);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1322,6 +1322,27 @@ class Test {
             }.RunAsync();
         }
 
+        [Theory]
+        [InlineData("Task<object>.Result")]
+        [InlineData("ValueTask<object>.Result")]
+        [WorkItem(6993, "https://github.com/dotnet/roslyn-analyzers/issues/6993")]
+        public Task WhenUsingNameOf_NoDiagnostic(string taskExpression)
+        {
+            var code = $$"""
+                       using System.Threading.Tasks;
+
+                       class Test
+                       {
+                           public async Task<string> Foo()
+                           {
+                               await Task.CompletedTask;
+                               return nameof({{taskExpression}});
+                           }
+                       }
+                       """;
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
         private static async Task CreateCSTestAndRunAsync(string testCS)
         {
             var csTestVerify = new VerifyCS.Test


### PR DESCRIPTION
This PR ensures that referencing properties like `Task<T>.Result` and `ValueTask<T>.Result` in a `nameof` expression doesn't trigger CA1849.

Fixes #6993