### PR TITLE
Remove target that warns that user needs to upgrade to a newer SDK NetAnalyzers version

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1702,16 +1702,6 @@ namespace GenerateDocumentationAndConfigFiles
                         <EmbeddedFiles Condition="'$(DebugType)' != 'none'" Include="$(PerformanceSensitiveAttributePath)" />
                       </ItemGroup>
                     """,
-                    NetAnalyzersPackageName => $"""
-
-                      <!-- Target to report a warning when SDK NetAnalyzers version is higher than the referenced NuGet NetAnalyzers version -->
-                      <Target Name="_ReportUpgradeNetAnalyzersNuGetWarning" BeforeTargets="CoreCompile" Condition="'$(_SkipUpgradeNetAnalyzersNuGetWarning)' != 'true' ">
-                        <Warning Text ="The .NET SDK has newer analyzers with version '$({NetAnalyzersSDKAssemblyVersionPropertyName})' than what version '$({NetAnalyzersNugetAssemblyVersionPropertyName})' of '{NetAnalyzersPackageName}' package provides. Update or remove this package reference. You can suppress this warning by setting the MSBuild property '_SkipUpgradeNetAnalyzersNuGetWarning' to 'true'."
-                                 Condition="'$({NetAnalyzersNugetAssemblyVersionPropertyName})' != '' AND
-                                             '$({NetAnalyzersSDKAssemblyVersionPropertyName})' != '' AND
-                                              $({NetAnalyzersNugetAssemblyVersionPropertyName}) &lt; $({NetAnalyzersSDKAssemblyVersionPropertyName})"/>
-                      </Target>
-                    """,
                     ResxSourceGeneratorPackageName => $"""
 
                       <!-- Special handling for embedded resources to show as nested in Solution Explorer -->


### PR DESCRIPTION
Addresses part of the problem reported in https://github.com/dotnet/roslyn-analyzers/issues/6878 by deleting the target that we have determined does not add enough value.