### PR TITLE
BannedApiAnalyzers: Support banning base types

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpSymbolIsBannedInAnalyzersAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/CSharp/MetaAnalyzers/CSharpSymbolIsBannedInAnalyzersAnalyzer.cs
@@ -3,6 +3,9 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Analyzers;
+using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Analyzers
 {
@@ -11,8 +14,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Analyzers
     {
         protected override SyntaxKind XmlCrefSyntaxKind => SyntaxKind.XmlCrefAttribute;
 
+        protected override ImmutableArray<SyntaxKind> BaseTypeSyntaxKinds => ImmutableArray.Create(SyntaxKind.BaseList);
+
         protected override SymbolDisplayFormat SymbolDisplayFormat => SymbolDisplayFormat.CSharpShortErrorMessageFormat;
 
         protected override SyntaxNode GetReferenceSyntaxNodeFromXmlCref(SyntaxNode syntaxNode) => ((XmlCrefAttributeSyntax)syntaxNode).Cref;
+
+        protected override IEnumerable<SyntaxNode> GetTypeSyntaxNodesFromBaseType(SyntaxNode syntaxNode) => ((BaseListSyntax)syntaxNode).Types.Select(t => (SyntaxNode)t.Type);
     }
 }

--- a/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicSymbolIsBannedInAnalyzersAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.Analyzers/VisualBasic/BasicSymbolIsBannedInAnalyzersAnalyzer.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Analyzers
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -15,6 +16,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Analyzers
             End Get
         End Property
 
+        Protected Overrides ReadOnly Property BaseTypeSyntaxKinds As ImmutableArray(Of SyntaxKind)
+            Get
+                Return ImmutableArray.Create(SyntaxKind.InheritsStatement, SyntaxKind.ImplementsStatement)
+            End Get
+        End Property
+
         Protected Overrides ReadOnly Property SymbolDisplayFormat As SymbolDisplayFormat
             Get
                 Return SymbolDisplayFormat.VisualBasicShortErrorMessageFormat
@@ -23,6 +30,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Analyzers
 
         Protected Overrides Function GetReferenceSyntaxNodeFromXmlCref(syntaxNode As SyntaxNode) As SyntaxNode
             Return CType(syntaxNode, XmlCrefAttributeSyntax).Reference
+        End Function
+
+        Protected Overrides Function GetTypeSyntaxNodesFromBaseType(syntaxNode As SyntaxNode) As IEnumerable(Of SyntaxNode)
+            If syntaxNode.IsKind(SyntaxKind.InheritsStatement) Then
+                Return CType(syntaxNode, InheritsStatementSyntax).Types
+            ElseIf syntaxNode.IsKind(SyntaxKind.ImplementsStatement) Then
+                Return CType(syntaxNode, ImplementsStatementSyntax).Types
+            Else
+                Return ImmutableArray(Of SyntaxNode).Empty
+            End If
         End Function
 
     End Class

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/CSharpSymbolIsBannedAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/CSharp/CSharpSymbolIsBannedAnalyzer.cs
@@ -3,6 +3,9 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.BannedApiAnalyzers;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers
 {
@@ -11,8 +14,12 @@ namespace Microsoft.CodeAnalysis.CSharp.BannedApiAnalyzers
     {
         protected override SyntaxKind XmlCrefSyntaxKind => SyntaxKind.XmlCrefAttribute;
 
+        protected override ImmutableArray<SyntaxKind> BaseTypeSyntaxKinds => ImmutableArray.Create(SyntaxKind.BaseList);
+
         protected override SymbolDisplayFormat SymbolDisplayFormat => SymbolDisplayFormat.CSharpShortErrorMessageFormat;
 
         protected override SyntaxNode GetReferenceSyntaxNodeFromXmlCref(SyntaxNode syntaxNode) => ((XmlCrefAttributeSyntax)syntaxNode).Cref;
+
+        protected override IEnumerable<SyntaxNode> GetTypeSyntaxNodesFromBaseType(SyntaxNode syntaxNode) => ((BaseListSyntax)syntaxNode).Types.Select(t => (SyntaxNode)t.Type);
     }
 }

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/UnitTests/SymbolIsBannedAnalyzerTests.cs
@@ -330,6 +330,62 @@ End Namespace";
         }
 
         [Fact]
+        public async Task DiagnosticReportedForInterfaceImplementationAsync()
+        {
+            var bannedText = "T:N.IBanned//comment here";
+
+            var csharpSource = @"
+namespace N
+{
+    interface IBanned { }
+    class C : {|#0:IBanned|}
+    {
+    }
+}";
+
+            await VerifyCSharpAnalyzerAsync(csharpSource, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "IBanned", ""));
+
+            var visualBasicSource = @"
+Namespace N
+    Interface IBanned : End Interface
+    Class C
+        Implements {|#0:IBanned|}
+    End Class
+End Namespace";
+
+            await VerifyBasicAnalyzerAsync(visualBasicSource, bannedText, GetBasicResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "IBanned", ""));
+
+        }
+
+        [Fact]
+        public async Task DiagnosticReportedForClassInheritanceAsync()
+        {
+            var bannedText = "T:N.Banned//comment here";
+
+            var csharpSource = @"
+namespace N
+{
+    class Banned { }
+    class C : {|#0:Banned|}
+    {
+    }
+}";
+
+            await VerifyCSharpAnalyzerAsync(csharpSource, bannedText, GetCSharpResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "Banned", ""));
+
+            var visualBasicSource = @"
+Namespace N
+    Class Banned : End Class
+    Class C
+        Inherits {|#0:Banned|}
+    End Class
+End Namespace";
+
+            await VerifyBasicAnalyzerAsync(visualBasicSource, bannedText, GetBasicResultAt(0, SymbolIsBannedAnalyzer.SymbolIsBannedRule, "Banned", ""));
+
+        }
+
+        [Fact]
         public async Task DiagnosticReportedForBannedApiLineWithWhitespaceThenCommentAtTheEndAsync()
         {
             var bannedText = "T:N.Banned \t //comment here";

--- a/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/BasicSymbolIsBannedAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.BannedApiAnalyzers/VisualBasic/BasicSymbolIsBannedAnalyzer.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.BannedApiAnalyzers
@@ -15,6 +16,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers
             End Get
         End Property
 
+        Protected Overrides ReadOnly Property BaseTypeSyntaxKinds As ImmutableArray(Of SyntaxKind)
+            Get
+                Return ImmutableArray.Create(SyntaxKind.InheritsStatement, SyntaxKind.ImplementsStatement)
+            End Get
+        End Property
+
         Protected Overrides ReadOnly Property SymbolDisplayFormat As SymbolDisplayFormat
             Get
                 Return SymbolDisplayFormat.VisualBasicShortErrorMessageFormat
@@ -23,6 +30,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.BannedApiAnalyzers
 
         Protected Overrides Function GetReferenceSyntaxNodeFromXmlCref(syntaxNode As SyntaxNode) As SyntaxNode
             Return CType(syntaxNode, XmlCrefAttributeSyntax).Reference
+        End Function
+
+        Protected Overrides Function GetTypeSyntaxNodesFromBaseType(syntaxNode As SyntaxNode) As IEnumerable(Of SyntaxNode)
+            If syntaxNode.IsKind(SyntaxKind.InheritsStatement) Then
+                Return CType(syntaxNode, InheritsStatementSyntax).Types
+            ElseIf syntaxNode.IsKind(SyntaxKind.ImplementsStatement) Then
+                Return CType(syntaxNode, ImplementsStatementSyntax).Types
+            Else
+                Return ImmutableArray(Of SyntaxNode).Empty
+            End If
         End Function
 
     End Class

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Test.Utilities
 {
@@ -16,7 +16,7 @@ namespace Test.Utilities
         where TAnalyzer : DiagnosticAnalyzer, new()
         where TCodeFix : CodeFixProvider, new()
     {
-        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+        public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
         {
             static Test()
             {


### PR DESCRIPTION
Fixes #6841 

Note I've had to change `XUnitVerifier` to `DefaultVerifier` due to the following exception:

```
  Error Message:
   System.MissingMethodException : Method not found: 'Void Xunit.Sdk.EqualException..ctor(System.Object, System.Object)'.
  Stack Trace:
     at Microsoft.CodeAnalysis.Testing.Verifiers.EqualWithMessageException..ctor(Object expected, Object actual, String userMessage)
   at Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier.Equal[T](T expected, T actual, String message) in /_/src/Microsoft.CodeAnalysis.Testing/Microsoft.CodeAnalysis.Testing.Verifiers.XUnit/XUnitVerifier.cs:line 49
```

See https://github.com/dotnet/roslyn-sdk/issues/1099#issuecomment-1723487931