### PR TITLE
Don't raise RS1039 when passing LocalFunctionStatementSyntax

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/SemanticModelGetDeclaredSymbolAlwaysReturnsNullAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/SemanticModelGetDeclaredSymbolAlwaysReturnsNullAnalyzerTests.cs
@@ -3,6 +3,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers;
 using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.CodeAnalysis.CSharp.Analyzers.MetaAnalyzers.CSharpSemanticModelGetDeclaredSymbolAlwaysReturnsNullAnalyzer,
@@ -94,6 +95,25 @@ public class Test {
         var x = semanticModel.{|CS7036:GetDeclaredSymbol|}();
     }
 }";
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact, WorkItem(7061, "https://github.com/dotnet/roslyn-analyzers/issues/7061")]
+        public Task LocalFunctionStatement_NoDiagnostic()
+        {
+            const string code = """
+                       using Microsoft.CodeAnalysis;
+                       using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+                       public class Test
+                       {
+                           public void M(SemanticModel semanticModel, LocalFunctionStatementSyntax syntax)
+                           {
+                               var x = semanticModel.GetDeclaredSymbol(syntax);
+                           }
+                       }
+                       """;
 
             return VerifyCS.VerifyAnalyzerAsync(code);
         }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -37,6 +37,7 @@ namespace Analyzer.Utilities
         public const string MicrosoftCodeAnalysisCSharpCSharpExtensions = "Microsoft.CodeAnalysis.CSharp.CSharpExtensions";
         public const string MicrosoftCodeAnalysisCSharpExtensions = "Microsoft.CodeAnalysis.CSharpExtensions";
         public const string MicrosoftCodeAnalysisCSharpSyntaxBaseFieldDeclarationSyntax = "Microsoft.CodeAnalysis.CSharp.Syntax.BaseFieldDeclarationSyntax";
+        public const string MicrosoftCodeAnalysisCSharpSyntaxLocalFunctionStatementSyntax = "Microsoft.CodeAnalysis.CSharp.Syntax.LocalFunctionStatementSyntax";
         public const string MicrosoftCodeAnalysisDiagnostic = "Microsoft.CodeAnalysis.Diagnostic";
         public const string MicrosoftCodeAnalysisDiagnosticDescriptor = "Microsoft.CodeAnalysis.DiagnosticDescriptor";
         public const string MicrosoftCodeAnalysisDiagnosticsAnalysisContext = "Microsoft.CodeAnalysis.Diagnostics.AnalysisContext";


### PR DESCRIPTION
This PR prevents raising RS1039 when passing a `LocalFunctionStatementSyntax` to `SemanticModel.GetDeclaredSymbol`. Currently the analyzer relies on the `SemanticModel` overloads and there currently is no overload for `LocalFunctionStatementSyntax`.
dotnet/roslyn#71028 tracks an API proposal to add this.

Fixes #7061