### PR TITLE
fix(CA2208): false positive when message start with parameter name followed by punctuation

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/InstantiateArgumentExceptionsCorrectlyTests.cs
@@ -593,6 +593,35 @@ End Class");
                End Class");
         }
 
+        [Fact, WorkItem(6863, "https://github.com/dotnet/roslyn-analyzers/issues/6863")]
+        public async Task ArgumentException_MessageStartWithParameterNameFollowedByPunctuation_DoesNotWarnAsync()
+        {
+            await VerifyCS.VerifyAnalyzerAsync(@"
+                public class Class
+                {
+                    public void Test1(string first)
+                    {
+                        throw new System.ArgumentException(""first.Length is incorrect"", nameof(first));
+                    }
+
+                    public void Test2(string first)
+                    {
+                        throw new System.ArgumentException(""first[0] is incorrect"", nameof(first));
+                    }
+                }");
+
+            await VerifyVB.VerifyAnalyzerAsync(@"
+               Public Class [MyClass]
+                   Public Sub Test1(first As String)
+                       Throw New System.ArgumentException(""first.Length is incorrect"", NameOf(first))
+                   End Sub
+
+                   Public Sub Test2(first As String)
+                       Throw New System.ArgumentException(""first(0) is incorrect"", NameOf(first))
+                   End Sub
+               End Class");
+        }
+
         [Fact]
         public async Task ArgumentException_GenericParameterName_DoesNotWarnAsync()
         {


### PR DESCRIPTION
fix: #6863 

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
