### PR TITLE
Change localization back to main

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -24,11 +24,10 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0.1xx') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: roslyn-analyzers
-        MirrorBranch: release/8.0.1xx
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-ROSANLZR'
   - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
Now that we shipped 8.0.1xx, we need to revert localization back to point to main. I already opened the [internal issue](https://ceapex.visualstudio.com/CEINTL/_workitems/edit/931170) for the loc team to track this request.

Here is the old PR that temporarily moved main to 8.0.1xx: https://github.com/dotnet/roslyn-analyzers/pull/6890/files

**Question**: This change [was also backported to the 8.0.1xx](https://github.com/dotnet/roslyn-analyzers/pull/6891) branch. Do I also need to revert the change in that branch, or can that one stay as is?

Edit: **Answer**: I need to backport it to release/8.0.2xx. I don't think I should backport it to 8.0.1xx, that branch won't be active again.