### PR TITLE
[release/8.0.2xx] Remove target that warns that user needs to upgrade to a newer SDK NetAnalyzers version

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1668,14 +1668,6 @@ $@"<Project>{GetCommonContents(packageName, categories)}{GetPackageSpecificConte
     <!-- Make sure the source file is embedded in PDB to support Source Link -->
     <EmbeddedFiles Condition=""'$(DebugType)' != 'none'"" Include=""$(PerformanceSensitiveAttributePath)"" />
   </ItemGroup>",
-                    NetAnalyzersPackageName => $@"
-  <!-- Target to report a warning when SDK NetAnalyzers version is higher than the referenced NuGet NetAnalyzers version -->
-  <Target Name=""_ReportUpgradeNetAnalyzersNuGetWarning"" BeforeTargets=""CoreCompile"" Condition=""'$(_SkipUpgradeNetAnalyzersNuGetWarning)' != 'true' "">
-    <Warning Text =""The .NET SDK has newer analyzers with version '$({NetAnalyzersSDKAssemblyVersionPropertyName})' than what version '$({NetAnalyzersNugetAssemblyVersionPropertyName})' of '{NetAnalyzersPackageName}' package provides. Update or remove this package reference. You can suppress this warning by setting the MSBuild property '_SkipUpgradeNetAnalyzersNuGetWarning' to 'true'.""
-             Condition=""'$({NetAnalyzersNugetAssemblyVersionPropertyName})' != '' AND
-                         '$({NetAnalyzersSDKAssemblyVersionPropertyName})' != '' AND
-                          $({NetAnalyzersNugetAssemblyVersionPropertyName}) &lt; $({NetAnalyzersSDKAssemblyVersionPropertyName})""/>
-  </Target>",
                     ResxSourceGeneratorPackageName => $@"
   <!-- Special handling for embedded resources to show as nested in Solution Explorer -->
   <ItemGroup>


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/roslyn-analyzers/pull/7040 

## Customer Impact

## Testing

## Risk
