### PR TITLE
Suppress CA1725 for generic parameters

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclaration.cs
@@ -114,6 +114,10 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines
             {
                 IParameterSymbol currentParameter = methodSymbol.Parameters[i];
                 IParameterSymbol bestMatchParameter = bestMatch.Parameters[i];
+                if (bestMatchParameter.OriginalDefinition.Type is ITypeParameterSymbol)
+                {
+                    continue;
+                }
 
                 if (currentParameter.Name != bestMatchParameter.Name)
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/ParameterNamesShouldMatchBaseDeclarationTests.cs
@@ -612,6 +612,66 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
                           End Class");
         }
 
+        [Fact]
+        public Task DontWarnWhenImplementingGenericParameterInInterface()
+        {
+            const string code = """
+                                public interface IService<TEntity>
+                                {
+                                    void Update(TEntity entity);
+                                }
+                                
+                                public class User {}
+                                
+                                public class UserService : IService<User>
+                                {
+                                    public void Update(User user) {}
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public Task DontWarnWhenImplementingGenericParameterInBaseClass()
+        {
+            const string code = """
+                                public class BaseService<TEntity>
+                                {
+                                    public virtual void Update(TEntity entity) {}
+                                }
+
+                                public class User {}
+
+                                public class UserService : BaseService<User>
+                                {
+                                    public override void Update(User user) {}
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public Task DontWarnWhenImplementingGenericParameterInAbstractBaseClass()
+        {
+            const string code = """
+                                public abstract class BaseService<TEntity>
+                                {
+                                    public abstract void Update(TEntity entity);
+                                }
+
+                                public class User {}
+
+                                public class UserService : BaseService<User>
+                                {
+                                    public override void Update(User user) {}
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string violatingMember, string violatingParameter, string baseParameter, string baseMember)
 #pragma warning disable RS0030 // Do not use banned APIs
             => VerifyCS.Diagnostic()


### PR DESCRIPTION
When implementing or overriding a method with a generic parameter, it often makes sense to deviate from the parameters name to make it more explicit. For example:
```csharp
public interface IService<TEntity>
{
    void Update(TEntity entity);
}

public class User {}

public class UserService : IService<User>
{
    public void Update(User user) {}
}
```

Implementing the method as `public void Update(User entity) {}` feels awkward.