### PR TITLE
Fix a number of issues in CA1859.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
@@ -143,6 +143,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     context.RegisterOperationAction(context => coll.HandleDeconstructionAssignment((IDeconstructionAssignmentOperation)context.Operation), OperationKind.DeconstructionAssignment);
                     context.RegisterOperationAction(context => coll.HandleFieldInitializer((IFieldInitializerOperation)context.Operation), OperationKind.FieldInitializer);
                     context.RegisterOperationAction(context => coll.HandlePropertyInitializer((IPropertyInitializerOperation)context.Operation), OperationKind.PropertyInitializer);
+                    context.RegisterOperationAction(context => coll.HandlePropertyReference((IPropertyReferenceOperation)context.Operation), OperationKind.PropertyReference);
                     context.RegisterOperationAction(context => coll.HandleVariableDeclarator((IVariableDeclaratorOperation)context.Operation), OperationKind.VariableDeclarator);
                     context.RegisterOperationAction(context => coll.HandleDeclarationExpression((IDeclarationExpressionOperation)context.Operation), OperationKind.DeclarationExpression);
                     context.RegisterOperationAction(context => coll.HandleReturn((IReturnOperation)context.Operation), OperationKind.Return);
@@ -323,7 +324,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     }
                 }
 
-                if (toType.TypeKind is not TypeKind.Class and not TypeKind.Array)
+                if (toType.TypeKind is not TypeKind.Class and not TypeKind.Array and not TypeKind.Struct)
                 {
                     // we only deal with classes or arrays
                     return;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.cs
@@ -13,6 +13,113 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
     public static partial class UseConcreteTypeTests
     {
         [Fact]
+        [WorkItem(6904, "https://github.com/dotnet/roslyn-analyzers/issues/6904")]
+        public static async Task AwaitBug()
+        {
+            await TestCSAsync(@"
+                using System.Threading.Tasks;
+
+                public class Class1
+                {
+                    private I Prop { get; set; } = new Impl1(); //<-- CA1859 
+
+                    public async Task Init()
+                    {
+                        Prop = await Task.FromResult<I>(new Impl2());
+                        Prop.M();
+                    }
+                }
+
+                internal interface I
+                {
+                    void M();
+                }
+
+                internal class Impl1 : I
+                {
+                    public void M() { }
+                }
+
+                internal class Impl2 : I
+                {
+                    public void M() { }
+                }
+            ");
+        }
+
+        [Fact]
+        [WorkItem(7078, "https://github.com/dotnet/roslyn-analyzers/issues/7078")]
+        public static async Task IndexerBug()
+        {
+            await TestCSAsync(@"
+                using System.Collections.Generic;
+
+                public struct MailAddress { }
+
+                public class C
+                {
+                    private IList<MailAddress> {|#1:_field|};
+                    private IList<MailAddress> {|#2:Property|} { get; set; }
+
+                    internal void ParseValue1(string addresses)
+                    {
+                        IList<MailAddress> {|#0:result|} = ParseMultipleAddresses(addresses); // should be flagged by CA1859
+
+                        var x = result[0];
+                    }
+
+                    internal void ParseValue2(string addresses)
+                    {
+                        _field = ParseMultipleAddresses(addresses); // should be flagged by CA1859
+
+                        var x = _field[0];
+                    }
+
+                    internal void ParseValue3(string addresses)
+                    {
+                        Property = ParseMultipleAddresses(addresses); // should be flagged by CA1859
+
+                        var x = Property[0];
+                    }
+
+                    internal static List<MailAddress> ParseMultipleAddresses(string data) => new();
+                }
+            ",
+            VerifyCS.Diagnostic(UseConcreteTypeAnalyzer.UseConcreteTypeForLocal)
+                .WithLocation(0)
+                .WithArguments("result", "System.Collections.Generic.IList<MailAddress>", "System.Collections.Generic.List<MailAddress>"),
+            VerifyCS.Diagnostic(UseConcreteTypeAnalyzer.UseConcreteTypeForField)
+                .WithLocation(1)
+                .WithArguments("_field", "System.Collections.Generic.IList<MailAddress>", "System.Collections.Generic.List<MailAddress>"),
+            VerifyCS.Diagnostic(UseConcreteTypeAnalyzer.UseConcreteTypeForProperty)
+                .WithLocation(2)
+                .WithArguments("Property", "System.Collections.Generic.IList<MailAddress>", "System.Collections.Generic.List<MailAddress>"));
+        }
+
+        [Fact]
+        [WorkItem(7127, "https://github.com/dotnet/roslyn-analyzers/issues/7127")]
+        public static async Task ImmutableArrayBug()
+        {
+            await TestCSAsync(@"
+                using System.Collections.Generic;
+                using System.Collections.Immutable;
+
+                public class Class1
+                {
+                    private IEnumerable<int> {|#0:CreateImmutableArrayPrivately|}()
+                    {
+                        return new ImmutableArray<int>
+                        {
+                            1, 2, 3, 4
+                        };
+                    }
+                }
+            ", VerifyCS.Diagnostic(UseConcreteTypeAnalyzer.UseConcreteTypeForMethodReturn)
+                .WithLocation(0)
+                .WithArguments("CreateImmutableArrayPrivately", "System.Collections.Generic.IEnumerable<int>", "System.Collections.Immutable.ImmutableArray<int>"));
+        }
+
+        [Fact]
         [WorkItem(6751, "https://github.com/dotnet/roslyn-analyzers/issues/6751")]
         public static async Task MultipleReturns()
         {
@@ -268,7 +375,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger_ValidatePublicSymbolUsage()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.Collections.Generic;
@@ -382,7 +489,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger1()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.Collections.Generic;
@@ -416,7 +523,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger2()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System.Collections.Generic;
 
@@ -458,7 +565,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger3()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.IO;
@@ -489,7 +596,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger4()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.IO;
@@ -520,7 +627,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldNotTrigger5()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 interface IFoo
                 {
@@ -652,7 +759,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldTrigger3()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.IO;
@@ -683,7 +790,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task ShouldTrigger4()
         {
             const string Source = @"
-                #nullable enable
+#nullable enable
 
                 using System;
                 using System.IO;
@@ -757,7 +864,7 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         public static async Task Conditional()
         {
             const string Source = @"
-            #nullable enable
+#nullable enable
             namespace Example
             {
                 public interface IFoo


### PR DESCRIPTION
- Fixes #6904. The logic didn't recognize await expressions.

- Fixes #7078. The logic didn't recognize indexer calls.

- Fixes #7127. The logic never suggested to upgrade from an interface to a struct type. There wasn't an obvious reason for that, it was an ommission on my part.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
