### PR TITLE
Don't report CA2257 on nested types

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementation.cs
@@ -128,7 +128,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
             foreach (var member in targetType.GetMembers())
             {
-                if (!member.IsImplementationOfAnyExplicitInterfaceMember() && !member.IsStatic)
+                if (!member.IsImplementationOfAnyExplicitInterfaceMember() && !member.IsStatic && !member.IsType())
                 {
                     // We don't want to emit diagnostics when the member is an accessor method.
                     if (member is not IMethodSymbol { AssociatedSymbol: IPropertySymbol or IEventSymbol })

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementationTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/DynamicInterfaceCastableImplementationTests.cs
@@ -1240,6 +1240,31 @@ public interface I2 : I
             await VerifyCSCodeFixAsync(source, fixedSource, CSharp.LanguageVersion.Preview, ReferenceAssemblies.Net.Net60);
         }
 
+        [Fact]
+        [WorkItem(7106, "htpts://github.com/dotnet/roslyn-analyzers/issues/7106")]
+        public async Task DynamicInterfaceCastableImplementation_NonStatic_NestedType()
+        {
+            string source = @"
+using System.Runtime.InteropServices;
+
+public interface IMyInterface
+{
+    void M();
+}
+
+[DynamicInterfaceCastableImplementation]
+internal interface IImpl : IMyInterface
+{
+    internal class C { }
+
+    void IMyInterface.M()
+    {
+    }
+}
+";
+            await VerifyCSAnalyzerAsync(source);
+        }
+
         private static Task VerifyCSAnalyzerAsync(string source)
         {
             return VerifyCSCodeFixAsync(source, source);


### PR DESCRIPTION
Fixes #7106

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
