### PR TITLE
Adjust message for banned symbol CultureInfo.CurrentCulture

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
@@ -2,9 +2,8 @@ T:System.Console; Analyzers should not be reading / writing to the console
 T:System.Diagnostics.Process; Analyzers should not inspect or create processes
 T:System.Diagnostics.ProcessStartInfo; Analyzers should not inspect or create processes
 T:System.Environment; Analyzers should not read their settings directly from environment variables
-P:System.Globalization.CultureInfo.CurrentCulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentCulture
-P:System.Globalization.CultureInfo.CurrentUICulture; Analyzers should use the locale given by the compiler command line arguments, not the CurrentUICulture
-T:System.IO.File; Do not do file IO in analyzers
+P:System.Globalization.CultureInfo.CurrentCulture; Analyzers should use LocalizableResourceString for culture-dependent messages
+P:System.Globalization.CultureInfo.CurrentUICulture; Analyzers should use LocalizableResourceString for culture-dependent messages
 T:System.IO.Directory; Do not do file IO in analyzers
 M:System.IO.Path.GetTempPath; Do not do file IO in analyzers
 T:System.Random; Analyzers should be deterministic

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerBannedSymbols.txt
@@ -4,6 +4,7 @@ T:System.Diagnostics.ProcessStartInfo; Analyzers should not inspect or create pr
 T:System.Environment; Analyzers should not read their settings directly from environment variables
 P:System.Globalization.CultureInfo.CurrentCulture; Analyzers should use LocalizableResourceString for culture-dependent messages
 P:System.Globalization.CultureInfo.CurrentUICulture; Analyzers should use LocalizableResourceString for culture-dependent messages
+T:System.IO.File; Do not do file IO in analyzers
 T:System.IO.Directory; Do not do file IO in analyzers
 M:System.IO.Path.GetTempPath; Do not do file IO in analyzers
 T:System.Random; Analyzers should be deterministic


### PR DESCRIPTION
Related to #7086

I looked into this scenario further and found the doc [Localizing Analyzers](https://github.com/dotnet/roslyn/blob/1b158968d85dfc7bce5baaf8795ada93e2e44527/docs/analyzers/Localizing%20Analyzers.md#using-localized-resources-in-analyzers). Basically, it appears that the pattern we want analyzer authors to use is to put culture-dependent formattable strings in a `.resx` file, and refer to those strings using [LocalizableResourceString](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.localizableresourcestring?view=roslyn-dotnet-4.7.0).

It's possible that we will still want to introduce a public API to get the `CultureInfo` which is being used by the compiler, mentioned in https://github.com/dotnet/roslyn-analyzers/issues/7086#issuecomment-1907101557. But I thought I would get this change in first thing, as it should help some people hitting the issue to move forward without needing to wait for a possible public API change and for a new compiler version to ship.