### PR TITLE
Update version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -26,7 +26,7 @@ _OR_
 
 **NuGet Package**: [Microsoft.CodeAnalysis.NetAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers)
 
-**Version**: 5.0.3 (Latest)
+**Version**: 8.0.0
 
 <!--
 NOTE: `Microsoft.CodeAnalysis.FxCopAnalyzers` package has been deprecated in favor of 'Microsoft.CodeAnalysis.NetAnalyzers', that ships with the .NET SDK.


### PR DESCRIPTION
This PR updates the bug template to reflect the latest version of the `Microsoft.CodeAnalysis.NetAnalyzers` package.

Also it removes the "Latest" suffix. I find it confusing both when creating an issue as well as when reading one. For example: https://github.com/dotnet/roslyn-analyzers/issues/7030.
On the 14th of November, 7.0.4 was the latest non-preview version, however not the latest version of the package.