### PR TITLE
fix CA2021 false positives

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer,

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.Analyzers.Runtime.DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer,
@@ -823,6 +824,45 @@ class C : IInterface
     VerifyCS.Diagnostic(castRule).WithLocation(56).WithArguments("string", "TStruct?"),
                 }
             }.RunAsync();
+        }
+
+        [Fact]
+        public async Task GenericRecordsAndInterfaces()
+        {
+            var test = new VerifyCS.Test
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+                LanguageVersion = LanguageVersion.CSharp10,
+                TestCode = @"
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var nodeChanges = new List<INodeUpdate<GraphNode>> { new DataNodeUpdate(new DataNode(0, 0)) };
+
+        //warning CA2021: This call will always result in an empty sequence because type 'INodeUpdate<GraphNode>' is incompatible with type 'DataNodeUpdate'
+        var nodeChangesFiltered = nodeChanges.OfType<DataNodeUpdate>();
+
+        Debug.Assert(nodeChangesFiltered.Count() == 1);
+    }
+}
+
+public abstract record class GraphNode(long Id);
+public sealed record class DataNode(long Id, long Value) : GraphNode(Id);
+
+public interface INodeUpdate<out T>
+{
+    T Updated { get; }
+}
+
+public abstract record class NodeUpdate<T>(T Updated) : INodeUpdate<T> where T : GraphNode;
+public sealed record class DataNodeUpdate(DataNode Updated) : NodeUpdate<DataNode>(Updated);"
+            };
+            await test.RunAsync();
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzerTests.cs
@@ -826,7 +826,7 @@ class C : IInterface
             }.RunAsync();
         }
 
-        [Fact]
+        [Fact, WorkItem(7153, "https://github.com/dotnet/roslyn-analyzers/issues/7153")]
         public async Task GenericRecordsAndInterfaces()
         {
             var test = new VerifyCS.Test


### PR DESCRIPTION
Can't say I really understand this that well, but adds the test case and fixes #7153 without breaking anything else as far I can tell.

---- 
The code was previously using `ITypeSymbol` property `AllInterfaces` which says the seemly relevantly:
> // This is not quite the same as "all interfaces of which this type
> // is a proper subtype" 
However, I couldn't find any sort of "proper subtype" API. 

So this change sprinkles some `OriginalDefinition` calls around, and switches to using `DerivesFrom` - which calls `OriginalDefinition` on all the interface symbols before checking equality.


