### PR TITLE
Support collection expressions for non-copyable analyzer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -70,7 +70,7 @@
     <!-- Versions for tests and general utility execution. -->
     <!-- This version is for utility and executable assemblies. The version here should not overlap with any of the surface
          area versions. -->
-    <MicrosoftCodeAnalysisVersionForTests>4.8.0</MicrosoftCodeAnalysisVersionForTests>
+    <MicrosoftCodeAnalysisVersionForTests>4.9.0-3.final</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForExecution>4.6.0-1.final</MicrosoftCodeAnalysisVersionForExecution>
     <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.6.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
     <MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>4.6.0</MicrosoftCodeAnalysisVisualBasicCodeStyleVersion>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.Lightup;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.FlowAnalysis;
@@ -1435,6 +1436,9 @@ namespace Roslyn.Diagnostics.Analyzers
                         };
 
                     case OperationKind.Throw:
+                        return RefKind.None;
+
+                    case OperationKindEx.CollectionExpression:
                         return RefKind.None;
 
                     default:

--- a/src/Utilities/Compiler/Lightup/OperationKindEx.cs
+++ b/src/Utilities/Compiler/Lightup/OperationKindEx.cs
@@ -12,6 +12,7 @@ namespace Analyzer.Utilities.Lightup
         public const OperationKind ImplicitIndexerReference = (OperationKind)0x7b;
         public const OperationKind Utf8String = (OperationKind)0x7c;
         public const OperationKind Attribute = (OperationKind)0x7d;
+        public const OperationKind CollectionExpression = (OperationKind)0x7f;
     }
 }
 


### PR DESCRIPTION
This supports using a collection expression to initialize a non-copyable collection type.