### PR TITLE
Remove temporary .NET 8 reference assemblies

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUnusedPrivateFieldsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUnusedPrivateFieldsTests.cs
@@ -258,7 +258,7 @@ public class Class
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net80,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
                 TestCode = @"
 using System.Runtime.CompilerServices;
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseSearchValuesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/UseSearchValuesTests.cs
@@ -1080,33 +1080,12 @@ namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
         {
             await new VerifyCS.Test
             {
-                ReferenceAssemblies = Net80,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
                 LanguageVersion = languageVersion,
                 TestCode = source,
                 FixedCode = expected,
                 TestState = { OutputKind = topLevelStatements ? OutputKind.ConsoleApplication : null },
             }.RunAsync();
         }
-
-        // TEMP - need newer version of Microsoft.CodeAnalysis.Analyzer.Testing
-        // Replace with 'ReferenceAssemblies.Net.Net80'
-        private static readonly Lazy<ReferenceAssemblies> _lazyNet80 =
-            new(() =>
-            {
-                if (!NuGet.Frameworks.NuGetFramework.Parse("net8.0").IsPackageBased)
-                {
-                    // The NuGet version provided at runtime does not recognize the 'net8.0' target framework
-                    throw new NotSupportedException("The 'net8.0' target framework is not supported by this version of NuGet.");
-                }
-
-                return new ReferenceAssemblies(
-                    "net8.0",
-                    new PackageIdentity(
-                        "Microsoft.NETCore.App.Ref",
-                        "8.0.0-preview.7.23375.6"),
-                    System.IO.Path.Combine("ref", "net8.0"));
-            });
-
-        public static ReferenceAssemblies Net80 => _lazyNet80.Value;
     }
 }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -216,7 +216,7 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests
 
         private async Task VerifyNet80CSharpAdditionalFileFixAsync(string source, string? shippedApiText, string? oldUnshippedApiText, string newUnshippedApiText)
         {
-            await VerifyAdditionalFileFixAsync(LanguageNames.CSharp, source, shippedApiText, oldUnshippedApiText, newUnshippedApiText, AdditionalMetadataReferences.Net80);
+            await VerifyAdditionalFileFixAsync(LanguageNames.CSharp, source, shippedApiText, oldUnshippedApiText, newUnshippedApiText, ReferenceAssemblies.Net.Net80);
         }
 
         private async Task VerifyAdditionalFileFixAsync(string language, string source, string? shippedApiText, string? oldUnshippedApiText, string newUnshippedApiText,
@@ -3269,7 +3269,7 @@ C.C() -> void";
 
             var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, DeclarePublicApiFix, XUnitVerifier>()
             {
-                ReferenceAssemblies = AdditionalMetadataReferences.Net80,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
                 CompilerDiagnostics = CompilerDiagnostics.None,
                 TestState =
                 {

--- a/src/Test.Utilities/AdditionalMetadataReferences.cs
+++ b/src/Test.Utilities/AdditionalMetadataReferences.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
@@ -10,13 +9,6 @@ namespace Test.Utilities
 {
     public static class AdditionalMetadataReferences
     {
-        public static ReferenceAssemblies Net80 { get; } = new ReferenceAssemblies(
-            "net8.0",
-            new PackageIdentity(
-                "Microsoft.NETCore.App.Ref",
-                "8.0.0-preview.6.23329.7"),
-            Path.Combine("ref", "net8.0"));
-
         public static ReferenceAssemblies Default { get; } = CreateDefaultReferenceAssemblies();
 
         public static ReferenceAssemblies DefaultWithoutRoslynSymbols { get; } = ReferenceAssemblies.Default


### PR DESCRIPTION
Fixes #6923.