### PR TITLE
Mark type as instantiated when used with a collection expression initializer

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClasses.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
+using Analyzer.Utilities.Lightup;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -78,12 +79,11 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
 
                 startContext.RegisterOperationAction(context =>
                 {
-                    var expr = (IObjectCreationOperation)context.Operation;
-                    if (expr.Type is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(context.ContainingSymbol.ContainingAssembly))
+                    if (context.Operation.Type is INamedTypeSymbol namedType && namedType.ContainingAssembly.Equals(context.ContainingSymbol.ContainingAssembly))
                     {
                         instantiatedTypes.TryAdd(namedType, null);
                     }
-                }, OperationKind.ObjectCreation);
+                }, OperationKind.ObjectCreation, OperationKindEx.CollectionExpression);
 
                 startContext.RegisterSymbolAction(context =>
                 {

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/AvoidUninstantiatedInternalClassesTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using Test.Utilities;
 
@@ -1654,6 +1655,47 @@ dotnet_code_quality.CA1812.ignore_internalsvisibleto = {ignoreInternalsVisibleTo
             }
 
             await test.RunAsync();
+        }
+
+        [Fact, WorkItem(7223, "https://github.com/dotnet/roslyn-analyzers/issues/7223")]
+        public Task CA1812_CollectionExpressionsInField_NoDiagnostic()
+        {
+            const string code = """
+                                using System.Collections.ObjectModel;
+
+                                public class Class1
+                                {
+                                    private readonly MyCollection _items = [];
+                                }
+                                internal sealed class MyCollection : Collection<int>;
+                                """;
+            return new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp12
+            }.RunAsync();
+        }
+
+        [Fact, WorkItem(7223, "https://github.com/dotnet/roslyn-analyzers/issues/7223")]
+        public Task CA1812_CollectionExpressionsInLocalVariable_NoDiagnostic()
+        {
+            const string code = """
+                                using System.Collections.ObjectModel;
+
+                                public class Class1
+                                {
+                                    private void M()
+                                    {
+                                        MyCollection c = [];
+                                    }
+                                }
+                                internal sealed class MyCollection : Collection<int>;
+                                """;
+            return new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp12
+            }.RunAsync();
         }
 
         private static DiagnosticResult GetCSharpResultAt(int line, int column, string className)


### PR DESCRIPTION
Affected analyzer: AvoidUninstantiatedInternalClassesAnalyzer
Affected diagnostic ID: [CA1812](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812)

This PR prevents an internal class which is instantiated via collection initializer to be marked as uninstantiated by the analyzer.

Fixes #7223 