### PR TITLE
Generate field for const arrays in constructor declarations

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.Fixer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArrays.Fixer.cs
@@ -74,6 +74,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             // Get method containing the symbol that is being diagnosed
             IOperation? methodContext = arrayArgument.GetAncestor<IMethodBodyOperation>(OperationKind.MethodBody);
             methodContext ??= arrayArgument.GetAncestor<IBlockOperation>(OperationKind.Block); // VB methods have a different structure than CS methods
+            methodContext ??= arrayArgument.GetAncestor<IConstructorBodyOperation>(OperationKind.ConstructorBody);
 
             // Create the new member
             SyntaxNode newMember = generator.FieldDeclaration(

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidConstArraysTests.cs
@@ -1053,5 +1053,38 @@ public class MyClass
                 }
             }.RunAsync();
         }
+
+        [Fact, WorkItem(7216, "https://github.com/dotnet/roslyn-analyzers/issues/7216")]
+        public Task BaseDeclaration_Diagnostic()
+        {
+            const string code = """
+                                public class Class1
+                                {
+                                    public Class1(int[] arr) { }
+                                }
+
+                                public class Class2 : Class1
+                                {
+                                    public Class2()
+                                        : base([|new int[] { 1, 2, 3 }|]) { }
+                                }
+                                """;
+            const string fixedCode = """
+                                     public class Class1
+                                     {
+                                         public Class1(int[] arr) { }
+                                     }
+                                     
+                                     public class Class2 : Class1
+                                     {
+                                         private static readonly int[] arr = new int[] { 1, 2, 3 };
+                                     
+                                         public Class2()
+                                             : base(arr) { }
+                                     }
+                                     """;
+
+            return VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+        }
     }
 }


### PR DESCRIPTION
Affected analyzer: AvoidConstArraysAnalyzer
Affected diagnostic ID: [CA1861](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1861)

This PR ensures the `static readonly` field gets created when the code fix is applied.

Fixes #7216