### PR TITLE
Include experimental attribute in API definition for properties

### DIFF
--- a/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
+++ b/src/PublicApiAnalyzers/Core/Analyzers/DeclarePublicApiAnalyzer.Impl.cs
@@ -599,7 +599,13 @@ namespace Microsoft.CodeAnalysis.PublicApiAnalyzers
                 {
                     for (var current = symbol; current is not null; current = current.ContainingSymbol)
                     {
-                        foreach (var attribute in current.GetAttributes())
+                        var attributes = current.GetAttributes();
+                        if (attributes.IsEmpty && current is IMethodSymbol { AssociatedSymbol: IPropertySymbol property })
+                        {
+                            attributes = property.GetAttributes();
+                        }
+
+                        foreach (var attribute in attributes)
                         {
                             if (attribute.AttributeClass is { Name: "ExperimentalAttribute", ContainingSymbol: INamespaceSymbol { Name: nameof(System.Diagnostics.CodeAnalysis), ContainingNamespace: { Name: nameof(System.Diagnostics), ContainingNamespace: { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true } } } })
                             {

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -3302,7 +3302,7 @@ C.C() -> void";
             var source = $$"""
                            using System.Diagnostics.CodeAnalysis;
 
-                           class C
+                           {{EnabledModifierCSharp}} class C
                            {
                                [Experimental("RSEXPERIMENTAL001")]
                                {{EnabledModifierCSharp}} bool DisableNullableAnalysis { {|{{AddNewApiId}}:get|}; }
@@ -3352,7 +3352,7 @@ C.C() -> void";
             var source = $$"""
                            using System.Diagnostics.CodeAnalysis;
 
-                           class C
+                           {{EnabledModifierCSharp}} class C
                            {
                                [Experimental("RSEXPERIMENTAL001")]
                                {{EnabledModifierCSharp}} abstract bool DisableNullableAnalysis { {|{{AddNewApiId}}:get|}; }

--- a/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
+++ b/src/PublicApiAnalyzers/UnitTests/DeclarePublicAPIAnalyzerTestsBase.cs
@@ -3295,6 +3295,106 @@ C.C() -> void";
             await test.RunAsync();
         }
 
+        [Fact]
+        [WorkItem(7195, "https://github.com/dotnet/roslyn-analyzers/issues/7195")]
+        public async Task TestExperimentalApiWithProperty()
+        {
+            var source = $$"""
+                           using System.Diagnostics.CodeAnalysis;
+
+                           class C
+                           {
+                               [Experimental("RSEXPERIMENTAL001")]
+                               {{EnabledModifierCSharp}} bool DisableNullableAnalysis { {|{{AddNewApiId}}:get|}; }
+                           }
+                           """;
+
+            const string shippedText = """
+                                       C
+                                       C.C() -> void
+                                       """;
+            const string fixedUnshippedText = """
+                                              [RSEXPERIMENTAL001]C.DisableNullableAnalysis.get -> bool
+                                              """;
+
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, DeclarePublicApiFix, XUnitVerifier>()
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+                CompilerDiagnostics = CompilerDiagnostics.None,
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles =
+                    {
+                        (ShippedFileName, shippedText),
+                        (UnshippedFileName, string.Empty),
+                    },
+                },
+                FixedState =
+                {
+                    AdditionalFiles =
+                    {
+                        (ShippedFileName, shippedText),
+                        (UnshippedFileName, fixedUnshippedText),
+                    },
+                },
+            };
+
+            test.DisabledDiagnostics.AddRange(DisabledDiagnostics);
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        [WorkItem(7195, "https://github.com/dotnet/roslyn-analyzers/issues/7195")]
+        public async Task TestExperimentalApiWithAbstractProperty()
+        {
+            var source = $$"""
+                           using System.Diagnostics.CodeAnalysis;
+
+                           class C
+                           {
+                               [Experimental("RSEXPERIMENTAL001")]
+                               {{EnabledModifierCSharp}} abstract bool DisableNullableAnalysis { {|{{AddNewApiId}}:get|}; }
+                           }
+                           """;
+
+            const string shippedText = """
+                                       C
+                                       C.C() -> void
+                                       """;
+            const string fixedUnshippedText = """
+                                              [RSEXPERIMENTAL001]abstract C.DisableNullableAnalysis.get -> bool
+                                              """;
+
+            var test = new CSharpCodeFixTest<DeclarePublicApiAnalyzer, DeclarePublicApiFix, XUnitVerifier>()
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+                CompilerDiagnostics = CompilerDiagnostics.None,
+                TestState =
+                {
+                    Sources = { source },
+                    AdditionalFiles =
+                    {
+                        (ShippedFileName, shippedText),
+                        (UnshippedFileName, string.Empty),
+                    },
+                },
+                FixedState =
+                {
+                    AdditionalFiles =
+                    {
+                        (ShippedFileName, shippedText),
+                        (UnshippedFileName, fixedUnshippedText),
+                    },
+                },
+            };
+
+            test.DisabledDiagnostics.AddRange(DisabledDiagnostics);
+
+            await test.RunAsync();
+        }
+
         #endregion
     }
 }

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -214,6 +214,7 @@ namespace Analyzer.Utilities
         public const string SystemDecimal = "System.Decimal";
         public const string SystemDiagnosticContractsContract = "System.Diagnostics.Contracts.Contract";
         public const string SystemDiagnosticsCodeAnalysisConstantExpectedAttribute = "System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute";
+        public const string SystemDiagnosticsCodeAnalysisExperimentalAttribute = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
         public const string SystemDiagnosticsCodeAnalysisNotNullAttribute = "System.Diagnostics.CodeAnalysis.NotNullAttribute";
         public const string SystemDiagnosticsCodeAnalysisNotNullIfNotNullAttribute = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
         public const string SystemDiagnosticsCodeAnalysisStringSyntaxAttributeName = "System.Diagnostics.CodeAnalysis.StringSyntaxAttribute";


### PR DESCRIPTION
Affected analyzer: DeclarePublicApiAnalyzer
Affected diagnostic IDs: RS0016 and RS0051

This PR ensures the diagnostic ID of the `ExperimentalAttribute` is included in the API definition for properties.

Fixes #7195