### PR TITLE
Remove unnecessary install .NET task

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -97,9 +97,6 @@ stages:
       - name: Codeql.TSAEnabled
         value: true
       steps:
-        - task: UseDotNet@2
-          inputs:
-            useGlobalJson: true
         - task: CodeQL3000Init@0
           displayName: CodeQL Initialize
         - script: eng\common\cibuild.cmd


### PR DESCRIPTION
The task is not part of the other build steps.

Fixes CodeQL step broken in official builds since https://github.com/dotnet/roslyn-analyzers/pull/7096. Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2397941&view=results