### PR TITLE
CA2263: Fix wrong fix for notnull constraints and fix crash on unbound generic types

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloads.cs
@@ -68,9 +68,11 @@ namespace Microsoft.NetCore.Analyzers.Usage
             //   3. It is not the same as the containing symbol containing the original invocation
             //      This is to prevent cases where the generic method forwards to a non generic one, e.g. Foo<T>() calls Foo(typeof(T)).
             //      Without this condition we would create an infinite loop as we would replace Foo(typeof(T)) with Foo<T>().
-            //   4. The return type is assignable to the original return type. We do not check the return type for expression statements.
-            //   5. All other arguments of the original invocation are assignable to the parameters of the method.
-            //   6. Speculative binding of the new invocation succeeds; this is to check if any type parameter constraints are violated.
+            //   4. No nullability generic constraint is violated.
+            //      We must explicitly check for this, and not rely on the speculative binding later, since it will still succeed even if a notnull constraint is violated.
+            //   5. The return type is assignable to the original return type. We do not check the return type for expression statements.
+            //   6. All other arguments of the original invocation are assignable to the parameters of the method.
+            //   7. Speculative binding of the new invocation succeeds; this is to check if any type parameter constraints are violated.
             bool IsApplicableGenericOverload(IMethodSymbol method)
             {
                 // Reduce method if original method was reduced.
@@ -88,7 +90,8 @@ namespace Microsoft.NetCore.Analyzers.Usage
 
                 var genericMethod = method.Construct(invocationContext.TypeArguments.ToArray());
 
-                if (!invocationContext.IsReturnTypeCompatible(genericMethod, context.Compilation) ||
+                if (AreNullabilityConstraintsViolated(method) ||
+                    !invocationContext.IsReturnTypeCompatible(genericMethod, context.Compilation) ||
                     !invocationContext.AreOtherArgumentsCompatible(genericMethod, context.Compilation) ||
                     !TryGetModifiedInvocationSyntax(invocationContext, out var modifiedInvocationSyntax))
                 {
@@ -116,6 +119,20 @@ namespace Microsoft.NetCore.Analyzers.Usage
                 // This prevents cases where we bind to a overload that was ruled out before (e.g. it is the same as the containing symbol).
                 return SymbolEqualityComparer.Default.Equals(boundMethod, genericMethod)
                     && SymbolEqualityComparer.Default.Equals(boundMethod.ReturnType, genericMethod.ReturnType);
+
+                static bool AreNullabilityConstraintsViolated(IMethodSymbol method)
+                {
+                    for (int i = 0; i < method.TypeParameters.Length; i++)
+                    {
+                        if (method.TypeParameters[i].HasNotNullConstraint &&
+                            method.TypeArguments[i].CanHoldNullValue())
+                        {
+                            return true;
+            }
+        }
+
+                    return false;
+                }
             }
         }
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloads.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloads.cs
@@ -128,8 +128,8 @@ namespace Microsoft.NetCore.Analyzers.Usage
                             method.TypeArguments[i].CanHoldNullValue())
                         {
                             return true;
-            }
-        }
+                        }
+                    }
 
                     return false;
                 }
@@ -169,6 +169,13 @@ namespace Microsoft.NetCore.Analyzers.Usage
                     .Select(t => t.TypeOperand)
                     .Where(t => t is not INamedTypeSymbol { IsUnboundGenericType: true })
                     .ToImmutableArray();
+
+                // Bail out if there are no type arguments left after filtering out unbound generic types.
+                if (typeArguments.Length == 0)
+                {
+                    return false;
+                }
+
                 var otherArguments = argumentsInParameterOrder.RemoveRange(typeOfArguments);
 
                 invocationContext = new RuntimeTypeInvocationContext(invocation, typeArguments, otherArguments);

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloadsTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
+using Test.Utilities;
 using Xunit;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
     Microsoft.NetCore.CSharp.Analyzers.Usage.CSharpPreferGenericOverloadsAnalyzer,
@@ -476,6 +477,62 @@ namespace Microsoft.NetCore.Analyzers.Usage.UnitTests
                 """;
 
             await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+        }
+
+        [Fact, WorkItem(7245, "https://github.com/dotnet/roslyn-analyzers/issues/7245")]
+        public async Task ViolatesNullabilityConstraint_NoDiagnostic_CS()
+        {
+            string source = """
+                #nullable enable
+
+                class C
+                {
+                    void M(System.Type type) {}
+                    void M<T>() where T : notnull {}
+
+                    void Test<T>()
+                    {
+                        M(typeof(T));
+                    }
+                }
+                """;
+
+            var test = new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9
+            };
+
+            await test.RunAsync();
+        }
+
+        [Fact, WorkItem(7245, "https://github.com/dotnet/roslyn-analyzers/issues/7245")]
+        public async Task ViolatesNullabilityConstraintNullableDisabled_NoDiagnostic_CS()
+        {
+            string source = """
+                #nullable disable
+
+                class C
+                {
+                    void M(System.Type type) {}
+                    void M<T>() where T : notnull {}
+
+                    void Test<T>()
+                    {
+                        M(typeof(T));
+                    }
+                }
+                """;
+
+            var test = new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = source,
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp9
+            };
+
+            await test.RunAsync();
         }
 
         [Fact]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloadsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Usage/PreferGenericOverloadsTests.cs
@@ -93,6 +93,28 @@ namespace Microsoft.NetCore.Analyzers.Usage.UnitTests
             await VerifyCS.VerifyCodeFixAsync(source, source);
         }
 
+        [Fact, WorkItem(7246, "https://github.com/dotnet/roslyn-analyzers/issues/7246")]
+        public async Task UnboundGenericTypeArgumentWithMatchingOtherArguments_NoDiagnostic_CS()
+        {
+            string source = """
+                class ViolatingType<T> {}
+
+                class C
+                {
+                    void M(System.Type type, object other) {}
+                    void M<T>() {}
+                    void M(object other) {}
+
+                    void Test()
+                    {
+                        M(typeof(ViolatingType<>), null);
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
+
         [Fact]
         public async Task WrongArity_NoDiagnostic_CS()
         {
@@ -1453,6 +1475,26 @@ namespace Microsoft.NetCore.Analyzers.Usage.UnitTests
                 Class C
                     Sub M(type as System.Type) : End Sub
                     Sub M(Of T)() : End Sub
+
+                    Sub Test()
+                        M(GetType(ViolatingType(Of )))
+                    End Sub
+                End Class
+                """;
+
+            await VerifyVB.VerifyCodeFixAsync(source, source);
+        }
+
+        [Fact, WorkItem(7246, "https://github.com/dotnet/roslyn-analyzers/issues/7246")]
+        public async Task UnboundGenericTypeArgumentWithMatchingOtherArguments_NoDiagnostic_VB()
+        {
+            string source = """
+                Class ViolatingType(Of T) : End Class
+                
+                Class C
+                    Sub M(type as System.Type, other as Object) : End Sub
+                    Sub M(Of T)() : End Sub
+                    Sub M(other as Object) : End Sub
 
                     Sub Test()
                         M(GetType(ViolatingType(Of )))


### PR DESCRIPTION
Fixes #7245 and fixes #7246.