### PR TITLE
Update to Microsoft.CodeAnalysis.Testing 1.1.2-beta1.24168.2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -83,7 +83,7 @@
     <MicrosoftCodeAnalysisTestResourcesProprietaryVersion>2.0.0-pre-20160714</MicrosoftCodeAnalysisTestResourcesProprietaryVersion>
     <MicrosoftVisualStudioThreadingAnalyzersVersion>17.0.26-alpha</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <!-- Roslyn Testing -->
-    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23509.1</MicrosoftCodeAnalysisTestingVersion>
+    <MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.24168.2</MicrosoftCodeAnalysisTestingVersion>
     <!-- Libs -->
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>


### PR DESCRIPTION
Adds `ReferenceAssemblies.Net.Net90` needed for a few tests in https://github.com/dotnet/roslyn-analyzers/pull/6967.