### PR TITLE
Add CollectionExpression support to CA1870 (UseSearchValues)

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.Fixer.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.Fixer.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/src/Utilities/Compiler/Analyzer.Utilities.projitems
+++ b/src/Utilities/Compiler/Analyzer.Utilities.projitems
@@ -66,6 +66,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WellKnownDiagnosticTagsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Index.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IsExternalInit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Lightup\ICollectionExpressionOperationWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\IOperationWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\IFunctionPointerInvocationOperationWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lightup\IUtf8StringOperationWrapper.cs" />

--- a/src/Utilities/Compiler/Lightup/ICollectionExpressionOperationWrapper.cs
+++ b/src/Utilities/Compiler/Lightup/ICollectionExpressionOperationWrapper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+#if HAS_IOPERATION
+
+namespace Analyzer.Utilities.Lightup
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.CodeAnalysis;
+
+    [SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Not a comparable instance.")]
+    internal readonly struct ICollectionExpressionOperationWrapper : IOperationWrapper
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.ICollectionExpressionOperation";
+        private static readonly Type? WrappedType = OperationWrapperHelper.GetWrappedType(typeof(ICollectionExpressionOperationWrapper));
+
+        private static readonly Func<IOperation, ImmutableArray<IOperation>> ElementsAccessor = LightupHelpers.CreateOperationPropertyAccessor<IOperation, ImmutableArray<IOperation>>(WrappedType, nameof(Elements), fallbackResult: default);
+
+        private ICollectionExpressionOperationWrapper(IOperation operation)
+        {
+            WrappedOperation = operation;
+        }
+
+        public IOperation WrappedOperation { get; }
+        public ITypeSymbol? Type => WrappedOperation.Type;
+        public ImmutableArray<IOperation> Elements => ElementsAccessor(WrappedOperation);
+
+        public static ICollectionExpressionOperationWrapper FromOperation(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return default;
+            }
+
+            if (!IsInstance(operation))
+            {
+                throw new InvalidCastException($"Cannot cast '{operation.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new ICollectionExpressionOperationWrapper(operation);
+        }
+
+        public static bool IsInstance(IOperation operation)
+        {
+            return operation != null && LightupHelpers.CanWrapOperation(operation, WrappedType);
+        }
+    }
+}
+
+#endif

--- a/src/Utilities/Compiler/Lightup/OperationWrapperHelper.cs
+++ b/src/Utilities/Compiler/Lightup/OperationWrapperHelper.cs
@@ -15,7 +15,8 @@ namespace Analyzer.Utilities.Lightup
 
         private static readonly ImmutableDictionary<Type, Type?> WrappedTypes = ImmutableDictionary.Create<Type, Type?>()
             .Add(typeof(IFunctionPointerInvocationOperationWrapper), s_codeAnalysisAssembly.GetType(IFunctionPointerInvocationOperationWrapper.WrappedTypeName))
-            .Add(typeof(IUtf8StringOperationWrapper), s_codeAnalysisAssembly.GetType(IUtf8StringOperationWrapper.WrappedTypeName));
+            .Add(typeof(IUtf8StringOperationWrapper), s_codeAnalysisAssembly.GetType(IUtf8StringOperationWrapper.WrappedTypeName))
+            .Add(typeof(ICollectionExpressionOperationWrapper), s_codeAnalysisAssembly.GetType(ICollectionExpressionOperationWrapper.WrappedTypeName));
 
         /// <summary>
         /// Gets the type that is wrapped by the given wrapper.


### PR DESCRIPTION
Followup after #6898 to add recognition for collection expression patterns as well.

Currently, if you write something like
```c#
private static readonly char[] s_chars = new[] { 'a', 'e', 'i', 'o', 'u', 'A' };
public static int Test(ReadOnlySpan<char> s) => s.IndexOfAny(s_chars);
```

you will be offered two fixers: one to replace `s_chars` with `SearchValues.Create("aeiouA")`, and the other to replace the array creation with `['a', 'e', 'i', 'o', 'u', 'A']`.
If you accept the latter, you won't be offered the `SearchValues` fixer anymore since we don't recognize the pattern.

This PR adds recognition for patterns like
```c#
static readonly char[] s_chars = ['a', 'e', 'i', 'o', 'u', 'A'];

text.IndexOfAny(['a', 'e', 'i', 'o', 'u', 'A']);
text.IndexOfAny([(byte)'a', (byte)'e', (byte)'i', (byte)'o', (byte)'u', (byte)'A']);
text.IndexOfAny(s_chars);
```