### PR TITLE
Improve support for RefKind.RefReadOnlyParameter in RS0042 (Do not copy value)

### DIFF
--- a/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/AbstractDoNotCopyValue.cs
@@ -1350,9 +1350,8 @@ namespace Roslyn.Diagnostics.Analyzers
                 return (sourceRefKind, targetRefKind) switch
                 {
                     (RefKind.None, _) => true,
-                    (RefKind.Ref, RefKind.Ref) => true,
-                    (RefKind.Ref, RefKind.RefReadOnly or RefKindEx.RefReadOnlyParameter) => true,
-                    (RefKind.RefReadOnly, RefKind.RefReadOnly or RefKindEx.RefReadOnlyParameter) => true,
+                    (RefKind.Ref, RefKind.Ref or RefKind.RefReadOnly or RefKindEx.RefReadOnlyParameter) => true,
+                    (RefKind.RefReadOnly or RefKindEx.RefReadOnlyParameter, RefKind.RefReadOnly or RefKindEx.RefReadOnlyParameter) => true,
                     _ => false,
                 };
             }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotCopyValueTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/DoNotCopyValueTests.cs
@@ -1052,7 +1052,7 @@ internal sealed class NonCopyableAttribute : System.Attribute {{ }}
         [Theory]
         [CombinatorialData]
         public async Task AllowUnsafeAsRefParameterReference2Async(
-            [CombinatorialValues("ref", "in")] string parameterModifiers,
+            [CombinatorialValues("ref", "in", "ref readonly")] string parameterModifiers,
             [CombinatorialValues("in", "scoped in", "ref readonly", "scoped ref readonly")] string asRefParameterModifiers)
         {
             var source = $@"


### PR DESCRIPTION
Related to #7128
