### PR TITLE
Remove CodeQL tasks duplicating injected ones

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -108,11 +108,8 @@ extends:
         - name: Codeql.TSAEnabled
           value: true
         steps:
-        - task: CodeQL3000Init@0
-          displayName: CodeQL Initialize
         - script: eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false
           displayName: Windows Build
-        - task: CodeQL3000Finalize@0
     - template: eng/common/templates-official/post-build/post-build.yml
       parameters:
         publishingInfraVersion: 3


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn-analyzers/pull/7253.

Currently official builds are getting stuck on CodeQL step: https://dnceng.visualstudio.com/internal/_build/results?buildId=2414766&view=results (interestingly, test run of https://github.com/dotnet/roslyn-analyzers/pull/7253 didn't get stuck, not sure why)
Test run of an official build of this PR: https://dnceng.visualstudio.com/internal/_build/results?buildId=2414884&view=results
This is like a change done in roslyn-sdk to resolve the same problem: https://github.com/dotnet/roslyn-sdk/pull/1152/commits/816cd02d2f99bde68614c6d833291b1a1fbbdff3