### PR TITLE
Check for the CollectionExpression syntax kind early in UseSearchValuesAnalyzer

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
@@ -90,6 +90,8 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
         // ConstString.ToCharArray()
         internal static bool IsConstantByteOrCharArrayCreationExpression(SemanticModel semanticModel, ExpressionSyntax expression, List<char>? values, out int length)
         {
+            const SyntaxKind CollectionExpressionSyntaxKind = (SyntaxKind)9076;
+
             length = 0;
 
             InitializerExpressionSyntax? arrayInitializer = null;
@@ -112,7 +114,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     return true;
                 }
             }
-            else
+            else if (expression.IsKind(CollectionExpressionSyntaxKind))
             {
                 return
                     semanticModel.GetOperation(expression) is { } operation &&

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
@@ -14,6 +14,12 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpUseSearchValuesAnalyzer : UseSearchValuesAnalyzer
     {
+        // The referenced SDK version doesn't yet contain these SyntaxKind values
+        // https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+        private const SyntaxKind Utf8StringLiteralToken = (SyntaxKind)8520;
+        private const SyntaxKind Utf8StringLiteralExpression = (SyntaxKind)8756;
+        private const SyntaxKind CollectionExpression = (SyntaxKind)9076;
+
         // char[] myField = new char[] { 'a', 'b', 'c' };
         // char[] myField = new[] { 'a', 'b', 'c' };
         // char[] myField = "abc".ToCharArray();
@@ -90,8 +96,6 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
         // ConstString.ToCharArray()
         internal static bool IsConstantByteOrCharArrayCreationExpression(SemanticModel semanticModel, ExpressionSyntax expression, List<char>? values, out int length)
         {
-            const SyntaxKind CollectionExpressionSyntaxKind = (SyntaxKind)9076;
-
             length = 0;
 
             InitializerExpressionSyntax? arrayInitializer = null;
@@ -114,7 +118,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     return true;
                 }
             }
-            else if (expression.IsKind(CollectionExpressionSyntaxKind))
+            else if (expression.IsKind(CollectionExpression))
             {
                 return
                     semanticModel.GetOperation(expression) is { } operation &&
@@ -167,9 +171,6 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
 
         private static bool IsUtf8StringLiteralExpression(ExpressionSyntax expression, out int length)
         {
-            const SyntaxKind Utf8StringLiteralExpression = (SyntaxKind)8756;
-            const SyntaxKind Utf8StringLiteralToken = (SyntaxKind)8520;
-
             if (expression.IsKind(Utf8StringLiteralExpression) &&
                 expression is LiteralExpressionSyntax literal &&
                 literal.Token.IsKind(Utf8StringLiteralToken) &&

--- a/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
+++ b/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Analyzer.Utilities.Lightup;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,12 +15,6 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpUseSearchValuesAnalyzer : UseSearchValuesAnalyzer
     {
-        // The referenced SDK version doesn't yet contain these SyntaxKind values
-        // https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
-        private const SyntaxKind Utf8StringLiteralToken = (SyntaxKind)8520;
-        private const SyntaxKind Utf8StringLiteralExpression = (SyntaxKind)8756;
-        private const SyntaxKind CollectionExpression = (SyntaxKind)9076;
-
         // char[] myField = new char[] { 'a', 'b', 'c' };
         // char[] myField = new[] { 'a', 'b', 'c' };
         // char[] myField = "abc".ToCharArray();
@@ -118,7 +113,7 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
                     return true;
                 }
             }
-            else if (expression.IsKind(CollectionExpression))
+            else if (expression.IsKind(SyntaxKindEx.CollectionExpression))
             {
                 return
                     semanticModel.GetOperation(expression) is { } operation &&
@@ -171,9 +166,9 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Performance
 
         private static bool IsUtf8StringLiteralExpression(ExpressionSyntax expression, out int length)
         {
-            if (expression.IsKind(Utf8StringLiteralExpression) &&
+            if (expression.IsKind(SyntaxKindEx.Utf8StringLiteralExpression) &&
                 expression is LiteralExpressionSyntax literal &&
-                literal.Token.IsKind(Utf8StringLiteralToken) &&
+                literal.Token.IsKind(SyntaxKindEx.Utf8StringLiteralToken) &&
                 literal.Token.Value is string value)
             {
                 length = value.Length;

--- a/src/Utilities/Compiler.CSharp/Analyzer.CSharp.Utilities.projitems
+++ b/src/Utilities/Compiler.CSharp/Analyzer.CSharp.Utilities.projitems
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SyntaxNodeExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Lightup\SyntaxKindEx.cs" />
   </ItemGroup>
 </Project>

--- a/src/Utilities/Compiler.CSharp/Lightup/SyntaxKindEx.cs
+++ b/src/Utilities/Compiler.CSharp/Lightup/SyntaxKindEx.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Analyzer.Utilities.Lightup
+{
+    internal static class SyntaxKindEx
+    {
+        // https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+        public const SyntaxKind Utf8StringLiteralToken = (SyntaxKind)8520;
+        public const SyntaxKind Utf8StringLiteralExpression = (SyntaxKind)8756;
+        public const SyntaxKind CollectionExpression = (SyntaxKind)9076;
+    }
+}


### PR DESCRIPTION
This appears to "resolve" the issue hit in https://github.com/dotnet/runtime/pull/100520 (failures after ingesting #7252)

The issue appears to be that this else block
https://github.com/dotnet/roslyn-analyzers/blob/e4d7ea6a967631713630cb1cf02efa7dfc35a8aa/src/NetAnalyzers/CSharp/Microsoft.NetCore.Analyzers/Performance/CSharpUseSearchValues.cs#L115-L120
is now being called with the [`@"\/"u8` expression](https://github.com/dotnet/runtime/blob/7def0b725852d55741262f43ed36ed501606f89f/src/libraries/Common/src/System/IO/PathInternal.Windows.cs#L58C71-L58C78).

While this condition will return `false` during the `IsConstantByteOrCharCollectionExpression` check, `semanticModel.GetOperation(expression)` intermittently fails when building `System.Formats.Tar` (consistently succeeds every second build ?!?).

Filtering out the expression kind before the call to `semanticModel.GetOperation` appears to "fix" the issue, but I don't understand why `GetOperation` would be failing like this in the first place 😕
We already have analyzer tests for this pattern (property returning utf8 string literals) that are perfectly happy with the current code, so this appears to be something specific to runtime code somehow.

The failing call stack from https://github.com/dotnet/runtime/pull/100520:
```
SyntaxTree: C:\MihaZupan\runtime\src\libraries\System.Formats.Tar\src\System\Formats\Tar\TarHeader.Write.cs
SyntaxNode: pathNameBytes.LastIndexOfAny(PathInternal ... [InvocationExpressionSyntax]@[30810..30876) (554,26)-(554,92)
System.ArgumentException: Syntax node is not within syntax tree
at Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.CheckSyntaxNode(CSharpSyntaxNode syntax)
at Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.GetOperationCore(SyntaxNode node, CancellationToken cancellationToken)
at Microsoft.NetCore.CSharp.Analyzers.Performance.CSharpUseSearchValuesAnalyzer.IsConstantByteOrCharArrayCreationExpression(SemanticModel semanticModel, ExpressionSyntax expression, List`1 values, Int32& length)
```