### PR TITLE
Stop publishing of additional packages

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -3,11 +3,4 @@
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ItemsToPushToBlobFeed Include="$(ArtifactsPackagesDir)Release\*.nupkg"
-                           IsShipping="true"
-                           UploadPathSegment="Roslyn-analyzers"
-                           Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4204

In the past we've required additional packages to be published to VMR location, during source-build. This was carried over with recent publishing work that modified VMR build to use regular arcade publishing infra - https://github.com/dotnet/source-build/issues/4204

With new changes in https://github.com/dotnet/installer/pull/19343 this is not needed anymore.