### PR TITLE
Avoid direct descriptor comparison, so the fix can be shown

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                 {
                     switch (rule)
                     {
-                        case nameof(CompareSymbolsCorrectlyAnalyzer.EqualityRule):
+                        case CompareSymbolsCorrectlyAnalyzer.EqualityRuleName:
                             context.RegisterCodeFix(
                                 CodeAction.Create(
                                     CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
                                     equivalenceKey: nameof(CompareSymbolsCorrectlyFix)),
                                 diagnostic);
                             break;
-                        case nameof(CompareSymbolsCorrectlyAnalyzer.CollectionRule):
+                        case CompareSymbolsCorrectlyAnalyzer.CollectionRuleName:
                             context.RegisterCodeFix(
                                 CodeAction.Create(
                                     CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/Fixers/CompareSymbolsCorrectlyFix.cs
@@ -32,23 +32,27 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.Fixers
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (diagnostic.Descriptor == CompareSymbolsCorrectlyAnalyzer.EqualityRule)
+                if (diagnostic.Properties.TryGetValue(CompareSymbolsCorrectlyAnalyzer.RulePropertyName, out var rule))
                 {
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,
-                            cancellationToken => ConvertToEqualsAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
-                            equivalenceKey: nameof(CompareSymbolsCorrectlyFix)),
-                        diagnostic);
-                }
-                else if (diagnostic.Descriptor == CompareSymbolsCorrectlyAnalyzer.CollectionRule)
-                {
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,
-                            cancellationToken => CallOverloadWithEqualityComparerAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
-                            equivalenceKey: nameof(CompareSymbolsCorrectlyFix)),
-                        diagnostic);
+                    switch (rule)
+                    {
+                        case nameof(CompareSymbolsCorrectlyAnalyzer.EqualityRule):
+                            context.RegisterCodeFix(
+                                CodeAction.Create(
+                                    CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,
+                                    cancellationToken => ConvertToEqualsAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
+                                    equivalenceKey: nameof(CompareSymbolsCorrectlyFix)),
+                                diagnostic);
+                            break;
+                        case nameof(CompareSymbolsCorrectlyAnalyzer.CollectionRule):
+                            context.RegisterCodeFix(
+                                CodeAction.Create(
+                                    CodeAnalysisDiagnosticsResources.CompareSymbolsCorrectlyCodeFix,
+                                    cancellationToken => CallOverloadWithEqualityComparerAsync(context.Document, diagnostic.Location.SourceSpan, cancellationToken),
+                                    equivalenceKey: nameof(CompareSymbolsCorrectlyFix)),
+                                diagnostic);
+                            break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn-analyzers/issues/4539

It turned out that despite `DiagnosticDescriptor` class is fully equatable, it isn't safe to compare instances in a codefix due to localized strings. For whatever reason all localizable strings in `diagnostic.Descriptor` are fixed strings while singleton descriptor instances in tha analyzer contain localizable resource strings, so the comparison could never succeed and thus fixes were not shown. I guess, this might be due to serialization-deserialization between devenv and roslyn OOP. To avoid that I made it so that diagnostics are now identified via `Rule` property, which is correctly passed between analyzer and a codefix provider. I've made a local setup where I verified, that this actually resolves the problem and the fix is finally shown. I don't really like the proposed fix, but that is a story for another PR)