### PR TITLE
Prevent SemaphoreSlim.Wait(0) from triggering CA1849

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -5,6 +5,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;
@@ -83,6 +85,20 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return;
                 }
 
+                INamedTypeSymbol? semaphoreSlimType = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemThreadingSemaphoreSlim);
+                INamedTypeSymbol? timeSpanType = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemTimeSpan);
+                INamedTypeSymbol intType = context.Compilation.GetSpecialType(SpecialType.System_Int32);
+                IFieldSymbol? timeSpanZero = timeSpanType?.GetMembers(nameof(TimeSpan.Zero))
+                    .OfType<IFieldSymbol>()
+                    .FirstOrDefault();
+                ISet<IMethodSymbol> semaphoreSlimWaitMethods = semaphoreSlimType
+                    ?.GetMembers(nameof(SemaphoreSlim.Wait))
+                    .OfType<IMethodSymbol>()
+                    .Where(m => m.Parameters.Length > 0
+                                && (SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, intType)
+                                    || SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, timeSpanType)))
+                    .ToSet() ?? ImmutableHashSet<IMethodSymbol>.Empty;
+
                 ImmutableArray<IMethodSymbol> excludedMethods = GetExcludedMethods(wellKnownTypeProvider);
                 context.RegisterOperationAction(context =>
                 {
@@ -91,7 +107,9 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         if (context.Operation is IInvocationOperation invocationOperation)
                         {
                             var methodSymbol = invocationOperation.TargetMethod;
-                            if (excludedMethods.Contains(methodSymbol.OriginalDefinition, SymbolEqualityComparer.Default) || InspectAndReportBlockingMemberAccess(context, methodSymbol, syncBlockingSymbols, SymbolKind.Method))
+                            if (excludedMethods.Contains(methodSymbol.OriginalDefinition, SymbolEqualityComparer.Default)
+                                || InspectAndReportBlockingMemberAccess(context, methodSymbol, syncBlockingSymbols, SymbolKind.Method)
+                                || IsSemaphoreSlimWaitWithZeroArgumentInvocation(invocationOperation, timeSpanZero, semaphoreSlimWaitMethods))
                             {
                                 // Don't return double-diagnostics.
                                 return;
@@ -146,6 +164,21 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     }
                 }, OperationKind.Invocation, OperationKind.PropertyReference);
             });
+        }
+
+        private static bool IsSemaphoreSlimWaitWithZeroArgumentInvocation(IInvocationOperation invocation, IFieldSymbol? timeSpanZero, ISet<IMethodSymbol> semaphoreSlimWaitMethods)
+        {
+            if(!semaphoreSlimWaitMethods.Contains(invocation.TargetMethod, SymbolEqualityComparer.Default) || invocation.Arguments.IsEmpty)
+            {
+                return false;
+            }
+
+            IOperation argumentValue = invocation.Arguments[0].Value;
+
+            return argumentValue.HasConstantValue(0)
+                   || timeSpanZero is not null
+                   && argumentValue is IFieldReferenceOperation fieldReference
+                   && SymbolEqualityComparer.Default.Equals(fieldReference.Field, timeSpanZero);
         }
 
         private static SymbolDisplayFormat GetLanguageSpecificFormat(IOperation operation) =>

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Analyzer.Utilities;
@@ -171,6 +172,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             {
                 return false;
             }
+
+            Debug.Assert(!invocation.Arguments.IsEmpty);
 
             IOperation argumentValue = invocation.Arguments[0].Value;
 

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -167,7 +167,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
         private static bool IsSemaphoreSlimWaitWithZeroArgumentInvocation(IInvocationOperation invocation, IFieldSymbol? timeSpanZero, ISet<IMethodSymbol> semaphoreSlimWaitMethods)
         {
-            if(!semaphoreSlimWaitMethods.Contains(invocation.TargetMethod, SymbolEqualityComparer.Default) || invocation.Arguments.IsEmpty)
+            if (!semaphoreSlimWaitMethods.Contains(invocation.TargetMethod, SymbolEqualityComparer.Default) || invocation.Arguments.IsEmpty)
             {
                 return false;
             }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Analyzer.Utilities;

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContext.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Microsoft.CodeAnalysis;

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1343,6 +1343,218 @@ class Test {
             return VerifyCS.VerifyAnalyzerAsync(code);
         }
 
+        [Fact, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        public Task WhenPassingZeroToSemaphoreSlimWait_NoDiagnostic()
+        {
+            const string code = """
+                                using System;
+                                using System.Threading;
+                                using System.Threading.Tasks;
+
+                                class Test
+                                {
+                                    async Task M()
+                                    {
+                                        SemaphoreSlim s = new SemaphoreSlim(0);
+                                        s.Wait(0);
+                                    }
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        public Task WhenPassingZeroWithCancellationTokenToSemaphoreSlimWait_NoDiagnostic()
+        {
+            const string code = """
+                                using System;
+                                using System.Threading;
+                                using System.Threading.Tasks;
+
+                                class Test
+                                {
+                                    async Task M()
+                                    {
+                                        SemaphoreSlim s = new SemaphoreSlim(0);
+                                        s.Wait(0, CancellationToken.None);
+                                    }
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        public Task WhenPassingTimeSpanZeroToSemaphoreSlimWait_NoDiagnostic()
+        {
+            const string code = """
+                                using System;
+                                using System.Threading;
+                                using System.Threading.Tasks;
+
+                                class Test
+                                {
+                                    async Task M()
+                                    {
+                                        SemaphoreSlim s = new SemaphoreSlim(0);
+                                        s.Wait(TimeSpan.Zero);
+                                    }
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        public Task WhenPassingTimeSpanZeroWithCancellationTokenToSemaphoreSlimWait_NoDiagnostic()
+        {
+            const string code = """
+                                using System;
+                                using System.Threading;
+                                using System.Threading.Tasks;
+
+                                class Test
+                                {
+                                    async Task M()
+                                    {
+                                        SemaphoreSlim s = new SemaphoreSlim(0);
+                                        s.Wait(TimeSpan.Zero, CancellationToken.None);
+                                    }
+                                }
+                                """;
+
+            return VerifyCS.VerifyAnalyzerAsync(code);
+        }
+
+        [Theory, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        [InlineData("1")]
+        [InlineData("500")]
+        public Task WhenPassingNonZeroToSemaphoreSlimWait_Diagnostic(string nonZero)
+        {
+            var code = $$"""
+                         using System;
+                         using System.Threading;
+                         using System.Threading.Tasks;
+
+                         class Test
+                         {
+                             async Task M()
+                             {
+                                 SemaphoreSlim s = new SemaphoreSlim(0);
+                                 {|#0:s.Wait({{nonZero}})|};
+                             }
+                         }
+                         """;
+            var result = new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor)
+                .WithLocation(0)
+                .WithArguments("SemaphoreSlim.Wait(int)", "SemaphoreSlim.WaitAsync()");
+
+            return VerifyCS.VerifyAnalyzerAsync(code, result);
+        }
+
+        [Theory, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        [InlineData("1")]
+        [InlineData("500")]
+        public Task WhenPassingNonZeroWithCancellationTokenToSemaphoreSlimWait_Diagnostic(string nonZero)
+        {
+            var code = $$"""
+                         using System;
+                         using System.Threading;
+                         using System.Threading.Tasks;
+
+                         class Test
+                         {
+                             async Task M()
+                             {
+                                 SemaphoreSlim s = new SemaphoreSlim(0);
+                                 {|#0:s.Wait({{nonZero}}, CancellationToken.None)|};
+                             }
+                         }
+                         """;
+            var result = new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor)
+                .WithLocation(0)
+                .WithArguments("SemaphoreSlim.Wait(int, CancellationToken)", "SemaphoreSlim.WaitAsync()");
+
+            return VerifyCS.VerifyAnalyzerAsync(code, result);
+        }
+
+        [Theory, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        [InlineData("TimeSpan.FromSeconds(30)")]
+        [InlineData("TimeSpan.Parse(\"0:32:0\")")]
+        public Task WhenPassingNonZeroTimeSpanToSemaphoreSlimWait_Diagnostic(string nonZero)
+        {
+            var code = $$"""
+                         using System;
+                         using System.Threading;
+                         using System.Threading.Tasks;
+
+                         class Test
+                         {
+                             async Task M()
+                             {
+                                 SemaphoreSlim s = new SemaphoreSlim(0);
+                                 {|#0:s.Wait({{nonZero}})|};
+                             }
+                         }
+                         """;
+            var result = new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor)
+                .WithLocation(0)
+                .WithArguments("SemaphoreSlim.Wait(TimeSpan)", "SemaphoreSlim.WaitAsync()");
+
+            return VerifyCS.VerifyAnalyzerAsync(code, result);
+        }
+
+        [Theory, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        [InlineData("TimeSpan.FromSeconds(30)")]
+        [InlineData("TimeSpan.Parse(\"0:32:0\")")]
+        public Task WhenPassingNonZeroTimeSpanWithCancellationTokenToSemaphoreSlimWait_Diagnostic(string nonZero)
+        {
+            var code = $$"""
+                         using System;
+                         using System.Threading;
+                         using System.Threading.Tasks;
+
+                         class Test
+                         {
+                             async Task M()
+                             {
+                                 SemaphoreSlim s = new SemaphoreSlim(0);
+                                 {|#0:s.Wait({{nonZero}}, CancellationToken.None)|};
+                             }
+                         }
+                         """;
+            var result = new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor)
+                .WithLocation(0)
+                .WithArguments("SemaphoreSlim.Wait(TimeSpan, CancellationToken)", "SemaphoreSlim.WaitAsync()");
+
+            return VerifyCS.VerifyAnalyzerAsync(code, result);
+        }
+
+        [Fact, WorkItem(7271, "https://github.com/dotnet/roslyn-analyzers/issues/7271")]
+        public Task WhenPassingCancellationTokenToSemaphoreSlimWait_Diagnostic()
+        {
+            const string code = """
+                                using System;
+                                using System.Threading;
+                                using System.Threading.Tasks;
+
+                                class Test
+                                {
+                                    async Task M()
+                                    {
+                                        SemaphoreSlim s = new SemaphoreSlim(0);
+                                        {|#0:s.Wait(CancellationToken.None)|};
+                                    }
+                                }
+                                """;
+            var result = new DiagnosticResult(UseAsyncMethodInAsyncContext.Descriptor)
+                .WithLocation(0)
+                .WithArguments("SemaphoreSlim.Wait(CancellationToken)", "SemaphoreSlim.WaitAsync()");
+
+            return VerifyCS.VerifyAnalyzerAsync(code, result);
+        }
+
         private static async Task CreateCSTestAndRunAsync(string testCS)
         {
             var csTestVerify = new VerifyCS.Test

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -426,6 +426,7 @@ namespace Analyzer.Utilities
         public const string SystemThreadingCancellationToken = "System.Threading.CancellationToken";
         public const string SystemThreadingInterlocked = "System.Threading.Interlocked";
         public const string SystemThreadingMonitor = "System.Threading.Monitor";
+        public const string SystemThreadingSemaphoreSlim = "System.Threading.SemaphoreSlim";
         public const string SystemThreadingSpinLock = "System.Threading.SpinLock";
         public const string SystemThreadingTasksConfigureAwaitOptions = "System.Threading.Tasks.ConfigureAwaitOptions";
         public const string SystemThreadingTasksTaskAsyncEnumerableExtensions = "System.Threading.Tasks.TaskAsyncEnumerableExtensions";


### PR DESCRIPTION
Affected analyzer: UseAsyncMethodInAsyncContext
Affected diagnostic IDs: [CA1849](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1849)

This PR suppresses CA1849 for calls to `SemaphoreSlim.Wait(0)`, `SemaphoreSlim.Wait(0, CancellationToken)`, `SemaphoreSlim.Wait(TimeSpan.Zero)` and `SemaphoreSlim.Wait(TimeSpan.Zero, CancellationToken)`.

Fixes #7271