### PR TITLE
Monthly run of the CI build to make sure all rel branches are buildable

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -13,7 +13,7 @@ trigger:
 - 2.9.x
 
 schedules:
-  - cron: "0 8 22-28 * 0"
+  - cron: "0 8 23-29 * 0"
     displayName: "Monthly smoke test"
     branches:
       include: 

--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -12,6 +12,18 @@ trigger:
 - features/*
 - 2.9.x
 
+schedules:
+  - cron: "0 8 22-28 * 0"
+    displayName: "Monthly smoke test"
+    branches:
+      include: 
+        - main
+        - release/*
+      exclude: 
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
 variables:
 - name: TeamName
   value: Roslyn


### PR DESCRIPTION
Adding a monthly run of the CI build to make sure all rel branches are buildable