### PR TITLE
Don't raise CA1849 when async version has fewer parameters

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/UseAsyncMethodInAsyncContextTests.cs
@@ -1343,6 +1343,33 @@ class Test {
             return VerifyCS.VerifyAnalyzerAsync(code);
         }
 
+        [Theory]
+        [InlineData("string s", "")]
+        [InlineData("string s", "bool b")]
+        [InlineData("string s", "bool b = true")]
+        [WorkItem(7289, "https://github.com/dotnet/roslyn-analyzers/issues/7289")]
+        public Task WhenAsyncVersionHasFewerParameters_NoDiagnostic(string syncParameters, string asyncParameters)
+        {
+            var code = $$"""
+                       using System.Threading.Tasks;
+
+                       class Test
+                       {
+                           private void Run({{syncParameters}}) { }
+                           private Task RunAsync({{asyncParameters}}) => Task.CompletedTask;
+                       
+                           private async Task ReproAsync()
+                           {
+                               await Task.Yield();
+                       
+                               Run("");
+                           }
+                       }
+                       """;
+
+            return CreateCSTestAndRunAsync(code);
+        }
+
         private static async Task CreateCSTestAndRunAsync(string testCS)
         {
             var csTestVerify = new VerifyCS.Test


### PR DESCRIPTION
Affected analyzer: UseAsyncMethodInAsyncContext
Affected diagnostic ID: [CA1849](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1849)

This PR prevents CA1849 being raised when the async alternative has fewer parameters than the sync method.
