### PR TITLE
Do not warn when invoking APIs that has SupportedOSPlatformGuard attribute

### DIFF
--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -2,7 +2,5 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-CA1871 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1871> | Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull' |
 CA2022 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2022> | Avoid inexact read with 'Stream.Read' |
-CA2264 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2264> | Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull' |
 CA2265 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265> | Do not compare Span\<T> to 'null' or 'default' |

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -4,3 +4,4 @@ Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA2022 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2022> | Avoid inexact read with 'Stream.Read' |
 CA2265 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265> | Do not compare Span\<T> to 'null' or 'default' |
+CA5360 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5360> | Do Not Call Dangerous Methods In Deserialization |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -1223,9 +1223,15 @@ public class Test
             string csDependencyCode = @"
 public class Library
 {
+    static bool s_isWindowsOrLinux = false;
+
     [System.Runtime.Versioning.SupportedOSPlatformGuard(""windows"")]
     [System.Runtime.Versioning.SupportedOSPlatformGuard(""linux"")]
-    public static bool IsSupported => false;
+    public static bool IsSupported => s_isWindowsOrLinux;
+
+    [System.Runtime.Versioning.UnsupportedOSPlatformGuard(""windows"")]
+    [System.Runtime.Versioning.UnsupportedOSPlatformGuard(""linux"")]
+    public static bool IsNotSupported => false;
 
     public static void AMethod() { }
 }";
@@ -1244,6 +1250,15 @@ public class Program
         if (Library.IsSupported)
         {
              Library.AMethod();
+        }
+
+        if (Library.IsNotSupported)
+        {
+             [|Library.AMethod()|]; // warn because guarded by unsupported
+        }
+        else
+        {
+             Library.AMethod(); // guarded
         }
     }
 }";
@@ -1275,7 +1290,7 @@ build_property.TargetFramework = net5
                         {
                             Sources =
                             {
-                                ("/PreviewAssembly/AssemblyInfo.g.cs", csDependencyCode)
+                                ("/PreviewAssembly/AssemblyInfo.cs", csDependencyCode)
                             },
                         },
                     },


### PR DESCRIPTION
### Do not warn when invoking Guard APIs that has SupportedOSPlatformGuard attribute

Fixes issue @ManickaP encountered on https://github.com/dotnet/runtime/compare/main...ManickaP:runtime:quic-platform-guard?expand=1

 Added unit test that reproes the issue

Repro:
```cs
[assembly: System.Runtime.Versioning.SupportedOSPlatform(""windows"")]
[assembly: System.Runtime.Versioning.SupportedOSPlatform(""linux"")]
[assembly: System.Runtime.Versioning.SupportedOSPlatform(""osx"")]

namespace System.Net.Quic;
public sealed partial class QuicConnection
{
    [SupportedOSPlatformGuard("windows")]
    [SupportedOSPlatformGuard("linux")]
    [SupportedOSPlatformGuard("osx")]
    public static bool IsSupported => false;
    ...
}
```
The Guard API used from another assembly, should not warn on `QuicConnection.IsSupported` invocation
```cs
namespace System.Net.Http;
internal sealed partial class HttpConnectionPool : IDisposable
{
    private async ValueTask<QuicConnection> ConnectAsync(CancellationToken cancellationToken) ()
    {
        if (QuicConnection.IsSupported) // Currently warning here, fixing this
        {
            await QuicConnection.ConnectAsync(new QuicClientConnectionOptions(), cancellationToken).ConfigureAwait(false);
        }
    }
}
```
