### PR TITLE
Highlight C# code in unit tests

### DIFF
--- a/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -22,7 +23,7 @@ namespace Test.Utilities
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
 
-        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        public static async Task VerifyAnalyzerAsync([StringSyntax("C#-test")] string source, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
@@ -33,13 +34,13 @@ namespace Test.Utilities
             await test.RunAsync();
         }
 
-        public static async Task VerifyCodeFixAsync(string source, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, string fixedSource)
             => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, string fixedSource)
             => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, string fixedSource)
         {
             var test = new Test
             {

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2.cs
@@ -34,13 +34,13 @@ namespace Test.Utilities
             await test.RunAsync();
         }
 
-        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, [StringSyntax("C#-test")] string fixedSource)
             => await VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, [StringSyntax("C#-test")] string fixedSource)
             => await VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
-        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, [StringSyntax("C#-test")] string fixedSource)
         {
             var test = new Test
             {

--- a/src/Test.Utilities/CSharpCodeRefactoringVerifier`1.cs
+++ b/src/Test.Utilities/CSharpCodeRefactoringVerifier`1.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeRefactorings;
 using Microsoft.CodeAnalysis.Testing;
@@ -10,15 +11,15 @@ namespace Test.Utilities
         where TRefactoring : CodeRefactoringProvider, new()
     {
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
-        public static async Task VerifyRefactoringAsync(string source, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, string fixedSource)
             => await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
-        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult expected, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, string fixedSource)
             => await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
 
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyRefactoringAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, string fixedSource)
         {
             var test = new Test
             {

--- a/src/Test.Utilities/CSharpCodeRefactoringVerifier`1.cs
+++ b/src/Test.Utilities/CSharpCodeRefactoringVerifier`1.cs
@@ -11,15 +11,15 @@ namespace Test.Utilities
         where TRefactoring : CodeRefactoringProvider, new()
     {
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, string)"/>
-        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, [StringSyntax("C#-test")] string fixedSource)
             => await VerifyRefactoringAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult, string)"/>
-        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, [StringSyntax("C#-test")] string fixedSource)
             => await VerifyRefactoringAsync(source, new[] { expected }, fixedSource);
 
         /// <inheritdoc cref="CodeRefactoringVerifier{TCodeRefactoring, TTest, TVerifier}.VerifyRefactoringAsync(string, DiagnosticResult[], string)"/>
-        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, string fixedSource)
+        public static async Task VerifyRefactoringAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, [StringSyntax("C#-test")] string fixedSource)
         {
             var test = new Test
             {

--- a/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2.cs
+++ b/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -22,7 +23,7 @@ namespace Test.Utilities
         public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
             => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(descriptor);
 
-        public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        public static async Task VerifyAnalyzerAsync([StringSyntax("C#-test")] string source, params DiagnosticResult[] expected)
         {
             var test = new Test
             {
@@ -32,13 +33,13 @@ namespace Test.Utilities
             await RunTestAsync(test, expected);
         }
 
-        public static Task VerifyCodeFixAsync(string source, string fixedSource)
+        public static Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, [StringSyntax("C#-test")] string fixedSource)
             => VerifyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
 
-        public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+        public static Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult expected, [StringSyntax("C#-test")] string fixedSource)
             => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
 
-        public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+        public static async Task VerifyCodeFixAsync([StringSyntax("C#-test")] string source, DiagnosticResult[] expected, [StringSyntax("C#-test")] string fixedSource)
         {
             var test = new Test
             {


### PR DESCRIPTION
Adds [StringSyntax("C#-test")] to verifier classes to enable syntax highlighting for embedded C# code in visual studio.

Before:
![devenv_lvavli5AG6](https://github.com/dotnet/roslyn-analyzers/assets/30874283/0a9aea03-f7f5-4c63-8652-2bc10168081d)

After:
![devenv_iOb5umXDDJ](https://github.com/dotnet/roslyn-analyzers/assets/30874283/34171fcc-b1d9-49e4-a92f-786d48612baa)
