### PR TITLE
CA2213: Handle overriden `DisposeCoreAsync` / `DisposeAsyncCore`

### DIFF
--- a/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/IMethodSymbolExtensions.cs
@@ -301,13 +301,13 @@ namespace Analyzer.Utilities.Extensions
         }
 
         /// <summary>
-        /// Checks if the given method has the signature "virtual ValueTask DisposeCoreAsync()" or "virtual ValueTask DisposeAsyncCore()".
+        /// Checks if the given method has the signature "{virtual|override} ValueTask DisposeCoreAsync()" or "{virtual|override} ValueTask DisposeAsyncCore()".
         /// </summary>
-        private static bool HasVirtualDisposeCoreAsyncMethodSignature(this IMethodSymbol method, [NotNullWhen(returnValue: true)] INamedTypeSymbol? valueTask)
+        private static bool HasVirtualOrOverrideDisposeCoreAsyncMethodSignature(this IMethodSymbol method, [NotNullWhen(returnValue: true)] INamedTypeSymbol? valueTask)
         {
             return (method.Name == "DisposeAsyncCore" || method.Name == "DisposeCoreAsync") &&
                 method.MethodKind == MethodKind.Ordinary &&
-                method.IsVirtual &&
+                (method.IsVirtual || method.IsOverride) &&
                 SymbolEqualityComparer.Default.Equals(method.ReturnType, valueTask) &&
                 method.Parameters.Length == 0;
         }
@@ -363,7 +363,7 @@ namespace Analyzer.Utilities.Extensions
                 {
                     return DisposeMethodKind.DisposeCoreAsync;
                 }
-                else if (method.HasVirtualDisposeCoreAsyncMethodSignature(valueTask))
+                else if (method.HasVirtualOrOverrideDisposeCoreAsyncMethodSignature(valueTask))
                 {
                     return DisposeMethodKind.DisposeCoreAsync;
                 }


### PR DESCRIPTION
Follow-up to #6976

This PR fixes up CA2213 implementation to handle the following use case:

```cs
using System;
using System.Threading.Tasks;

class A : IAsyncDisposable
{
    private readonly object disposedValueLock = new object();
    private bool disposedValue;
    private readonly Inner innerA;

    public A() 
    {
        innerA = new Inner();
    }

    protected virtual async ValueTask DisposeCoreAsync()
    {
        lock (disposedValueLock)
        {
            if (disposedValue)
            {
                return;
            }

            disposedValue = true;
        }

        await innerA.DisposeAsync().ConfigureAwait(false);
    }

    public ValueTask DisposeAsync()
    {
        return default(ValueTask);
    }
}

class B : A
{
    private readonly object disposedValueLock = new object();
    private bool disposedValue;

    // Newly, we want to test that no diagnostic is reported on this line.
    private readonly Inner innerB;  /* <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< */

    public B() : base()
    {
        innerB = new Inner();
    }

    protected override async ValueTask DisposeCoreAsync()
    {
        lock (disposedValueLock)
        {
            if (disposedValue)
            {
                return;
            }

            disposedValue = true;
        }

        await innerB.DisposeAsync().ConfigureAwait(false);

        await base.DisposeCoreAsync().ConfigureAwait(false);
    }
}

// Declares an IAsyncDisposable type.
class Inner : IAsyncDisposable
{
    public Inner() 
    {
    }

    public ValueTask DisposeAsync()
    {
        return default(ValueTask);
    }
}
```

That is `innerB` is now marked as not disposed because its `DisposeCoreAsync` method has in its [method signature](https://github.com/dotnet/roslyn-analyzers/pull/7347/files#diff-5a72cda0b6e4fe072ec3ad611132009049afb0a1d445e15b2997688a9f82ac4eR3797) `override` instead of [`virtual`](https://github.com/dotnet/roslyn-analyzers/pull/7347/files#diff-5c64baff71ef87389c5737257afa6bf2f743cdd33ce2b029f01ababa4882b4f1R310).