### PR TITLE
Execute NameAndParametersValid only when needed.

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 {
                     if (m.IsStatic &&
                         m.ReturnType.SpecialType == SpecialType.System_Boolean &&
-                        (IsOSPlatform == m.Name) || NameAndParametersValid(m))
+                        (IsOSPlatform == m.Name || NameAndParametersValid(m)))
                     {
                         CheckDependentPlatforms(m, relatedPlatforms);
                         return true;


### PR DESCRIPTION
The NameAndParametersValid is executed for ALL methods in a class, independently of the methods being static and returning a boolean.

If you look carefully at the code, we have a || after a && therefore the NamedAndParametersValid is executed ALWAYS. This means that we are performing the check for EVEVERY method, rather than on those methods that are static and return a bool.

