### PR TITLE
ResxSourceGenerator: Added XML comment summary to the generated classes and properties to avoid warning CS1591 if they are public

### DIFF
--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -520,7 +520,8 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                             break;
 
                         case Lang.VisualBasic:
-                            getStringMethod = $@"{memberIndent}Public Shared Property Culture As Global.System.Globalization.CultureInfo
+                            getStringMethod = $@"{memberIndent}''' <summary>Culture</summary>
+{memberIndent}Public Shared Property Culture As Global.System.Globalization.CultureInfo
 {memberIndent}<Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
 {memberIndent}Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
 {memberIndent}    Return ResourceManager.GetString(resourceKey, Culture)
@@ -644,6 +645,7 @@ Imports System.Reflection
 
 {resourceTypeDefinition}
 {namespaceStart}
+{classIndent}''' <summary>{className}</summary>
 {classIndent}{(ResourceInformation.Public ? "Public" : "Friend")} Partial Class {className}
 {memberIndent}Private Sub New
 {memberIndent}End Sub

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -494,7 +494,8 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                                 getResourceStringAttributes.Add("[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(\"defaultValue\")]");
                             }
 
-                            getStringMethod = $@"{memberIndent}public static global::System.Globalization.CultureInfo{(CompilationInformation.SupportsNullable ? "?" : "")} Culture {{ get; set; }}
+                            getStringMethod = $@"{memberIndent}/// <summary>Culture</summary>
+{memberIndent}public static global::System.Globalization.CultureInfo{(CompilationInformation.SupportsNullable ? "?" : "")} Culture {{ get; set; }}
 {string.Join(Environment.NewLine, getResourceStringAttributes.Select(attr => memberIndent + attr))}
 {memberIndent}internal static {(CompilationInformation.SupportsNullable ? "string?" : "string")} GetResourceString(string resourceKey, {(CompilationInformation.SupportsNullable ? "string?" : "string")} defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;";
                             if (ResourceInformation.EmitFormatMethods)
@@ -623,9 +624,11 @@ using System.Reflection;
 
 {resourceTypeDefinition}
 {namespaceStart}
+{classIndent}/// <summary>{className}</summary>
 {classIndent}{(ResourceInformation.Public ? "public" : "internal")} static partial class {className}
 {classIndent}{{
 {memberIndent}private static global::System.Resources.ResourceManager{(CompilationInformation.SupportsNullable ? "?" : "")} s_resourceManager;
+{memberIndent}/// <summary>ResourceManager</summary>
 {memberIndent}public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof({resourceTypeName})));
 {getStringMethod}
 {strings}
@@ -646,6 +649,7 @@ Imports System.Reflection
 {memberIndent}End Sub
 {memberIndent}
 {memberIndent}Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+{memberIndent}''' <summary>ResourceManager</summary>
 {memberIndent}Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
 {memberIndent}    Get
 {memberIndent}        If s_resourceManager Is Nothing Then


### PR DESCRIPTION
If the classes generated by the ResxSourceGenerator are public, the warning CS1591 has been emitted, since the XML comments were missing.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->
