### PR TITLE
Compare the generic types of source and destination to ensure they are identical before raising CA2009

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValue.cs
@@ -92,7 +92,8 @@ namespace Microsoft.NetCore.Analyzers.ImmutableCollections
                     }
 
                     if (invocation.GetReceiverType(operationContext.Compilation, beforeConversion: true, cancellationToken: operationContext.CancellationToken) is INamedTypeSymbol receiverType
-                        && receiverType.DerivesFromOrImplementsAnyConstructionOf(immutableCollectionType))
+                        && receiverType.DerivesFromOrImplementsAnyConstructionOf(immutableCollectionType)
+                        && ((INamedTypeSymbol)invocation.Type!).TypeArguments[0].Equals(receiverType.TypeArguments[0]))
                     {
                         operationContext.ReportDiagnostic(
                             invocation.CreateDiagnostic(

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/ImmutableCollections/DoNotCallToImmutableCollectionOnAnImmutableCollectionValueTests.cs
@@ -54,14 +54,23 @@ static class Extensions
      }}
 }}
 
+interface IValue
+{{
+}}
+
+class Value : IValue
+{{
+}}
+
 class C
 {{
-    public void M(IEnumerable<int> p1, List<int> p2, {collectionName}<int> p3, IEqualityComparer<int> comparer)
+    public void M(IEnumerable<int> p1, List<int> p2, {collectionName}<int> p3, {collectionName}<Value> p4, IEqualityComparer<int> comparer)
     {{
         // Allowed
         p1.To{collectionName}();
         p2.To{collectionName}();
         p3.To{collectionName}(comparer); // Potentially modifies the collection
+        p4.To{collectionName}<IValue>(); // Changes the generic type
 
         Extensions.To{collectionName}(p1);
         Extensions.To{collectionName}(p2);


### PR DESCRIPTION
A hacky fix for #7374 , with an associated test case which is hopefully reasonable.
I am not very familiar with Roslyn, but something along these lines would likely resolve the issue. Creating this PR in hopes that someone else can tell me what changes are required.
