### PR TITLE
Temporarily disable pragma SYSLIB0014 from CSharp CodeFix Verifiers

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DataSetDataTableInWebSerializableObjectGraphTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Security/DataSetDataTableInWebSerializableObjectGraphTests.cs
@@ -90,7 +90,9 @@ public class MyClass
         private static async Task VerifyServiceModelCSharpAsync(string source, params DiagnosticResult[] expected)
         {
 #pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
             var csharpTest = new VerifyCS.Test
             {
@@ -110,7 +112,9 @@ public class MyClass
         private static async Task VerifyWebServicesCSharpAsync(string source, params DiagnosticResult[] expected)
         {
 #pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
             var csharpTest = new VerifyCS.Test
             {

--- a/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs
@@ -24,12 +24,16 @@ namespace Test.Utilities
                 // reasonable TLS protocol version for outgoing connections.
 #pragma warning disable CA5364 // Do Not Use Deprecated Security Protocols
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
                 if (ServicePointManager.SecurityProtocol == (SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls))
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA5364 // Do Not Use Deprecated Security Protocols
                 {
 #pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
                 }
             }

--- a/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
+++ b/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs
@@ -21,12 +21,16 @@ namespace Test.Utilities
                 // reasonable TLS protocol version for outgoing connections.
 #pragma warning disable CA5364 // Do Not Use Deprecated Security Protocols
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
                 if (ServicePointManager.SecurityProtocol == (SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls))
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CA5364 // Do Not Use Deprecated Security Protocols
                 {
 #pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete
                     ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#pragma warning restore SYSLIB0014 // ServicePointManager is obsolete
 #pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
                 }
             }


### PR DESCRIPTION
Workaround to address the failure in the official builds:

```
/mnt/vss/_work/1/s/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs(24,21): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [/mnt/vss/_work/1/s/src/Test.Utilities/Test.Utilities.csproj]
/mnt/vss/_work/1/s/src/Test.Utilities/CSharpSecurityCodeFixVerifier`2+Test.cs(29,21): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [/mnt/vss/_work/1/s/src/Test.Utilities/Test.Utilities.csproj]
/mnt/vss/_work/1/s/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs(27,21): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [/mnt/vss/_work/1/s/src/Test.Utilities/Test.Utilities.csproj]
/mnt/vss/_work/1/s/src/Test.Utilities/CSharpCodeFixVerifier`2+Test.cs(32,21): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [/mnt/vss/_work/1/s/src/Test.Utilities/Test.Utilities.csproj]
...
D:\a\_work\1\s\src\NetAnalyzers\UnitTests\Microsoft.NetCore.Analyzers\Security\DataSetDataTableInWebSerializableObjectGraphTests.cs(93,13): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014)  [D:\a\_work\1\s\src\NetAnalyzers\UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj]
D:\a\_work\1\s\src\NetAnalyzers\UnitTests\Microsoft.NetCore.Analyzers\Security\DataSetDataTableInWebSerializableObjectGraphTests.cs(113,13): error SYSLIB0014: 'ServicePointManager' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead. Settings on ServicePointManager no longer affect SslStream or HttpClient.' (https://aka.ms/dotnet-warnings/SYSLIB0014) [D:\a\_work\1\s\src\NetAnalyzers\UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj]

```

The ideal fix would be to replace the functionality with the preferred new set of APIs.

This will be cherry-picked into the arcade deps flow for release/9.0.1xx: 
https://github.com/dotnet/roslyn-analyzers/pull/7386