### PR TITLE
Add an analyzer for Debug.Assert

### DIFF
--- a/eng/GenerateAnalyzerNuspec.targets
+++ b/eng/GenerateAnalyzerNuspec.targets
@@ -54,6 +54,10 @@
       <GenerateAnalyzerRulesMissingDocumentationFile Condition="'$(Sign)' == 'true'">false</GenerateAnalyzerRulesMissingDocumentationFile>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(ReleaseTrackingOptOut)' == ''">
+      <ReleaseTrackingOptOut>false</ReleaseTrackingOptOut>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(GeneratePackagePropsFile)' == 'true'">
       <PackagePropsFileDir>$(IntermediateOutputPath)Build</PackagePropsFileDir>
       <PackagePropsFileName>$(NuspecPackageId).props</PackagePropsFileName>
@@ -108,9 +112,9 @@
 
     <!-- Only run validate only in CI builds. Running them in local builds will prevent refreshing auto-generated files. -->
     <Exec Condition="'$(ContinuousIntegrationBuild)' == 'true'"
-          Command='"$(DotNetExecutable)" --roll-forward major "$(_GenerateDocumentationAndConfigFilesPath)" "-validateOnly:true" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(ArtifactsBinDir)$(EscapeDirectorySuffix)" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "@(AnalyzerRulesetAssembly)" "$(PackagePropsFileDir)" "$(PackagePropsFileName)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "$(DisableNETAnalyzersPackagePropsFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(VersionPrefix)" $(NuspecPackageId) $(ContainsPortedFxCopRules) $(GenerateAnalyzerRulesMissingDocumentationFile) "$(ReleaseTrackingOptOut)" $(_ValidateOffline)' />
+          Command='"$(DotNetExecutable)" --roll-forward major "$(_GenerateDocumentationAndConfigFilesPath)" "-validateOnly:true" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(ArtifactsBinDir)$(EscapeDirectorySuffix)" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "@(AnalyzerRulesetAssembly)" "$(PackagePropsFileDir)" "$(PackagePropsFileName)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "$(DisableNETAnalyzersPackagePropsFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(VersionPrefix)" $(NuspecPackageId) $(ContainsPortedFxCopRules) $(GenerateAnalyzerRulesMissingDocumentationFile) $(ReleaseTrackingOptOut) $(_ValidateOffline)' />
 
-    <Exec Command='"$(DotNetExecutable)" --roll-forward major "$(_GenerateDocumentationAndConfigFilesPath)" "-validateOnly:false" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(ArtifactsBinDir)$(EscapeDirectorySuffix)" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "@(AnalyzerRulesetAssembly)" "$(PackagePropsFileDir)" "$(PackagePropsFileName)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "$(DisableNETAnalyzersPackagePropsFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(VersionPrefix)" $(NuspecPackageId) $(ContainsPortedFxCopRules) $(GenerateAnalyzerRulesMissingDocumentationFile) "$(ReleaseTrackingOptOut)" $(_ValidateOffline)' />
+    <Exec Command='"$(DotNetExecutable)" --roll-forward major "$(_GenerateDocumentationAndConfigFilesPath)" "-validateOnly:false" "$(_GeneratedRulesetsDir)" "$(_GeneratedEditorconfigsDir)" "$(_GeneratedGlobalAnalyzerConfigsDir)" "$(ArtifactsBinDir)$(EscapeDirectorySuffix)" "$(Configuration)" "%(AnalyzerRulesetAssembly.TargetFramework)" "@(AnalyzerRulesetAssembly)" "$(PackagePropsFileDir)" "$(PackagePropsFileName)" "$(PackageTargetsFileDir)" "$(PackageTargetsFileName)" "$(DisableNETAnalyzersPackagePropsFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerDocumentationFileName)" "$(AnalyzerSarifFileDir)" "$(AnalyzerSarifFileName)" "$(VersionPrefix)" $(NuspecPackageId) $(ContainsPortedFxCopRules) $(GenerateAnalyzerRulesMissingDocumentationFile) $(ReleaseTrackingOptOut) $(_ValidateOffline)' />
 
     <ItemGroup Condition="Exists('$(PackageTargetsFileDir)\$(PackageTargetsFileName)')">
       <AnalyzerNupkgFile Include="$(PackageTargetsFileDir)\$(PackageTargetsFileName)"/>

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/AnalyzerReleases.Unshipped.md
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RS0062 | RoslynDiagnosticsMaintainability | Disabled | DoNotCapturePrimaryConstructorParametersAnalyzer
+RS0063 | RoslynDiagnosticsPerformance | Disabled | CSharpDoNotUseDebugAssertForInterpolatedStrings 

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/AnalyzerReleases.Unshipped.md
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/AnalyzerReleases.Unshipped.md
@@ -5,4 +5,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RS0062 | RoslynDiagnosticsMaintainability | Disabled | DoNotCapturePrimaryConstructorParametersAnalyzer
-RS0063 | RoslynDiagnosticsPerformance | Disabled | CSharpDoNotUseDebugAssertForInterpolatedStrings 
+RS0063 | RoslynDiagnosticsPerformance | Disabled | CSharpDoNotUseDebugAssertForInterpolatedStrings

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using Roslyn.Diagnostics.Analyzers;
+
+namespace Roslyn.Diagnostics.CSharp.Analyzers
+{
+    using static RoslynDiagnosticsAnalyzersResources;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class CSharpDoNotUseDebugAssertForInterpolatedStrings : DiagnosticAnalyzer
+    {
+        internal static readonly DiagnosticDescriptor Rule = new(
+            RoslynDiagnosticIds.DoNotUseInterpolatedStringsWithDebugAssertRuleId,
+            CreateLocalizableResourceString(nameof(DoNotUseInterpolatedStringsWithDebugAssertTitle)),
+            CreateLocalizableResourceString(nameof(DoNotUseInterpolatedStringsWithDebugAssertMessage)),
+            DiagnosticCategory.RoslynDiagnosticsPerformance,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: false,
+            description: CreateLocalizableResourceString(nameof(DoNotUseInterpolatedStringsWithDebugAssertDescription)),
+            helpLinkUri: null,
+            customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(context =>
+            {
+                var debugType = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemDiagnosticsDebug);
+
+                if (debugType is null)
+                {
+                    return;
+                }
+
+                IMethodSymbol? assertMethod = null;
+
+                foreach (var member in debugType.GetMembers("Assert"))
+                {
+                    if (member is IMethodSymbol { Parameters: [{ Type.SpecialType: SpecialType.System_Boolean }, { Type.SpecialType: SpecialType.System_String }] } method)
+                    {
+                        assertMethod = method;
+                        break;
+                    }
+                }
+
+                if (assertMethod is null)
+                {
+                    return;
+                }
+
+                context.RegisterOperationAction(context =>
+                {
+                    var invocation = (IInvocationOperation)context.Operation;
+
+                    if (invocation.TargetMethod.Equals(assertMethod) &&
+                        invocation.Arguments is [_, IArgumentOperation { Value: IInterpolatedStringOperation }])
+                    {
+                        context.ReportDiagnostic(invocation.CreateDiagnostic(Rule));
+                    }
+                }, OperationKind.Invocation);
+            });
+        }
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
@@ -12,7 +12,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 {
     using static RoslynDiagnosticsAnalyzersResources;
 
-    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CSharpDoNotUseDebugAssertForInterpolatedStrings : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor Rule = new(

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
@@ -63,7 +63,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
                     var invocation = (IInvocationOperation)context.Operation;
 
                     if (invocation.TargetMethod.Equals(assertMethod) &&
-                        invocation.Arguments is [_, IArgumentOperation { Value: IInterpolatedStringOperation }])
+                        invocation.Arguments is [_, IArgumentOperation { Value: IInterpolatedStringOperation { ConstantValue.HasValue: false } }])
                     {
                         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule));
                     }

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStrings.cs
@@ -13,7 +13,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
     using static RoslynDiagnosticsAnalyzersResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class CSharpDoNotUseDebugAssertForInterpolatedStrings : DiagnosticAnalyzer
+    public sealed class CSharpDoNotUseDebugAssertForInterpolatedStrings : DiagnosticAnalyzer
     {
         internal static readonly DiagnosticDescriptor Rule = new(
             RoslynDiagnosticIds.DoNotUseInterpolatedStringsWithDebugAssertRuleId,
@@ -26,7 +26,7 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
             helpLinkUri: null,
             customTags: WellKnownDiagnosticTagsExtensions.Telemetry);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
@@ -17,9 +17,9 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpDoNotUseDebugAssertForInterpolatedStringsFixer))]
     [Shared]
-    public class CSharpDoNotUseDebugAssertForInterpolatedStringsFixer : CodeFixProvider
+    public sealed class CSharpDoNotUseDebugAssertForInterpolatedStringsFixer : CodeFixProvider
     {
-        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RoslynDiagnosticIds.DoNotUseInterpolatedStringsWithDebugAssertRuleId);
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(RoslynDiagnosticIds.DoNotUseInterpolatedStringsWithDebugAssertRuleId);
 
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Roslyn.Diagnostics.Analyzers;
+
+namespace Roslyn.Diagnostics.CSharp.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CSharpDoNotUseDebugAssertForInterpolatedStringsFixer))]
+    [Shared]
+    public class CSharpDoNotUseDebugAssertForInterpolatedStringsFixer : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(RoslynDiagnosticIds.DoNotUseInterpolatedStringsWithDebugAssertRuleId);
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var compilation = await context.Document.Project.GetCompilationAsync(context.CancellationToken);
+
+            if (compilation is null)
+            {
+                return;
+            }
+
+            var roslynDebugSymbol = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.RoslynDebug);
+
+            if (roslynDebugSymbol is null)
+            {
+                return;
+            }
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        RoslynDiagnosticsAnalyzersResources.DoNotUseInterpolatedStringsWithDebugAssertCodeFix,
+                        ct => ReplaceWithDebugAssertAsync(context.Document, diagnostic.Location, roslynDebugSymbol, ct),
+                        equivalenceKey: nameof(CSharpDoNotUseDebugAssertForInterpolatedStringsFixer)),
+                    diagnostic);
+            }
+        }
+
+        private static async Task<Document> ReplaceWithDebugAssertAsync(Document document, Location location, INamedTypeSymbol roslynDebugSymbol, CancellationToken cancellationToken)
+        {
+            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var syntax = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+            var generator = SyntaxGenerator.GetGenerator(document);
+
+            if (syntax is not InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax
+                    {
+                        Expression: IdentifierNameSyntax { Identifier.ValueText: "Debug" } debugIdentifierNode,
+                        Name.Identifier.ValueText: "Assert"
+                    },
+                })
+            {
+                return document;
+            }
+
+            var roslynDebugNode = generator.TypeExpression(roslynDebugSymbol)
+                .WithAddImportsAnnotation()
+                .WithLeadingTrivia(debugIdentifierNode.GetLeadingTrivia())
+                .WithTrailingTrivia(debugIdentifierNode.GetTrailingTrivia());
+
+            var newRoot = root.ReplaceNode(debugIdentifierNode, roslynDebugNode);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        public override FixAllProvider? GetFixAllProvider() => base.GetFixAllProvider();
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotUseDebugAssertForInterpolatedStringsFixer.cs
@@ -75,6 +75,6 @@ namespace Roslyn.Diagnostics.CSharp.Analyzers
             return document.WithSyntaxRoot(newRoot);
         }
 
-        public override FixAllProvider? GetFixAllProvider() => base.GetFixAllProvider();
+        public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticIds.cs
@@ -68,6 +68,7 @@ namespace Roslyn.Diagnostics.Analyzers
         public const string OverloadWithOptionalParametersShouldHaveMostParametersInternal = "RS0060";
         public const string ExposedNoninstantiableTypeRuleIdInternal = "RS0061";
         public const string DoNotCapturePrimaryConstructorParametersRuleId = "RS0062";
+        public const string DoNotUseInterpolatedStringsWithDebugAssertRuleId = "RS0063";
 
         //public const string WrapStatementsRuleId = "RS0100"; // Now ported to dotnet/roslyn https://github.com/dotnet/roslyn/pull/50358
         //public const string BlankLinesRuleId = "RS0101"; // Now ported to dotnet/roslyn https://github.com/dotnet/roslyn/pull/50358

--- a/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/RoslynDiagnosticsAnalyzersResources.resx
@@ -403,4 +403,16 @@
   <data name="DoNotCapturePrimaryConstructorParametersDescription" xml:space="preserve">
     <value>Primary constructor parameters should not be implicitly captured. Manually assign them to fields at the start of the type.</value>
   </data>
+  <data name="DoNotUseInterpolatedStringsWithDebugAssertTitle" xml:space="preserve">
+    <value>Do not use interpolated strings with 'Debug.Assert'</value>
+  </data>
+  <data name="DoNotUseInterpolatedStringsWithDebugAssertMessage" xml:space="preserve">
+    <value>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</value>
+  </data>
+  <data name="DoNotUseInterpolatedStringsWithDebugAssertDescription" xml:space="preserve">
+    <value>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</value>
+  </data>
+  <data name="DoNotUseInterpolatedStringsWithDebugAssertCodeFix" xml:space="preserve">
+    <value>Use 'RoslynDebug.Assert'.</value>
+  </data>
 </root>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.cs.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.cs.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Nepodporované použití nekopírovatelného typu {0} v operaci {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Explicitně definujte importující konstruktor.</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.de.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.de.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Nicht unterstützte Verwendung des nicht kopierbaren Typs "{0}" im Vorgang "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Importierenden Konstruktor explizit definieren</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.es.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.es.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Uso no admitido del tipo "{0}" que no se puede copiar en la operación "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Definir explícitamente el constructor de importación</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.fr.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.fr.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Utilisation non prise en charge du type '{0}' non copiable dans l'opération '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Définir explicitement le constructeur d'importation</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.it.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.it.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Uso non supportato del tipo non copiabile '{0}' nell'operazione '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Definire esplicitamente il costruttore di importazione</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ja.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ja.xlf
@@ -187,6 +187,26 @@
         <target state="translated">'{1}' 操作でコピー不可の型 '{0}' の使用はサポートされていません</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">インポート コンストラクターを明示的に定義します</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ko.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ko.xlf
@@ -187,6 +187,26 @@
         <target state="translated">'{1}' 작업에서 복사할 수 없는 형식 '{0}'의 사용이 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">명시적으로 가져오기 생성자 정의</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pl.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pl.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Nieobsługiwane użycie typu bez możliwości kopiowania „{0}” w operacji „{1}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Jawnie zdefiniuj konstruktor importujący</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pt-BR.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.pt-BR.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Não há suporte para o uso do tipo não copiável '{0}' na operação '{1}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Definir explicitamente o construtor de importação</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ru.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.ru.xlf
@@ -187,6 +187,26 @@
         <target state="translated">Неподдерживаемое использование типа "{0}", не допускающего копирование, в операции "{1}"</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">Явно определите конструктор импорта.</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.tr.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.tr.xlf
@@ -187,6 +187,26 @@
         <target state="translated">'{1}' işleminde kopyalanabilir olmayan '{0}' türünün kullanımı desteklenmiyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">İçeri aktarma oluşturucusunu açıkça tanımlayın</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hans.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hans.xlf
@@ -187,6 +187,26 @@
         <target state="translated">不支持在“{1}”操作中使用不可复制的类型“{0}”</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">显式定义导入构造函数</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hant.xlf
+++ b/src/Roslyn.Diagnostics.Analyzers/Core/xlf/RoslynDiagnosticsAnalyzersResources.zh-Hant.xlf
@@ -187,6 +187,26 @@
         <target state="translated">不支援在 '{1}' 作業中使用無法複製的類型 '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertCodeFix">
+        <source>Use 'RoslynDebug.Assert'.</source>
+        <target state="new">Use 'RoslynDebug.Assert'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertDescription">
+        <source>'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</source>
+        <target state="new">'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertMessage">
+        <source>Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'. Use 'RoslynDebug.Assert' instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseInterpolatedStringsWithDebugAssertTitle">
+        <source>Do not use interpolated strings with 'Debug.Assert'</source>
+        <target state="new">Do not use interpolated strings with 'Debug.Assert'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExportedPartsShouldHaveImportingConstructorCodeFix_ImplicitConstructor">
         <source>Explicitly define the importing constructor</source>
         <target state="translated">明確定義匯入建構函式</target>

--- a/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.md
+++ b/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.md
@@ -191,3 +191,15 @@ Primary constructor parameters should not be implicitly captured. Manually assig
 |Severity|Error|
 |CodeFix|False|
 ---
+
+## RS0063: Do not use interpolated strings with 'Debug.Assert'
+
+'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.
+
+|Item|Value|
+|-|-|
+|Category|RoslynDiagnosticsPerformance|
+|Enabled|False|
+|Severity|Warning|
+|CodeFix|True|
+---

--- a/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -288,8 +288,7 @@
             "isEnabledByDefault": false,
             "typeName": "CSharpDoNotUseDebugAssertForInterpolatedStrings",
             "languages": [
-              "C#",
-              "Visual Basic"
+              "C#"
             ],
             "tags": [
               "Telemetry"

--- a/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
+++ b/src/Roslyn.Diagnostics.Analyzers/Roslyn.Diagnostics.Analyzers.sarif
@@ -277,6 +277,24 @@
               "C#"
             ]
           }
+        },
+        "RS0063": {
+          "id": "RS0063",
+          "shortDescription": "Do not use interpolated strings with 'Debug.Assert'",
+          "fullDescription": "'Debug.Assert' on .NET Framework eagerly creates the string value. This can cause OOMs in tests, particularly for strings that involve syntax nodes. Use 'RoslynDebug.Assert' instead, which will only create the string if required.",
+          "defaultLevel": "warning",
+          "properties": {
+            "category": "RoslynDiagnosticsPerformance",
+            "isEnabledByDefault": false,
+            "typeName": "CSharpDoNotUseDebugAssertForInterpolatedStrings",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ],
+            "tags": [
+              "Telemetry"
+            ]
+          }
         }
       }
     },

--- a/src/Roslyn.Diagnostics.Analyzers/RulesMissingDocumentation.md
+++ b/src/Roslyn.Diagnostics.Analyzers/RulesMissingDocumentation.md
@@ -18,3 +18,4 @@ RS0043 |  | Do not call 'GetTestAccessor()' |
 RS0046 |  | Avoid the 'Opt' suffix |
 RS0049 |  | Instance of TemporaryArray\<T>.AsRef() must be a 'using' variable |
 RS0062 |  | Do not capture primary constructor parameters |
+RS0063 |  | Do not use interpolated strings with 'Debug.Assert' |

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Roslyn.Diagnostics.CSharp.Analyzers.CSharpDoNotUseDebugAssertForInterpolatedStrings,
+    Roslyn.Diagnostics.CSharp.Analyzers.CSharpDoNotUseDebugAssertForInterpolatedStringsFixer>;
+
+namespace Roslyn.Diagnostics.Analyzers.UnitTests
+{
+    public class CSharpDoNotUseInterpolatedStringsForDebugAssertTests
+    {
+        private const string RoslynDebug =
+            """
+            namespace Roslyn.Utilities
+            {
+                public static class RoslynDebug
+                {
+                    public static void Assert(bool condition, string message) { }
+                }
+            }
+            """;
+
+        [Theory]
+        [InlineData("""
+            $"{0}"
+            """)]
+        [InlineData("""
+            $@"{0}"
+            """)]
+        [InlineData("""
+            @$"{0}"
+            """)]
+        [InlineData(""""
+            $"""{0}"""
+            """")]
+        public async Task InterpolatedString(string @string)
+        {
+            var source = $$"""
+                using System.Diagnostics;
+
+                class C
+                {
+                    void M()
+                    {
+                        [|Debug.Assert(false, {{@string}})|];
+                    }
+                }
+
+                {{RoslynDebug}}
+                """;
+
+            var @fixed = $$"""
+                using System.Diagnostics;
+                using Roslyn.Utilities;
+
+                class C
+                {
+                    void M()
+                    {
+                        RoslynDebug.Assert(false, {{@string}});
+                    }
+                }
+
+                {{RoslynDebug}}
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                FixedCode = @fixed,
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task NoCrashOnUsingStaticedAssert()
+        {
+            var source = """
+                using static System.Diagnostics.Debug;
+
+                class C
+                {
+                    void M()
+                    {
+                        [|Assert(false, $"{0}")|];
+                    }
+                }
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+            }.RunAsync();
+        }
+    }
+}

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
@@ -96,5 +96,41 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
                 LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12,
             }.RunAsync();
         }
+
+        [Theory]
+        [InlineData("""
+            $"{"0"}"
+            """)]
+        [InlineData("""
+            $@"{"0"}"
+            """)]
+        [InlineData("""
+            @$"{"0"}"
+            """)]
+        [InlineData(""""
+            $"""{"0"}"""
+            """")]
+        public async Task NoAssertForConstantString(string @string)
+        {
+            var source = $$"""
+                using System.Diagnostics;
+
+                class C
+                {
+                    void M()
+                    {
+                        Debug.Assert(false, {{@string}});
+                    }
+                }
+
+                {{RoslynDebug}}
+                """;
+
+            await new VerifyCS.Test
+            {
+                TestCode = source,
+                LanguageVersion = Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+            }.RunAsync();
+        }
     }
 }

--- a/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
+++ b/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotUseDebugAssertForInterpolatedStringsTests.cs
@@ -76,7 +76,7 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
         [Fact]
         public async Task NoCrashOnUsingStaticedAssert()
         {
-            var source = """
+            var source = $$"""
                 using static System.Diagnostics.Debug;
 
                 class C
@@ -86,6 +86,8 @@ namespace Roslyn.Diagnostics.Analyzers.UnitTests
                         [|Assert(false, $"{0}")|];
                     }
                 }
+
+                {{RoslynDebug}}
                 """;
 
             await new VerifyCS.Test

--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -35,13 +35,13 @@ namespace GenerateDocumentationAndConfigFiles
 
             if (args.Length != expectedArguments)
             {
-                await Console.Error.WriteLineAsync($"Excepted {expectedArguments} arguments, found {args.Length}: {string.Join(';', args)}").ConfigureAwait(false);
+                await Console.Error.WriteLineAsync($"Expected {expectedArguments} arguments, found {args.Length}: {string.Join(';', args)}").ConfigureAwait(false);
                 return 1;
             }
 
             if (!args[0].StartsWith("-validateOnly:", StringComparison.OrdinalIgnoreCase))
             {
-                await Console.Error.WriteLineAsync($"Excepted the first argument to start with `{validateOnlyPrefix}`. found `{args[0]}`.").ConfigureAwait(false);
+                await Console.Error.WriteLineAsync($"Expected the first argument to start with `{validateOnlyPrefix}`. found `{args[0]}`.").ConfigureAwait(false);
                 return 1;
             }
 

--- a/src/Utilities/Compiler/WellKnownTypeNames.cs
+++ b/src/Utilities/Compiler/WellKnownTypeNames.cs
@@ -111,6 +111,7 @@ namespace Analyzer.Utilities
         public const string NUnitFrameworkTearDownAttribute = "NUnit.Framework.TearDownAttribute";
         public const string NUnitFrameworkTestAttribute = "NUnit.Framework.TestAttribute";
         public const string RoslynUtilitiesNonDefaultableAttribute = "Roslyn.Utilities.NonDefaultableAttribute";
+        public const string RoslynDebug = "Roslyn.Utilities.RoslynDebug";
         public const string SystemActivator = "System.Activator";
         public const string SystemAppContext = "System.AppContext";
         public const string SystemAppDomain = "System.AppDomain";


### PR DESCRIPTION
As @jaredpar found in https://github.com/dotnet/roslyn/pull/75163, interpolated strings in `Debug.Assert` can consume a surprising amount of memory. On modern .NET, this is fine; `Debug.Assert` has an interpolated string handler that will avoid the allocations if the assert isn't triggered. However, on our framework tests, this can be very bad and OOM our tests. So, this analyzer looks for cases where interpolated strings are passed to `Debug.Assert`, and recommends moving over to `RoslynDebug.Assert` instead, which is an interpolated string handler on all platforms. Note that I only did C# support, as there's no equivalent handler API for VB.
