### PR TITLE
Add new analyzer for deprecating implementing an interface

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 RS1038 | MicrosoftCodeAnalysisCorrectness | Warning | CompilerExtensionStrictApiAnalyzer
 RS1041 | MicrosoftCodeAnalysisCorrectness | Warning | CompilerExtensionTargetFrameworkAnalyzer, [Documentation](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1041.md)
+RS1042 | MicrosoftCodeAnalysisCompatibility | Error | ImplementationIsObsoleteAnalyzer

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -595,4 +595,14 @@
   <data name="DoNotDeclareCompilerFeatureInAssemblyWithUnsupportedTargetFrameworkRuleTitle" xml:space="preserve">
     <value>Compiler extensions should be implemented in assemblies targeting netstandard2.0</value>
   </data>
+  <data name="ImplementationIsObsoleteDescription" xml:space="preserve">
+    <value>The author of this interface has deprecated implementing this interface.</value>
+  </data>
+  <data name="ImplementationIsObsoleteMessage" xml:space="preserve">
+    <value>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</value>
+    <remarks>{2} is a URL</remarks>
+  </data>
+  <data name="ImplementationIsObsoleteTitle" xml:space="preserve">
+    <value>Implementations of this interface are not allowed</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
@@ -45,6 +45,7 @@ namespace Microsoft.CodeAnalysis.Analyzers
         public const string SemanticModelGetDeclaredSymbolAlwaysReturnsNull = "RS1039";
         public const string SemanticModelGetDeclaredSymbolAlwaysReturnsNullForField = "RS1040";
         public const string DoNotRegisterCompilerTypesWithBadTargetFrameworkRuleId = "RS1041";
+        public const string ImplementationIsObsoleteRuleId = "RS1042";
 
         // Release tracking analyzer IDs
         public const string DeclareDiagnosticIdInAnalyzerReleaseRuleId = "RS2000";

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/ImplementationIsObsoleteAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/ImplementationIsObsoleteAnalyzer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Analyzers
+{
+    using static CodeAnalysisDiagnosticsResources;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class ImplementationIsObsoleteAnalyzer : DiagnosticAnalyzer
+    {
+        private const string ImplementationIsObsoleteAttributeName = "ImplementationIsObsoleteAttribute";
+        private const string ImplementationIsObsoleteAttributeFullName = "System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute";
+
+        public static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticIds.ImplementationIsObsoleteRuleId,
+            CreateLocalizableResourceString(nameof(ImplementationIsObsoleteTitle)),
+            CreateLocalizableResourceString(nameof(ImplementationIsObsoleteMessage)),
+            DiagnosticCategory.MicrosoftCodeAnalysisCompatibility,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: CreateLocalizableResourceString(nameof(ImplementationIsObsoleteDescription)));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.NamedType);
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context)
+        {
+            var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+            // If any interface implemented by this type has the attribute and if the interface and this type are not
+            // in "internals visible" context, then issue an error.
+            foreach (INamedTypeSymbol iface in namedTypeSymbol.AllInterfaces)
+            {
+                System.Collections.Generic.IEnumerable<AttributeData> attributes = iface.GetAttributes();
+
+                // We are doing a string comparison of the name here because we don't care where the attribute comes from.
+                // CodeAnalysis.dll itself has this attribute and if the user assembly also had it, symbol equality will fail
+                // but we should still issue the error.
+                if (attributes.FirstOrDefault(a => a is { AttributeClass.Name: ImplementationIsObsoleteAttributeName, ConstructorArguments: [{ Value: string }] }
+                                                   && a.AttributeClass.ToDisplayString().Equals(ImplementationIsObsoleteAttributeFullName, StringComparison.Ordinal)) is { } attr &&
+                    !iface.ContainingAssembly.GivesAccessTo(namedTypeSymbol.ContainingAssembly))
+                {
+                    context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(Rule, namedTypeSymbol.Name, iface.Name, (string)attr.ConstructorArguments[0].Value!));
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Povolit souběžné provádění</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Neplatná položka v souboru vydané verze analyzátoru</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Gleichzeitige Ausführung aktivieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Ungültiger Eintrag in Analysetool-Releasedatei.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Habilitar la ejecución simultánea</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrada no válida en el archivo de versión del analizador.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Activer l'exécution simultanée</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrée non valide dans le fichier de version d'analyseur.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Abilita l'esecuzione simultanea</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Voce non valida nel file di versione dell'analizzatore.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -217,6 +217,21 @@
         <target state="translated">同時実行を有効にします</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">アナライザー リリース ファイルに無効なエントリがあります。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -217,6 +217,21 @@
         <target state="translated">동시 실행 사용</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">분석기 릴리스 파일에 잘못된 항목이 있습니다.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Włącz wykonywanie współbieżne</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Nieprawidłowy wpis w pliku wydania analizatora.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Habilitar execução simultânea</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Entrada inválida no arquivo de versão do analisador.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Включение параллельного выполнения</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Недопустимая запись в файле выпуска анализатора.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -217,6 +217,21 @@
         <target state="translated">Eşzamanlı yürütmeyi etkinleştir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">Çözümleyici yayın dosyasında geçersiz girdi.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -217,6 +217,21 @@
         <target state="translated">启用并发执行</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">分析器版本文件中的条目无效。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -217,6 +217,21 @@
         <target state="translated">啟用同時執行</target>
         <note />
       </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteDescription">
+        <source>The author of this interface has deprecated implementing this interface.</source>
+        <target state="new">The author of this interface has deprecated implementing this interface.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteMessage">
+        <source>Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</source>
+        <target state="new">Type {0} cannot implement interface {1} because {1} is obsolete for implementation. See {2} for more details.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ImplementationIsObsoleteTitle">
+        <source>Implementations of this interface are not allowed</source>
+        <target state="new">Implementations of this interface are not allowed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidEntryInAnalyzerReleasesFileRuleDescription">
         <source>Invalid entry in analyzer release file.</source>
         <target state="translated">分析器版本檔案中的項目無效。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
@@ -508,6 +508,18 @@ Types which implement compiler extension points should only be declared in assem
 |CodeFix|False|
 ---
 
+## RS1042: Implementations of this interface are not allowed
+
+The author of this interface has deprecated implementing this interface.
+
+|Item|Value|
+|-|-|
+|Category|MicrosoftCodeAnalysisCompatibility|
+|Enabled|True|
+|Severity|Error|
+|CodeFix|False|
+---
+
 ## [RS2000](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md): Add analyzer diagnostic IDs to analyzer release
 
 All supported analyzer diagnostic IDs should be part of an analyzer release.

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -513,6 +513,21 @@
             ]
           }
         },
+        "RS1042": {
+          "id": "RS1042",
+          "shortDescription": "Implementations of this interface are not allowed",
+          "fullDescription": "The author of this interface has deprecated implementing this interface.",
+          "defaultLevel": "error",
+          "properties": {
+            "category": "MicrosoftCodeAnalysisCompatibility",
+            "isEnabledByDefault": true,
+            "typeName": "ImplementationIsObsoleteAnalyzer",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ]
+          }
+        },
         "RS2000": {
           "id": "RS2000",
           "shortDescription": "Add analyzer diagnostic IDs to analyzer release",

--- a/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
@@ -39,3 +39,4 @@ RS1036 |  | Specify analyzer banned API enforcement setting |
 RS1037 |  | Add "CompilationEnd" custom tag to compilation end diagnostic descriptor |
 RS1039 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1040 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
+RS1042 |  | Implementations of this interface are not allowed |

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/ImplementationIsObsoleteAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/ImplementationIsObsoleteAnalyzerTests.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Test.Utilities;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<Microsoft.CodeAnalysis.Analyzers.ImplementationIsObsoleteAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<Microsoft.CodeAnalysis.Analyzers.ImplementationIsObsoleteAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.CodeAnalysis.Analyzers.UnitTests
+{
+    public class ImplementationIsObsoleteAnalyzerTests
+    {
+        private const string AttributeStringCSharp = """
+
+            namespace System.Runtime.CompilerServices
+            {
+                internal class ImplementationIsObsoleteAttribute : System.Attribute { public ImplementationIsObsoleteAttribute(string url) { } }
+            }
+
+            """;
+        [Fact]
+        public async Task CSharp_VerifySameAssemblyAsync()
+        {
+            string source = $$"""
+                {{AttributeStringCSharp}}
+
+                [System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")]
+                public interface IMyInterface { }
+
+                class SomeClass : IMyInterface { }
+                """;
+
+            // Verify no diagnostic since interface is in the same assembly.
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState = { Sources = { source } },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CSharp_VerifyDifferentAssemblyAsync()
+        {
+            string source1 = AttributeStringCSharp + """
+
+
+                [System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")]
+                public interface IMyInterface { }
+
+                public interface IMyOtherInterface : IMyInterface { }
+                """;
+
+            var source2 = """
+
+                class SomeClass : IMyInterface { }
+
+                class SomeOtherClass : IMyOtherInterface { }
+                """;
+
+            // Verify errors since interface is not in a friend assembly.
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState =
+                {
+                    Sources = { source2 },
+                    AdditionalProjects =
+                    {
+                        ["DependencyProject"] =
+                        {
+                            Sources = { source1 },
+                        },
+                    },
+                    AdditionalProjectReferences = { "DependencyProject" },
+                    ExpectedDiagnostics =
+                    {
+                        // /0/Test0.cs(2,7): error RS1042: Type SomeClass cannot implement interface IMyInterface because IMyInterface is obsolete for implementation. See https://example.com for more details.
+                        VerifyCS.Diagnostic().WithSpan(2, 7, 2, 16).WithArguments("SomeClass", "IMyInterface", "https://example.com"),
+                        // /0/Test0.cs(4,7): error RS1042: Type SomeOtherClass cannot implement interface IMyInterface because IMyInterface is obsolete for implementation. See https://example.com for more details.
+                        VerifyCS.Diagnostic().WithSpan(4, 7, 4, 21).WithArguments("SomeOtherClass", "IMyInterface", "https://example.com"),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CSharp_VerifyDifferentFriendAssemblyAsync()
+        {
+            string source1 = $$"""
+
+                [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TestProject")]
+
+                {{AttributeStringCSharp}}
+
+
+                [System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")]
+                public interface IMyInterface { }
+
+                public interface IMyOtherInterface : IMyInterface { }
+                """;
+
+            var source2 = """
+
+                class SomeClass : IMyInterface { }
+
+                class SomeOtherClass : IMyOtherInterface { }
+                """;
+
+            // Verify no diagnostic since interface is in a friend assembly.
+            await new VerifyCS.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState =
+                {
+                    Sources = { source2 },
+                    AdditionalProjects =
+                    {
+                        ["DependencyProject"] =
+                        {
+                            Sources = { source1 },
+                        },
+                    },
+                    AdditionalProjectReferences = { "DependencyProject" },
+                },
+            }.RunAsync();
+        }
+
+        private const string AttributeStringBasic = """
+
+            Namespace System.Runtime.CompilerServices
+                Friend Class ImplementationIsObsoleteAttribute 
+                    Inherits System.Attribute
+
+                    Public Sub New(url As String)
+                    End Sub
+                End Class
+            End Namespace
+
+            """;
+
+        [Fact]
+        public async Task Basic_VerifySameAssemblyAsync()
+        {
+            string source = $"""
+                {AttributeStringBasic}
+
+                <System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")>
+                Public Interface IMyInterface
+                End Interface
+
+                Class SomeClass 
+                    Implements IMyInterface 
+                End Class
+                """;
+
+            // Verify no diagnostic since interface is in the same assembly.
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState = { Sources = { source } },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task Basic_VerifyDifferentAssemblyAsync()
+        {
+            string source1 = $"""
+                {AttributeStringBasic}
+
+                <System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")>
+                Public Interface IMyInterface
+                End Interface
+
+                Public Interface IMyOtherInterface
+                    Inherits IMyInterface
+                End Interface
+
+                """;
+
+            var source2 = """
+
+                Class SomeClass 
+                    Implements IMyInterface 
+                End Class
+
+                Class SomeOtherClass
+                    Implements IMyOtherInterface
+                End Class
+
+                """;
+
+            // Verify errors since interface is not in a friend assembly.
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState =
+                {
+                    Sources = { source2 },
+                    AdditionalProjects =
+                    {
+                        ["DependencyProject"] =
+                        {
+                            Sources = { source1 },
+                        },
+                    },
+                    AdditionalProjectReferences = { "DependencyProject" },
+                    ExpectedDiagnostics =
+                    {
+                        // /0/Test0.vb(2,7): error RS1042: Type SomeClass cannot implement interface IMyInterface because IMyInterface is obsolete for implementation. See https://example.com for more details.
+                        VerifyVB.Diagnostic().WithSpan(2, 7, 2, 16).WithArguments("SomeClass", "IMyInterface", "https://example.com"),
+                        // /0/Test0.vb(6,7): error RS1042: Type SomeOtherClass cannot implement interface IMyInterface because IMyInterface is obsolete for implementation. See https://example.com for more details.
+                        VerifyVB.Diagnostic().WithSpan(6, 7, 6, 21).WithArguments("SomeOtherClass", "IMyInterface", "https://example.com"),
+                    },
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task Basic_VerifyDifferentFriendAssemblyAsync()
+        {
+            string source1 = $"""
+                <Assembly: System.Runtime.CompilerServices.InternalsVisibleTo("TestProject")>
+                {AttributeStringBasic}
+
+                <System.Runtime.CompilerServices.ImplementationIsObsoleteAttribute("https://example.com")>
+                Public Interface IMyInterface
+                End Interface
+
+                Public Interface IMyOtherInterface
+                    Inherits IMyInterface
+                End Interface
+                """;
+
+            var source2 = @"
+Class SomeClass 
+    Implements IMyInterface 
+End Class
+
+Class SomeOtherClass
+    Implements IMyOtherInterface
+End Class
+";
+
+            // Verify no diagnostic since interface is in a friend assembly.
+            await new VerifyVB.Test
+            {
+                ReferenceAssemblies = AdditionalMetadataReferences.DefaultWithoutRoslynSymbols,
+                TestState =
+                {
+                    Sources = { source2 },
+                    AdditionalProjects =
+                    {
+                        ["DependencyProject"] =
+                        {
+                            Sources = { source1 },
+                        },
+                    },
+                    AdditionalProjectReferences = { "DependencyProject" },
+                },
+            }.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
We're officially marking `ISourceGenerator` as deprecated, but we can't actually deprecate the interface, because it's used in several APIs like AnalyzerFileReference. So instead, we just add an analyzer to indicate that the interface should not be implemented. I've made this more general so we can do this with more interfaces in the future if necessary, based the implementation on InternalImplementationOnlyAnalyzer.
