### PR TITLE
Update field references

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
 
         public bool HasConstantValue => Symbol switch
         {
-            IFieldSymbol field => field.HasConstantValue,
+            IFieldSymbol fieldSymbol => fieldSymbol.HasConstantValue,
             ILocalSymbol local => local.HasConstantValue,
             _ => false,
         };

--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/AnalysisEntity.cs
@@ -187,7 +187,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
         public bool HasConstantValue => Symbol switch
         {
             IFieldSymbol fieldSymbol => fieldSymbol.HasConstantValue,
-            ILocalSymbol local => local.HasConstantValue,
+            ILocalSymbol localSymbol => localSymbol.HasConstantValue,
             _ => false,
         };
 


### PR DESCRIPTION
Rename or qualify `field` references in property accessors to avoid conflict with [`field` keyword](https://github.com/dotnet/csharplang/blob/main/proposals/field-keyword.md) in C# compiler preview.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/7429