### PR TITLE
Iterator modifier removed when applying mark member as static fixer in VB

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/QualityGuidelines/MarkMembersAsStaticTests.Fixer.cs
@@ -1635,5 +1635,27 @@ partial class Class1
                     """,
             }.RunAsync();
         }
+
+        [Fact]
+        public async Task TestBasic_Iterator_ModifierRemoved()
+        {
+            await VerifyVB.VerifyCodeFixAsync(@"
+Imports System
+Imports System.Collections.Generic
+Public Class MembersTests
+    Public Iterator Function [|Method1|]() As IEnumerable(Of Integer)
+        Yield 1
+    End Function
+End Class",
+@"
+Imports System
+Imports System.Collections.Generic
+Public Class MembersTests
+    Public Shared Iterator Function Method1() As IEnumerable(Of Integer)
+        Yield 1
+    End Function
+End Class");
+        }
+
     }
 }


### PR DESCRIPTION
For now just has a failing test.
Relates to #7433 and [this Roslyn issue](https://github.com/dotnet/roslyn/issues/75388).

Please let me know if I am doing something wrong I am new to this process.