### PR TITLE
Fixed line break issue

### DIFF
--- a/src/Tools/Scripts/CopyAllResourceStrings.ps1
+++ b/src/Tools/Scripts/CopyAllResourceStrings.ps1
@@ -36,7 +36,7 @@ $xlfDirectories | ForEach-Object {
 };
 
 $resxFiles = Get-ChildItem -Filter *.resx -File -Recurse $destinationSrcDirectory `
-    | ForEach-Object { $_.FullName }
+    | ForEach-Object { $_.FullName } `
     | ForEach-Object { [System.IO.Path]::GetRelativePath($destinationRepo, $_) };
 
 $resxFiles | ForEach-Object {


### PR DESCRIPTION
The last `| ForEach-Object { [System ... }` was not actually being included in the previous line. The `\`` will cause it to be included
