### PR TITLE
Add config parameter for value task consumption

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Tasks/UseValueTasksCorrectly.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -130,6 +131,16 @@ namespace Microsoft.NetCore.Analyzers.Tasks
                             case nameof(ValueTask.ConfigureAwait):
                                 // ConfigureAwait returns another awaitable. Use that one instead for subsequent analysis.
                                 operation = invocation = parentIo;
+                                break;
+                            default:
+                                var additionalMethods =
+                                    operationContext.Options.GetStringOptionValue(
+                                        EditorConfigOptionNames.AdditionalValidValueTaskConsumption, GeneralRule,
+                                        operation.Syntax.SyntaxTree, operationContext.Compilation)
+                                    .Split(['|'], StringSplitOptions.RemoveEmptyEntries)
+                                    .ToImmutableArray();
+                                if (additionalMethods.Contains(parentIo.TargetMethod.Name))
+                                    return;
                                 break;
                         }
                     }

--- a/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
+++ b/src/Utilities/Compiler/Options/EditorConfigOptionNames.cs
@@ -234,5 +234,10 @@ namespace Analyzer.Utilities
         /// Boolean option whether to perform the analysis even if the assembly exposes its internals.
         /// </summary>
         public const string IgnoreInternalsVisibleTo = "ignore_internalsvisibleto";
+
+        /// <summary>
+        /// String option to configure names of additional safe value task consumptions (separated by '|') for CA2012.
+        /// </summary>
+        public const string AdditionalValidValueTaskConsumption = "additional_valid_valuetask_consumption";
     }
 }


### PR DESCRIPTION
This adds a config option to CA2012 (ValueTask consumption).
The analyzer allows consumption via ConfigureAwait and a few others however it maybe useful to allow other methods as well.
For example:

```vb.net
    <Extension>
    Public Function KeepContext(a As ValueTask) As ConfiguredValueTaskAwaitable
        Return a.ConfigureAwait(True)
    End Function

    <Extension>
    Public Function FreeContext(a As ValueTask) As ConfiguredValueTaskAwaitable
        Return a.ConfigureAwait(False)
    End Function
```
Using these methods would trigger the warning.
```
dotnet_code_quality.additional_valid_valuetask_consumption=KeepContext|FreeContext
```
Or can configured like so.

Sorry if I did something incorrectly.