### PR TITLE
Fix RS2007 not allowing table borders

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReleaseTrackingHelper.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/ReleaseTrackingHelper.cs
@@ -31,10 +31,10 @@ namespace Microsoft.CodeAnalysis.ReleaseTracking
         internal const string TableHeaderNewOrRemovedRulesLine2 = @"--------|----------|----------|-------";
         internal const string TableHeaderChangedRulesLine1 = @"Rule ID | New Category | New Severity | Old Category | Old Severity | Notes";
         internal const string TableHeaderChangedRulesLine2 = @"--------|--------------|--------------|--------------|--------------|-------";
-        internal const string TableHeaderNewOrRemovedRulesLine1RegexPattern = @"^\s*Rule ID\s*\|\s*Category\s*\|\s*\Severity\s*\|\s*Notes";
-        internal const string TableHeaderChangedRulesLine1RegexPattern = @"^\s*Rule ID\s*\|\s*New Category\s*\|\s*New Severity\s*\|\s*Old Category\s*\|\s*Old Severity\s*\|\s*Notes";
-        internal const string TableHeaderNewOrRemovedRulesLine2RegexPattern = @"^-{3,}\|-{3,}\|-{3,}\|-{3,}";
-        internal const string TableHeaderChangedRulesLine2RegexPattern = @"^-{3,}\|-{3,}\|-{3,}\|-{3,}\|-{3,}\|-{3,}";
+        internal const string TableHeaderNewOrRemovedRulesLine1RegexPattern = @"^\|?\s*Rule ID\s*\|\s*Category\s*\|\s*\Severity\s*\|\s*Notes\s*\|?";
+        internal const string TableHeaderChangedRulesLine1RegexPattern = @"^\|?\s*Rule ID\s*\|\s*New Category\s*\|\s*New Severity\s*\|\s*Old Category\s*\|\s*Old Severity\s*\|\s*Notes\s*\|?";
+        internal const string TableHeaderNewOrRemovedRulesLine2RegexPattern = @"^\|?-{3,}\|-{3,}\|-{3,}\|-{3,}\|?";
+        internal const string TableHeaderChangedRulesLine2RegexPattern = @"^\|?-{3,}\|-{3,}\|-{3,}\|-{3,}\|-{3,}\|-{3,}\|?";
 
         internal static Version UnshippedVersion { get; } = new Version(int.MaxValue, int.MaxValue);
 
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.ReleaseTracking
 
                 RoslynDebug.Assert(currentRuleEntryKind != null);
 
-                var parts = lineText.Split('|').Select(s => s.Trim()).ToArray();
+                var parts = lineText.Trim('|').Split('|').Select(s => s.Trim()).ToArray();
                 if (IsInvalidEntry(parts, currentRuleEntryKind.Value))
                 {
                     // Report invalid entry, but continue parsing remaining entries.

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/ReleaseTrackingAnalyzerTests.cs
@@ -101,25 +101,46 @@ class MyAnalyzer : DiagnosticAnalyzer
 
         // Unshipped release with existing new rules table.
         [InlineData("", DefaultUnshippedHeader + "Id1 | Category1 | Warning |")]
+        // Unshipped release with existing new rules table with borders.
+        [InlineData("", DefaultUnshippedHeaderWithBorders + "| Id1 | Category1 | Warning | |")]
         // Shipped release with existing new rules table.
         [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |", "")]
+        // Shipped release with existing new rules table with borders.
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id1 | Category1 | Warning | |", "")]
         // Releases with separate new rules and changed rules table.
         [InlineData(DefaultShippedHeader + "Id1 | Category0 | Warning |" + BlankLine +
                     DefaultChangedShippedHeader2 + "Id1 | Category1 | Warning | Category0 | Warning |", "")]
+        // Releases with separate new rules and changed rules table with borders.
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id1 | Category0 | Warning | |" + BlankLine +
+                    DefaultChangedShippedHeader2WithBorders + "| Id1 | Category1 | Warning | Category0 | Warning | |", "")]
         // Releases with separate new rules and removed rules table.
         [InlineData(DefaultShippedHeader + "Id1 | Category1 | Warning |" + BlankLine + "Id2 | Category1 | Warning |" + BlankLine +
                     DefaultRemovedShippedHeader2 + "Id2 | Category1 | Warning ", "")]
+        // Releases with separate new rules and removed rules table with borders.
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id1 | Category1 | Warning | |" + BlankLine + "| Id2 | Category1 | Warning | |" + BlankLine +
+                    DefaultRemovedShippedHeader2WithBorders + "| Id2 | Category1 | Warning | |", "")]
         // Release with new rules and changed rules table.
         [InlineData(DefaultShippedHeader + "Id2 | Category0 | Warning |" + BlankLine +
                     DefaultShippedHeader2 + "Id1 | Category1 | Warning |" + BlankLine + DefaultChangedUnshippedHeader + "Id2 | Category1 | Warning | Category0 | Warning |",
                     DefaultRemovedUnshippedHeader + "Id2 | Category1 | Warning |")]
+        // Release with new rules and changed rules table with borders.
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id2 | Category0 | Warning | |" + BlankLine +
+                    DefaultShippedHeader2WithBorders + "| Id1 | Category1 | Warning | |" + BlankLine + DefaultChangedUnshippedHeaderWithBorders + "| Id2 | Category1 | Warning | Category0 | Warning | |",
+                    DefaultRemovedUnshippedHeaderWithBorders + "| Id2 | Category1 | Warning | |")]
         // Release with new rules and removed rules table.
         [InlineData(DefaultShippedHeader + "Id2 | Category0 | Warning |" + BlankLine +
                     DefaultShippedHeader2 + "Id1 | Category1 | Warning |" + BlankLine + DefaultRemovedUnshippedHeader + "Id2 | Category0 | Warning |", "")]
+        // Release with new rules and removed rules table with borders.
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id2 | Category0 | Warning | |" + BlankLine +
+                    DefaultShippedHeader2WithBorders + "| Id1 | Category1 | Warning | |" + BlankLine + DefaultRemovedUnshippedHeaderWithBorders + "| Id2 | Category0 | Warning | |", "")]
         // Release with all 3 tables
         [InlineData(DefaultShippedHeader + "Id3 | Category1 | Warning |" + BlankLine + "Id2 | Category0 | Warning |" + BlankLine +
                     DefaultShippedHeader2 + "Id1 | Category1 | Warning |" + BlankLine + DefaultChangedUnshippedHeader + "Id3 | Category2 | Warning | Category1 | Warning |" + BlankLine + DefaultRemovedUnshippedHeader + "Id2 | Category1 | Warning |",
                     DefaultRemovedUnshippedHeader + "Id3 | Category2 | Warning |")]
+        // Release with all 3 tables with borders
+        [InlineData(DefaultShippedHeaderWithBorders + "| Id3 | Category1 | Warning | |" + BlankLine + "| Id2 | Category0 | Warning | |" + BlankLine +
+                    DefaultShippedHeader2WithBorders + "| Id1 | Category1 | Warning | |" + BlankLine + DefaultChangedUnshippedHeaderWithBorders + "| Id3 | Category2 | Warning | Category1 | Warning | |" + BlankLine + DefaultRemovedUnshippedHeaderWithBorders + "| Id2 | Category1 | Warning | |",
+                    DefaultRemovedUnshippedHeaderWithBorders + "| Id3 | Category2 | Warning | |")]
         [Theory]
         public async Task TestReleasesFileAlreadyHasEntryAsync(string shippedText, string unshippedText)
         {
@@ -975,6 +996,24 @@ class MyAnalyzer : DiagnosticAnalyzer
 
         private const string DefaultShippedHeader3 = ReleaseTrackingHelper.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultUnshippedHeader;
         private const string DefaultChangedShippedHeader3 = ReleaseTrackingHelper.ReleasePrefix + " 3.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeader;
+
+        private const string DefaultUnshippedHeaderWithBorders = ReleaseTrackingHelper.TableTitleNewRules + BlankLine + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + "|" + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + "|" + BlankLine;
+
+        private const string DefaultRemovedUnshippedHeaderWithBorders = ReleaseTrackingHelper.TableTitleRemovedRules + BlankLine + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine1 + "|" + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderNewOrRemovedRulesLine2 + "|" + BlankLine;
+
+        private const string DefaultChangedUnshippedHeaderWithBorders = ReleaseTrackingHelper.TableTitleChangedRules + BlankLine + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderChangedRulesLine1 + "|" + BlankLine +
+            "|" + ReleaseTrackingHelper.TableHeaderChangedRulesLine2 + "|" + BlankLine;
+
+        private const string DefaultShippedHeaderWithBorders = ReleaseTrackingHelper.ReleasePrefix + " 1.0" + BlankLine + BlankLine + DefaultUnshippedHeaderWithBorders;
+
+        private const string DefaultShippedHeader2WithBorders = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultUnshippedHeaderWithBorders;
+        private const string DefaultRemovedShippedHeader2WithBorders = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultRemovedUnshippedHeaderWithBorders;
+        private const string DefaultChangedShippedHeader2WithBorders = ReleaseTrackingHelper.ReleasePrefix + " 2.0" + BlankLine + BlankLine + DefaultChangedUnshippedHeaderWithBorders;
 
         private static DiagnosticResult GetAdditionalFileResultAt(int line, int column, string path, DiagnosticDescriptor descriptor, params object[] arguments)
         {


### PR DESCRIPTION
Allows release trackers to have table borders without raising a warning for RS2007.

<!--

Make sure you have read the contribution guidelines: 
- https://learn.microsoft.com/contribute/dotnet/dotnet-contribute-code-analysis#contribute-docs-for-caxxxx-rules
- https://github.com/dotnet/roslyn-analyzers/blob/main/GuidelinesForNewRules.md

If your Pull Request is doing one of the following:

- Adding a new diagnostic analyzer or a code fix
- Adding or updating resource strings used by analyzers and code fixes
- Updating analyzer package versions in [Versions.props](../eng/Versions.props)

Then, make sure to run `msbuild /t:pack /v:m` in the repository root; otherwise, the CI build will fail.

- This command must be run from a Visual Studio Developer Command Prompt
- Alternatively, `dotnet msbuild RoslynAnalyzers.sln -t:pack -v:m` can be used from a standard terminal window

Note: Consider merging the PR base branch (`2.9.x`, `main`, or `release/*`) into your branch before you run the pack command to reduce merge conflicts.

-->

Fixes #7465
