### PR TITLE
[ResxSourceGenerator] Add a `/// <summary />` comment to public and internal generated members

### DIFF
--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsCSharpAsync_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsCSharpAsync_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsCSharpAsync_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsCSharpAsync_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsVisualBasicAsync_False/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsVisualBasicAsync_False/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsVisualBasicAsync_True/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_AsConstantsVisualBasicAsync_True/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync_NS/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync_NS/Resources.Designer.cs
@@ -8,11 +8,15 @@ namespace TestProject
     internal static class Resources { }
 }
 
+/// <summary />
 internal static partial class NS
 {
     private static global::System.Resources.ResourceManager? s_resourceManager;
+    /// <summary />
     public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(TestProject.Resources)));
+    /// <summary />
     public static global::System.Globalization.CultureInfo? Culture { get; set; }
+    /// <summary />
     [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
     internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync_NS1.NS2/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameCSharpAsync_NS1.NS2/Resources.Designer.cs
@@ -9,11 +9,15 @@ namespace TestProject
 }
 namespace NS1
 {
+    /// <summary />
     internal static partial class NS2
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(TestProject.Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync_NS/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync_NS/Resources.Designer.vb
@@ -7,11 +7,13 @@ Namespace TestProject
     End Class
 End Namespace
 
+''' <summary />
 Friend Partial Class NS
     Private Sub New
     End Sub
     
     Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+    ''' <summary />
     Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
         Get
             If s_resourceManager Is Nothing Then
@@ -20,7 +22,9 @@ Friend Partial Class NS
             Return s_resourceManager
         End Get
     End Property
+    ''' <summary />
     Public Shared Property Culture As Global.System.Globalization.CultureInfo
+    ''' <summary />
     <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
     Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
         Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync_NS1.NS2/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_ClassNameVisualBasicAsync_NS1.NS2/Resources.Designer.vb
@@ -7,11 +7,13 @@ Namespace TestProject
     End Class
 End Namespace
 Namespace Global.NS1
+    ''' <summary />
     Friend Partial Class NS2
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -20,7 +22,9 @@ Namespace Global.NS1
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp5/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp5/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager s_resourceManager;
+        /// <summary />
         internal static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         internal static global::System.Globalization.CultureInfo Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string GetResourceString(string resourceKey, string defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp6/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp6/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string GetResourceString(string resourceKey, string defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp7/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp7/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string GetResourceString(string resourceKey, string defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp8/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp8/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp9/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultCSharpAsync_CSharp9/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultVisualBasicAsync/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_DefaultVisualBasicAsync/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsVisualBasicAsync_False/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsVisualBasicAsync_False/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesCSharpAsync_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesCSharpAsync_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesCSharpAsync_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesCSharpAsync_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesVisualBasicAsync_False/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesVisualBasicAsync_False/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesVisualBasicAsync_True/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_IncludeDefaultValuesVisualBasicAsync_True/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringCSharpAsync_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringCSharpAsync_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringCSharpAsync_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringCSharpAsync_True/Resources.Designer.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
 
         /// <summary>value</summary>

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringVisualBasicAsync_False/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringVisualBasicAsync_False/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringVisualBasicAsync_True/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_OmitGetResourceStringVisualBasicAsync_True/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicCSharpAsync_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicCSharpAsync_False/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicCSharpAsync_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicCSharpAsync_True/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     public static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicVisualBasicAsync_False/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicVisualBasicAsync_False/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicVisualBasicAsync_True/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_PublicVisualBasicAsync_True/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Public Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync_NS/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync_NS/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject
 {
+    /// <summary />
     internal static partial class NSResources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(NSResources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync_NS1.NS2/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirCSharpAsync_NS1.NS2/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject.NS1
 {
+    /// <summary />
     internal static partial class NS2Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(NS2Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync_NS/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync_NS/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject
+    ''' <summary />
     Friend Partial Class NSResources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync_NS1.NS2/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RelativeDirVisualBasicAsync_NS1.NS2/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject.NS1
+    ''' <summary />
     Friend Partial Class NS2Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject.NS1
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace 
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         internal static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         internal static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync_NS/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync_NS/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace NS
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync_NS1.NS2/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceCSharpAsync_NS1.NS2/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace NS1.NS2
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Friend Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Friend Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync_NS/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync_NS/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.NS
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.NS
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync_NS1.NS2/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_RootNamespaceVisualBasicAsync_NS1.NS2/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.NS1.NS2
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.NS1.NS2
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultCSharpAsync/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultCSharpAsync/Resources.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject.First
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultCSharpAsync/Resources0.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultCSharpAsync/Resources0.Designer.cs
@@ -6,11 +6,15 @@ using System.Reflection;
 
 namespace TestProject.Second
 {
+    /// <summary />
     internal static partial class Resources
     {
         private static global::System.Resources.ResourceManager? s_resourceManager;
+        /// <summary />
         public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof(Resources)));
+        /// <summary />
         public static global::System.Globalization.CultureInfo? Culture { get; set; }
+        /// <summary />
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultVisualBasicAsync/Resources.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultVisualBasicAsync/Resources.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject.First
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject.First
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultVisualBasicAsync/Resources0.Designer.vb
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/TwoResourcesSameName_DefaultVisualBasicAsync/Resources0.Designer.vb
@@ -4,11 +4,13 @@ Imports System.Reflection
 
 
 Namespace Global.TestProject.Second
+    ''' <summary />
     Friend Partial Class Resources
         Private Sub New
         End Sub
         
         Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+        ''' <summary />
         Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
             Get
                 If s_resourceManager Is Nothing Then
@@ -17,7 +19,9 @@ Namespace Global.TestProject.Second
                 Return s_resourceManager
             End Get
         End Property
+        ''' <summary />
         Public Shared Property Culture As Global.System.Globalization.CultureInfo
+        ''' <summary />
         <Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
         Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
             Return ResourceManager.GetString(resourceKey, Culture)

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -494,7 +494,8 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                                 getResourceStringAttributes.Add("[return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull(\"defaultValue\")]");
                             }
 
-                            getStringMethod = $@"{memberIndent}public static global::System.Globalization.CultureInfo{(CompilationInformation.SupportsNullable ? "?" : "")} Culture {{ get; set; }}
+                            getStringMethod = $@"{memberIndent}/// <summary />{Environment.NewLine}{memberIndent}public static global::System.Globalization.CultureInfo{(CompilationInformation.SupportsNullable ? "?" : "")} Culture {{ get; set; }}
+{memberIndent}/// <summary />
 {string.Join(Environment.NewLine, getResourceStringAttributes.Select(attr => memberIndent + attr))}
 {memberIndent}internal static {(CompilationInformation.SupportsNullable ? "string?" : "string")} GetResourceString(string resourceKey, {(CompilationInformation.SupportsNullable ? "string?" : "string")} defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;";
                             if (ResourceInformation.EmitFormatMethods)
@@ -519,7 +520,8 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                             break;
 
                         case Lang.VisualBasic:
-                            getStringMethod = $@"{memberIndent}Public Shared Property Culture As Global.System.Globalization.CultureInfo
+                            getStringMethod = $@"{memberIndent}''' <summary />{Environment.NewLine}{memberIndent}Public Shared Property Culture As Global.System.Globalization.CultureInfo
+{memberIndent}''' <summary />
 {memberIndent}<Global.System.Runtime.CompilerServices.MethodImpl(Global.System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)>
 {memberIndent}Friend Shared Function GetResourceString(ByVal resourceKey As String, Optional ByVal defaultValue As String = Nothing) As String
 {memberIndent}    Return ResourceManager.GetString(resourceKey, Culture)
@@ -623,9 +625,11 @@ using System.Reflection;
 
 {resourceTypeDefinition}
 {namespaceStart}
+{classIndent}{"/// <summary />"}
 {classIndent}{(ResourceInformation.Public ? "public" : "internal")} static partial class {className}
 {classIndent}{{
 {memberIndent}private static global::System.Resources.ResourceManager{(CompilationInformation.SupportsNullable ? "?" : "")} s_resourceManager;
+{memberIndent}{"/// <summary />"}
 {memberIndent}public static global::System.Resources.ResourceManager ResourceManager => s_resourceManager ?? (s_resourceManager = new global::System.Resources.ResourceManager(typeof({resourceTypeName})));
 {getStringMethod}
 {strings}
@@ -641,11 +645,13 @@ Imports System.Reflection
 
 {resourceTypeDefinition}
 {namespaceStart}
+{classIndent}{"''' <summary />"}
 {classIndent}{(ResourceInformation.Public ? "Public" : "Friend")} Partial Class {className}
 {memberIndent}Private Sub New
 {memberIndent}End Sub
 {memberIndent}
 {memberIndent}Private Shared s_resourceManager As Global.System.Resources.ResourceManager
+{memberIndent}{"''' <summary />"}
 {memberIndent}Public Shared ReadOnly Property ResourceManager As Global.System.Resources.ResourceManager
 {memberIndent}    Get
 {memberIndent}        If s_resourceManager Is Nothing Then


### PR DESCRIPTION
# [ResxSourceGenerator] Add a `/// <summary />` comment to public and internal generated members

See #7478 

## Analyzer

Microsoft.CodeAnalysis.ResxSourceGenerator

## Describe the improvement

Add a `/// <summary />` comment to **public** and **internals** generated members (classes and methods).

Example:
![{67B60FCB-FE48-4164-B0BB-A8C5EFB6546F}](https://github.com/user-attachments/assets/94256cd9-b722-4d1f-a7aa-e2fcd4aa9626)


### Describe suggestions on how to achieve the rule

I use this csproj configuration containing the `<Public>` flag to generate a public class.
My `editorconfig` rules require all public classes/methods to contain XML documentation.
So I get the following error “CS1592 Missing XML comment for publicly visible type or member ‘LanguageResource’”.
I can't add an exclusion to this file because it's not generated in my source folders (but in a temporary folder).


```xml
<ItemGroup>
  <PackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator">
    <PrivateAssets>all</PrivateAssets>
    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
  </PackageReference>
    
  <EmbeddedResource Update="Localization\LanguageResource.resx">
    <Public>true</Public>
    <OmitGetResourceString>true</OmitGetResourceString>
    <AsConstants>true</AsConstants>
  </EmbeddedResource>
</ItemGroup>
```

## Unit Tests

All unit tests are updated to include these new `<summary />` comments.