### PR TITLE
Fix CA1515 nested types false positives

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/MakeTypesInternal.cs
+++ b/src/NetAnalyzers/Core/Microsoft.CodeQuality.Analyzers/Maintainability/MakeTypesInternal.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability
         private void AnalyzeType(SymbolAnalysisContext context)
         {
             INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
-            if (namedTypeSymbol.IsPublic()
+            if (namedTypeSymbol.IsExternallyVisible()
                 && GetIdentifier(namedTypeSymbol.DeclaringSyntaxReferences[0].GetSyntax()) is SyntaxToken identifier)
             {
                 context.ReportDiagnostic(identifier.CreateDiagnostic(Rule));

--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/MakeTypesInternalTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/Maintainability/MakeTypesInternalTests.cs
@@ -440,20 +440,9 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
                 {
                     public static void Main() {}
                 
-                    public struct [|MyValueType|]
+                    public struct MyValueType
                     {
-                        public class [|Nested|] {}
-                    }
-                }
-                """,
-                """
-                class Program
-                {
-                    public static void Main() {}
-                
-                    internal struct MyValueType
-                    {
-                        internal class Nested {}
+                        public class Nested {}
                     }
                 }
                 """);
@@ -463,19 +452,8 @@ namespace Microsoft.CodeQuality.Analyzers.Maintainability.UnitTests
                     Public Shared Sub Main()
                     End Sub
                 
-                    Public Structure [|MyValueType|]
-                        Public Class [|Nested|]
-                        End Class
-                    End Structure
-                End Class
-                """,
-                """
-                Class Program
-                    Public Shared Sub Main()
-                    End Sub
-                
-                    Friend Structure MyValueType
-                        Friend Class Nested
+                    Public Structure MyValueType
+                        Public Class Nested
                         End Class
                     End Structure
                 End Class


### PR DESCRIPTION
Fixes publicly nested types being reported as a CA1515 regardless of whether they are actually externally accessible.

Fixes https://github.com/dotnet/roslyn-analyzers/issues/7464
