### PR TITLE
[Backport] Fix CA2021 false positive for generic class types

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DoNotCallEnumerableCastOrOfTypeWithIncompatibleTypesAnalyzer.cs
@@ -196,6 +196,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return false;
                 }
 
+                // Most checks are better with OriginalDefinition, but keep the ones passed in around.
+                ITypeSymbol castFromParam = castFrom;
+                ITypeSymbol castToParam = castTo;
+
                 castFrom = castFrom.OriginalDefinition;
                 castTo = castTo.OriginalDefinition;
 
@@ -269,8 +273,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         return false;
 
                     case (TypeKind.Class, TypeKind.Class):
-                        return !castFrom.DerivesFrom(castTo)
-                            && !castTo.DerivesFrom(castFrom);
+                        return !castFromParam.DerivesFrom(castToParam)
+                            && !castToParam.DerivesFrom(castFromParam);
 
                     case (TypeKind.Interface, TypeKind.Class):
                         return castTo.IsSealed && !castTo.DerivesFrom(castFrom);


### PR DESCRIPTION
Backport of #7488

Fix for #7357.

#7183 changed the `CastWillAlwaysFail(ITypeSymbol castFrom, ITypeSymbol castTo)` to work with `castFrom.OriginalDefinition`/`castTo.OriginalDefinition`, eliding the generic type information in order to fix issues with interfaces, but that appears to have broken the check for class types. This reverts just the class type case to use the `castFrom`/`castTo` types passed in instead of the `.OriginalDefinition`. I'm not sure I quite understand why that's the only place this matters, but I tried a few variations with `struct`s and `interface`s and couldn't get any other false positives.