### PR TITLE
Fix effective analysis level trimming regex

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1559,7 +1559,7 @@ namespace GenerateDocumentationAndConfigFiles
                         propertyStr += $"""
 
                                   <!-- Default '{packageVersionPropName}' to '{effectiveAnalysisLevelPropName}' with trimmed trailing '.0' -->
-                                  <{packageVersionPropName} Condition="'$({packageVersionPropName})' == '' and $({effectiveAnalysisLevelPropName}) != ''">$([System.Text.RegularExpressions.Regex]::Replace($({effectiveAnalysisLevelPropName}), '(.0)*$', ''))</{packageVersionPropName}>
+                                  <{packageVersionPropName} Condition="'$({packageVersionPropName})' == '' and $({effectiveAnalysisLevelPropName}) != ''">$([System.Text.RegularExpressions.Regex]::Replace($({effectiveAnalysisLevelPropName}), '(\.0)*$', ''))</{packageVersionPropName}>
 
                             """;
                         return propertyStr;


### PR DESCRIPTION
Trim `\.0` instead of `.0` so that "10" or "10.0" doesn't get replaced with the empty string.

I've executed restore.cmd, build.cmd, and test.cmd and everything passes.