### PR TITLE
Error when users use a `file` type for things we need to load

### DIFF
--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 RS1038 | MicrosoftCodeAnalysisCorrectness | Warning | CompilerExtensionStrictApiAnalyzer
 RS1041 | MicrosoftCodeAnalysisCorrectness | Warning | CompilerExtensionTargetFrameworkAnalyzer, [Documentation](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1041.md)
 RS1042 | MicrosoftCodeAnalysisCompatibility | Error | ImplementationIsObsoleteAnalyzer
+RS1043 | MicrosoftCodeAnalysisCorrectness | Error | DoNotUseFileTypesForAnalyzersOrGenerators

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -606,12 +606,12 @@
     <value>Implementations of this interface are not allowed</value>
   </data>
   <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription" xml:space="preserve">
-    <value>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</value>
+    <value>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</value>
   </data>
   <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage" xml:space="preserve">
     <value>Type '{0}' should not be marked with 'file'</value>
   </data>
   <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle" xml:space="preserve">
-    <value>Do not use file types for analyzers, generators, and code fixers</value>
+    <value>Do not use file types for implementing analyzers, generators, and code fixers</value>
   </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/CodeAnalysisDiagnosticsResources.resx
@@ -605,4 +605,13 @@
   <data name="ImplementationIsObsoleteTitle" xml:space="preserve">
     <value>Implementations of this interface are not allowed</value>
   </data>
+  <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription" xml:space="preserve">
+    <value>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</value>
+  </data>
+  <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage" xml:space="preserve">
+    <value>Type '{0}' should not be marked with 'file'</value>
+  </data>
+  <data name="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle" xml:space="preserve">
+    <value>Do not use file types for analyzers, generators, and code fixers</value>
+  </data>
 </root>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/DiagnosticIds.cs
@@ -46,6 +46,7 @@ namespace Microsoft.CodeAnalysis.Analyzers
         public const string SemanticModelGetDeclaredSymbolAlwaysReturnsNullForField = "RS1040";
         public const string DoNotRegisterCompilerTypesWithBadTargetFrameworkRuleId = "RS1041";
         public const string ImplementationIsObsoleteRuleId = "RS1042";
+        public const string DoNotUseFileTypesForAnalyzersOrGenerators = "RS1043";
 
         // Release tracking analyzer IDs
         public const string DeclareDiagnosticIdInAnalyzerReleaseRuleId = "RS2000";

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
             isEnabledByDefault: true,
             description: CreateLocalizableResourceString(nameof(DoNotUseFileTypesForAnalyzersOrGeneratorsDescription)));
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
     using static CodeAnalysisDiagnosticsResources;
 
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    public class DoNotUseFileTypesForAnalyzersOrGenerators : DiagnosticAnalyzer
+    public sealed class DoNotUseFileTypesForAnalyzersOrGenerators : DiagnosticAnalyzer
     {
         private static readonly DiagnosticDescriptor Rule = new(
             DiagnosticIds.DoNotUseFileTypesForAnalyzersOrGenerators,

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/MetaAnalyzers/DoNotUseFileTypesForAnalyzersOrGenerators.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Analyzer.Utilities;
+using Analyzer.Utilities.Extensions;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers
+{
+    using static CodeAnalysisDiagnosticsResources;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class DoNotUseFileTypesForAnalyzersOrGenerators : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            DiagnosticIds.DoNotUseFileTypesForAnalyzersOrGenerators,
+            CreateLocalizableResourceString(nameof(DoNotUseFileTypesForAnalyzersOrGeneratorsTitle)),
+            CreateLocalizableResourceString(nameof(DoNotUseFileTypesForAnalyzersOrGeneratorsMessage)),
+            DiagnosticCategory.MicrosoftCodeAnalysisCorrectness,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            description: CreateLocalizableResourceString(nameof(DoNotUseFileTypesForAnalyzersOrGeneratorsDescription)));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(context =>
+            {
+                INamedTypeSymbol? diagnosticAnalyzer = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisDiagnosticsDiagnosticAnalyzer);
+                if (diagnosticAnalyzer == null)
+                {
+                    // Does not contain any diagnostic analyzers.
+                    return;
+                }
+
+                // There may or may not be a code fix provider type and generator types, depending on what this assembly depends on.
+                INamedTypeSymbol? codeFixProvider = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisCodeFixesCodeFixProvider);
+                INamedTypeSymbol? isourceGenerator = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisISourceGenerator);
+                INamedTypeSymbol? iincrementalGenerator = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftCodeAnalysisIIncrementalGenerator);
+
+                context.RegisterSymbolAction(symbolContext => AnalyzeSymbol(symbolContext, diagnosticAnalyzer, codeFixProvider, isourceGenerator, iincrementalGenerator), SymbolKind.NamedType);
+            });
+        }
+
+        private static void AnalyzeSymbol(SymbolAnalysisContext context, INamedTypeSymbol diagnosticAnalyzer, INamedTypeSymbol? codeFixProvider, INamedTypeSymbol? isourceGenerator, INamedTypeSymbol? iincrementalGenerator)
+        {
+            var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+            if (!namedTypeSymbol.IsFileLocal())
+            {
+                return;
+            }
+
+            if (namedTypeSymbol.Inherits(diagnosticAnalyzer) ||
+                namedTypeSymbol.Inherits(codeFixProvider) ||
+                namedTypeSymbol.Inherits(isourceGenerator) ||
+                namedTypeSymbol.Inherits(iincrementalGenerator))
+            {
+                var diagnostic = Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], namedTypeSymbol.Name);
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Nevolejte metodu Compilation.GetSemanticModel() v diagnostickém analyzátoru</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">Hodnoty DiagnosticId pro analyzátory by neměly používat rezervovaná ID.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.cs.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Compilation.GetSemanticModel()-Methode nicht innerhalb eines Diagnoseanalysetools aufrufen</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">Die DiagnosticId für Analysetools darf keine reservierten IDs verwenden.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.de.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -172,6 +172,21 @@
         <target state="translated">No invoque el método Compilation.GetSemanticModel() en un analizador de diagnóstico</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">El valor DiagnosticId para los analizadores no debe usar identificadores reservados.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.es.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -172,6 +172,21 @@
         <target state="translated">N'appelez pas la méthode Compilation.GetSemanticModel() dans un analyseur de diagnostic</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">DiagnosticId pour les analyseurs ne doit pas utiliser d'ID réservés.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.fr.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.it.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Non richiamare il metodo Compilation.GetSemanticModel() in un analizzatore diagnostico</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">L'ID diagnostica per gli analizzatori non deve usare ID riservati.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ja.xlf
@@ -172,6 +172,21 @@
         <target state="translated">診断アナライザー内での Compilation.GetSemanticModel() メソッドの呼び出し禁止</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">アナライザーの診断 ID には、予約済み ID を使用しないでください。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -172,6 +172,21 @@
         <target state="translated">진단 분석기 내에서 Compilation.GetSemanticModel() 메서드를 호출하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">분석기의 DiagnosticId에는 예약된 ID를 사용해서는 안 됩니다.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ko.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Nie wywołuj metody Compilation.GetSemanticModel() w analizatorze diagnostycznym</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">W elemencie DiagnosticId dla analizatorów nie należy używać zastrzeżonych identyfikatorów.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pl.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Não invocar o método Compilation.GetSemanticModel() em um analisador de diagnóstico</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">A DiagnosticId dos analisadores não deve usar IDs reservadas.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.pt-BR.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.ru.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Не вызывайте метод Compilation.GetSemanticModel() в диагностическом анализаторе</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">Идентификатор диагностики DiagnosticId для анализатора не должен включать зарезервированные идентификаторы.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.tr.xlf
@@ -172,6 +172,21 @@
         <target state="translated">Bir tanılama çözümleyicisi içinde Compilation.GetSemanticModel() yöntemini çağırma</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">Çözümleyiciler için DiagnosticId, ayrılmış kimlikler kullanmamalıdır.</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -172,6 +172,21 @@
         <target state="translated">请勿在诊断分析器中调用 Compilation.GetSemanticModel() 方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">分析器的 DiagnosticId 不应使用保留 ID。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hans.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -172,6 +172,21 @@
         <target state="translated">請不要在診斷分析器內叫用 Compilation.GetSemanticModel() 方法</target>
         <note />
       </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
+        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
+        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
+        <source>Type '{0}' should not be marked with 'file'</source>
+        <target state="new">Type '{0}' should not be marked with 'file'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
+        <source>Do not use file types for analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">
         <source>DiagnosticId for analyzers should not use reserved IDs.</source>
         <target state="translated">分析器的診斷識別碼不應使用保留的識別碼。</target>

--- a/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Core/xlf/CodeAnalysisDiagnosticsResources.zh-Hant.xlf
@@ -173,8 +173,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsDescription">
-        <source>Using a 'file' type is not allowed for analyzers, generators, or code fixers.</source>
-        <target state="new">Using a 'file' type is not allowed for analyzers, generators, or code fixers.</target>
+        <source>Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</source>
+        <target state="new">Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsMessage">
@@ -183,8 +183,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseFileTypesForAnalyzersOrGeneratorsTitle">
-        <source>Do not use file types for analyzers, generators, and code fixers</source>
-        <target state="new">Do not use file types for analyzers, generators, and code fixers</target>
+        <source>Do not use file types for implementing analyzers, generators, and code fixers</source>
+        <target state="new">Do not use file types for implementing analyzers, generators, and code fixers</target>
         <note />
       </trans-unit>
       <trans-unit id="DoNotUseReservedDiagnosticIdDescription">

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
@@ -520,9 +520,9 @@ The author of this interface has deprecated implementing this interface.
 |CodeFix|False|
 ---
 
-## RS1043: Do not use file types for analyzers, generators, and code fixers
+## RS1043: Do not use file types for implementing analyzers, generators, and code fixers
 
-Using a 'file' type is not allowed for analyzers, generators, or code fixers.
+Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.
 
 |Item|Value|
 |-|-|

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.md
@@ -520,6 +520,18 @@ The author of this interface has deprecated implementing this interface.
 |CodeFix|False|
 ---
 
+## RS1043: Do not use file types for analyzers, generators, and code fixers
+
+Using a 'file' type is not allowed for analyzers, generators, or code fixers.
+
+|Item|Value|
+|-|-|
+|Category|MicrosoftCodeAnalysisCorrectness|
+|Enabled|True|
+|Severity|Error|
+|CodeFix|False|
+---
+
 ## [RS2000](https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md): Add analyzer diagnostic IDs to analyzer release
 
 All supported analyzer diagnostic IDs should be part of an analyzer release.

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -528,6 +528,21 @@
             ]
           }
         },
+        "RS1043": {
+          "id": "RS1043",
+          "shortDescription": "Do not use file types for analyzers, generators, and code fixers",
+          "fullDescription": "Using a 'file' type is not allowed for analyzers, generators, or code fixers.",
+          "defaultLevel": "error",
+          "properties": {
+            "category": "MicrosoftCodeAnalysisCorrectness",
+            "isEnabledByDefault": true,
+            "typeName": "DoNotUseFileTypesForAnalyzersOrGenerators",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ]
+          }
+        },
         "RS2000": {
           "id": "RS2000",
           "shortDescription": "Add analyzer diagnostic IDs to analyzer release",

--- a/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
+++ b/src/Microsoft.CodeAnalysis.Analyzers/Microsoft.CodeAnalysis.Analyzers.sarif
@@ -530,8 +530,8 @@
         },
         "RS1043": {
           "id": "RS1043",
-          "shortDescription": "Do not use file types for analyzers, generators, and code fixers",
-          "fullDescription": "Using a 'file' type is not allowed for analyzers, generators, or code fixers.",
+          "shortDescription": "Do not use file types for implementing analyzers, generators, and code fixers",
+          "fullDescription": "Using a 'file' type is not allowed for implementing analyzers, generators, or code fixers. This can break analyzer loading on some platforms.",
           "defaultLevel": "error",
           "properties": {
             "category": "MicrosoftCodeAnalysisCorrectness",

--- a/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
@@ -40,4 +40,4 @@ RS1037 |  | Add "CompilationEnd" custom tag to compilation end diagnostic descri
 RS1039 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1040 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1042 |  | Implementations of this interface are not allowed |
-RS1043 |  | Do not use file types for analyzers, generators, and code fixers |
+RS1043 |  | Do not use file types for implementing analyzers, generators, and code fixers |

--- a/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
+++ b/src/Microsoft.CodeAnalysis.Analyzers/RulesMissingDocumentation.md
@@ -40,3 +40,4 @@ RS1037 |  | Add "CompilationEnd" custom tag to compilation end diagnostic descri
 RS1039 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1040 |  | This call to 'SemanticModel.GetDeclaredSymbol()' will always return 'null' |
 RS1042 |  | Implementations of this interface are not allowed |
+RS1043 |  | Do not use file types for analyzers, generators, and code fixers |

--- a/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DoNotUseFileLocalTypesForAnalyzersOrGeneratorsTests.cs
+++ b/src/Microsoft.CodeAnalysis.Analyzers/UnitTests/MetaAnalyzers/DoNotUseFileLocalTypesForAnalyzersOrGeneratorsTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
+    Microsoft.CodeAnalysis.Analyzers.MetaAnalyzers.DoNotUseFileTypesForAnalyzersOrGenerators,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.MetaAnalyzers
+{
+    public sealed partial class MetaAnalyzersTests
+    {
+        private const string CompilerReferenceVersion = "4.6.0";
+
+        [Fact]
+        public async Task FiresOnFileLocalType_CodeFixProvider()
+        {
+            var code = """
+                using System.Collections.Immutable;
+                using System.Threading.Tasks;
+                using Microsoft.CodeAnalysis;
+                using Microsoft.CodeAnalysis.CodeFixes;
+                file class Type : Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider
+                {
+                    public override ImmutableArray<string> FixableDiagnosticIds => throw null!;
+                    public override FixAllProvider GetFixAllProvider() => throw null!;
+                    public override Task RegisterCodeFixesAsync(CodeFixContext context) => throw null!;
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp11,
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(5,12): error RS1043: Type 'Type' should not be marked with 'file'
+                    VerifyCS.Diagnostic().WithSpan(5, 12, 5, 16).WithArguments("Type"),
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task FiresOnFileLocalType_DiagnosticAnalyzer()
+        {
+            var code = """
+                using System.Collections.Immutable;
+                using Microsoft.CodeAnalysis;
+                using Microsoft.CodeAnalysis.Diagnostics;
+                file class Type : Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer
+                {
+                    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => throw null!;
+                    public override void Initialize(AnalysisContext context) => throw null!;
+                   
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp11,
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(4,12): error RS1043: Type 'Type' should not be marked with 'file'
+                    VerifyCS.Diagnostic().WithSpan(4, 12, 4, 16).WithArguments("Type"),
+                }
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task FiresOnFileLocalType_ISourceGenerator()
+        {
+            var code = """
+                using Microsoft.CodeAnalysis;
+                file class Type : Microsoft.CodeAnalysis.ISourceGenerator
+                {
+                    public void Initialize(GeneratorInitializationContext context) => throw null!;
+                    public void Execute(GeneratorExecutionContext context) => throw null!;
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp11,
+                ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard20.AddPackages([new PackageIdentity("Microsoft.CodeAnalysis.Common", CompilerReferenceVersion)]),
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(2,12): error RS1043: Type 'Type' should not be marked with 'file'
+                    VerifyCS.Diagnostic().WithSpan(2, 12, 2, 16).WithArguments("Type"),
+                },
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task FiresOnFileLocalType_IIncrementalGenerator()
+        {
+            var code = """
+                using Microsoft.CodeAnalysis;
+                file class Type : Microsoft.CodeAnalysis.IIncrementalGenerator
+                {
+                    public void Initialize(IncrementalGeneratorInitializationContext context) => throw null!;
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                TestCode = code,
+                LanguageVersion = LanguageVersion.CSharp11,
+                ReferenceAssemblies = ReferenceAssemblies.NetStandard.NetStandard20.AddPackages([new PackageIdentity("Microsoft.CodeAnalysis.Common", CompilerReferenceVersion)]),
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(2,12): error RS1043: Type 'Type' should not be marked with 'file'
+                    VerifyCS.Diagnostic().WithSpan(2, 12, 2, 16).WithArguments("Type"),
+                },
+            }.RunAsync();
+        }
+    }
+}

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -2,7 +2,5 @@
 
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
-CA2022 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2022> | Avoid inexact read with 'Stream.Read' |
 CA2023 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2023> | Invalid braces in message template |
 CA2024 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2024> | Do not use 'StreamReader.EndOfStream' in async methods |
-CA2265 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265> | Do not compare Span\<T> to 'null' or 'default' |


### PR DESCRIPTION
Inspired by https://github.com/dotnet/roslyn/discussions/76355. `file` types can cause errors on .NET Framework hosts, and we should just prevent these from being used. The purpose of `file` types is to not be visible outside the current file, and the purpose of analyzers is to be loaded by some other plugin system. These goals are mutually exclusive.
