### PR TITLE
Fixes dotnet/roslyn-analyzers#7536

### DIFF
--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_False/Resources.Designer.cs
@@ -15,7 +15,7 @@ namespace TestProject
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
         /// <summary>value {0}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
 
     }
 }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_0_True/Resources.Designer.cs
@@ -29,10 +29,10 @@ namespace TestProject
         }
 
         /// <summary>value {0}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
         /// <summary>value {0}</summary>
-        internal static string FormatName(object? p0)
-           => string.Format(Culture, GetResourceString("Name") ?? "", p0);
+        internal static string FormatName_with_dots(object? p0)
+           => string.Format(Culture, GetResourceString("Name.with.dots") ?? "", p0);
 
 
     }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_False/Resources.Designer.cs
@@ -15,7 +15,7 @@ namespace TestProject
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
         /// <summary>value {replacement}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
 
     }
 }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_replacement_True/Resources.Designer.cs
@@ -29,10 +29,10 @@ namespace TestProject
         }
 
         /// <summary>value {replacement}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
         /// <summary>value {replacement}</summary>
-        internal static string FormatName(object? replacement)
-           => string.Format(Culture, GetResourceString("Name", new[] { "replacement" }), replacement);
+        internal static string FormatName_with_dots(object? replacement)
+           => string.Format(Culture, GetResourceString("Name.with.dots", new[] { "replacement" }), replacement);
 
 
     }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_False/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_False/Resources.Designer.cs
@@ -15,7 +15,7 @@ namespace TestProject
         [return: global::System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultValue")]
         internal static string? GetResourceString(string resourceKey, string? defaultValue = null) =>  ResourceManager.GetString(resourceKey, Culture) ?? defaultValue;
         /// <summary>value {x}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
 
     }
 }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_True/Resources.Designer.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/Resources/SingleString_EmitFormatMethodsCSharpAsync_x_True/Resources.Designer.cs
@@ -29,10 +29,10 @@ namespace TestProject
         }
 
         /// <summary>value {x}</summary>
-        public static string @Name => GetResourceString("Name")!;
+        public static string @Name_with_dots => GetResourceString("Name.with.dots")!;
         /// <summary>value {x}</summary>
-        internal static string FormatName(object? x)
-           => string.Format(Culture, GetResourceString("Name", new[] { "x" }), x);
+        internal static string FormatName_with_dots(object? x)
+           => string.Format(Culture, GetResourceString("Name.with.dots", new[] { "x" }), x);
 
 
     }

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/ResxGeneratorTests.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator.UnitTests/ResxGeneratorTests.cs
@@ -630,7 +630,7 @@ build_metadata.AdditionalFiles.IncludeDefaultValues = {(includeDefaultValues ? "
             bool emitFormatMethods)
         {
             var code = ResxHeader
-                + $@"  <data name=""Name"" xml:space=""preserve"">
+                + $@"  <data name=""Name.with.dots"" xml:space=""preserve"">
     <value>value {{{placeholder}}}</value>
     <comment>comment</comment>
   </data>"

--- a/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
+++ b/src/Microsoft.CodeAnalysis.ResxSourceGenerator/Microsoft.CodeAnalysis.ResxSourceGenerator/AbstractResxGenerator.cs
@@ -450,7 +450,7 @@ namespace Microsoft.CodeAnalysis.ResxSourceGenerator
                                 if (resourceString.HasArguments)
                                 {
                                     RenderDocComment(language, memberIndent, strings, docCommentString);
-                                    RenderFormatMethod(memberIndent, language, CompilationInformation.SupportsNullable, strings, resourceString);
+                                    RenderFormatMethod(memberIndent, language, CompilationInformation.SupportsNullable, strings, resourceString, identifier);
                                 }
                             }
 
@@ -811,9 +811,9 @@ Imports System.Reflection
                 }
             }
 
-            private static void RenderFormatMethod(string indent, Lang language, bool supportsNullable, StringBuilder strings, ResourceString resourceString)
+            private static void RenderFormatMethod(string indent, Lang language, bool supportsNullable, StringBuilder strings, ResourceString resourceString, string identifier)
             {
-                strings.AppendLine($"{indent}internal static string Format{resourceString.Name}({resourceString.GetMethodParameters(language, supportsNullable)})");
+                strings.AppendLine($"{indent}internal static string Format{identifier}({resourceString.GetMethodParameters(language, supportsNullable)})");
                 if (resourceString.UsingNamedArgs)
                 {
                     strings.AppendLine($@"{indent}   => string.Format(Culture, GetResourceString(""{resourceString.Name}"", new[] {{ {resourceString.GetArgumentNames()} }}), {resourceString.GetArguments()});");

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -3,4 +3,3 @@
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA2023 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2023> | Invalid braces in message template |
-CA2024 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2024> | Do not use 'StreamReader.EndOfStream' in async methods |


### PR DESCRIPTION
This update uses exactly the same identifier name for `Format` functions and generated properties. The tests for the `Format` function have been updated to have the resource name `Name.with.dots` instead of a simple `Name`.