### PR TITLE
Restore suppressed maccatalyst for proper flow analysis

### DIFF
--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -3,4 +3,3 @@
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA2023 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2023> | Invalid braces in message template |
-CA2024 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2024> | Do not use 'StreamReader.EndOfStream' in async methods |

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -5338,6 +5338,30 @@ class MyType { }
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [Fact]
+        public async Task MacCatalystWithMandatorySupportFound()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+class TestType
+{
+    [SupportedOSPlatform(""ios13.0"")]
+    [SupportedOSPlatform(""maccatalyst13.0"")]
+    private void Tapped()
+    {
+	    if (OperatingSystem.IsIOSVersionAtLeast(15,0))
+		    DoSomething();
+    }
+    [SupportedOSPlatform(""ios14.0"")]
+    [SupportedOSPlatform(""maccatalyst"")]
+    public void DoSomething() {}
+}";
+
+            string msBuildPlatforms = "build_property.TargetFramework=net8.0-maccatalyst13;";
+            await VerifyAnalyzerCSAsync(source, msBuildPlatforms);
+        }
+
         private readonly string TargetTypesForTest = @"
 namespace PlatformCompatDemo.SupportedUnupported
 {


### PR DESCRIPTION
```cs
class TestType
{
    [SupportedOSPlatform("ios13.0")]
    [SupportedOSPlatform("maccatalyst13.0")]  // THIS suppresses lower versions
    private void Tapped()
    {
        if (OperatingSystem.IsIOSVersionAtLeast(15,0))
           DoSomething(); // when it called here only [SupportedOSPlatform(""ios14.0"")] left in the list
                         // as OperatingSystem.IsIOSVersionAtLeast(15,0) applies to ios15.0 and maccatalys15.0 warns 
    }

    [SupportedOSPlatform("ios14.0")]
    [SupportedOSPlatform("maccatalyst")]   // when version less or <= 13.0 then suppressed by callsite attribute 
    public void DoSomething() {}
}
```
`[SupportedOSPlatform("maccatalyst")]` is suppressed (removed) by call site `[SupportedOSPlatform("maccatalyst13.0")]` attribute,  but `[SupportedOSPlatform("ios14.0")]` is not suppressed by `[SupportedOSPlatform("ios13.0")]` because the version is higher. So when `DoSomething()` called above it become only supported on ios14.0 but `OperatingSystem.IsIOSVersionAtLeast(15,0)` is reachable on ios15.0 and maccatalys15.0 therefore warns.

I think the best way to solve this is to restore the suppressed `maccatalyst` support in case `ios` support is not suppressed.

See more details from https://github.com/dotnet/roslyn-analyzers/issues/7239#issuecomment-2586399605

Fixes https://github.com/dotnet/roslyn-analyzers/issues/7239