### PR TITLE
Trim leading v from TargetFrameworkVersion

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -285,8 +285,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
             string tfmVersion = options.GetMSBuildPropertyValue(MSBuildPropertyOptionNames.TargetFrameworkVersion, compilation) ?? "";
 
             if (tfmIdentifier.Equals(NetCoreAppIdentifier, StringComparison.OrdinalIgnoreCase) &&
-                tfmVersion.StartsWith("v", StringComparison.OrdinalIgnoreCase) &&
-                Version.TryParse(tfmVersion[1..], out var version) &&
+                Version.TryParse(tfmVersion.TrimStart(['v', 'V']), out var version) &&
                 version.Major >= 5)
             {
                 // We want to only support cases we know are well-formed by default

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -63,6 +63,8 @@ public class Test
 
             // Custom TFMs with valid user specified Identifier/Version
             yield return new object[] { "build_property.TargetFramework = nonesense\nbuild_property.TargetFrameworkIdentifier=.NETCoreApp\nbuild_property.TargetFrameworkVersion=v11.0", true };
+            yield return new object[] { "build_property.TargetFramework = nonesense\nbuild_property.TargetFrameworkIdentifier=.NETCoreApp\nbuild_property.TargetFrameworkVersion=V11.0", true };
+            yield return new object[] { "build_property.TargetFramework = nonesense\nbuild_property.TargetFrameworkIdentifier=.NETCoreApp\nbuild_property.TargetFrameworkVersion=11.0", true };
 
             // Custom TFMs with invalid user specified Identifier/Version
             yield return new object[] { "build_property.TargetFramework = nonesense\nbuild_property.TargetFrameworkIdentifier=.NETCoreApp\nbuild_property.TargetFrameworkVersion=v5", false };


### PR DESCRIPTION
This is follow up to https://github.com/dotnet/roslyn-analyzers/pull/7542 which ensures that our checks of `build_property.TargetFrameworkVersion` support no leading `v`, the same as the SDK allows.