### PR TITLE
Fix two more cases where the live CodeAnalysis version isn't used

### DIFF
--- a/src/NetAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.csproj
+++ b/src/NetAnalyzers/CSharp/Microsoft.CodeAnalysis.CSharp.NetAnalyzers.csproj
@@ -11,7 +11,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.NetAnalyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersionForNetAnalyzers)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
   <Import Project="..\..\Utilities\Compiler.CSharp\Analyzer.CSharp.Utilities.projitems" Label="Shared" />
 </Project>

--- a/src/NetAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.vbproj
+++ b/src/NetAnalyzers/VisualBasic/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.vbproj
@@ -11,6 +11,6 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.NetAnalyzers.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersionForNetAnalyzers)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Follow-up on https://github.com/dotnet/roslyn-analyzers/commit/8bfe8b84962ceb734510a7524da27dc8d09f61e2
Partially unblocks https://github.com/dotnet/sdk/pull/47100