### PR TITLE
Update xcopy-msbuild and vs to latest available version

### DIFF
--- a/global.json
+++ b/global.json
@@ -10,7 +10,7 @@
     "vs": {
       "version": "17.7.0"
     },
-    "xcopy-msbuild": "17.7.4"
+    "xcopy-msbuild": "17.13.0"
   },
   "sdk": {
     "version": "9.0.102",

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
       ]
     },
     "vs": {
-      "version": "17.7.0"
+      "version": "17.13.0"
     },
     "xcopy-msbuild": "17.13.0"
   },


### PR DESCRIPTION
Updated `xcopy-msbuild` in `global.json` to the latest available version on dotnet-eng
Updated vs to the [latest available version](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes-v17.13)

I am raising this as I made the change in [aspnetcore](https://github.com/dotnet/aspnetcore) via https://github.com/dotnet/aspnetcore/pull/60666 and spotted this repository was using an older version of 17.x