### PR TITLE
Set PackageProjectUrl

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,8 @@
   <PropertyGroup>
     <!-- Do not ship packages by default -->
     <IsShippingPackage>false</IsShippingPackage>
+    <!-- Explicitly set the PackageProjectUrl so that builds from the VMR do not override it with dotnet/dotnet -->
+    <PackageProjectUrl>https://github.com/dotnet/roslyn-analyzers</PackageProjectUrl>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Avoids the SDK setting this to dotnet/dotnet automatically, which is generally not useful for customers.