### PR TITLE
Switch the PerformanceTests project to net8.0

### DIFF
--- a/src/PerformanceTests/Tests/PerformanceTests.csproj
+++ b/src/PerformanceTests/Tests/PerformanceTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This fixes build on FreeBSD as it started to have a RID since .NET 8

Suggested in https://github.com/dotnet/source-build/issues/5035#issuecomment-2794935476