### PR TITLE
Remove direct dependency on System.Composition

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,11 +29,6 @@
       <Sha>37f732fbfa006386f89a16be417278ea4fee375e</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
-    <!-- Used in repo tooling. Not updated automatically -->
-    <Dependency Name="System.Composition" Version="8.0.0-preview.4.23259.5">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>84a3d0e37e8f22b0b55f8bf932cb788b2bdd728f</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="10.0.0-beta.25206.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>37f732fbfa006386f89a16be417278ea4fee375e</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -87,7 +87,6 @@
     <SQLitePCLRawVersion>1.1.2</SQLitePCLRawVersion>
     <SystemCommandLineVersion>2.0.0-beta5.25208.1</SystemCommandLineVersion>
     <SystemComponentModelCompositionVersion>4.7.0</SystemComponentModelCompositionVersion>
-    <SystemCompositionVersion>8.0.0-preview.4.23259.5</SystemCompositionVersion>
     <XunitCombinatorialVersion>1.2.7</XunitCombinatorialVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>
   </PropertyGroup>

--- a/src/Tools/GenerateDocumentationAndConfigFilesForBrokenRuntime/GenerateDocumentationAndConfigFilesForBrokenRuntime.csproj
+++ b/src/Tools/GenerateDocumentationAndConfigFilesForBrokenRuntime/GenerateDocumentationAndConfigFilesForBrokenRuntime.csproj
@@ -14,6 +14,5 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="System.Composition" Version="$(SystemCompositionVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
A direct dependency on System.Composition is not needed and actually causes issues when building a dev version of source build in the VMR:

```
/repos/dotnet/src/roslyn-analyzers/src/Tools/GenerateDocumentationAndConfigFilesForBrokenRuntime/GenerateDocumentationAndConfigFilesForBrokenRuntime.csproj error NU1605: Warning As Error: Detected package downgrade: System.Composition from 10.0.0-preview.4.25174.9 to 10.0.0-dev. Reference the package directly from the project to select a different version. 
 GenerateDocumentationAndConfigFilesForBrokenRuntime -> Microsoft.CodeAnalysis 4.14.0-3.25179.1 -> System.Composition (>= 10.0.0-preview.4.25174.9) 
 GenerateDocumentationAndConfigFilesForBrokenRuntime -> System.Composition (>= 10.0.0-dev) [/repos/dotnet/src/roslyn-analyzers/RoslynAnalyzers.sln]
```
Binlog: [source-inner-build.roslyn-analyzers.zip](https://github.com/user-attachments/files/19795049/source-inner-build.roslyn-analyzers.zip)

Related to the work in https://github.com/dotnet/sdk/pull/48327