### PR TITLE
Fix: Unsupported maccatalyst attribute is getting applied to child attributes but not accounted parent child attributes merge

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1888,11 +1888,14 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                             if (childAttributes.TryGetValue(platform, out var childAttribute))
                             {
                                 // only later versions could narrow, other versions ignored
-                                if (childAttribute.SupportedFirst.IsGreaterThanOrEqualTo(attributes.SupportedFirst) &&
-                                    (attributes.SupportedSecond == null || attributes.SupportedSecond < childAttribute.SupportedFirst))
+                                if (childAttribute.SupportedFirst.IsGreaterThanOrEqualTo(attributes.SupportedFirst))
                                 {
-                                    attributes.SupportedSecond = childAttribute.SupportedFirst;
                                     supportFound = true;
+                                    if (attributes.SupportedSecond == null || attributes.SupportedSecond < childAttribute.SupportedFirst)
+                                    {
+                                        attributes.SupportedSecond = childAttribute.SupportedFirst;
+
+                                    }
                                 }
 
                                 if (childAttribute.UnsupportedFirst != null)
@@ -1920,13 +1923,6 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         attributes.UnsupportedFirst = childAttribute.UnsupportedSecond;
                                         attributes.UnsupportedMessage = childAttribute.UnsupportedMessage;
                                     }
-                                }
-                                else if (relatedPlatforms.TryGetValue(platform, out var relation) && !relation.isSubset && !childAttribute.IsSet())
-                                // if it was related platform like MacCatalyst and child attributes are empty then the supported attribute(s) must have
-                                // suppressed with UnsupportedOSPlatform attribute, we need to apply the same to the parent attribute list
-                                {
-                                    attributes.SupportedFirst = null;
-                                    attributes.SupportedSecond = null;
                                 }
                             }
                             else
@@ -2004,7 +2000,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         {
                             allowList = true;
                         }
-                        else if (DenyList(attributes))
+                        else if (DenyList(attributes) || !attributes.IsSet())
                         {
                             unsupportedList.Add(platform);
                         }

--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1921,6 +1921,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                                         attributes.UnsupportedMessage = childAttribute.UnsupportedMessage;
                                     }
                                 }
+                                else if (relatedPlatforms.TryGetValue(platform, out var relation) && !relation.isSubset && !childAttribute.IsSet())
+                                // if it was related platform like MacCatalyst and child attributes are empty then the supported attribute(s) must have
+                                // suppressed with UnsupportedOSPlatform attribute, we need to apply the same to the parent attribute list
+                                {
+                                    attributes.SupportedFirst = null;
+                                    attributes.SupportedSecond = null;
+                                }
                             }
                             else
                             {

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -4158,6 +4158,34 @@ class TestType
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [Fact, WorkItem(7633, "https://github.com/dotnet/roslyn-analyzers/issues/7633")]
+        public async Task SuppressedMacCatalystWithinChildAttributesShouldAlsoAppliedToParentAttributesOnMerge()
+        {
+            var source = @"
+using System;
+using System.Runtime.Versioning;
+
+[SupportedOSPlatform (""maccatalyst"")]
+[SupportedOSPlatform (""ios"")]
+partial class TestType {
+    [UnsupportedOSPlatform (""maccatalyst"")]
+    [SupportedOSPlatform (""ios"")]
+    void DoSomething ()
+    {
+        Console.WriteLine (GetSomething);
+    }
+
+    [UnsupportedOSPlatform (""maccatalyst"")]
+    [SupportedOSPlatform (""ios"")]
+    public static object GetSomething {
+        [UnsupportedOSPlatform (""maccatalyst"")]
+        [SupportedOSPlatform (""ios"")]
+        get => """";
+    }
+}";
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
         private string GetFormattedString(string resource, params string[] args) =>
             string.Format(CultureInfo.InvariantCulture, resource, args);
 


### PR DESCRIPTION
When an API supported on IOS it also supported by maccatalyst as they are related. To remove implicit `maccatalyst` support one need to add `[UnsupportedOSPlatform (""maccatalyst"")]` to the `[SupportedOSPlatform (""ios"")]` 

The `[UnsupportedOSPlatform (""maccatalyst"")]` applied to the immediate (child) attributes list  and removed the implicit `maccatalyst` support  but when child attributes are merged to the parent attributes list this is not accounted and merged list will keep the implicit `maccatalyst` support. The PR fixes this bug


Fixes https://github.com/dotnet/roslyn-analyzers/issues/7633
