### PR TITLE
Improve fixer for `CA1067` - generate correct parameter nullability when overriding `object.Equals`

### DIFF
--- a/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzerTests.Fixer.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.CodeQuality.Analyzers/ApiDesignGuidelines/EquatableAnalyzerTests.Fixer.cs
@@ -15,160 +15,160 @@ namespace Microsoft.CodeQuality.Analyzers.ApiDesignGuidelines.UnitTests
         [Fact]
         public async Task CodeFixForStructWithEqualsOverrideButNoIEquatableImplementationAsync()
         {
-            await VerifyCS.VerifyCodeFixAsync(@"
-using System;
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
 
-struct {|CA1066:S|}
-{
-    public override bool Equals(object other)
-    {
-        return true;
-    }
+                struct {|CA1066:S|}
+                {
+                    public override bool Equals(object other)
+                    {
+                        return true;
+                    }
 
-    public override int GetHashCode() => 0;
-}
-", @"
-using System;
+                    public override int GetHashCode() => 0;
+                }
+                """, """
+                using System;
 
-struct S : IEquatable<S>
-{
-    public override bool Equals(object other)
-    {
-        return true;
-    }
+                struct S : IEquatable<S>
+                {
+                    public override bool Equals(object other)
+                    {
+                        return true;
+                    }
 
-    public override int GetHashCode() => 0;
+                    public override int GetHashCode() => 0;
 
-    public bool Equals(S other)
-    {
-        throw new NotImplementedException();
-    }
-}
-");
+                    public bool Equals(S other)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task CodeFixForStructWithIEquatableImplementationButNoEqualsOverrideAsync()
         {
-            await VerifyCS.VerifyCodeFixAsync(@"
-using System;
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
 
-struct {|CA1067:S|} : IEquatable<S>
-{
-    public bool Equals(S other)
-    {
-        return true;
-    }
-}
-", @"
-using System;
+                struct {|CA1067:S|} : IEquatable<S>
+                {
+                    public bool Equals(S other)
+                    {
+                        return true;
+                    }
+                }
+                """, """
+                using System;
 
-struct S : IEquatable<S>
-{
-    public bool Equals(S other)
-    {
-        return true;
-    }
+                struct S : IEquatable<S>
+                {
+                    public bool Equals(S other)
+                    {
+                        return true;
+                    }
 
-    public override bool Equals(object obj)
-    {
-        return obj is S && Equals((S)obj);
-    }
-}
-");
+                    public override bool Equals(object obj)
+                    {
+                        return obj is S && Equals((S)obj);
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task CodeFixForClassWithIEquatableImplementationButNoEqualsOverrideAsync()
         {
-            await VerifyCS.VerifyCodeFixAsync(@"
-using System;
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
 
-class {|CA1067:C|} : IEquatable<C>
-{
-    public bool Equals(C other)
-    {
-        return true;
-    }
-}
-", @"
-using System;
+                class {|CA1067:C|} : IEquatable<C>
+                {
+                    public bool Equals(C other)
+                    {
+                        return true;
+                    }
+                }
+                """, """
+                using System;
 
-class C : IEquatable<C>
-{
-    public bool Equals(C other)
-    {
-        return true;
-    }
+                class C : IEquatable<C>
+                {
+                    public bool Equals(C other)
+                    {
+                        return true;
+                    }
 
-    public override bool Equals(object obj)
-    {
-        return Equals(obj as C);
-    }
-}
-");
+                    public override bool Equals(object obj)
+                    {
+                        return Equals(obj as C);
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task CodeFixForClassWithExplicitIEquatableImplementationAndNoEqualsOverrideAsync()
         {
-            await VerifyCS.VerifyCodeFixAsync(@"
-using System;
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
 
-class {|CA1067:C|} : IEquatable<C>
-{
-    bool IEquatable<C>.Equals(C other)
-    {
-        return true;
-    }
-}
-", @"
-using System;
+                class {|CA1067:C|} : IEquatable<C>
+                {
+                    bool IEquatable<C>.Equals(C other)
+                    {
+                        return true;
+                    }
+                }
+                """, """
+                using System;
 
-class C : IEquatable<C>
-{
-    bool IEquatable<C>.Equals(C other)
-    {
-        return true;
-    }
+                class C : IEquatable<C>
+                {
+                    bool IEquatable<C>.Equals(C other)
+                    {
+                        return true;
+                    }
 
-    public override bool Equals(object obj)
-    {
-        return ((IEquatable<C>)this).Equals(obj as C);
-    }
-}
-");
+                    public override bool Equals(object obj)
+                    {
+                        return ((IEquatable<C>)this).Equals(obj as C);
+                    }
+                }
+                """);
         }
 
         [Fact]
         public async Task CodeFixForStructWithExplicitIEquatableImplementationAndNoEqualsOverrideAsync()
         {
-            await VerifyCS.VerifyCodeFixAsync(@"
-using System;
+            await VerifyCS.VerifyCodeFixAsync("""
+                using System;
 
-struct {|CA1067:S|} : IEquatable<S>
-{
-    bool IEquatable<S>.Equals(S other)
-    {
-        return true;
-    }
-}
-", @"
-using System;
+                struct {|CA1067:S|} : IEquatable<S>
+                {
+                    bool IEquatable<S>.Equals(S other)
+                    {
+                        return true;
+                    }
+                }
+                """, """
+                using System;
 
-struct S : IEquatable<S>
-{
-    bool IEquatable<S>.Equals(S other)
-    {
-        return true;
-    }
+                struct S : IEquatable<S>
+                {
+                    bool IEquatable<S>.Equals(S other)
+                    {
+                        return true;
+                    }
 
-    public override bool Equals(object obj)
-    {
-        return obj is S && ((IEquatable<S>)this).Equals((S)obj);
-    }
-}
-");
+                    public override bool Equals(object obj)
+                    {
+                        return obj is S && ((IEquatable<S>)this).Equals((S)obj);
+                    }
+                }
+                """);
         }
 
         [Fact]


### PR DESCRIPTION
Part of https://github.com/dotnet/roslyn-analyzers/issues/4073. This PR fixes the part, when an overriden method doesn't preserve parameter type nullability.

The issue also mentions other potential improvements, e.g. an opportunity to use more modern pattern matching syntax. I didn't implement it in this PR because:
1. It is a C#-only thing, while currently we have a universal fixer fot both C# and VB
2. (more important) In order to generate a pattern we need to generate new variable name. There are convinient utilities for this in roslyn repo, but I didn't find matching helpers in this project. So if I'm gonna introduce all that, it deserves a separate PR.