### PR TITLE
Fix missing quotes in NetAnalyzers...RulesVersion expression

### DIFF
--- a/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
+++ b/src/Tools/GenerateDocumentationAndConfigFiles/Program.cs
@@ -1559,7 +1559,7 @@ namespace GenerateDocumentationAndConfigFiles
                         propertyStr += $"""
 
                                   <!-- Default '{packageVersionPropName}' to '{effectiveAnalysisLevelPropName}' with trimmed trailing '.0' -->
-                                  <{packageVersionPropName} Condition="'$({packageVersionPropName})' == '' and '$({effectiveAnalysisLevelPropName})' != ''">$([System.Text.RegularExpressions.Regex]::Replace($({effectiveAnalysisLevelPropName}), '([.]0)*$', ''))</{packageVersionPropName}>
+                                  <{packageVersionPropName} Condition="'$({packageVersionPropName})' == '' and '$({effectiveAnalysisLevelPropName})' != ''">$([System.Text.RegularExpressions.Regex]::Replace($({effectiveAnalysisLevelPropName}), '(\.0)*$', ''))</{packageVersionPropName}>
 
                             """;
                         return propertyStr;


### PR DESCRIPTION
**What**
- Fixes a syntax error causing a conditional to always evaluate as false.
- Fixes a malformed regex matching too many characters

**Why**
Fixes dotnet/roslyn#63036

**Testing**
I manually patched `C:\Program Files\dotnet\sdk\9.0.300\Sdks\Microsoft.NET.Sdk\analyzers\build\Microsoft.CodeAnalysis.NetAnalyzers.targets` on my dev box to incorporate the fix.

After patching it, setting any of the analysis mode properties below will include the corresponding editorconfig.
```
<AnalysisModeDesign>All</AnalysisModeDesign>
<AnalysisModeDocumentation>All</AnalysisModeDocumentation>
<AnalysisModeGlobalization>All</AnalysisModeGlobalization>
<AnalysisModeInteroperability>All</AnalysisModeInteroperability>
<AnalysisModeMaintainability>All</AnalysisModeMaintainability>
<AnalysisModeNaming>All</AnalysisModeNaming>
<AnalysisModePerformance>All</AnalysisModePerformance>
<AnalysisModeSingleFile>All</AnalysisModeSingleFile>
<AnalysisModeReliability>All</AnalysisModeReliability>
<AnalysisModeSecurity>All</AnalysisModeSecurity>
<AnalysisModeStyle>All</AnalysisModeStyle>
<AnalysisModeUsage>All</AnalysisModeUsage>
```