### PR TITLE
Fix CA1856 and CA2252 for missed attributes when multiple interfaces implemented

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureAnalyzer.cs
@@ -533,7 +533,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
 
-            if (propertyOrMethodSymbol.IsImplementationOfAnyImplicitInterfaceMember(out ISymbol baseInterfaceMember))
+            foreach (var baseInterfaceMember in propertyOrMethodSymbol.GetImplementedImplicitInterfaceMembers<ISymbol>())
             {
                 if (SymbolIsAnnotatedAsPreview(baseInterfaceMember, requiresPreviewFeaturesSymbols, previewFeatureAttributeSymbol))
                 {
@@ -555,6 +555,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         ReportDiagnosticWithCustomMessageIfItExists(context, baseInterfaceMember, propertyOrMethodSymbol, requiresPreviewFeaturesSymbols,
                             ImplementsPreviewMethodRule, ImplementsPreviewMethodRuleWithCustomMessage, propertyOrMethodSymbol.Name, baseInterfaceMemberName);
                     }
+
+                    break;
                 }
             }
 

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/ConstantExpectedTests.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Performance/ConstantExpectedTests.cs
@@ -134,6 +134,10 @@ public class Test
     {{
         T Method(T operand1, [ConstantExpected] T operand2);
     }}
+    public interface ITest3<T>
+    {{
+        T Method(T operand1, T operand2);
+    }}
     public abstract class AbstractTest<T>
     {{
         public abstract T Method2(T operand1, [ConstantExpected] T operand2);
@@ -145,6 +149,20 @@ public class Test
         {type} ITest2<{type}>.Method({type} operand1, {{|#1:{type} operand2|}}) => throw new NotImplementedException();
         public override {type} Method2({type} operand1, {{|#2:{type} operand2|}}) => throw new NotImplementedException();
     }}
+
+    public class GenericExplicit : ITest<{type}>, ITest3<{type}>
+    {{
+        public {type} Method({type} operand1, {type} operand2) => throw new NotImplementedException();
+        {type} ITest<{type}>.Method({type} operand1, {{|#3:{type} operand2|}}) => throw new NotImplementedException();
+    }}
+    public class Generic13 : ITest<{type}>, ITest3<{type}>
+    {{
+        public {type} Method({type} operand1, {{|#4:{type} operand2|}}) => throw new NotImplementedException();
+    }}
+    public class Generic31 : ITest3<{type}>, ITest<{type}>
+    {{
+        public {type} Method({type} operand1, {{|#5:{type} operand2|}}) => throw new NotImplementedException();
+    }}
 }}
 ";
             await TestCSAsync(csInput,
@@ -153,7 +171,13 @@ public class Test
                 VerifyCS.Diagnostic(ConstantExpectedAnalyzer.CA1857.AttributeExpectedRule)
                         .WithLocation(1),
                 VerifyCS.Diagnostic(ConstantExpectedAnalyzer.CA1857.AttributeExpectedRule)
-                        .WithLocation(2));
+                        .WithLocation(2),
+                VerifyCS.Diagnostic(ConstantExpectedAnalyzer.CA1857.AttributeExpectedRule)
+                        .WithLocation(3),
+                VerifyCS.Diagnostic(ConstantExpectedAnalyzer.CA1857.AttributeExpectedRule)
+                        .WithLocation(4),
+                VerifyCS.Diagnostic(ConstantExpectedAnalyzer.CA1857.AttributeExpectedRule)
+                        .WithLocation(5));
         }
 
         [Theory]

--- a/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
+++ b/src/NetAnalyzers/UnitTests/Microsoft.NetCore.Analyzers/Runtime/DetectPreviewFeatureUnitTests.Misc.cs
@@ -398,6 +398,54 @@ namespace Preview_Feature_Scratch
             await test.RunAsync();
         }
 
+
+        [Fact]
+        public async Task TestInterfaceMethodDoubleImplementations()
+        {
+            var csInput = @" 
+        using System.Runtime.Versioning; using System;
+        namespace Preview_Feature_Scratch
+        {
+            class Program : IProgram, IProgram2
+            {
+                static void Main(string[] args)
+                {
+                }
+
+                public void {|#0:Foo|}()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            class Program2 : IProgram2, IProgram
+            {
+                public void {|#1:Foo|}()
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            public interface IProgram
+            {
+                [RequiresPreviewFeatures]
+                public void Foo();
+            }
+
+            public interface IProgram2
+            {
+                public void Foo();
+            }
+        }
+
+            ";
+
+            var test = TestCS(csInput);
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(0).WithArguments("Foo", "IProgram.Foo", DetectPreviewFeatureAnalyzer.DefaultURL));
+            test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(DetectPreviewFeatureAnalyzer.ImplementsPreviewMethodRule).WithLocation(1).WithArguments("Foo", "IProgram.Foo", DetectPreviewFeatureAnalyzer.DefaultURL));
+            await test.RunAsync();
+        }
+
         [Fact]
         public async Task TestDelegate()
         {

--- a/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
+++ b/src/Utilities/Compiler/Extensions/ISymbolExtensions.cs
@@ -471,27 +471,13 @@ namespace Analyzer.Utilities.Extensions
         public static bool IsImplementationOfAnyImplicitInterfaceMember<TSymbol>(this ISymbol symbol)
             where TSymbol : ISymbol
         {
-            if (symbol.ContainingType != null)
-            {
-                foreach (INamedTypeSymbol interfaceSymbol in symbol.ContainingType.AllInterfaces)
-                {
-                    foreach (var interfaceMember in interfaceSymbol.GetMembers().OfType<TSymbol>())
-                    {
-                        if (IsImplementationOfInterfaceMember(symbol, interfaceMember))
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-
-            return false;
+            return GetImplementedImplicitInterfaceMembers(symbol).Any();
         }
 
         /// <summary>
-        /// Checks if a given symbol implements an interface member implicitly
+        /// Checks if a given symbol implements an interface member implicitly and interface member satisfies given predicate
         /// </summary>
-        public static bool IsImplementationOfAnyImplicitInterfaceMember<TSymbol>(this ISymbol symbol, out TSymbol interfaceMember)
+        public static IEnumerable<TSymbol> GetImplementedImplicitInterfaceMembers<TSymbol>(this ISymbol symbol)
             where TSymbol : ISymbol
         {
             if (symbol.ContainingType != null)
@@ -500,17 +486,13 @@ namespace Analyzer.Utilities.Extensions
                 {
                     foreach (var baseInterfaceMember in interfaceSymbol.GetMembers().OfType<TSymbol>())
                     {
-                        if (IsImplementationOfInterfaceMember(symbol, baseInterfaceMember))
+                        if (IsImplementationOfInterfaceMember(symbol, baseInterfaceMember) && predicate(symbol))
                         {
-                            interfaceMember = baseInterfaceMember;
-                            return true;
+                            yield return baseInterfaceMember;
                         }
                     }
                 }
             }
-
-            interfaceMember = default;
-            return false;
         }
 
         public static bool IsImplementationOfInterfaceMember(this ISymbol symbol, [NotNullWhen(returnValue: true)] ISymbol? interfaceMember)


### PR DESCRIPTION
Fix the case when interfaces implementation order affects if CA1857 (The parameter expects a constant for optimal performance) and CA2252 (Opt in to preview features before using them) are applicable, e.g.:

```cs
public interface I1<T>
{
    T M1(T operand1, [ConstantExpected] T operand2);
}

public interface I2
{
    [RequiresPreviewFeatures] int M1(int operand1, int operand2);
}

public class CBase1 : I2, I1<int>
{
    public virtual int M1(int operand1, int operand2) => // currently, CA2252 only
        throw new NotImplementedException();
}

public class CBase2 : I1<int>, I2
{
    public virtual int M1(int operand1, int operand2) => // currently CA1857 only
        throw new NotImplementedException();
}
```