### PR TITLE
Avoid ConcurrentDictionary allocation in DisposeObjectsBeforeLosingScope

### DIFF
--- a/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
+++ b/src/NetAnalyzers/Core/Microsoft.NetCore.Analyzers/Runtime/DisposeObjectsBeforeLosingScope.cs
@@ -1,9 +1,10 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Analyzer.Utilities;
 using Analyzer.Utilities.Extensions;
 using Analyzer.Utilities.PooledObjects;
@@ -83,7 +84,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                     return;
                 }
 
-                var reportedLocations = new ConcurrentDictionary<Location, bool>();
+                ConcurrentDictionary<Location, bool>? reportedLocations = null;
+
                 compilationContext.RegisterOperationBlockAction(operationBlockContext =>
                 {
                     if (operationBlockContext.OwningSymbol is not IMethodSymbol containingMethod ||
@@ -146,6 +148,11 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                         // and avoiding duplicates.
                         foreach (var diagnostic in notDisposedDiagnostics.Concat(mayBeNotDisposedDiagnostics))
                         {
+                            if (reportedLocations is null)
+                            {
+                                Interlocked.CompareExchange(ref reportedLocations, new(), comparand: null);
+                            }
+
                             if (reportedLocations.TryAdd(diagnostic.Location, true))
                             {
                                 operationBlockContext.ReportDiagnostic(diagnostic);


### PR DESCRIPTION
**Description**

Currently `DisposeObjectsBeforeLosingScope` analyzer always allocates a `ConcurrentDictionary<K, V>` when it's initialized. As it's used to avoid reporting duplicate diagnostics for the same location, it's only needed when there are rule violations in code.

**Suggested improvement**

Defer dictionary allocation until it's actually needed in the case when rule violations are detected. This should avoid the allocation for successful builds.

**Testing**

All unit tests for this analyzer passed.