### PR TITLE
Suggested perf improvements in DataFlowAnalysis

### DIFF
--- a/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
+++ b/src/Utilities/FlowAnalysis/FlowAnalysis/Framework/DataFlow/DataFlowAnalysis.cs
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                 var block = cfg.Blocks[blockOrdinal];
 
                 // Ensure that we execute potential nested catch blocks before the finally region.
-                if (pendingBlocksNeedingAtLeastOnePass.Any())
+                if (pendingBlocksNeedingAtLeastOnePass.Count > 0)
                 {
                     var finallyRegion = block.GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Finally);
                     if (finallyRegion?.EnclosingRegion!.Kind == ControlFlowRegionKind.TryAndFinally)
@@ -229,17 +229,20 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
                         var tryRegion = finallyRegion.EnclosingRegion.NestedRegions[0];
                         Debug.Assert(tryRegion.Kind == ControlFlowRegionKind.Try);
 
-                        var nestedCatchBlockOrdinals = pendingBlocksNeedingAtLeastOnePass.Where(
-                            p => p >= tryRegion.FirstBlockOrdinal &&
-                                 p <= tryRegion.LastBlockOrdinal &&
-                                 cfg.Blocks[p].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null);
-                        if (nestedCatchBlockOrdinals.Any())
+                        var hasNestedCatchBlockOrdinals = false;
+                        foreach (var ordinal in pendingBlocksNeedingAtLeastOnePass)
                         {
-                            foreach (var catchBlockOrdinal in nestedCatchBlockOrdinals)
+                            if (ordinal >= tryRegion.FirstBlockOrdinal &&
+                                 ordinal <= tryRegion.LastBlockOrdinal &&
+                                 cfg.Blocks[ordinal].GetInnermostRegionStartedByBlock(ControlFlowRegionKind.Catch) != null)
                             {
-                                worklist.Add(catchBlockOrdinal);
+                                worklist.Add(ordinal);
+                                hasNestedCatchBlockOrdinals = true;
                             }
+                        }
 
+                        if (hasNestedCatchBlockOrdinals)
+                        {
                             // Also add back the finally start block to be processed after catch blocks.
                             worklist.Add(blockOrdinal);
                             continue;
@@ -580,9 +583,16 @@ namespace Microsoft.CodeAnalysis.FlowAnalysis.DataFlow
             bool HasUnprocessedPredecessorBlock(BasicBlock block)
             {
                 var predecessorsWithBranches = block.GetPredecessorsWithBranches(cfg);
-                return predecessorsWithBranches.Any(predecessorWithBranch =>
-                    predecessorWithBranch.predecessorBlock.Ordinal < block.Ordinal &&
-                    pendingBlocksNeedingAtLeastOnePass.Contains(predecessorWithBranch.predecessorBlock.Ordinal));
+
+                foreach (var (predecessorBlock, _) in predecessorsWithBranches)
+                {
+                    if (predecessorBlock.Ordinal < block.Ordinal && pendingBlocksNeedingAtLeastOnePass.Contains(predecessorBlock.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             // If this block starts a catch/filter region, return the enclosing TryAndCatch region.


### PR DESCRIPTION
I have a few suggested performance improvements in `DataFlowAnalysis`:

1. `.Any()` call on `PooledSortedSet<T>` is `Enumerable.Any` extension method call, that type does not have its own `Any` method like some types do, e.g. `ArrayBuilder<T>`. As `Enumerable.Any` performs type checks, it should be better to check `.Count`. 
    I believe it could have been caught by [CA1829](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1829) analyzer.

2. There are a few issues with the part of code in `RunCore` method:
    - It calls `.Where` allocating an enumerable
    - Delegate passed to `.Where` creates closure
    - Enumerable returned by `.Where` is enumerated multiple times.

    I'd suggest to re-write that part with a simple loop to avoid these issues.
    Regarding multiple enumeration, there's a standard [CA1851](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1851) rule, I believe it was added in .NET 7.

3. The delegate passed to `.Any` call in `HasUnprocessedPredecessorBlock` also creates closure.