### PR TITLE
Add network isolation policy to yml

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -13,7 +13,7 @@ trigger:
 - 2.9.x
 
 schedules:
-  - cron: "0 8 23-29 * 0"
+  - cron: "0 8 22-28 * 0"
     displayName: "Monthly smoke test"
     branches:
       include: 
@@ -47,6 +47,8 @@ extends:
         name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: windows.vs2022preview.amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
       displayName: Set PATH Environment Variable
     - pwsh: Write-Host "##vso[task.setvariable variable=VSTEST_DUMP_FORCEPROCDUMP;]1"
       displayName: Set VSTEST_DUMP_FORCEPROCDUMP Environment Variable
-    - script: eng\common\cibuild.cmd -configuration $(_configuration) -prepareMachine /p:Coverage=$(_codeCoverage)
+    - script: eng\common\cibuild.cmd -configuration $(_configuration) -test -prepareMachine /p:Coverage=$(_codeCoverage)
       displayName: Build and Test
     - task: PublishTestResults@2
       inputs:

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -sign -pack -publish -ci %*"

--- a/src/NetAnalyzers/RulesMissingDocumentation.md
+++ b/src/NetAnalyzers/RulesMissingDocumentation.md
@@ -3,3 +3,4 @@
 Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA1000 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1000> | Do not declare static members on generic types |
+CA1001 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1001> | Types that own disposable fields should be disposable |

--- a/src/PerformanceSensitiveAnalyzers/RulesMissingDocumentation.md
+++ b/src/PerformanceSensitiveAnalyzers/RulesMissingDocumentation.md
@@ -5,6 +5,7 @@ Rule ID | Missing Help Link | Title |
 HAA0101 |  | Array allocation for params parameter |
 HAA0102 |  | Non-overridden virtual method call on value type |
 HAA0201 | <http://msdn.microsoft.com/en-us/library/2839d5h5(v=vs.110).aspx> | Implicit string concatenation allocation |
+HAA0202 | <http://msdn.microsoft.com/en-us/library/yz2be5wk.aspx> | Value type to reference type conversion allocation for string concatenation |
 HAA0301 |  | Closure Allocation Source |
 HAA0302 |  | Display class allocation to capture closure |
 HAA0303 |  | Lambda or anonymous method in a generic method allocates a delegate instance |
@@ -16,3 +17,4 @@ HAA0601 |  | Value type to reference type conversion causing boxing allocation |
 HAA0602 |  | Delegate on struct instance caused a boxing allocation |
 HAA0603 |  | Delegate allocation from a method group |
 HAA0604 |  | Delegate allocation from a method group |
+  

--- a/src/PerformanceSensitiveAnalyzers/RulesMissingDocumentation.md
+++ b/src/PerformanceSensitiveAnalyzers/RulesMissingDocumentation.md
@@ -12,9 +12,9 @@ HAA0303 |  | Lambda or anonymous method in a generic method allocates a delegate
 HAA0401 |  | Possible allocation of reference type enumerator |
 HAA0501 |  | Explicit new array type allocation |
 HAA0502 |  | Explicit new reference type allocation |
+HAA0503 | <http://msdn.microsoft.com/en-us/library/bb397696.aspx> | Explicit new anonymous object allocation |
 HAA0506 |  | Let clause induced allocation |
 HAA0601 |  | Value type to reference type conversion causing boxing allocation |
 HAA0602 |  | Delegate on struct instance caused a boxing allocation |
 HAA0603 |  | Delegate allocation from a method group |
 HAA0604 |  | Delegate allocation from a method group |
-  

--- a/src/Text.Analyzers/RulesMissingDocumentation.md
+++ b/src/Text.Analyzers/RulesMissingDocumentation.md
@@ -4,3 +4,5 @@ Rule ID | Missing Help Link | Title |
 --------|-------------------|-------|
 CA1704 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1704> | Identifiers should be spelled correctly |
 CA1714 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1714> | Flags enums should have plural names |
+CA1717 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1717> | Only FlagsAttribute enums should have plural names |
+  

--- a/src/Text.Analyzers/RulesMissingDocumentation.md
+++ b/src/Text.Analyzers/RulesMissingDocumentation.md
@@ -5,4 +5,3 @@ Rule ID | Missing Help Link | Title |
 CA1704 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1704> | Identifiers should be spelled correctly |
 CA1714 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1714> | Flags enums should have plural names |
 CA1717 | <https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1717> | Only FlagsAttribute enums should have plural names |
-  


### PR DESCRIPTION
Set the networkIsolationPolicy

This leaves us with some network calls during official builds as part of tests; move the tests to be PR-only.

CherryPick of #7785