### PR TITLE
Add network isolation policy to yml (#7785)

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -12,6 +12,18 @@ trigger:
 - features/*
 - 2.9.x
 
+schedules:
+  - cron: "0 8 22-28 * 0"
+    displayName: "Monthly smoke test"
+    branches:
+      include: 
+        - main
+        - release/*
+      exclude: 
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
 variables:
 - name: TeamName
   value: Roslyn
@@ -35,6 +47,8 @@ extends:
         name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: windows.vs2022preview.amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
       displayName: Set PATH Environment Variable
     - pwsh: Write-Host "##vso[task.setvariable variable=VSTEST_DUMP_FORCEPROCDUMP;]1"
       displayName: Set VSTEST_DUMP_FORCEPROCDUMP Environment Variable
-    - script: eng\common\cibuild.cmd -configuration $(_configuration) -prepareMachine /p:Coverage=$(_codeCoverage)
+    - script: eng\common\cibuild.cmd -configuration $(_configuration) -test -prepareMachine /p:Coverage=$(_codeCoverage)
       displayName: Build and Test
     - task: PublishTestResults@2
       inputs:

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -sign -pack -publish -ci %*"


### PR DESCRIPTION
Set the networkIsolationPolicy

This leaves us with some network calls during official builds as part of tests; move the tests to be PR-only.

CherryPick of https://github.com/dotnet/roslyn-analyzers/pull/7785