### PR TITLE
Disable runnign tests in the official build

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -89,7 +89,7 @@ extends:
             steps:
             - checkout: self
               clean: true
-            - script: eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:DotNetSignType=$(_SignType) /p:DotnetPublishUsingPipelines=true
+            - script: eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:DotNetSignType=$(_SignType) /p:DotnetPublishUsingPipelines=true  /p:Test=false
               displayName: Build and Test
             templateContext:
               outputs:


### PR DESCRIPTION
Currently the ReferenceAssemblies fallback to nuget.org when they cannot find the package already in the cache. This fails due to nuget.org being disallowed in official builds. Tests should already have run and passed in PR prior to merging.