### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -1,0 +1,136 @@
+parameters:
+  # Optionally do not publish to TSA. Useful for e.g., verifying fixes before PR.
+- name: TSAEnabled
+  displayName: Publish results to TSA
+  type: boolean
+  default: true
+
+# Branches that trigger a build on commit
+trigger:
+- main
+- release/*
+- features/*
+- 2.9.x
+
+schedules:
+  - cron: "0 8 23-29 * 0"
+    displayName: "Monthly smoke test"
+    branches:
+      include: 
+        - main
+        - release/*
+      exclude: 
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
+variables:
+- name: TeamName
+  value: Roslyn
+- group: DotNet-Roslyn-SDLValidation-Params
+- group: DotNet-Symbol-Server-Pats
+- group: DotNet-Versions-Publish
+- group: ManagedLanguageSecrets
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows        
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
+        configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      image: windows.vs2022preview.amd64
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build
+      jobs:
+      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/9.0.1xx') }}:
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: roslyn-analyzers
+            MirrorBranch: release/9.0.1xx
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-ROSANLZR'
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: true
+          enablePublishUsingPipelines: true
+          enableTelemetry: true
+          enableSourceBuild: true
+          jobs:
+          - job: Signed_Build
+            pool:
+              name: NetCore1ESPool-Internal
+              demands: ImageOverride -equals windows.vs2022preview.amd64
+            variables:
+            - name: _BuildConfig
+              value: Release
+            - name: _SignType
+              value: real
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng\common\CIBuild.cmd -configuration $(_BuildConfig) /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:DotNetSignType=$(_SignType) /p:DotnetPublishUsingPipelines=true
+              displayName: Build and Test
+            templateContext:
+              outputs:
+              # Archive NuGet packages to DevOps.
+              - output: pipelineArtifact
+                path: artifacts/packages/$(_BuildConfig)
+                artifact: Packages
+              # Archive VSIX packages to DevOps.
+              - output: pipelineArtifact
+                path: artifacts/VSSetup/$(_BuildConfig)
+                artifact: VSIXes
+    - stage: analysis
+      displayName: Code analysis
+      pool:
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals windows.vs2022preview.amd64
+      jobs:
+      - job: codeql
+        displayName: CodeQL
+        timeoutInMinutes: 120
+        variables:
+        # CG is handled in the primary CI pipeline
+        - name: skipComponentGovernanceDetection
+          value: true
+        # Force CodeQL enabled so it may be run on any branch
+        - name: Codeql.Enabled
+          value: true
+        # Do not let CodeQL 3000 Extension gate scan frequency
+        - name: Codeql.Cadence
+          value: 0
+        - name: Codeql.TSAEnabled
+          value: true
+        steps:
+        - script: eng\common\cibuild.cmd -configuration Release -prepareMachine /p:Test=false
+          displayName: Windows Build
+    - template: eng/common/templates-official/post-build/post-build.yml
+      parameters:
+        publishingInfraVersion: 3
+        enableSymbolValidation: false
+        enableSigningValidation: false
+        enableSourceLinkValidation: false
+        enableNugetValidation: false


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines-microbuild.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131