### PR TITLE
Remove Publish-Build-Assets variable group from release/9.0.1xx

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -81,7 +81,6 @@ extends:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2022.amd64
             variables:
-            - group: Publish-Build-Assets
             - name: _BuildConfig
               value: Release
             - name: _SignType


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines-microbuild.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131