### PR TITLE
Remove stale symbol server PAT variable group from release/9.0.1xx

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -28,7 +28,6 @@ variables:
 - name: TeamName
   value: Roslyn
 - group: DotNet-Roslyn-SDLValidation-Params
-- group: DotNet-Symbol-Server-Pats
 - group: DotNet-Versions-Publish
 - group: ManagedLanguageSecrets
 


### PR DESCRIPTION
## Summary

- remove the stale `DotNet-Symbol-Server-Pats` variable-group import
- allow the release pipeline to compile and reach the App-authenticated OneLoc job

The variable group was deleted as part of symbol-server PAT retirement. Pipeline 830 currently fails during YAML compilation before OneLoc can run. The generated symbol-redaction inputs do not require restoring or replacing this group.

## Validation

- `git diff --check`
- confirmed no `DotNet-Symbol-Server-Pats` references remain in checked-in YAML
- AB#12307 documents an Azure DevOps preview in which removing only this import allowed the complete pipeline to expand successfully

Related: AB#12307